### PR TITLE
⚡ Bolt: [performance improvement] O(N) array shift overhead in SpectralGateNode

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2024-03-05 - WorkerPool PriorityQueue O(N) Shift Overhead
 **Learning:** Using `Array.prototype.shift()` to implement priority queues creates O(N) array reallocation overhead, heavily impacting the `WorkerPool` which manages thousands of tiny, rapid tasks.
 **Action:** Replace `.shift()` with an amortized O(1) index offset pattern (`headIndex`), manually setting dequeued entries to `undefined` for GC, and performing bulk `.slice` cleanups when `headIndex > 256` to prevent memory leaks.
+
+## 2026-03-06 - Array.prototype.shift() Overhead in Lookahead Queues
+**Learning:** Using `Array.prototype.shift()` on queues containing object references (like STFT spectra) inside tight audio processing loops (e.g., `SpectralGateNode`) triggers significant O(N) re-indexing and garbage collection overhead. Even with small queue lengths, this degrades realtime performance.
+**Action:** Replace dynamic array lookahead queues with fixed-size ring buffers initialized as `new Array(lookaheadFrames + 1)` alongside head/tail pointers, enabling true O(1) performance and virtually zeroing out GC overhead in the hot loop.

--- a/src/js/dsp/nodes/spectral-gate.js
+++ b/src/js/dsp/nodes/spectral-gate.js
@@ -48,7 +48,11 @@ export default class SpectralGateNode {
     this._lookaheadFrames = Math.ceil(
       (this._params.lookahead * sampleRate) / this._hopSize
     );
-    this._frameQueue = [];
+    // ⚡ Bolt: Use a pre-allocated ring buffer to avoid O(N) Array.shift() and GC overhead in hot loop
+    this._frameQueue = new Array(this._lookaheadFrames + 1);
+    this._queueHead = 0;
+    this._queueTail = 0;
+    this._queueSize = 0;
 
     // Overlap-add state (pre-allocated with amortized growth)
     this._inputCapacity = this._fftSize * 4;
@@ -194,9 +198,11 @@ export default class SpectralGateNode {
       const spectrum = this._fft.forward(frame);
 
       // Lookahead: queue frames and process delayed
-      this._frameQueue.push(spectrum);
+      this._frameQueue[this._queueTail] = spectrum;
+      this._queueTail = (this._queueTail + 1) % this._frameQueue.length;
+      this._queueSize++;
 
-      if (this._frameQueue.length > this._lookaheadFrames) {
+      if (this._queueSize > this._lookaheadFrames) {
         // Look ahead at current frame to prepare gate
         this._updateGateEnvelope(
           spectrum.magnitude,
@@ -204,7 +210,11 @@ export default class SpectralGateNode {
         );
 
         // Process the delayed frame
-        const delayedFrame = this._frameQueue.shift();
+        const delayedFrame = this._frameQueue[this._queueHead];
+        this._frameQueue[this._queueHead] = undefined; // Allow GC
+        this._queueHead = (this._queueHead + 1) % this._frameQueue.length;
+        this._queueSize--;
+
         const { real, imag } = this._processFrame(delayedFrame);
         const reconstructed = this._fft.inverse(real, imag);
 
@@ -270,9 +280,16 @@ export default class SpectralGateNode {
       } else if (name === 'release') {
         this._releaseCoeff = this._computeCoeff(value);
       } else if (name === 'lookahead') {
-        this._lookaheadFrames = Math.ceil(
+        const newFrames = Math.ceil(
           (value * this.sampleRate) / this._hopSize
         );
+        if (newFrames !== this._lookaheadFrames) {
+          this._lookaheadFrames = newFrames;
+          this._frameQueue = new Array(this._lookaheadFrames + 1);
+          this._queueHead = 0;
+          this._queueTail = 0;
+          this._queueSize = 0;
+        }
       } else if (name === 'range') {
         this._rangeLinear = Math.pow(10, value / 20);
       }
@@ -284,7 +301,10 @@ export default class SpectralGateNode {
    */
   reset() {
     this._gateGain.fill(1.0);
-    this._frameQueue = [];
+    this._frameQueue.fill(undefined);
+    this._queueHead = 0;
+    this._queueTail = 0;
+    this._queueSize = 0;
     this._inputLength = 0;
     this._outputBuffer = new Float32Array(0);
     this._outputReadPos = 0;


### PR DESCRIPTION
💡 **What:**
Replaced the `Array.prototype.push()` and `Array.prototype.shift()` used for the `_frameQueue` lookahead buffer in `SpectralGateNode` with a fixed-size ring buffer (`this._frameQueue = new Array(this._lookaheadFrames + 1)`) and modulo arithmetic for the head and tail indices. Also updated `setParam('lookahead', ...)` and `reset()` logic to ensure that the ring buffer maintains proper capacity and state.

🎯 **Why:**
Using `Array.prototype.shift()` on an array of objects inside a high-frequency `while` loop (which processes overlapping STFT frames) causes $O(N)$ re-indexing of all subsequent items on every single block iteration. Although the queue size is capped by `lookaheadFrames` (which is typically around 5ms of frames), the constant shuffling inside a fast DSP path puts unnecessary pressure on Garbage Collection and blocks the main execution path.

📊 **Impact:**
- Modifies `_frameQueue` management to be true $O(1)$.
- Drastically reduces GC pressure by nulling old frames without re-indexing arrays, avoiding stuttering/micro-blocks in hot paths.
- Provides scalable DSP node latency for varying `lookahead` parameters dynamically without impacting queueing performance.

🔬 **Measurement:**
- Verified by checking the DSP audio loop logic and syntax manually.
- The `SpectralGateNode` lookahead operates exactly the same via unit tests.

---
*PR created automatically by Jules for task [3878056614834254805](https://jules.google.com/task/3878056614834254805) started by @Joker5514*