### PR TITLE
🎨 Palette: [UX improvement] Add labels to tpSpeed and fsColormap selects

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,7 +137,7 @@
           <div class="tp-time"><span id="tpCur">0:00</span> / <span id="tpTotal">0:00</span></div>
           <input type="range" id="tpSeek" class="tp-seek" min="0" max="1000" value="0" disabled />
           <div class="tp-speed">
-            <label>Speed</label>
+            <label for="tpSpeed">Speed</label>
             <select id="tpSpeed" disabled>
               <option value="0.25">0.25x</option>
               <option value="0.5">0.5x</option>
@@ -162,7 +162,7 @@
           <div class="viz-actions">
             <span id="fsProgress" class="fs-progress-lbl"></span>
             <button id="fsBtnAB" class="btn btn-xs" disabled>Show Processed</button>
-            <select id="fsColormap" class="fs-cmap-sel">
+            <select id="fsColormap" class="fs-cmap-sel" aria-label="Spectrogram Colormap">
               <option value="plasma">Plasma</option>
               <option value="ocean">Ocean</option>
               <option value="voice">Voice ID</option>

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -151,7 +151,7 @@
           <div class="tp-time"><span id="tpCur">0:00</span> / <span id="tpTotal">0:00</span></div>
           <input type="range" id="tpSeek" class="tp-seek" min="0" max="1000" value="0" disabled aria-label="Seek through audio" />
           <div class="tp-speed">
-            <label>Speed</label>
+            <label for="tpSpeed">Speed</label>
             <select id="tpSpeed" disabled>
               <option value="0.25">0.25x</option>
               <option value="0.5">0.5x</option>

--- a/v19-demo/index.html
+++ b/v19-demo/index.html
@@ -151,7 +151,7 @@
           <div class="tp-time"><span id="tpCur">0:00</span> / <span id="tpTotal">0:00</span></div>
           <input type="range" id="tpSeek" class="tp-seek" min="0" max="1000" value="0" disabled aria-label="Seek through audio" />
           <div class="tp-speed">
-            <label>Speed</label>
+            <label for="tpSpeed">Speed</label>
             <select id="tpSpeed" disabled>
               <option value="0.25">0.25x</option>
               <option value="0.5">0.5x</option>


### PR DESCRIPTION
💡 What: Added explicitly linked `<label for="tpSpeed">` to the speed `<select>` inputs across `index.html`, `public/app/index.html`, and `v19-demo/index.html`. Also added an `aria-label="Spectrogram Colormap"` to the `fsColormap` select in `index.html`.
🎯 Why: These small changes fix classic accessibility issues where isolated labels do not provide screen readers with context for the corresponding input fields, and also improve mouse usability by increasing the clickable hit area.
📸 Before/After: Visual presentation is identical.
♿ Accessibility: Screen readers will now correctly associate "Speed" with the playback rate control, and announce the purpose of the Spectrogram Colormap dropdown.

---
*PR created automatically by Jules for task [3687560062171433481](https://jules.google.com/task/3687560062171433481) started by @Joker5514*