### PR TITLE
🧪 Add missing unit tests for `toggleAB` method

### DIFF
--- a/tests/transport.test.js
+++ b/tests/transport.test.js
@@ -89,12 +89,43 @@ describe('Transport Methods (Missing Buffers)', () => {
       expect(mockContext.dom.tpAB.classList.toggle).not.toHaveBeenCalled();
     });
 
-    it('works normally when outputBuffer exists', () => {
+    it('works normally when outputBuffer exists and is not playing', () => {
       mockContext.outputBuffer = { length: 44100 };
       VoiceIsolatePro.prototype.toggleAB.call(mockContext);
 
       expect(mockContext.abMode).toBe('processed');
       expect(mockContext.dom.tpAB.classList.toggle).toHaveBeenCalledWith('active', true);
+      expect(mockContext.dom.tpABLabel.textContent).toBe('Processed');
+      expect(mockContext.play).not.toHaveBeenCalled();
+    });
+
+    it('works normally when outputBuffer exists and is playing', () => {
+      mockContext.outputBuffer = { length: 44100 };
+      mockContext.isPlaying = true;
+      mockContext.ctx.currentTime = 10;
+      mockContext.playStartTime = 5;
+      mockContext.playOffset = 2;
+      mockContext.dom.tpSpeed.value = '1.5';
+
+      VoiceIsolatePro.prototype.toggleAB.call(mockContext);
+
+      expect(mockContext.abMode).toBe('processed');
+      expect(mockContext.dom.tpAB.classList.toggle).toHaveBeenCalledWith('active', true);
+      // playOffset += (currentTime - playStartTime) * speed -> 2 + (10 - 5) * 1.5 = 9.5
+      expect(mockContext.playOffset).toBe(9.5);
+      expect(mockContext.play).toHaveBeenCalled();
+      expect(mockContext.dom.tpABLabel.textContent).toBe('Processed');
+    });
+
+    it('toggles back to original correctly', () => {
+      mockContext.outputBuffer = { length: 44100 };
+      mockContext.abMode = 'processed';
+
+      VoiceIsolatePro.prototype.toggleAB.call(mockContext);
+
+      expect(mockContext.abMode).toBe('original');
+      expect(mockContext.dom.tpAB.classList.toggle).toHaveBeenCalledWith('active', false);
+      expect(mockContext.dom.tpABLabel.textContent).toBe('Original');
     });
   });
 });


### PR DESCRIPTION
🎯 **What:** 
Added unit tests covering the previously untested `toggleAB` method in the `VoiceIsolatePro` module.

📊 **Coverage:**
The added test suites verify the state transitions during 'Original' vs 'Processed' A/B testing:
- It tests that `dom.tpABLabel.textContent` label updates properly depending on `abMode`.
- It tests state transitions correctly updates `abMode` and the `active` toggle state in `classList`.
- It tests when `isPlaying` is true, verifying the offset logic updates properly via calculations with `currentTime`, `playStartTime`, and `speed`, and verifying that `.play()` is invoked.
- It tests the reverse logic: toggling back to original from 'processed'.
- It verifies that the method returns early when `outputBuffer` is missing.

✨ **Result:**
Test coverage of `toggleAB` is thoroughly improved ensuring that modifications to the application transport logic have fewer risks of regressions. All existing transport test suites pass perfectly.

---
*PR created automatically by Jules for task [17554306369870049928](https://jules.google.com/task/17554306369870049928) started by @Joker5514*