### PR TITLE
Resolve merge conflicts in zero-noise-processor.worklet.ts

### DIFF
--- a/src/audio/zero-noise-processor.worklet.ts
+++ b/src/audio/zero-noise-processor.worklet.ts
@@ -16,7 +16,17 @@ const HOP_SIZE = 512;           // 75% overlap
 const SAMPLE_RATE = 44100;
 
 class ZeroNoiseProcessor extends AudioWorkletProcessor {
-  // Ring buffer: accumulate 128-sample blocks until we have FFT_SIZE samples
+  // 1. Core config
+  private channels: number = 2;
+
+  // 2. DC offset state
+  private dcOffsetL: number = 0;
+  private dcOffsetYL: number = 0;
+  private dcOffsetR: number = 0;
+  private dcOffsetYR: number = 0;
+  private s: number = 0;
+
+  // 3. Ring buffer: accumulate 128-sample blocks until we have FFT_SIZE samples
   private inputRing: Float32Array;
   private outputRing: Float32Array;
   private inputWritePos: number = 0;
@@ -24,7 +34,7 @@ class ZeroNoiseProcessor extends AudioWorkletProcessor {
   private outputWritePos: number = 0;
   private ringFilled: boolean = false;
 
-  // FFT workspace
+  // 4. FFT workspace
   private fftBuffer: Float32Array;
   private window: Float32Array;
   private noiseFloor: Float32Array;


### PR DESCRIPTION
I resolved the merge conflicts in `src/audio/zero-noise-processor.worklet.ts` between the `onnx-model-integration` branch and `main`.

**Changes Made:**
1. Kept the new `channels` configuration property.
2. Kept the new expanded `dcOffset` state properties (`dcOffsetL`, `dcOffsetYL`, `dcOffsetR`, `dcOffsetYR`, and `s`).
3. Replaced the un-numbered comments with the numbered comment structure from the `onnx-model-integration` branch (`// 1. Core config`, `// 2. DC offset state`, `// 3. Ring buffer`, `// 4. FFT workspace`).

The file compiles properly via `npx vite build` and the Vitest test suite runs without errors.

---
*PR created automatically by Jules for task [8954787789207693572](https://jules.google.com/task/8954787789207693572) started by @Joker5514*