### PR TITLE
fix: Remove video file size limit to allow long videos

### DIFF
--- a/app.js
+++ b/app.js
@@ -299,8 +299,6 @@ class VoiceIsolatePro {
   async handleFile(file) {
     try {
       // 🛡️ Sentinel: Validate file size (max 200MB) and MIME type
-      const MAX_SIZE = 200 * 1024 * 1024;
-      if (file.size > MAX_SIZE) throw new Error('File exceeds maximum allowed size (200MB)');
 
       const allowedTypes = ['audio/wav', 'audio/mpeg', 'audio/ogg', 'audio/flac', 'audio/webm', 'audio/mp4', 'audio/aac', 'video/mp4', 'video/webm', 'video/ogg', 'video/quicktime'];
       if (file.type && !allowedTypes.includes(file.type)) throw new Error('Unsupported file type');

--- a/demos/v14-complete.html
+++ b/demos/v14-complete.html
@@ -783,8 +783,6 @@ class VoiceIsolatePro {
   async handleFile(file) {
     try {
       // 🛡️ Sentinel: Validate file size (max 200MB) and MIME type
-      const MAX_SIZE = 200 * 1024 * 1024;
-      if (file.size > MAX_SIZE) throw new Error('File exceeds maximum allowed size (200MB)');
 
       const allowedTypes = ['audio/wav', 'audio/mpeg', 'audio/ogg', 'audio/flac', 'audio/webm', 'audio/mp4', 'audio/aac', 'video/mp4', 'video/webm', 'video/ogg', 'video/quicktime'];
       if (file.type && !allowedTypes.includes(file.type)) throw new Error('Unsupported file type');

--- a/demos/v14-engineer-mode.html
+++ b/demos/v14-engineer-mode.html
@@ -783,8 +783,6 @@ class VoiceIsolatePro {
   async handleFile(file) {
     try {
       // 🛡️ Sentinel: Validate file size (max 200MB) and MIME type
-      const MAX_SIZE = 200 * 1024 * 1024;
-      if (file.size > MAX_SIZE) throw new Error('File exceeds maximum allowed size (200MB)');
 
       const allowedTypes = ['audio/wav', 'audio/mpeg', 'audio/ogg', 'audio/flac', 'audio/webm', 'audio/mp4', 'audio/aac', 'video/mp4', 'video/webm', 'video/ogg', 'video/quicktime'];
       if (file.type && !allowedTypes.includes(file.type)) throw new Error('Unsupported file type');

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -351,8 +351,6 @@ class VoiceIsolatePro {
   async handleFile(file) {
     try {
       // 🛡️ Sentinel: Validate file size (max 200MB) and MIME type
-      const MAX_SIZE = 200 * 1024 * 1024;
-      if (file.size > MAX_SIZE) throw new Error('File exceeds maximum allowed size (200MB)');
 
       const allowedTypes = ['audio/wav', 'audio/mpeg', 'audio/ogg', 'audio/flac', 'audio/webm', 'audio/mp4', 'audio/aac', 'video/mp4', 'video/webm', 'video/ogg', 'video/quicktime'];
       if (file.type && !allowedTypes.includes(file.type)) throw new Error('Unsupported file type');

--- a/tests/utility.test.js
+++ b/tests/utility.test.js
@@ -210,6 +210,9 @@ describe('Utility Functions from app.js', () => {
     test('handles empty buffer gracefully (0 blocks)', () => {
       const buf = makeMockBuffer(44100, 0, 0);
       expect(estVoices(buf)).toBe('0-1');
+    });
+  });
+
   describe('encWav', () => {
     // Helper to create a mock AudioBuffer
     function createMockBuffer(nCh, len, sr, fillValueOrFn) {

--- a/v19-demo/app.js
+++ b/v19-demo/app.js
@@ -387,8 +387,6 @@ class VoiceIsolatePro {
   async handleFile(file) {
     try {
       // 🛡️ Sentinel: Validate file size (max 200MB) and MIME type
-      const MAX_SIZE = 200 * 1024 * 1024;
-      if (file.size > MAX_SIZE) throw new Error('File exceeds maximum allowed size (200MB)');
 
       const allowedTypes = ['audio/wav', 'audio/mpeg', 'audio/ogg', 'audio/flac', 'audio/webm', 'audio/mp4', 'audio/aac', 'video/mp4', 'video/webm', 'video/ogg', 'video/quicktime'];
       if (file.type && !allowedTypes.includes(file.type)) throw new Error('Unsupported file type');


### PR DESCRIPTION
This pull request removes the 200MB file size restriction across all application instances (`app.js`, `public/app/app.js`, `v19-demo/app.js`, and the `v14` demos). This ensures users can upload long videos and audio files without encountering the `MAX_SIZE` error. It also fixes a minor pre-existing syntax error in `tests/utility.test.js` to get the test suite to pass.

---
*PR created automatically by Jules for task [3948569140270693336](https://jules.google.com/task/3948569140270693336) started by @Joker5514*