### PR TITLE
⚡ Bolt: [performance improvement] O(1) Priority Queue Optimization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-03-03 - DSP Hot Loop O(N) Array Operations
 **Learning:** Using `Array.prototype.shift()` (e.g., to manage a history/latency queue) inside a hot DSP loop like `DSPPipeline.processFrame` causes significant O(N) re-indexing overhead and increased garbage collection, which severely impacts realtime audio performance.
 **Action:** Replace `push()` and `shift()` on arrays with a pre-allocated fixed-size `TypedArray` (e.g., `Float32Array(100)`) acting as a ring buffer with a wrap-around index pointer (`this.latencyIndex = (this.latencyIndex + 1) % 100`). This ensures O(1) read/write performance and zeroes out GC pressure.
+
+## 2024-03-05 - WorkerPool PriorityQueue O(N) Shift Overhead
+**Learning:** Using `Array.prototype.shift()` to implement priority queues creates O(N) array reallocation overhead, heavily impacting the `WorkerPool` which manages thousands of tiny, rapid tasks.
+**Action:** Replace `.shift()` with an amortized O(1) index offset pattern (`headIndex`), manually setting dequeued entries to `undefined` for GC, and performing bulk `.slice` cleanups when `headIndex > 256` to prevent memory leaks.

--- a/src/dsp/worker-pool.ts
+++ b/src/dsp/worker-pool.ts
@@ -85,6 +85,7 @@ interface PendingTask<T = unknown, R = unknown> {
 
 class PriorityQueue<T extends { task: WorkerTask }> {
   private buckets: T[][] = [[], [], [], []]; // one per priority level
+  private heads: number[] = [0, 0, 0, 0]; // ⚡ Bolt: offset tracker to avoid O(N) shift()
   private _size = 0;
 
   enqueue(item: T): void {
@@ -95,7 +96,20 @@ class PriorityQueue<T extends { task: WorkerTask }> {
 
   dequeue(): T | undefined {
     for (let p = 0; p <= 3; p++) {
-      if (this.buckets[p].length) { this._size--; return this.buckets[p].shift(); }
+      if (this.buckets[p].length > this.heads[p]) {
+        this._size--;
+        const item = this.buckets[p][this.heads[p]];
+        this.buckets[p][this.heads[p]] = undefined as unknown as T; // allow GC
+        this.heads[p]++;
+
+        // Cleanup to prevent memory leak
+        if (this.heads[p] > 256 && this.heads[p] > this.buckets[p].length / 2) {
+          this.buckets[p] = this.buckets[p].slice(this.heads[p]);
+          this.heads[p] = 0;
+        }
+
+        return item;
+      }
     }
     return undefined;
   }
@@ -103,7 +117,9 @@ class PriorityQueue<T extends { task: WorkerTask }> {
   /** Peek at next item without removing */
   peek(): T | undefined {
     for (let p = 0; p <= 3; p++) {
-      if (this.buckets[p].length) return this.buckets[p][0];
+      if (this.buckets[p].length > this.heads[p]) {
+        return this.buckets[p][this.heads[p]];
+      }
     }
     return undefined;
   }
@@ -120,9 +136,16 @@ class PriorityQueue<T extends { task: WorkerTask }> {
 
   /** Remove a specific task by id */
   remove(taskId: string): boolean {
-    for (const bucket of this.buckets) {
-      const idx = bucket.findIndex((i) => i.task.id === taskId);
-      if (idx !== -1) { bucket.splice(idx, 1); this._size--; return true; }
+    for (let p = 0; p < this.buckets.length; p++) {
+      const bucket = this.buckets[p];
+      const head = this.heads[p];
+      for (let i = head; i < bucket.length; i++) {
+        if (bucket[i]?.task.id === taskId) {
+          bucket.splice(i, 1);
+          this._size--;
+          return true;
+        }
+      }
     }
     return false;
   }


### PR DESCRIPTION
### 💡 What: 
Optimized the `PriorityQueue` within `src/dsp/worker-pool.ts` by replacing `Array.prototype.shift()` with a `headIndex` tracking array (`this.heads`). This transforms the `dequeue` operation from an O(N) to an amortized O(1) time complexity. It incorporates memory leak safeguards that explicitly `undefined` dequeued slots and periodically triggers a `.slice()` cleanup once the array head exceeds 256 elements.

### 🎯 Why: 
The `WorkerPool` processes thousands of small audio chunks rapidly (e.g. 512 samples per chunk). As the queue grows (especially when backpressured up to its 256/512 limits), removing elements using `.shift()` constantly reallocates and shifts every remaining element in the array, destroying real-time performance and massively increasing garbage collection pressure.

### 📊 Impact: 
- Eliminates O(N) reallocation overhead during DSP job scheduling.
- Expected to stabilize CPU load during heavy thread concurrency.
- Drastically reduces GC pressure by avoiding constant array copying when jobs are popped.

### 🔬 Measurement: 
To verify this improvement, benchmark the `WorkerPool` using a rapid micro-task stress test (e.g., dispatching 10,000 tasks that immediately resolve). The optimized queue should process the entire batch substantially faster with minimal garbage collection pauses compared to the original `.shift()` implementation.

---
*PR created automatically by Jules for task [17797902056426635707](https://jules.google.com/task/17797902056426635707) started by @Joker5514*