### PR TITLE
🧹 Replace var with const in dsp-worker.js

### DIFF
--- a/src/js/workers/dsp-worker.js
+++ b/src/js/workers/dsp-worker.js
@@ -47,7 +47,7 @@ var STAGE_NAMES = [
   /* 17 */ 'True Peak Limiter'
 ];
 
-var TOTAL_STAGES = STAGE_NAMES.length;
+const TOTAL_STAGES = STAGE_NAMES.length;
 
 /* ================================================================
  * Utility Functions


### PR DESCRIPTION
🎯 **What:** Replaced the `var` declaration with `const` for `TOTAL_STAGES` in `src/js/workers/dsp-worker.js` at line 50.
💡 **Why:** Using `const` clarifies that this variable is intended to be constant and will not be reassigned. This prevents accidental modifications and leverages modern block-scoping instead of function-level scoping, improving code maintainability.
✅ **Verification:** Ran `node -c src/js/workers/dsp-worker.js` to ensure the syntax remains valid and there are no parsing errors. This change is entirely safe since `TOTAL_STAGES` is a constant derived from the static array `STAGE_NAMES` and is only ever read by other worker functions.
✨ **Result:** A more modern, robust, and readable DSP worker script aligned with the rest of the codebase's standard practices for constants.

---
*PR created automatically by Jules for task [2174600930567236281](https://jules.google.com/task/2174600930567236281) started by @Joker5514*