### PR TITLE
feat: Add m4a upload support

### DIFF
--- a/app.js
+++ b/app.js
@@ -300,7 +300,7 @@ class VoiceIsolatePro {
     try {
       // 🛡️ Sentinel: Validate file size (max 200MB) and MIME type
 
-      const allowedTypes = ['audio/wav', 'audio/mpeg', 'audio/ogg', 'audio/flac', 'audio/webm', 'audio/mp4', 'audio/aac', 'video/mp4', 'video/webm', 'video/ogg', 'video/quicktime'];
+      const allowedTypes = ['audio/wav', 'audio/mpeg', 'audio/ogg', 'audio/flac', 'audio/webm', 'audio/mp4', 'audio/aac', 'audio/x-m4a', 'audio/m4a', 'video/mp4', 'video/webm', 'video/ogg', 'video/quicktime'];
       if (file.type && !allowedTypes.includes(file.type)) throw new Error('Unsupported file type');
 
       this.ensureCtx();

--- a/demos/v14-complete.html
+++ b/demos/v14-complete.html
@@ -272,7 +272,7 @@ input[type="range"]:focus-visible::-moz-range-thumb {
           <svg class="upload-svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
           <p class="upload-title">Drop Audio or Video</p>
           <p class="upload-sub">MP3 · WAV · FLAC · OGG · M4A · MP4 · MOV · WEBM — No limit</p>
-          <input type="file" id="fileInput" accept="audio/*,video/*" hidden />
+          <input type="file" id="fileInput" accept="audio/*,video/*,audio/mp4,audio/x-m4a,audio/m4a" hidden />
           <button id="fileBtn" class="btn btn-outline">Browse Files</button>
         </div>
         <div class="upload-row">
@@ -784,7 +784,7 @@ class VoiceIsolatePro {
     try {
       // 🛡️ Sentinel: Validate file size (max 200MB) and MIME type
 
-      const allowedTypes = ['audio/wav', 'audio/mpeg', 'audio/ogg', 'audio/flac', 'audio/webm', 'audio/mp4', 'audio/aac', 'video/mp4', 'video/webm', 'video/ogg', 'video/quicktime'];
+      const allowedTypes = ['audio/wav', 'audio/mpeg', 'audio/ogg', 'audio/flac', 'audio/webm', 'audio/mp4', 'audio/aac', 'audio/x-m4a', 'audio/m4a', 'video/mp4', 'video/webm', 'video/ogg', 'video/quicktime'];
       if (file.type && !allowedTypes.includes(file.type)) throw new Error('Unsupported file type');
 
       this.ensureCtx();

--- a/demos/v14-engineer-mode.html
+++ b/demos/v14-engineer-mode.html
@@ -272,7 +272,7 @@ input[type="range"]:focus-visible::-moz-range-thumb {
           <svg class="upload-svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
           <p class="upload-title">Drop Audio or Video</p>
           <p class="upload-sub">MP3 · WAV · FLAC · OGG · M4A · MP4 · MOV · WEBM — No limit</p>
-          <input type="file" id="fileInput" accept="audio/*,video/*" hidden />
+          <input type="file" id="fileInput" accept="audio/*,video/*,audio/mp4,audio/x-m4a,audio/m4a" hidden />
           <button id="fileBtn" class="btn btn-outline">Browse Files</button>
         </div>
         <div class="upload-row">
@@ -784,7 +784,7 @@ class VoiceIsolatePro {
     try {
       // 🛡️ Sentinel: Validate file size (max 200MB) and MIME type
 
-      const allowedTypes = ['audio/wav', 'audio/mpeg', 'audio/ogg', 'audio/flac', 'audio/webm', 'audio/mp4', 'audio/aac', 'video/mp4', 'video/webm', 'video/ogg', 'video/quicktime'];
+      const allowedTypes = ['audio/wav', 'audio/mpeg', 'audio/ogg', 'audio/flac', 'audio/webm', 'audio/mp4', 'audio/aac', 'audio/x-m4a', 'audio/m4a', 'video/mp4', 'video/webm', 'video/ogg', 'video/quicktime'];
       if (file.type && !allowedTypes.includes(file.type)) throw new Error('Unsupported file type');
 
       this.ensureCtx();

--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
           <svg class="upload-svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
           <p class="upload-title">Drop Audio or Video</p>
           <p class="upload-sub">MP3 · WAV · FLAC · OGG · M4A · MP4 · MOV · WEBM — No limit</p>
-          <input type="file" id="fileInput" accept="audio/*,video/*" hidden />
+          <input type="file" id="fileInput" accept="audio/*,video/*,audio/mp4,audio/x-m4a,audio/m4a" hidden />
           <button id="fileBtn" class="btn btn-outline">Browse Files</button>
         </div>
         <div class="upload-row">

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -352,7 +352,7 @@ class VoiceIsolatePro {
     try {
       // 🛡️ Sentinel: Validate file size (max 200MB) and MIME type
 
-      const allowedTypes = ['audio/wav', 'audio/mpeg', 'audio/ogg', 'audio/flac', 'audio/webm', 'audio/mp4', 'audio/aac', 'video/mp4', 'video/webm', 'video/ogg', 'video/quicktime'];
+      const allowedTypes = ['audio/wav', 'audio/mpeg', 'audio/ogg', 'audio/flac', 'audio/webm', 'audio/mp4', 'audio/aac', 'audio/x-m4a', 'audio/m4a', 'video/mp4', 'video/webm', 'video/ogg', 'video/quicktime'];
       if (file.type && !allowedTypes.includes(file.type)) throw new Error('Unsupported file type');
 
       this.ensureCtx();

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -49,7 +49,7 @@
           <svg class="upload-svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
           <p class="upload-title">Drop Audio or Video</p>
           <p class="upload-sub">MP3 · WAV · FLAC · OGG · M4A · MP4 · MOV · WEBM — No limit</p>
-          <input type="file" id="fileInput" accept="audio/*,video/*" hidden aria-label="Select audio or video file" />
+          <input type="file" id="fileInput" accept="audio/*,video/*,audio/mp4,audio/x-m4a,audio/m4a" hidden aria-label="Select audio or video file" />
           <button id="fileBtn" class="btn btn-outline">Browse Files</button>
         </div>
         <div class="upload-row">

--- a/v19-demo/app.js
+++ b/v19-demo/app.js
@@ -388,7 +388,7 @@ class VoiceIsolatePro {
     try {
       // 🛡️ Sentinel: Validate file size (max 200MB) and MIME type
 
-      const allowedTypes = ['audio/wav', 'audio/mpeg', 'audio/ogg', 'audio/flac', 'audio/webm', 'audio/mp4', 'audio/aac', 'video/mp4', 'video/webm', 'video/ogg', 'video/quicktime'];
+      const allowedTypes = ['audio/wav', 'audio/mpeg', 'audio/ogg', 'audio/flac', 'audio/webm', 'audio/mp4', 'audio/aac', 'audio/x-m4a', 'audio/m4a', 'video/mp4', 'video/webm', 'video/ogg', 'video/quicktime'];
       if (file.type && !allowedTypes.includes(file.type)) throw new Error('Unsupported file type');
 
       this.ensureCtx();

--- a/v19-demo/index.html
+++ b/v19-demo/index.html
@@ -49,7 +49,7 @@
           <svg class="upload-svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
           <p class="upload-title">Drop Audio or Video</p>
           <p class="upload-sub">MP3 · WAV · FLAC · OGG · M4A · MP4 · MOV · WEBM — No limit</p>
-          <input type="file" id="fileInput" accept="audio/*,video/*" hidden aria-label="Select audio or video file" />
+          <input type="file" id="fileInput" accept="audio/*,video/*,audio/mp4,audio/x-m4a,audio/m4a" hidden aria-label="Select audio or video file" />
           <button id="fileBtn" class="btn btn-outline">Browse Files</button>
         </div>
         <div class="upload-row">


### PR DESCRIPTION
Added `.m4a` and `x-m4a` audio file extensions to the `allowedTypes` array and the `accept` attribute in the file upload HTML tag. This ensures that users can successfully upload `.m4a` files for processing in VoiceIsolatePro.

### 🎯 What:
- Added `audio/m4a` and `audio/x-m4a` mime types to the `allowedTypes` whitelist across all environments (`app.js`, `public/app/app.js`, `demos/v14-complete.html`, `demos/v14-engineer-mode.html`, and `v19-demo/app.js`).
- Added `audio/mp4`, `audio/x-m4a`, and `audio/m4a` extensions to the `accept` attributes for the file inputs across all HTML demo and app files.

### 💡 Why:
- Resolves the error users faced when uploading valid `.m4a` audio files, which were not properly validated or allowed for selection.

### ✅ Verification:
- Unit tests (`pnpm test`) execute correctly.
- A Playwright script was used to verify the DOM changes for the `accept` attribute parameter in the file inputs correctly reflects the new file types.

### ✨ Result:
- VoiceIsolatePro is now capable of correctly validating and processing user-supplied `.m4a` audio files.

---
*PR created automatically by Jules for task [14075000725145506427](https://jules.google.com/task/14075000725145506427) started by @Joker5514*