### PR TITLE
🧪 [testing] add missing tests for pause method

### DIFF
--- a/pr_desc.md
+++ b/pr_desc.md
@@ -1,0 +1,9 @@
+🎯 **What:** The `pause()` method in `app.js` was missing unit test coverage. Added comprehensive test cases in `tests/transport.test.js` to ensure the correct behavior of the playback pausing logic.
+
+📊 **Coverage:**
+- Added test verifying early return when `isPlaying` is false.
+- Added test verifying accurate calculation and update of `playOffset` considering `currentTime` and playback speed.
+- Added test verifying state cleanup operations (`teardownChain` and `stopSpectro`) and setting `isPlaying` back to false.
+- Added test verifying conditional pausing of the internal video element if `isVideo` is true.
+
+✨ **Result:** Improved test reliability by confirming `pause()` calculates exact audio offsets and triggers side effects safely without crashing, catching potential regressions.

--- a/tests/transport.test.js
+++ b/tests/transport.test.js
@@ -40,6 +40,56 @@ describe('Transport Methods (Missing Buffers)', () => {
     };
   });
 
+    describe('pause', () => {
+    beforeEach(() => {
+      mockContext.teardownChain = jest.fn();
+      mockContext.stopSpectro = jest.fn();
+      mockContext.isVideo = false;
+      mockContext.dom.videoPlayer = { pause: jest.fn() };
+    });
+
+    it('returns early if not playing', () => {
+      mockContext.isPlaying = false;
+      VoiceIsolatePro.prototype.pause.call(mockContext);
+
+      expect(mockContext.teardownChain).not.toHaveBeenCalled();
+      expect(mockContext.stopSpectro).not.toHaveBeenCalled();
+      expect(mockContext.isPlaying).toBe(false);
+    });
+
+    it('updates playOffset based on currentTime and speed', () => {
+      mockContext.isPlaying = true;
+      mockContext.playStartTime = 10;
+      mockContext.ctx.currentTime = 15;
+      mockContext.playOffset = 5;
+      mockContext.dom.tpSpeed.value = '1.5';
+
+      VoiceIsolatePro.prototype.pause.call(mockContext);
+
+      // (15 - 10) * 1.5 = 7.5. Added to initial playOffset (5) = 12.5.
+      expect(mockContext.playOffset).toBe(12.5);
+    });
+
+    it('cleans up state and stops processing', () => {
+      mockContext.isPlaying = true;
+
+      VoiceIsolatePro.prototype.pause.call(mockContext);
+
+      expect(mockContext.teardownChain).toHaveBeenCalled();
+      expect(mockContext.stopSpectro).toHaveBeenCalled();
+      expect(mockContext.isPlaying).toBe(false);
+    });
+
+    it('pauses video if isVideo is true', () => {
+      mockContext.isPlaying = true;
+      mockContext.isVideo = true;
+
+      VoiceIsolatePro.prototype.pause.call(mockContext);
+
+      expect(mockContext.dom.videoPlayer.pause).toHaveBeenCalled();
+    });
+  });
+
   describe('seekDelta', () => {
     it('returns early when inputBuffer is missing', () => {
       // Intentionally don't set inputBuffer


### PR DESCRIPTION
🎯 **What:** The `pause()` method in `app.js` was missing unit test coverage. Added comprehensive test cases in `tests/transport.test.js` to ensure the correct behavior of the playback pausing logic.

📊 **Coverage:**
- Added test verifying early return when `isPlaying` is false.
- Added test verifying accurate calculation and update of `playOffset` considering `currentTime` and playback speed.
- Added test verifying state cleanup operations (`teardownChain` and `stopSpectro`) and setting `isPlaying` back to false.
- Added test verifying conditional pausing of the internal video element if `isVideo` is true.

✨ **Result:** Improved test reliability by confirming `pause()` calculates exact audio offsets and triggers side effects safely without crashing, catching potential regressions.

---
*PR created automatically by Jules for task [13807957032375490353](https://jules.google.com/task/13807957032375490353) started by @Joker5514*