### PR TITLE
fix: handle missing Web Crypto in generateUUID

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1731,9 +1731,14 @@ function setupVizTabs() {
  * =================================================================== */
 
 function addToBatch(file) {
-  const id = `batch_${generateUUID()}`;
-  state.batchQueue.push({ id, file, status: 'pending', progress: 0 });
-  updateBatchUI();
+  try {
+    const id = `batch_${generateUUID()}`;
+    state.batchQueue.push({ id, file, status: 'pending', progress: 0 });
+    updateBatchUI();
+  } catch (error) {
+    console.error('[Batch] Failed to add file to batch:', error);
+    alert('Failed to add file to batch: ' + error.message);
+  }
 }
 
 function updateBatchUI() {

--- a/src/js/utils/crypto-utils.js
+++ b/src/js/utils/crypto-utils.js
@@ -251,6 +251,13 @@ export function generateUUID() {
     return crypto.randomUUID();
   }
 
+  if (typeof crypto === 'undefined' || typeof crypto.getRandomValues !== 'function') {
+    throw new Error(
+      'Web Crypto API (crypto.getRandomValues) is not available. ' +
+        'This application must be served over HTTPS or from localhost.',
+    );
+  }
+
   // Manual UUID v4 generation using crypto.getRandomValues.
   const bytes = new Uint8Array(16);
   crypto.getRandomValues(bytes);


### PR DESCRIPTION
Add a guard inside `generateUUID()` to throw an explicit error when `crypto.getRandomValues` is unavailable, similarly to `getSubtle()`. Also wrapped `addToBatch()` in a try/catch block to prevent UI crashes if generation fails and provide a user alert instead.