### PR TITLE
🔒 Fix insecure key storage: use non-extractable CryptoKey in IndexedDB

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -26,8 +26,6 @@ import {
 } from './utils/audio-utils.js';
 import {
   generateKey,
-  exportKey,
-  importKey,
   encrypt,
   decrypt,
   hashSHA256,
@@ -1503,8 +1501,9 @@ async function startVoiceprintEnrollment() {
       // Encrypt and store
       if (!state.cryptoKey) {
         state.cryptoKey = await generateKey();
-        const jwk = await exportKey(state.cryptoKey);
-        await db.put('settings', { _id: 'cryptoKey', jwk }, 'cryptoKey');
+        // Key stored as non-extractable CryptoKey via structured clone.
+        // Cannot be exported via exportKey(). Upgrade path: derive from user password via PBKDF2.
+        await db.put('settings', { _id: 'cryptoKey', key: state.cryptoKey }, 'cryptoKey');
       }
 
       const encrypted = await encrypt(
@@ -1575,8 +1574,8 @@ async function loadVoiceprint() {
   try {
     // Load crypto key
     const keyData = await db.get('settings', 'cryptoKey');
-    if (keyData && keyData.jwk) {
-      state.cryptoKey = await importKey(keyData.jwk);
+    if (keyData && keyData.key) {
+      state.cryptoKey = keyData.key;
     }
 
     // Load voiceprint

--- a/src/js/utils/crypto-utils.js
+++ b/src/js/utils/crypto-utils.js
@@ -47,7 +47,7 @@ export async function generateKey() {
       name: ALGORITHM,
       length: KEY_LENGTH,
     },
-    true, // extractable
+    false, // extractable
     ['encrypt', 'decrypt'],
   );
 }


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed was the insecure storage of the dynamically generated encryption key used for voiceprints. The key was being generated as extractable, exported to a JWK format, and stored in plaintext within IndexedDB.

⚠️ **Risk:** Any script running on the origin or any user with DevTools access could extract this key and decrypt the sensitive voiceprint data stored alongside it, compromising the user's data.

🛡️ **Solution:** The fix implements storing the CryptoKey directly in IndexedDB using the structured clone algorithm. Specifically, the `extractable` parameter during key generation is now set to `false`, the `exportKey` call was removed, and the raw CryptoKey object is directly stored and retrieved from the database, preventing it from being exported.

---
*PR created automatically by Jules for task [12400230938958460870](https://jules.google.com/task/12400230938958460870) started by @Joker5514*