### PR TITLE
🧹 [code health improvement] Fix undefined variable in JS fallback DSP processor

### DIFF
--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,9 @@
+🧹 [code health improvement] Fix undefined variable in JS fallback DSP processor
+
+🎯 **What:** The `w` variable was referenced but undefined in the overlap-add loop within the `_processJS` method in `src/dsp-processor.js`. This has been resolved by correctly utilizing the pre-calculated window array directly using `win[i % N]`.
+
+💡 **Why:** By referencing the intended variables within the loop properly, we guarantee that the JavaScript fallback code works if WASM goes unavailable, improving maintainability by eliminating a silent failure mode in the fallback logic. Unused variables were safely removed.
+
+✅ **Verification:** Verified by ensuring the code lints without unused variable errors. No tests were broken and the change preserves all existing functionality and structure for the WASM fallback.
+
+✨ **Result:** The fallback processing will no longer crash due to `w is not defined` when evaluating overlap-add.

--- a/src/dsp-processor.js
+++ b/src/dsp-processor.js
@@ -82,7 +82,6 @@ class DspProcessor extends AudioWorkletProcessor {
 
     // Simple windowed gain + noise gate (placeholder for full FFT path)
     for (let i = 0; i < input.length; i++) {
-      const w = win[i % N];
       // Minimum statistics: exponential minimum tracker
       const mag = Math.abs(input[i]);
       nf[i % bins] = Math.min(
@@ -99,7 +98,7 @@ class DspProcessor extends AudioWorkletProcessor {
 
     // Overlap-add
     for (let i = 0; i < input.length; i++) {
-      output[i] = output[i] * w + over[i];
+      output[i] = output[i] * win[i % N] + over[i];
     }
     for (let i = 0; i < hop; i++) {
       over[i] = output[hop + i] || 0;


### PR DESCRIPTION
🎯 **What:** The `w` variable was referenced but undefined in the overlap-add loop within the `_processJS` method in `src/dsp-processor.js`. This has been resolved by correctly utilizing the pre-calculated window array directly using `win[i % N]`.

💡 **Why:** By referencing the intended variables within the loop properly, we guarantee that the JavaScript fallback code works if WASM goes unavailable, improving maintainability by eliminating a silent failure mode in the fallback logic. Unused variables were safely removed.

✅ **Verification:** Verified by ensuring the code lints without unused variable errors. No tests were broken and the change preserves all existing functionality and structure for the WASM fallback.

✨ **Result:** The fallback processing will no longer crash due to `w is not defined` when evaluating overlap-add.

---
*PR created automatically by Jules for task [1563179501415928386](https://jules.google.com/task/1563179501415928386) started by @Joker5514*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/joker5514/voiceisolate-pro/pull/172" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a critical undefined variable bug in the JavaScript fallback audio processor that could cause failures or crashes when WebAssembly is unavailable. The fix ensures proper window coefficient application throughout the audio processing pipeline, significantly improving overall reliability and preventing previously silent failures.

* **Documentation**
  * Added comprehensive documentation file detailing the bug fix and all verification results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->