### PR TITLE
feat: add ability to upload m4a

### DIFF
--- a/app.js
+++ b/app.js
@@ -300,7 +300,7 @@ class VoiceIsolatePro {
     try {
       // 🛡️ Sentinel: Validate file size (max 200MB) and MIME type
 
-      const allowedTypes = ['audio/wav', 'audio/mpeg', 'audio/ogg', 'audio/flac', 'audio/webm', 'audio/mp4', 'audio/aac', 'video/mp4', 'video/webm', 'video/ogg', 'video/quicktime'];
+      const allowedTypes = ['audio/wav', 'audio/mpeg', 'audio/ogg', 'audio/flac', 'audio/webm', 'audio/mp4', 'audio/aac', 'audio/x-m4a', 'audio/m4a', 'video/mp4', 'video/webm', 'video/ogg', 'video/quicktime'];
       if (file.type && !allowedTypes.includes(file.type)) throw new Error('Unsupported file type');
 
       this.ensureCtx();

--- a/demos/v14-complete.html
+++ b/demos/v14-complete.html
@@ -784,7 +784,7 @@ class VoiceIsolatePro {
     try {
       // 🛡️ Sentinel: Validate file size (max 200MB) and MIME type
 
-      const allowedTypes = ['audio/wav', 'audio/mpeg', 'audio/ogg', 'audio/flac', 'audio/webm', 'audio/mp4', 'audio/aac', 'video/mp4', 'video/webm', 'video/ogg', 'video/quicktime'];
+      const allowedTypes = ['audio/wav', 'audio/mpeg', 'audio/ogg', 'audio/flac', 'audio/webm', 'audio/mp4', 'audio/aac', 'audio/x-m4a', 'audio/m4a', 'video/mp4', 'video/webm', 'video/ogg', 'video/quicktime'];
       if (file.type && !allowedTypes.includes(file.type)) throw new Error('Unsupported file type');
 
       this.ensureCtx();

--- a/demos/v14-engineer-mode.html
+++ b/demos/v14-engineer-mode.html
@@ -784,7 +784,7 @@ class VoiceIsolatePro {
     try {
       // 🛡️ Sentinel: Validate file size (max 200MB) and MIME type
 
-      const allowedTypes = ['audio/wav', 'audio/mpeg', 'audio/ogg', 'audio/flac', 'audio/webm', 'audio/mp4', 'audio/aac', 'video/mp4', 'video/webm', 'video/ogg', 'video/quicktime'];
+      const allowedTypes = ['audio/wav', 'audio/mpeg', 'audio/ogg', 'audio/flac', 'audio/webm', 'audio/mp4', 'audio/aac', 'audio/x-m4a', 'audio/m4a', 'video/mp4', 'video/webm', 'video/ogg', 'video/quicktime'];
       if (file.type && !allowedTypes.includes(file.type)) throw new Error('Unsupported file type');
 
       this.ensureCtx();

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -352,7 +352,7 @@ class VoiceIsolatePro {
     try {
       // 🛡️ Sentinel: Validate file size (max 200MB) and MIME type
 
-      const allowedTypes = ['audio/wav', 'audio/mpeg', 'audio/ogg', 'audio/flac', 'audio/webm', 'audio/mp4', 'audio/aac', 'video/mp4', 'video/webm', 'video/ogg', 'video/quicktime'];
+      const allowedTypes = ['audio/wav', 'audio/mpeg', 'audio/ogg', 'audio/flac', 'audio/webm', 'audio/mp4', 'audio/aac', 'audio/x-m4a', 'audio/m4a', 'video/mp4', 'video/webm', 'video/ogg', 'video/quicktime'];
       if (file.type && !allowedTypes.includes(file.type)) throw new Error('Unsupported file type');
 
       this.ensureCtx();

--- a/v19-demo/app.js
+++ b/v19-demo/app.js
@@ -388,7 +388,7 @@ class VoiceIsolatePro {
     try {
       // 🛡️ Sentinel: Validate file size (max 200MB) and MIME type
 
-      const allowedTypes = ['audio/wav', 'audio/mpeg', 'audio/ogg', 'audio/flac', 'audio/webm', 'audio/mp4', 'audio/aac', 'video/mp4', 'video/webm', 'video/ogg', 'video/quicktime'];
+      const allowedTypes = ['audio/wav', 'audio/mpeg', 'audio/ogg', 'audio/flac', 'audio/webm', 'audio/mp4', 'audio/aac', 'audio/x-m4a', 'audio/m4a', 'video/mp4', 'video/webm', 'video/ogg', 'video/quicktime'];
       if (file.type && !allowedTypes.includes(file.type)) throw new Error('Unsupported file type');
 
       this.ensureCtx();


### PR DESCRIPTION
Add 'audio/x-m4a' and 'audio/m4a' to allowedTypes arrays in all app.js implementations (root, public/app/, and v19-demo/) and v14 demos to correctly permit user uploads of M4A audio files, aligning with existing support claims in the UI upload text ("M4A").

---
*PR created automatically by Jules for task [11677469937003305044](https://jules.google.com/task/11677469937003305044) started by @Joker5514*