### PR TITLE
🎨 Palette: [UX improvement] Enhance slider keyboard focus visibility and ARIA value updates

### DIFF
--- a/public/app/app.js
+++ b/public/app/app.js
@@ -321,6 +321,7 @@ class VoiceIsolatePro {
     for (const tab of Object.values(SLIDERS)) { const s = tab.find(s => s.id === id); if (s) { unit = s.unit; break; } }
     const ve = document.getElementById(id + 'Val');
     if (ve) ve.textContent = v + unit;
+    el.setAttribute('aria-valuenow', v);
     if (el.classList.contains('realtime') && this.liveChainBuilt) this.updateLiveChain();
   }
 
@@ -331,7 +332,7 @@ class VoiceIsolatePro {
       for (const s of sliders) {
         const el = document.getElementById(s.id);
         const ve = document.getElementById(s.id + 'Val');
-        if (el && this.params[s.id] !== undefined) { el.value = this.params[s.id]; if (ve) ve.textContent = this.params[s.id] + s.unit; }
+        if (el && this.params[s.id] !== undefined) { el.value = this.params[s.id]; el.setAttribute('aria-valuenow', this.params[s.id]); if (ve) ve.textContent = this.params[s.id] + s.unit; }
       }
     }
     document.querySelectorAll('.btn-preset').forEach(b => b.classList.toggle('active', b.dataset.preset === name));

--- a/public/app/style.css
+++ b/public/app/style.css
@@ -180,7 +180,8 @@ input[type="range"].realtime::-webkit-slider-thumb{background:var(--cyan);box-sh
   outline-offset: 2px;
 }
 input[type="range"]:focus-visible {
-  outline: none;
+  outline: 2px solid var(--cyan);
+  outline-offset: 4px;
 }
 input[type="range"]:focus-visible::-webkit-slider-thumb {
   outline: 2px solid var(--cyan);


### PR DESCRIPTION
💡 What: 
- Added a visible cyan focus ring to custom `<input type="range">` elements using the `:focus-visible` pseudo-class.
- Updated the JavaScript `onSlider` and `applyPreset` functions to dynamically update the `aria-valuenow` attribute as the slider value changes.

🎯 Why: 
- Due to `-webkit-appearance: none`, the browser's default focus ring was hidden when a user focused on the custom range sliders using the keyboard, causing keyboard users to lose track of which slider they were modifying.
- The `aria-valuenow` attribute was initially set but not updated dynamically during user interaction or preset application, causing screen readers to announce stale values.

📸 Before/After: 
- Before: Pressing Tab through the sliders gave no visual feedback of the focused element.
- After: A crisp cyan focus outline appears around the focused slider track and thumb.

♿ Accessibility: 
- Drastically improves keyboard navigation and spatial awareness for visual users relying on Tab navigation.
- Ensures screen readers have access to the real-time numeric value of the currently focused slider.

---
*PR created automatically by Jules for task [6742590818209141938](https://jules.google.com/task/6742590818209141938) started by @Joker5514*