### PR TITLE
🧪 [testing improvement] Add missing test for calcPeak edge case

### DIFF
--- a/tests/utility.test.js
+++ b/tests/utility.test.js
@@ -115,6 +115,10 @@ describe('Utility Functions from app.js', () => {
       expect(calcPeak(new Float32Array([0, 0.5, 0]))).toBeCloseTo(20 * Math.log10(0.5), 5);
       expect(calcPeak(new Float32Array([0, 0, 0.5]))).toBeCloseTo(20 * Math.log10(0.5), 5);
     });
+
+    test('empty array should return -96 dB', () => {
+      expect(calcPeak(new Float32Array([]))).toBe(-96);
+    });
   });
 
   describe('fmtDur', () => {


### PR DESCRIPTION
🎯 **What:** The `calcPeak` utility function computes the peak amplitude of an audio buffer and converts it to dB. It falls back to `-96` dB if no valid peak is found (e.g., when the input array is empty). This fallback scenario was previously untested.
📊 **Coverage:** A new test case was added to `tests/utility.test.js` to verify that `calcPeak` correctly returns `-96` when provided an empty `Float32Array`.
✨ **Result:** Test coverage for the `calcPeak` function is now improved, ensuring its behavior on edge cases remains reliable during future refactoring.

---
*PR created automatically by Jules for task [14235247843953412594](https://jules.google.com/task/14235247843953412594) started by @Joker5514*