### PR TITLE
⚡ Bolt: Optimize DSP latency tracking with O(1) ring buffer

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-03-02 - DSP Node Iterative Slicing Overhead
 **Learning:** In audio processing blocks (like `FFTNode`, `SpectralSubtractionNode`, etc.), repeatedly calling `TypedArray.prototype.slice()` inside a `while` loop to advance the input buffer causes $O(K^2)$ array allocations and massive GC overhead.
 **Action:** Use an `inputOffset` pointer to track the read position within the loop, and perform a single `.slice(inputOffset)` at the end to keep the remainder for the next block. This pattern improved buffer shifting speed by ~28x in synthetic benchmarks.
+
+## 2024-03-03 - DSP Hot Loop O(N) Array Operations
+**Learning:** Using `Array.prototype.shift()` (e.g., to manage a history/latency queue) inside a hot DSP loop like `DSPPipeline.processFrame` causes significant O(N) re-indexing overhead and increased garbage collection, which severely impacts realtime audio performance.
+**Action:** Replace `push()` and `shift()` on arrays with a pre-allocated fixed-size `TypedArray` (e.g., `Float32Array(100)`) acting as a ring buffer with a wrap-around index pointer (`this.latencyIndex = (this.latencyIndex + 1) % 100`). This ensures O(1) read/write performance and zeroes out GC pressure.

--- a/src/dsp/pipeline.ts
+++ b/src/dsp/pipeline.ts
@@ -604,7 +604,11 @@ export class DSPPipeline {
   private stages: DSPNode[] = [];
   private eventHandlers: PipelineEventHandler[] = [];
   private frameIndex = 0;
-  private latencies: number[] = [];
+
+  // ⚡ Bolt: Use a pre-allocated ring buffer to avoid O(N) Array.shift() and GC overhead in hot loop
+  private latencies = new Float32Array(100);
+  private latencyIndex = 0;
+  private latencyCount = 0;
 
   // Public node references for external control
   readonly dcOffset = new DCOffsetNode();
@@ -714,8 +718,11 @@ export class DSPPipeline {
         this.emit({ type: 'error', nodeId: 'pipeline', error: err as Error });
       }
       const latency = performance.now() - t0;
-      this.latencies.push(latency);
-      if (this.latencies.length > 100) this.latencies.shift();
+      // ⚡ Bolt: Write latency into fixed-size ring buffer in O(1)
+      this.latencies[this.latencyIndex] = latency;
+      this.latencyIndex = (this.latencyIndex + 1) % 100;
+      if (this.latencyCount < 100) this.latencyCount++;
+
       this.emit({ type: 'frame_processed', frameIndex: this.frameIndex, latencyMs: latency });
       this.frameIndex++;
     }
@@ -803,8 +810,12 @@ export class DSPPipeline {
   }
 
   private avgLatency(): number {
-    if (!this.latencies.length) return 0;
-    return this.latencies.reduce((a, b) => a + b, 0) / this.latencies.length;
+    if (this.latencyCount === 0) return 0;
+    let sum = 0;
+    for (let i = 0; i < this.latencyCount; i++) {
+      sum += this.latencies[i];
+    }
+    return sum / this.latencyCount;
   }
 
   /** Bypass a specific node by ID */
@@ -822,7 +833,8 @@ export class DSPPipeline {
     for (const node of this.stages) node.dispose();
     this.stages = [];
     this.eventHandlers = [];
-    this.latencies = [];
+    this.latencyIndex = 0;
+    this.latencyCount = 0;
   }
 }
 


### PR DESCRIPTION
💡 **What:** 
Replaced `Array.prototype.push()` and `Array.prototype.shift()` used for tracking DSP latency in `src/dsp/pipeline.ts` with a pre-allocated `Float32Array(100)` ring buffer using a modulo wrap-around index.

🎯 **Why:** 
Calling `.shift()` on an array inside a high-frequency loop like `DSPPipeline.processChunk` forces JavaScript to re-index all remaining elements. This creates an $O(N)$ performance overhead per frame and forces garbage collection as arrays are constantly reallocated. By using a pre-allocated fixed-size ring buffer, latency tracking becomes an $O(1)$ operation, completely eliminating GC pressure.

📊 **Impact:** 
Eliminates $O(N)$ latency array re-indexing in the hot audio processing loop, avoiding constant garbage collector triggers and ensuring stable realtime audio processing frame times.

🔬 **Measurement:** 
Verification was done using `pnpm vitest run` and `node -c src/dsp/pipeline.ts`. To measure the difference, profiling `avgLatency` or analyzing the GC pauses during high-load processing using Chrome DevTools Performance tab would demonstrate the stabilized overhead.

---
*PR created automatically by Jules for task [15539051448998820112](https://jules.google.com/task/15539051448998820112) started by @Joker5514*