### PR TITLE
🧹 Remove unused math utility functions from param-buffer.js

### DIFF
--- a/pr_desc.md
+++ b/pr_desc.md
@@ -1,22 +1,6 @@
-🔒 Sentinel: [CRITICAL/HIGH] Fix weak random number generator for dither noise
+🧹 Remove unused math utility functions from param-buffer.js
 
-🚨 **Severity:** HIGH
-
-💡 **Vulnerability:** The codebase was explicitly utilizing the weak `Math.random()` PRNG method for generating TPDF dither noise in audio buffers.
-
-🎯 **Impact:** `Math.random()` is not considered cryptographically secure. While dither noise isn't strictly a cryptographic concern, a security-audited codebase flagged it as a vulnerability because the output is predictable and can lead to structural security risks during audits.
-
-🔧 **Fix:** Replaced the weak `Math.random()` call with a secure `crypto.getRandomValues()` 1-line implementation to generate the random noise required for TPDF dither, eliminating the predictable sequence vulnerability and complying with the PRNG security standard without overcomplicating the codebase.
-
-✅ **Verification:**
-- Ran the Jest test suite (`pnpm test`) to ensure audio processing unit tests passed, especially DSP-related tests.
-- Replaced `Math.random()` in `tests/dsp.test.js` to align with the core security fix.
-🎯 **What:** The `pause()` method in `app.js` was missing unit test coverage. Added comprehensive test cases in `tests/transport.test.js` to ensure the correct behavior of the playback pausing logic.
-
-📊 **Coverage:**
-- Added test verifying early return when `isPlaying` is false.
-- Added test verifying accurate calculation and update of `playOffset` considering `currentTime` and playback speed.
-- Added test verifying state cleanup operations (`teardownChain` and `stopSpectro`) and setting `isPlaying` back to false.
-- Added test verifying conditional pausing of the internal video element if `isVideo` is true.
-
-✨ **Result:** Improved test reliability by confirming `pause()` calculates exact audio offsets and triggers side effects safely without crashing, catching potential regressions.
+🎯 **What:** Removed the unused `freqMap` and `sqrtMap` functions from `src/shared/param-buffer.js`.
+💡 **Why:** To reduce dead code and improve the maintainability and readability of the codebase by keeping only the utilities that are actually needed and used.
+✅ **Verification:** Verified by checking occurrences of both functions in the codebase (`grep`) and confirmed that `gainMap` is the only function currently imported and used. I also ran the project's tests and linting to ensure no regressions were introduced.
+✨ **Result:** A cleaner codebase with less dead code in `param-buffer.js`.

--- a/src/shared/param-buffer.js
+++ b/src/shared/param-buffer.js
@@ -31,10 +31,3 @@ export function createParamBuffer() {
 /** Volume slider 0–1 → linear gain (via dB scale) */
 export const gainMap = (s, dbMin = -60, dbMax = 6) =>
   s <= 0 ? 0 : Math.pow(10, (dbMin + s * (dbMax - dbMin)) / 20);
-
-/** Frequency slider 0–1 → Hz (exponential) */
-export const freqMap = (s, fMin = 20, fMax = 20000) =>
-  fMin * Math.pow(fMax / fMin, Math.max(0, Math.min(1, s)));
-
-/** Threshold / ratio slider 0–1 → square-root (perceptual mid-range precision) */
-export const sqrtMap = (s) => Math.sqrt(Math.max(0, s));


### PR DESCRIPTION
🎯 **What:** Removed the unused `freqMap` and `sqrtMap` functions from `src/shared/param-buffer.js`.
💡 **Why:** To reduce dead code and improve the maintainability and readability of the codebase by keeping only the utilities that are actually needed and used.
✅ **Verification:** Verified by checking occurrences of both functions in the codebase (`grep`) and confirmed that `gainMap` is the only function currently imported and used. I also ran the project's tests and linting to ensure no regressions were introduced.
✨ **Result:** A cleaner codebase with less dead code in `param-buffer.js`.

---
*PR created automatically by Jules for task [11889864721634965331](https://jules.google.com/task/11889864721634965331) started by @Joker5514*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/joker5514/voiceisolate-pro/pull/171" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
