### PR TITLE
🧪 Add test for ml-worker Silero VAD loading error path

### DIFF
--- a/tests/ml-worker.test.js
+++ b/tests/ml-worker.test.js
@@ -1,0 +1,79 @@
+const fs = require('fs');
+const path = require('path');
+
+const workerCode = fs.readFileSync(path.join(__dirname, '../public/app/ml-worker.js'), 'utf8');
+
+describe('ml-worker.js', () => {
+  let workerGlobal;
+  let postedMessages;
+
+  beforeEach(() => {
+    postedMessages = [];
+
+    // Mock ort and other globals
+    const mockOrt = {
+      env: {
+        wasm: {},
+        logLevel: 'warning'
+      },
+      InferenceSession: {
+        create: jest.fn()
+      },
+      Tensor: class {
+        constructor(type, data, dims) {
+          this.type = type;
+          this.data = data;
+          this.dims = dims;
+        }
+      }
+    };
+
+    workerGlobal = {
+      importScripts: jest.fn(),
+      self: {
+        postMessage: jest.fn((msg) => postedMessages.push(msg)),
+        onmessage: null
+      },
+      navigator: {},
+      ort: mockOrt,
+      Float32Array: Float32Array,
+      Promise: Promise,
+      console: console,
+    };
+
+    // Evaluate the worker code in the mock global context
+    const argNames = Object.keys(workerGlobal);
+    const argValues = argNames.map(name => workerGlobal[name]);
+
+    // Create function that executes worker code with injected globals
+    const fn = new Function(...argNames, workerCode);
+    fn(...argValues);
+  });
+
+  it('should handle Silero VAD loading error path', async () => {
+    // Mock the InferenceSession.create to throw an error specifically for silero_vad.onnx
+    workerGlobal.ort.InferenceSession.create.mockImplementation((modelPath) => {
+      if (modelPath.includes('silero_vad.onnx')) {
+        return Promise.reject(new Error('Simulated VAD load error'));
+      }
+      return Promise.resolve({}); // Mock success for other models
+    });
+
+    // Trigger the init handler
+    await workerGlobal.self.onmessage({ data: { type: 'init' } });
+
+    // Verify error logging
+    expect(postedMessages).toContainEqual({
+      type: 'log',
+      level: 'warn',
+      msg: 'VAD unavailable: Simulated VAD load error'
+    });
+
+    // Verify ready message shows vad: false
+    const readyMsg = postedMessages.find(m => m.type === 'ready');
+    expect(readyMsg).toBeDefined();
+    expect(readyMsg.models.vad).toBe(false);
+    expect(readyMsg.models.deepfilter).toBe(true); // Assuming others succeed
+    expect(readyMsg.models.demucs).toBe(true); // Assuming others succeed
+  });
+});


### PR DESCRIPTION
🎯 **What:** 
Added a unit test file `tests/ml-worker.test.js` to cover the error path during the initialization of the Silero VAD model in `public/app/ml-worker.js`. When `ort.InferenceSession.create` fails to load `./models/silero_vad.onnx`, the worker should log a warning message and set the `vad` status to `false` without crashing the other model loading logic.

📊 **Coverage:**
- Tests the global script evaluation environment for `ml-worker.js`.
- Covers the specific initialization logic in `initModels` for `silero_vad.onnx`.
- Specifically verifies that the initialization error path behaves as expected, logging the fallback warning properly and correctly flagging the ready message with `vad: false` while succeeding for other models like DeepFilterNet.

✨ **Result:** 
Enhanced the test coverage to safely test Web Worker scripts locally with Jest. Provided an active safeguard that guarantees graceful degradation when users experience network failures or missing models while running the ML pipeline.

---
*PR created automatically by Jules for task [2734302076517554466](https://jules.google.com/task/2734302076517554466) started by @Joker5514*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for model initialization and error handling to verify robust fallback behavior when models become unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/joker5514/voiceisolate-pro/pull/179" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
