### PR TITLE
⚡ Bolt: optimize per-block DSP constant recalculations

### DIFF
--- a/public/app/dsp-worker.js
+++ b/public/app/dsp-worker.js
@@ -36,13 +36,31 @@ class VoiceIsolateProcessor extends AudioWorkletProcessor {
     };
   }
 
-  // Pre-compute biquad coefficients from current params
+  // Pre-compute biquad coefficients and linear gains from current params
   _computeCoeffs() {
     const sr = this._sr;
     // High-pass Butterworth
     this._hp = this._biquadHP(this.params.hpFreq, this.params.hpQ, sr);
     // Low-pass Butterworth
     this._lp = this._biquadLP(this.params.lpFreq, this.params.lpQ, sr);
+
+    // Gate constants
+    this._gateThreshLin = Math.pow(10, this.params.gateThresh / 20);
+    this._gateReleaseCoef = Math.exp(-1 / (sr * (this.params.gateRelease / 1000)));
+
+    // Compressor constants
+    this._compThreshLin = Math.pow(10, this.params.compThresh / 20);
+    const ratio = Math.max(1, this.params.compRatio);
+    this._compSlope = 1 - 1 / ratio;
+    this._compAttackCoef = Math.exp(-1 / (sr * (this.params.compAttack / 1000)));
+    this._compReleaseCoef = Math.exp(-1 / (sr * (this.params.compRelease / 1000)));
+    this._compMakeupLin = Math.pow(10, this.params.compMakeup / 20);
+
+    // Limiter constants
+    this._limThreshLin = Math.pow(10, this.params.limThresh / 20);
+
+    // Global output gain
+    this._outGainLin = Math.pow(10, (this.params.outGain || 0) / 20);
   }
 
   // Biquad high-pass coefficients
@@ -80,8 +98,8 @@ class VoiceIsolateProcessor extends AudioWorkletProcessor {
 
   // Simple RMS-based noise gate (time domain)
   _applyGate(block, ch) {
-    const threshLin = Math.pow(10, this.params.gateThresh / 20);
-    const releaseCoef = Math.exp(-1 / (this._sr * (this.params.gateRelease / 1000)));
+    const threshLin = this._gateThreshLin;
+    const releaseCoef = this._gateReleaseCoef;
     let g = this._gateGain[ch];
     for (let i = 0; i < block.length; i++) {
       const abs = Math.abs(block[i]);
@@ -94,12 +112,12 @@ class VoiceIsolateProcessor extends AudioWorkletProcessor {
 
   // Feed-forward compressor with makeup gain
   _applyComp(block, ch) {
-    const threshLin = Math.pow(10, this.params.compThresh / 20);
-    const ratio = Math.max(1, this.params.compRatio);
-    const attackCoef = Math.exp(-1 / (this._sr * (this.params.compAttack / 1000)));
-    const releaseCoef = Math.exp(-1 / (this._sr * (this.params.compRelease / 1000)));
-    const makeupLin = Math.pow(10, this.params.compMakeup / 20);
-    const limThreshLin = Math.pow(10, this.params.limThresh / 20);
+    const threshLin = this._compThreshLin;
+    const slope = this._compSlope;
+    const attackCoef = this._compAttackCoef;
+    const releaseCoef = this._compReleaseCoef;
+    const makeupLin = this._compMakeupLin;
+    const limThreshLin = this._limThreshLin;
     let env = this._compEnv[ch];
     for (let i = 0; i < block.length; i++) {
       const abs = Math.abs(block[i]);
@@ -108,7 +126,7 @@ class VoiceIsolateProcessor extends AudioWorkletProcessor {
       let gain = 1;
       if (env > threshLin) {
         const overDb = 20 * Math.log10(env / threshLin);
-        const gainDb = overDb * (1 - 1/ratio);
+        const gainDb = overDb * slope;
         gain = Math.pow(10, -gainDb / 20);
       }
       // Brickwall limiter
@@ -141,7 +159,7 @@ class VoiceIsolateProcessor extends AudioWorkletProcessor {
       this._applyComp(outCh, ch);
 
       // Output gain
-      const outGainLin = Math.pow(10, (this.params.outGain || 0) / 20);
+      const outGainLin = this._outGainLin;
       for (let i = 0; i < outCh.length; i++) outCh[i] *= outGainLin;
     }
     return true; // keep processor alive


### PR DESCRIPTION
Move invariant parameter-derived constants to `_computeCoeffs` to reduce CPU overhead in the `process` block.