### PR TITLE
🛡️ Sentinel: [HIGH] Fix Overly Permissive Content Security Policy (CSP)

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -26,4 +26,4 @@ services:
         value: strict-origin-when-cross-origin
       - path: /*
         name: Content-Security-Policy
-        value: "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net /_vercel/; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob:; media-src 'self' blob:; connect-src 'self' data: blob:; worker-src 'self' blob:;"
+        value: "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net /_vercel/; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob:; media-src 'self' blob:; connect-src 'self' data: blob:; worker-src 'self' blob:;"

--- a/vercel.json
+++ b/vercel.json
@@ -29,7 +29,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net /_vercel; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob:; media-src 'self' blob:; connect-src 'self' https://cdn.jsdelivr.net; worker-src 'self' blob:;"
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net /_vercel; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob:; media-src 'self' blob:; connect-src 'self' https://cdn.jsdelivr.net; worker-src 'self' blob:;"
         }
       ]
     },


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The 'unsafe-eval' directive was present in the Content-Security-Policy script-src header for both the Render and Vercel environments. This directive allows the execution of strings as code (e.g., via `eval()`, `setTimeout(string)`, etc.), which significantly increases the risk of successful Cross-Site Scripting (XSS) attacks by allowing attackers to execute injected code even if inline scripts are blocked.
🎯 **Impact:** An attacker who successfully injects code (e.g., through a separate vulnerability) could leverage 'unsafe-eval' to execute malicious JavaScript within the context of the user's session, leading to data exfiltration or account compromise.
🔧 **Fix:** Removed the 'unsafe-eval' string from the `script-src` directive in `vercel.json` and `render.yaml`. The core application does not depend on `eval` functionality, enabling a more secure CSP without breaking the site.
✅ **Verification:** Verified that linting passes on the deployment configurations and no new test failures were introduced by this infrastructure change.

---
*PR created automatically by Jules for task [15833633618120193978](https://jules.google.com/task/15833633618120193978) started by @Joker5514*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/joker5514/voiceisolate-pro/pull/175" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
