### PR TITLE
🛡️ Sentinel: [MEDIUM] Add Content Security Policy

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,29 +3,63 @@
     {
       "source": "/(.*)",
       "headers": [
-        { "key": "Cross-Origin-Opener-Policy",   "value": "same-origin" },
-        { "key": "Cross-Origin-Embedder-Policy",  "value": "require-corp" },
-        { "key": "Cross-Origin-Resource-Policy",  "value": "same-origin" },
-        { "key": "X-Content-Type-Options",         "value": "nosniff" },
-        { "key": "X-Frame-Options",                "value": "DENY" },
-        { "key": "Referrer-Policy",                "value": "strict-origin-when-cross-origin" }
+        {
+          "key": "Cross-Origin-Opener-Policy",
+          "value": "same-origin"
+        },
+        {
+          "key": "Cross-Origin-Embedder-Policy",
+          "value": "require-corp"
+        },
+        {
+          "key": "Cross-Origin-Resource-Policy",
+          "value": "same-origin"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        },
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net /_vercel; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob:; media-src 'self' blob:; connect-src 'self' https://cdn.jsdelivr.net; worker-src 'self' blob:;"
+        }
       ]
     },
     {
       "source": "/wasm/(.*)",
       "headers": [
-        { "key": "Content-Type", "value": "application/wasm" },
-        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+        {
+          "key": "Content-Type",
+          "value": "application/wasm"
+        },
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
       ]
     },
     {
       "source": "/models/(.*)",
       "headers": [
-        { "key": "Cache-Control", "value": "public, max-age=86400" }
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=86400"
+        }
       ]
     }
   ],
   "rewrites": [
-    { "source": "/health", "destination": "/api/health" }
+    {
+      "source": "/health",
+      "destination": "/api/health"
+    }
   ]
 }


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The application lacked a Content Security Policy (CSP), which is a critical defense-in-depth mechanism against Cross-Site Scripting (XSS), data injection, and other content-based attacks.
🎯 Impact: Without a CSP, the application relies solely on input sanitization and secure coding practices. If an XSS vulnerability were to be introduced, there would be no secondary layer of defense to prevent the execution of malicious scripts.
🔧 Fix: Added a robust `Content-Security-Policy` header to `vercel.json` for all routes (`/(.*)`). The policy is tailored to support the application's specific needs, including `'self'`, specific CDNs (like `https://cdn.jsdelivr.net` for ONNX Runtime), necessary fonts, and `blob:` sources for Web Workers, AudioWorklets, and local file handling.
✅ Verification: Ran `pnpm lint`, `node scripts/validate.js`, and `pnpm test` to ensure the change does not break the build process or introduce syntax errors in `vercel.json`.

---
*PR created automatically by Jules for task [2324026745932298345](https://jules.google.com/task/2324026745932298345) started by @Joker5514*