### PR TITLE
🧪 Add testing for encodeWav validation and error paths

### DIFF
--- a/src/js/export/encoders.test.js
+++ b/src/js/export/encoders.test.js
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { AudioEncoders } from './encoders.js';
+
+describe('AudioEncoders', () => {
+  describe('encodeWav', () => {
+    // Error paths
+    it('throws an error if channelData is missing or empty', () => {
+      expect(() => AudioEncoders.encodeWav(null, 44100)).toThrow('encodeWav: channelData must be a non-empty array of Float32Arrays');
+      expect(() => AudioEncoders.encodeWav([], 44100)).toThrow('encodeWav: channelData must be a non-empty array of Float32Arrays');
+    });
+
+    it('throws an error if bitDepth is not 16 or 24', () => {
+      const validData = [new Float32Array([0.1, -0.1])];
+      expect(() => AudioEncoders.encodeWav(validData, 44100, 8)).toThrow('encodeWav: bitDepth must be 16 or 24');
+      expect(() => AudioEncoders.encodeWav(validData, 44100, 32)).toThrow('encodeWav: bitDepth must be 16 or 24');
+    });
+
+    // Happy paths
+    it('encodes 16-bit WAV data without throwing', () => {
+      const validData = [new Float32Array([0.1, -0.1, 0.5])];
+      const result = AudioEncoders.encodeWav(validData, 44100, 16);
+      expect(result).toBeInstanceOf(ArrayBuffer);
+      // Optional: Check if header has correct size/length
+      expect(result.byteLength).toBeGreaterThan(44); // 44 bytes header + data
+    });
+
+    it('encodes 24-bit WAV data without throwing', () => {
+      const validData = [new Float32Array([0.1, -0.1, 0.5])];
+      const result = AudioEncoders.encodeWav(validData, 44100, 24);
+      expect(result).toBeInstanceOf(ArrayBuffer);
+      // Optional: Check if header has correct size/length
+      expect(result.byteLength).toBeGreaterThan(44); // 44 bytes header + data
+    });
+  });
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `encodeWav` method in `AudioEncoders` was lacking dedicated unit tests to verify that it correctly throws descriptive errors when encountering invalid input data such as an empty or null `channelData` or an invalid `bitDepth` value (e.g., 32). This PR addresses this by introducing `src/js/export/encoders.test.js`.

📊 **Coverage:** What scenarios are now tested
This change introduces test coverage for the following explicitly:
- Error when `channelData` is null or an empty array.
- Error when `bitDepth` is an unsupported configuration, like 8 or 32 instead of 16 or 24.
- Happy path for correctly encoding valid 16-bit data without throwing an error.
- Happy path for correctly encoding valid 24-bit data without throwing an error.

✨ **Result:** The improvement in test coverage
`AudioEncoders.encodeWav` edge and happy paths are now explicitly tested. This provides a safe foundation to rely upon if future refactoring or additional bit rate supports are introduced. This guards regressions directly related to correct RIFF/WAVE error handling.

---
*PR created automatically by Jules for task [9614560487206352247](https://jules.google.com/task/9614560487206352247) started by @Joker5514*