### PR TITLE
Upgrade to v14: PWA offline caching, COOP/COEP headers, and deployment fixes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           cache: 'npm'
       
       - name: Install dependencies

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <!-- Background circle -->
+  <circle cx="32" cy="32" r="32" fill="#0c0c10"/>
+  <!-- Microphone body -->
+  <rect x="24" y="10" width="16" height="26" rx="8" fill="#dc2626"/>
+  <!-- Microphone stand arc -->
+  <path d="M18 32a14 14 0 0 0 28 0" stroke="#dc2626" stroke-width="3" stroke-linecap="round" fill="none"/>
+  <!-- Stand pole -->
+  <line x1="32" y1="46" x2="32" y2="54" stroke="#dc2626" stroke-width="3" stroke-linecap="round"/>
+  <!-- Stand base -->
+  <line x1="22" y1="54" x2="42" y2="54" stroke="#dc2626" stroke-width="3" stroke-linecap="round"/>
+</svg>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -9,14 +9,10 @@
   "orientation": "any",
   "icons": [
     {
-      "src": "/VoiceIsolate-Pro/icon-192.png",
-      "sizes": "192x192",
-      "type": "image/png"
-    },
-    {
-      "src": "/VoiceIsolate-Pro/icon-512.png",
-      "sizes": "512x512",
-      "type": "image/png"
+      "src": "/VoiceIsolate-Pro/favicon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
     }
   ]
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,139 @@
+/**
+ * VoiceIsolate Pro v14.0 — Service Worker
+ *
+ * Dual responsibility:
+ *  1. Inject COOP/COEP headers for every response so SharedArrayBuffer is
+ *     available on GitHub Pages (which doesn't support custom HTTP headers).
+ *     SharedArrayBuffer is required for ffmpeg.wasm and ONNX Runtime WASM threads.
+ *  2. Provide PWA offline caching with appropriate strategies.
+ *
+ * Caching strategies:
+ *   - ML models & WASM binaries  → cache-first (large, versioned by URL)
+ *   - CDN assets (ffmpeg core)   → cache-first
+ *   - App shell (hashed JS/CSS)  → cache-first (Vite hash = eternal cache)
+ *   - Navigation                 → network-first with offline fallback
+ */
+
+const CACHE_NAME = 'voiceisolate-v14';
+
+const COOP_HEADERS = {
+  'Cross-Origin-Opener-Policy':   'same-origin',
+  'Cross-Origin-Embedder-Policy': 'require-corp',
+};
+
+// Resources to pre-cache on install (static app shell)
+const PRECACHE_URLS = [
+  '/VoiceIsolate-Pro/',
+  '/VoiceIsolate-Pro/index.html',
+  '/VoiceIsolate-Pro/manifest.json',
+  '/VoiceIsolate-Pro/favicon.svg',
+];
+
+// ── Install ──────────────────────────────────────────────────────────────────
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) =>
+      cache.addAll(PRECACHE_URLS).catch((err) => {
+        console.warn('[SW v14] Pre-cache failed (non-fatal):', err);
+      })
+    )
+  );
+  self.skipWaiting();
+});
+
+// ── Activate ─────────────────────────────────────────────────────────────────
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(keys.filter((k) => k !== CACHE_NAME).map((k) => caches.delete(k)))
+    )
+  );
+  self.clients.claim();
+});
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Clone a Response and inject COOP/COEP headers so the browser treats the
+ * document as cross-origin isolated (enables SharedArrayBuffer on GitHub Pages).
+ */
+function addCoopCoep(response) {
+  const headers = new Headers(response.headers);
+  for (const [k, v] of Object.entries(COOP_HEADERS)) headers.set(k, v);
+  return new Response(response.body, {
+    status:     response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+// ── Fetch ─────────────────────────────────────────────────────────────────────
+
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+  const url = new URL(request.url);
+
+  // Only handle GET
+  if (request.method !== 'GET') return;
+
+  const isSameOrigin = url.origin === self.location.origin;
+  const isAllowedCDN = url.hostname === 'cdn.jsdelivr.net' || url.hostname === 'unpkg.com';
+
+  if (!isSameOrigin && !isAllowedCDN) return;
+
+  // ── ML models, WASM, CDN assets → cache-first ─────────────────────────────
+  if (
+    url.pathname.includes('/models/') ||
+    url.pathname.endsWith('.onnx')    ||
+    url.pathname.endsWith('.wasm')    ||
+    isAllowedCDN
+  ) {
+    event.respondWith(
+      caches.open(CACHE_NAME).then(async (cache) => {
+        const cached = await cache.match(request);
+        if (cached) return addCoopCoep(cached);
+        const response = await fetch(request);
+        if (response.ok) cache.put(request, response.clone());
+        return addCoopCoep(response);
+      })
+    );
+    return;
+  }
+
+  // ── Navigation → network-first + COOP/COEP injection ─────────────────────
+  if (request.mode === 'navigate') {
+    event.respondWith(
+      fetch(request)
+        .then((response) => {
+          if (response.ok) {
+            caches.open(CACHE_NAME).then((c) => c.put(request, response.clone()));
+          }
+          return addCoopCoep(response);
+        })
+        .catch(async () => {
+          const cached = await caches.match('/VoiceIsolate-Pro/index.html');
+          return cached
+            ? addCoopCoep(cached)
+            : new Response('Offline', { status: 503 });
+        })
+    );
+    return;
+  }
+
+  // ── App shell assets → cache-first + COOP/COEP injection ─────────────────
+  event.respondWith(
+    caches.open(CACHE_NAME).then(async (cache) => {
+      const cached = await cache.match(request);
+      if (cached) return addCoopCoep(cached);
+      try {
+        const response = await fetch(request);
+        if (response.ok && response.type === 'basic') cache.put(request, response.clone());
+        return addCoopCoep(response);
+      } catch {
+        return new Response('Offline', { status: 503 });
+      }
+    })
+  );
+});

--- a/src/audio/zero-noise-processor.worklet.ts
+++ b/src/audio/zero-noise-processor.worklet.ts
@@ -261,7 +261,7 @@ class ZeroNoiseProcessor extends AudioWorkletProcessor {
       return true;
     }
 
-    const t0 = currentTime * 1000;
+    const t0 = performance.now();
     const blockSize = input[0].length; // 128
 
     // Accumulate into ring buffer
@@ -296,7 +296,7 @@ class ZeroNoiseProcessor extends AudioWorkletProcessor {
     this.s.olaRight.fill(0, this.s.olaRight.length - blockSize);
 
     // Metrics
-    const elapsed = currentTime * 1000 - t0;
+    const elapsed = performance.now() - t0;
     this.s.avgProcMs = 0.95 * this.s.avgProcMs + 0.05 * elapsed;
     if (elapsed > this.s.peakProcMs) this.s.peakProcMs = elapsed;
     this.s.frameCount++;

--- a/src/dsp/fft.ts
+++ b/src/dsp/fft.ts
@@ -144,6 +144,7 @@ export function fftInPlace(
 export class FFTEngine {
   readonly fftSize: number;
   readonly hopSize: number;
+  readonly sampleRate: number;
   private window: Float32Array;
   private overlapBuffer: Float32Array;
   private bitReverseTable: Uint16Array;
@@ -153,11 +154,12 @@ export class FFTEngine {
   private olaScale: number;
 
   constructor(config: AudioConfig) {
-    const { fftSize, hopSize, windowFunction } = config;
+    const { fftSize, hopSize, windowFunction, sampleRate } = config;
     if (fftSize !== 2048) console.warn(`FFTEngine: fftSize=${fftSize}, optimised for 2048`);
 
     this.fftSize = fftSize;
     this.hopSize = hopSize;
+    this.sampleRate = sampleRate;
     this.overlapBuffer = new Float32Array(fftSize);
     this.bitReverseTable = buildBitReverseTable(fftSize);
 
@@ -264,9 +266,9 @@ export class FFTEngine {
     return power;
   }
 
-  /** Convert bin index to frequency in Hz */
+  /** Convert bin index to frequency in Hz using the engine's own sample rate */
   binToHz(bin: number): number {
-    return (bin * this.hopSize) / this.fftSize; // placeholder – callers pass sampleRate
+    return (bin * this.sampleRate) / this.fftSize;
   }
 
   binToFreq(bin: number, sampleRate: number): number {

--- a/src/dsp/nodes/vad-node.ts
+++ b/src/dsp/nodes/vad-node.ts
@@ -1,7 +1,11 @@
-import { PCMBuffer, DSPNode } from '../types';
-
-export class VADNode implements DSPNode {
-  public name = 'VoiceActivityGate';
+/**
+ * Standalone VAD node that communicates with the ML worker via a direct MessageChannel.
+ * This is NOT part of the main DSP pipeline (pipeline.ts has its own energy-based VADNode);
+ * use this when you need ML-backed VAD with smoothed gain gating outside the pipeline.
+ */
+export class VADNode {
+  public readonly id = 'vad-node-ml';
+  public readonly name = 'VoiceActivityGate';
   public bypass = false;
 
   private workerPort: MessagePort;
@@ -50,7 +54,15 @@ export class VADNode implements DSPNode {
     // Clone the input PCM before transfer so we don't detach the caller's buffer
     const frameToProcess = new Float32Array(input);
 
-    const msg: any = {
+    const msg: {
+      taskId: string;
+      payload: {
+        task: 'vad';
+        pcm: Float32Array;
+        sr: number;
+        state?: Float32Array;
+      };
+    } = {
       taskId: `vad_${Date.now()}`,
       payload: {
         task: 'vad',
@@ -79,5 +91,9 @@ export class VADNode implements DSPNode {
     }
 
     return output;
+  }
+
+  public dispose(): void {
+    this.workerPort.close();
   }
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,3 +8,14 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
     <App />
   </React.StrictMode>
 );
+
+// Register service worker for PWA offline support
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker
+      .register('/VoiceIsolate-Pro/sw.js', { scope: '/VoiceIsolate-Pro/' })
+      .catch((err) => {
+        console.warn('[SW] Registration failed:', err);
+      });
+  });
+}

--- a/src/sw.js
+++ b/src/sw.js
@@ -1,110 +1,114 @@
 /**
- * VoiceIsolate Pro v9.0 — Service Worker
- * Enables offline-first PWA with cache-first strategy for app shell
- * and network-first for dynamic resources (ML models, etc.).
+ * VoiceIsolate Pro v14.0 — Service Worker
+ * PWA offline strategy:
+ *   - App shell (HTML, CSS, JS) → cache-first (Vite hashes ensure freshness)
+ *   - ML models (/models/*.onnx) → cache-first (large, rarely change)
+ *   - ffmpeg.wasm CDN assets → cache-first (versioned CDN URLs)
+ *   - Navigation requests → network-first with offline fallback
+ *
+ * NOTE: Because Vite emits hashed filenames, updating the CACHE_NAME
+ * on each deploy is sufficient to bust old assets.
  */
 
-const CACHE_NAME = 'voiceisolate-v9';
-const APP_SHELL = [
-  '/',
-  '/index.html',
-  '/css/styles.css',
-  '/js/app.js',
-  '/js/ui/controls.js',
-  '/js/ui/visualizer.js',
-  '/js/export/encoders.js',
-  '/js/ml/model-manager.js',
-  '/js/utils/audio-utils.js',
-  '/js/utils/crypto-utils.js',
-  '/js/utils/db.js',
-  '/js/workers/dispatcher-worker.js',
-  '/js/workers/dsp-worker.js',
-  '/js/dsp/nodes/decode.js',
-  '/js/dsp/nodes/fft.js',
-  '/js/dsp/nodes/hum-removal.js',
-  '/js/dsp/nodes/noise-profile.js',
-  '/js/dsp/nodes/normalize.js',
-  '/js/dsp/nodes/spectral-gate.js',
-  '/js/dsp/nodes/spectral-subtraction.js',
-  '/js/dsp/nodes/vad.js',
-  '/js/dsp/nodes/voiceprint.js',
-  '/manifest.json',
+const CACHE_NAME = 'voiceisolate-v14';
+
+// Resources to pre-cache on install (static app shell)
+const PRECACHE_URLS = [
+  '/VoiceIsolate-Pro/',
+  '/VoiceIsolate-Pro/index.html',
+  '/VoiceIsolate-Pro/manifest.json',
+  '/VoiceIsolate-Pro/favicon.svg',
 ];
 
-// Install — cache app shell
+// Install — pre-cache app shell
 self.addEventListener('install', (event) => {
   event.waitUntil(
     caches.open(CACHE_NAME).then((cache) => {
-      return cache.addAll(APP_SHELL).catch((err) => {
-        console.warn('[SW] Some assets failed to cache during install:', err);
+      return cache.addAll(PRECACHE_URLS).catch((err) => {
+        console.warn('[SW v14] Some assets failed to pre-cache:', err);
       });
     })
   );
   self.skipWaiting();
 });
 
-// Activate — clean old caches
+// Activate — delete all caches that don't match CACHE_NAME
 self.addEventListener('activate', (event) => {
   event.waitUntil(
-    caches.keys().then((keys) => {
-      return Promise.all(
-        keys
-          .filter((key) => key !== CACHE_NAME)
-          .map((key) => caches.delete(key))
-      );
-    })
+    caches.keys().then((keys) =>
+      Promise.all(keys.filter((k) => k !== CACHE_NAME).map((k) => caches.delete(k)))
+    )
   );
   self.clients.claim();
 });
 
-// Fetch — cache-first for app shell, network-first for other requests
+// Fetch — routing strategy
 self.addEventListener('fetch', (event) => {
-  const url = new URL(event.request.url);
+  const { request } = event;
+  const url = new URL(request.url);
 
   // Skip non-GET requests
-  if (event.request.method !== 'GET') return;
+  if (request.method !== 'GET') return;
 
-  // Skip cross-origin requests (except fonts)
-  if (url.origin !== self.location.origin && !url.hostname.includes('fonts.googleapis.com') && !url.hostname.includes('fonts.gstatic.com')) {
-    return;
-  }
+  // Skip cross-origin requests (except known CDN assets for ffmpeg/onnx)
+  const isSameOrigin = url.origin === self.location.origin;
+  const isAllowedCDN =
+    url.hostname === 'cdn.jsdelivr.net' ||
+    url.hostname === 'unpkg.com';
 
-  // Font requests — cache-first with long TTL
-  if (url.hostname.includes('fonts.googleapis.com') || url.hostname.includes('fonts.gstatic.com')) {
+  if (!isSameOrigin && !isAllowedCDN) return;
+
+  // ML models and CDN assets — cache-first (large binaries, versioned URLs)
+  if (
+    url.pathname.includes('/models/') ||
+    url.pathname.endsWith('.onnx') ||
+    url.pathname.endsWith('.wasm') ||
+    isAllowedCDN
+  ) {
     event.respondWith(
-      caches.match(event.request).then((cached) => {
-        if (cached) return cached;
-        return fetch(event.request).then((response) => {
-          if (response.ok) {
-            const clone = response.clone();
-            caches.open(CACHE_NAME).then((cache) => cache.put(event.request, clone));
-          }
-          return response;
-        });
-      })
+      caches.open(CACHE_NAME).then((cache) =>
+        cache.match(request).then((cached) => {
+          if (cached) return cached;
+          return fetch(request).then((response) => {
+            if (response.ok) cache.put(request, response.clone());
+            return response;
+          });
+        })
+      )
     );
     return;
   }
 
-  // App shell — cache-first
-  event.respondWith(
-    caches.match(event.request).then((cached) => {
-      if (cached) return cached;
+  // Navigation requests — network-first with offline fallback
+  if (request.mode === 'navigate') {
+    event.respondWith(
+      fetch(request)
+        .then((response) => {
+          if (response.ok) {
+            const clone = response.clone();
+            caches.open(CACHE_NAME).then((c) => c.put(request, clone));
+          }
+          return response;
+        })
+        .catch(() => caches.match('/VoiceIsolate-Pro/index.html')
+          .then((cached) => cached ?? new Response('Offline', { status: 503 }))
+        )
+    );
+    return;
+  }
 
-      return fetch(event.request).then((response) => {
-        // Cache successful responses
-        if (response.ok && response.type === 'basic') {
-          const clone = response.clone();
-          caches.open(CACHE_NAME).then((cache) => cache.put(event.request, clone));
-        }
-        return response;
-      }).catch(() => {
-        // Offline fallback for navigation requests
-        if (event.request.mode === 'navigate') {
-          return caches.match('/index.html');
-        }
-        return new Response('Offline', { status: 503, statusText: 'Service Unavailable' });
-      });
-    })
+  // App shell assets (JS, CSS, fonts, icons) — cache-first
+  event.respondWith(
+    caches.open(CACHE_NAME).then((cache) =>
+      cache.match(request).then((cached) => {
+        if (cached) return cached;
+        return fetch(request).then((response) => {
+          if (response.ok && response.type === 'basic') {
+            cache.put(request, response.clone());
+          }
+          return response;
+        }).catch(() => new Response('Offline', { status: 503 }));
+      })
+    )
   );
 });

--- a/src/workers/ml-worker.ts
+++ b/src/workers/ml-worker.ts
@@ -19,10 +19,13 @@ let vadSession: ort.InferenceSession;
 
 let vadWorkletPort: MessagePort | null = null;
 
+// Use BASE_URL so model paths resolve correctly when deployed to a sub-path
+// (e.g. GitHub Pages at /VoiceIsolate-Pro/). Vite replaces import.meta.env.BASE_URL at build time.
+const BASE = import.meta.env.BASE_URL.replace(/\/$/, '');
 const MODELS = {
-  DEMUCS: '/models/demucs_v4_quant.onnx',
-  ECAPA: '/models/ecapa_tdnn.onnx',
-  VAD: '/models/silero_vad.onnx'
+  DEMUCS: `${BASE}/models/demucs_v4_quant.onnx`,
+  ECAPA:  `${BASE}/models/ecapa_tdnn.onnx`,
+  VAD:    `${BASE}/models/silero_vad.onnx`,
 };
 
 // Silero VAD state size — v4: [2,1,128]=256 floats; v5: [2,1,64]=128 floats

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true,
+    "strict": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,11 @@ import { resolve } from 'path';
 export default defineConfig({
   base: '/VoiceIsolate-Pro/',
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, './src'),
+    },
+  },
   build: {
     outDir: 'dist',
     rollupOptions: {


### PR DESCRIPTION
## Summary
This PR upgrades VoiceIsolate Pro to v14 with significant improvements to PWA offline support, cross-origin isolation for SharedArrayBuffer on GitHub Pages, and deployment configuration fixes.

## Key Changes

### Service Worker & PWA Offline Support
- **Dual service worker strategy**: Maintains `src/sw.js` (source) and `public/sw.js` (deployed with COOP/COEP header injection)
- **COOP/COEP header injection**: The public SW now injects `Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Embedder-Policy: require-corp` headers on all responses to enable SharedArrayBuffer on GitHub Pages (which doesn't support custom HTTP headers)
- **Refined caching strategies**:
  - ML models (`.onnx`), WASM binaries, and CDN assets → cache-first (large, versioned by URL)
  - Navigation requests → network-first with offline fallback to `/VoiceIsolate-Pro/index.html`
  - App shell assets → cache-first (Vite's content hashing ensures freshness)
- **Simplified precache list**: Only essential files (`index.html`, `manifest.json`, `favicon.svg`) are pre-cached; Vite-hashed assets are cached on first use
- **Service worker registration**: Added explicit registration in `src/main.tsx` with proper scope for sub-path deployment

### Deployment & Configuration
- **Base path support**: Updated ML model paths in `src/workers/ml-worker.ts` to use `import.meta.env.BASE_URL` so models resolve correctly when deployed to `/VoiceIsolate-Pro/`
- **Favicon migration**: Replaced PNG icons with SVG favicon (`public/favicon.svg`) in manifest for better scalability and smaller bundle size
- **Vite alias**: Added `@` path alias for cleaner imports
- **Node.js version**: Updated CI to Node 20 for better tooling support

### Code Quality & Type Safety
- **VADNode improvements**: 
  - Added JSDoc clarifying it's a standalone ML-backed VAD (separate from pipeline's energy-based VAD)
  - Improved TypeScript types for message payloads
  - Added `dispose()` method for proper cleanup
- **FFTEngine**: Added `sampleRate` property to engine for frequency conversion utilities
- **Timing fix**: Changed `currentTime * 1000` to `performance.now()` in audio worklet for accurate elapsed time measurement
- **Added `tsconfig.node.json`**: Proper TypeScript configuration for Vite config file

## Notable Implementation Details
- The COOP/COEP header injection in `public/sw.js` is critical for enabling SharedArrayBuffer on GitHub Pages, which is required by ffmpeg.wasm and ONNX Runtime WASM threads
- Cache versioning via `CACHE_NAME` (v14) ensures old caches are cleaned up on deploy; Vite's content hashing handles individual asset freshness
- Cross-origin requests are now explicitly whitelisted (cdn.jsdelivr.net, unpkg.com) for CDN assets

https://claude.ai/code/session_01N1yQmW1FZSW1C8jees2W3y