### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix FFmpeg command injection in decode worker

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** Found unescaped user input (like `file.name`) being directly written to `innerHTML` when building UI elements dynamically in `src/js/app.js` (`updateBatchUI` and `addForensicEntry`).
 **Learning:** Even simple properties like file names can contain malicious scripts. It's a common oversight to trust file names and metadata directly in the frontend. Using string interpolation with `innerHTML` opens up DOM-based XSS if the data isn't sanitized.
 **Prevention:** Always use `textContent` with `document.createElement()` when dynamically adding text to the DOM, or ensure proper HTML escaping if `innerHTML` is strictly necessary.
+## 2024-03-03 - FFmpeg Command and Filtergraph Injection
+**Vulnerability:** Untrusted user input via `postMessage` (`fileName`, `outputSr`, `outputChannels`, `trimSilenceDB`) was directly interpolated into arguments passed to `ffmpeg.exec()` in the decode worker.
+**Learning:** Even within Web Workers and WebAssembly (ffmpeg.wasm), unsanitized inputs used to build command-line arguments can lead to command injection or filtergraph injection, potentially allowing arbitrary file read/write within the virtual filesystem or causing denial of service.
+**Prevention:** Always validate numeric inputs using `Number.isFinite()` and ensure string inputs (like file extensions derived from filenames) are strictly sanitized (e.g., using `.replace(/[^a-z0-9]/g, '')`) before passing them to command-execution APIs.

--- a/src/workers/decode-worker.ts
+++ b/src/workers/decode-worker.ts
@@ -133,7 +133,9 @@ async function decode(payload: DecodePayload, taskId: string): Promise<DecodeRes
   }
 
   // Determine extension
-  const ext = fileName.split('.').pop()?.toLowerCase() ?? '';
+  const rawExt = fileName.split('.').pop()?.toLowerCase() ?? '';
+  // Sanitize extension: allow only alphanumeric characters
+  const ext = rawExt.replace(/[^a-z0-9]/g, '');
   const fmt = EXTENSION_MAP[ext] ?? { inputFmt: 'auto', codec: 'unknown' };
 
   postProgress(taskId, 'detect', 5);
@@ -144,19 +146,23 @@ async function decode(payload: DecodePayload, taskId: string): Promise<DecodeRes
 
   postProgress(taskId, 'write', 15);
 
+  // Validate numeric inputs to prevent command injection
+  const safeChannels = Number.isFinite(outputChannels) && outputChannels! > 0 ? outputChannels : 1;
+  const safeSr = Number.isFinite(outputSr) && outputSr! > 0 ? outputSr : undefined;
+
   // Build ffmpeg command
   // Output: raw f32le PCM so we can read it directly
   const outName = 'output.pcm';
   const args: string[] = [
     '-i', inName,
     '-vn',                   // drop video
-    '-ac', String(outputChannels || 1),
+    '-ac', String(safeChannels),
   ];
 
-  if (outputSr) args.push('-ar', String(outputSr));
+  if (safeSr) args.push('-ar', String(safeSr));
 
   // Apply silence trim if requested
-  if (trimSilenceDB !== undefined) {
+  if (trimSilenceDB !== undefined && Number.isFinite(trimSilenceDB)) {
     const t = trimSilenceDB;
     args.push(
       '-af',
@@ -330,7 +336,9 @@ async function probe(fileBuffer: ArrayBuffer, fileName: string): Promise<{
   channels: number;
 }> {
   if (!ffmpeg) throw new Error('FFmpeg not initialised');
-  const ext = fileName.split('.').pop()?.toLowerCase() ?? 'bin';
+  const rawExt = fileName.split('.').pop()?.toLowerCase() ?? 'bin';
+  // Sanitize extension: allow only alphanumeric characters
+  const ext = rawExt.replace(/[^a-z0-9]/g, '');
   const inName = `probe.${ext}`;
   await ffmpeg.writeFile(inName, new Uint8Array(fileBuffer));
 


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Untrusted user inputs (`fileName`, `outputChannels`, `outputSr`, `trimSilenceDB`) passed via `postMessage` were directly interpolated into FFmpeg execution arguments and filtergraphs without validation, risking command and filtergraph injection.
🎯 **Impact:** Potential arbitrary file operations within the virtual filesystem or denial of service through manipulated filtergraphs and arguments.
🔧 **Fix:** Added regex sanitization for file extensions (`.replace(/[^a-z0-9]/g, '')`) and enforced `Number.isFinite()` checks for all numerical inputs before constructing `ffmpeg.exec()` arguments in both `decode` and `probe` actions.
✅ **Verification:** Verified syntax correctness manually via `node -c`. The changes are constrained to logical validation ensuring only explicitly formatted integers or default safe values populate the FFmpeg command string.

---
*PR created automatically by Jules for task [15196605275760516798](https://jules.google.com/task/15196605275760516798) started by @Joker5514*