### PR TITLE
feat(dsp): add preset pack v1.0 + Qodo DSP safety rules

### DIFF
--- a/.qodo/rules.md
+++ b/.qodo/rules.md
@@ -7,4 +7,4 @@
 - gateAttack must be <= 10ms
 - dryWetMix and denoiseMix must be 0.0 to 1.0
 - all preset IDs must be kebab-case
-- aggressive-isolation requires denoiseStrength >= 0.8
+- aggressive-isolation requires denoiseMix >= 0.8

--- a/.qodo/rules.md
+++ b/.qodo/rules.md
@@ -1,0 +1,10 @@
+# Qodo DSP safety rules
+
+- gateThreshold must be <= -30 dBFS
+- compRatio must be 1-20
+- outputGain must be -12 to 6 dB
+- compAttack in live path must be <= 20ms
+- gateAttack must be <= 10ms
+- dryWetMix and denoiseMix must be 0.0 to 1.0
+- all preset IDs must be kebab-case
+- aggressive-isolation requires denoiseStrength >= 0.8

--- a/tests/voiceisolate_presets.test.js
+++ b/tests/voiceisolate_presets.test.js
@@ -1,0 +1,308 @@
+/**
+ * VoiceIsolate Pro — voiceisolate_presets.ts Tests
+ * Verifies preset structure, DSP parameter completeness, and
+ * all safety rules defined in .qodo/rules.md.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+// Load and eval the TypeScript file by stripping TS-only syntax so it runs as JS.
+const tsSource = fs.readFileSync(
+  path.join(__dirname, '../voiceisolate_presets.ts'),
+  'utf8'
+);
+
+// Remove TypeScript interface blocks and type annotations, then expose exports.
+const jsSource = tsSource
+  // Remove interface declarations (export interface Foo { ... })
+  .replace(/export\s+interface\s+\w+\s*\{[^}]*\}/g, '')
+  // Remove generic type annotation on PRESETS: Record<string, VoiceIsolatePreset>
+  .replace(/:\s*Record<[^>]+>/g, '')
+  // Remove 'export' keywords so assignments become plain 'const' declarations
+  .replace(/^export\s+/gm, '');
+
+const moduleExports = {};
+// eslint-disable-next-line no-new-func
+new Function('exports', jsSource)(moduleExports);
+
+// Pull out the values we need to test
+// They are plain 'const' in the eval scope; capture via the script returning them.
+const evalResult = (function () {
+  // Re-evaluate with an explicit return of the bindings we need.
+  const src = jsSource + '\nreturn { PRESETS, DEFAULT_PRESET_ID };';
+  // eslint-disable-next-line no-new-func
+  return new Function(src)();
+})();
+
+const { PRESETS, DEFAULT_PRESET_ID } = evalResult;
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+/**
+ * Returns true if the string is strictly kebab-case:
+ * one or more lowercase-alphanumeric segments joined by single hyphens.
+ */
+function isKebabCase(str) {
+  return /^[a-z0-9]+(-[a-z0-9]+)*$/.test(str);
+}
+
+const EXPECTED_PARAM_KEYS = [
+  'highPassFreq',
+  'lowPassFreq',
+  'compThreshold',
+  'compRatio',
+  'gateThreshold',
+  'denoiseMix',
+  'spectralGateDB',
+  'outputGain',
+  'clarityBoost',
+  'dryWetMix',
+];
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('voiceisolate_presets — module shape', () => {
+  test('PRESETS is a non-null object', () => {
+    expect(PRESETS).toBeDefined();
+    expect(typeof PRESETS).toBe('object');
+    expect(PRESETS).not.toBeNull();
+  });
+
+  test('PRESETS contains exactly 3 presets', () => {
+    expect(Object.keys(PRESETS).length).toBe(3);
+  });
+
+  test('DEFAULT_PRESET_ID is a string', () => {
+    expect(typeof DEFAULT_PRESET_ID).toBe('string');
+  });
+
+  test('DEFAULT_PRESET_ID is "podcast-clean"', () => {
+    expect(DEFAULT_PRESET_ID).toBe('podcast-clean');
+  });
+
+  test('DEFAULT_PRESET_ID references an existing preset key', () => {
+    expect(PRESETS).toHaveProperty(DEFAULT_PRESET_ID);
+  });
+});
+
+describe('voiceisolate_presets — named presets exist', () => {
+  const EXPECTED_KEYS = ['podcast-clean', 'voice-stream', 'aggressive-isolation'];
+
+  EXPECTED_KEYS.forEach(key => {
+    test(`PRESETS has key "${key}"`, () => {
+      expect(PRESETS).toHaveProperty(key);
+    });
+  });
+});
+
+describe('voiceisolate_presets — preset object structure', () => {
+  Object.entries(PRESETS).forEach(([key, preset]) => {
+    describe(`Preset "${key}"`, () => {
+      test('has an id string', () => {
+        expect(typeof preset.id).toBe('string');
+        expect(preset.id.length).toBeGreaterThan(0);
+      });
+
+      test('has a name string', () => {
+        expect(typeof preset.name).toBe('string');
+        expect(preset.name.length).toBeGreaterThan(0);
+      });
+
+      test('has a params object', () => {
+        expect(typeof preset.params).toBe('object');
+        expect(preset.params).not.toBeNull();
+      });
+
+      test('preset key matches preset.id', () => {
+        expect(preset.id).toBe(key);
+      });
+
+      test('params contains all 10 expected DSP fields', () => {
+        EXPECTED_PARAM_KEYS.forEach(field => {
+          expect(preset.params).toHaveProperty(field);
+          expect(typeof preset.params[field]).toBe('number');
+        });
+      });
+    });
+  });
+});
+
+describe('voiceisolate_presets — safety rules (.qodo/rules.md)', () => {
+  describe('Rule: gateThreshold must be <= -30 dBFS', () => {
+    Object.entries(PRESETS).forEach(([key, preset]) => {
+      test(`${key}: gateThreshold (${preset.params.gateThreshold}) <= -30`, () => {
+        expect(preset.params.gateThreshold).toBeLessThanOrEqual(-30);
+      });
+    });
+  });
+
+  describe('Rule: compRatio must be 1–20', () => {
+    Object.entries(PRESETS).forEach(([key, preset]) => {
+      test(`${key}: compRatio (${preset.params.compRatio}) is in [1, 20]`, () => {
+        expect(preset.params.compRatio).toBeGreaterThanOrEqual(1);
+        expect(preset.params.compRatio).toBeLessThanOrEqual(20);
+      });
+    });
+  });
+
+  describe('Rule: outputGain must be -12 to 6 dB', () => {
+    Object.entries(PRESETS).forEach(([key, preset]) => {
+      test(`${key}: outputGain (${preset.params.outputGain}) is in [-12, 6]`, () => {
+        expect(preset.params.outputGain).toBeGreaterThanOrEqual(-12);
+        expect(preset.params.outputGain).toBeLessThanOrEqual(6);
+      });
+    });
+  });
+
+  describe('Rule: dryWetMix must be 0.0 to 1.0', () => {
+    Object.entries(PRESETS).forEach(([key, preset]) => {
+      test(`${key}: dryWetMix (${preset.params.dryWetMix}) is in [0, 1]`, () => {
+        expect(preset.params.dryWetMix).toBeGreaterThanOrEqual(0.0);
+        expect(preset.params.dryWetMix).toBeLessThanOrEqual(1.0);
+      });
+    });
+  });
+
+  describe('Rule: denoiseMix must be 0.0 to 1.0', () => {
+    Object.entries(PRESETS).forEach(([key, preset]) => {
+      test(`${key}: denoiseMix (${preset.params.denoiseMix}) is in [0, 1]`, () => {
+        expect(preset.params.denoiseMix).toBeGreaterThanOrEqual(0.0);
+        expect(preset.params.denoiseMix).toBeLessThanOrEqual(1.0);
+      });
+    });
+  });
+
+  describe('Rule: all preset IDs must be kebab-case', () => {
+    Object.entries(PRESETS).forEach(([key, preset]) => {
+      test(`preset key "${key}" is kebab-case`, () => {
+        expect(isKebabCase(key)).toBe(true);
+      });
+
+      test(`preset.id "${preset.id}" is kebab-case`, () => {
+        expect(isKebabCase(preset.id)).toBe(true);
+      });
+    });
+  });
+
+  describe('Rule: aggressive-isolation requires denoiseMix >= 0.8', () => {
+    test('aggressive-isolation: denoiseMix >= 0.8', () => {
+      const preset = PRESETS['aggressive-isolation'];
+      expect(preset).toBeDefined();
+      expect(preset.params.denoiseMix).toBeGreaterThanOrEqual(0.8);
+    });
+  });
+});
+
+describe('voiceisolate_presets — individual preset values', () => {
+  describe('podcast-clean', () => {
+    const preset = PRESETS['podcast-clean'];
+
+    test('highPassFreq is 80', () => expect(preset.params.highPassFreq).toBe(80));
+    test('lowPassFreq is 16000', () => expect(preset.params.lowPassFreq).toBe(16000));
+    test('compThreshold is -24', () => expect(preset.params.compThreshold).toBe(-24));
+    test('compRatio is 3.5', () => expect(preset.params.compRatio).toBe(3.5));
+    test('gateThreshold is -48', () => expect(preset.params.gateThreshold).toBe(-48));
+    test('denoiseMix is 0.35', () => expect(preset.params.denoiseMix).toBe(0.35));
+    test('spectralGateDB is 8', () => expect(preset.params.spectralGateDB).toBe(8));
+    test('outputGain is 1.5', () => expect(preset.params.outputGain).toBe(1.5));
+    test('clarityBoost is 2', () => expect(preset.params.clarityBoost).toBe(2));
+    test('dryWetMix is 0.95', () => expect(preset.params.dryWetMix).toBe(0.95));
+    test('name is "Podcast Clean"', () => expect(preset.name).toBe('Podcast Clean'));
+  });
+
+  describe('voice-stream', () => {
+    const preset = PRESETS['voice-stream'];
+
+    test('highPassFreq is 100', () => expect(preset.params.highPassFreq).toBe(100));
+    test('lowPassFreq is 14000', () => expect(preset.params.lowPassFreq).toBe(14000));
+    test('compThreshold is -20', () => expect(preset.params.compThreshold).toBe(-20));
+    test('compRatio is 3', () => expect(preset.params.compRatio).toBe(3));
+    test('gateThreshold is -44', () => expect(preset.params.gateThreshold).toBe(-44));
+    test('denoiseMix is 0.3', () => expect(preset.params.denoiseMix).toBe(0.3));
+    test('spectralGateDB is 6', () => expect(preset.params.spectralGateDB).toBe(6));
+    test('outputGain is 1', () => expect(preset.params.outputGain).toBe(1));
+    test('clarityBoost is 1.5', () => expect(preset.params.clarityBoost).toBe(1.5));
+    test('dryWetMix is 0.9', () => expect(preset.params.dryWetMix).toBe(0.9));
+    test('name is "Voice Stream"', () => expect(preset.name).toBe('Voice Stream'));
+  });
+
+  describe('aggressive-isolation', () => {
+    const preset = PRESETS['aggressive-isolation'];
+
+    test('highPassFreq is 120', () => expect(preset.params.highPassFreq).toBe(120));
+    test('lowPassFreq is 12000', () => expect(preset.params.lowPassFreq).toBe(12000));
+    test('compThreshold is -18', () => expect(preset.params.compThreshold).toBe(-18));
+    test('compRatio is 5', () => expect(preset.params.compRatio).toBe(5));
+    test('gateThreshold is -38', () => expect(preset.params.gateThreshold).toBe(-38));
+    test('denoiseMix is 0.85', () => expect(preset.params.denoiseMix).toBe(0.85));
+    test('spectralGateDB is 14', () => expect(preset.params.spectralGateDB).toBe(14));
+    test('outputGain is 2', () => expect(preset.params.outputGain).toBe(2));
+    test('clarityBoost is 3', () => expect(preset.params.clarityBoost).toBe(3));
+    test('dryWetMix is 1.0', () => expect(preset.params.dryWetMix).toBe(1.0));
+    test('name is "Aggressive Isolation"', () => expect(preset.name).toBe('Aggressive Isolation'));
+  });
+});
+
+describe('voiceisolate_presets — boundary and regression checks', () => {
+  test('No preset has gateThreshold exactly at the boundary (-30)', () => {
+    // All should be strictly below -30, not right at the edge
+    Object.entries(PRESETS).forEach(([key, preset]) => {
+      expect(preset.params.gateThreshold).toBeLessThan(-30);
+    });
+  });
+
+  test('No preset outputGain reaches the upper boundary (6 dB)', () => {
+    Object.entries(PRESETS).forEach(([, preset]) => {
+      expect(preset.params.outputGain).toBeLessThanOrEqual(6);
+    });
+  });
+
+  test('No preset outputGain falls below the lower boundary (-12 dB)', () => {
+    Object.entries(PRESETS).forEach(([, preset]) => {
+      expect(preset.params.outputGain).toBeGreaterThanOrEqual(-12);
+    });
+  });
+
+  test('highPassFreq is lower than lowPassFreq in every preset (valid band)', () => {
+    Object.entries(PRESETS).forEach(([key, preset]) => {
+      expect(preset.params.highPassFreq).toBeLessThan(preset.params.lowPassFreq);
+    });
+  });
+
+  test('All compRatio values are positive numbers', () => {
+    Object.entries(PRESETS).forEach(([, preset]) => {
+      expect(preset.params.compRatio).toBeGreaterThan(0);
+    });
+  });
+
+  test('All spectralGateDB values are positive', () => {
+    Object.entries(PRESETS).forEach(([, preset]) => {
+      expect(preset.params.spectralGateDB).toBeGreaterThan(0);
+    });
+  });
+
+  test('All clarityBoost values are non-negative', () => {
+    Object.entries(PRESETS).forEach(([, preset]) => {
+      expect(preset.params.clarityBoost).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  test('PRESETS object keys are the same set as preset.id values', () => {
+    const keys = Object.keys(PRESETS).sort();
+    const ids = Object.values(PRESETS).map(p => p.id).sort();
+    expect(keys).toEqual(ids);
+  });
+
+  test('No two presets share the same id', () => {
+    const ids = Object.values(PRESETS).map(p => p.id);
+    const unique = new Set(ids);
+    expect(unique.size).toBe(ids.length);
+  });
+
+  test('No two presets share the same name', () => {
+    const names = Object.values(PRESETS).map(p => p.name);
+    const unique = new Set(names);
+    expect(unique.size).toBe(names.length);
+  });
+});

--- a/tests/voiceisolate_presets.test.js
+++ b/tests/voiceisolate_presets.test.js
@@ -22,9 +22,12 @@ const jsSource = tsSource
   // Remove 'export' keywords so assignments become plain 'const' declarations
   .replace(/^export\s+/gm, '');
 
-const moduleExports = {};
-// eslint-disable-next-line no-new-func
-new Function('exports', jsSource)(moduleExports);
+// Pull out the values we need to test
+const evalResult = (function () {
+  const src = jsSource + '\nreturn { PRESETS, DEFAULT_PRESET_ID };';
+  // eslint-disable-next-line no-new-func
+  return new Function(src)();
+})();
 
 // Pull out the values we need to test
 // They are plain 'const' in the eval scope; capture via the script returning them.

--- a/tests/voiceisolate_presets.test.js
+++ b/tests/voiceisolate_presets.test.js
@@ -31,12 +31,6 @@ const evalResult = (function () {
 
 // Pull out the values we need to test
 // They are plain 'const' in the eval scope; capture via the script returning them.
-const evalResult = (function () {
-  // Re-evaluate with an explicit return of the bindings we need.
-  const src = jsSource + '\nreturn { PRESETS, DEFAULT_PRESET_ID };';
-  // eslint-disable-next-line no-new-func
-  return new Function(src)();
-})();
 
 const { PRESETS, DEFAULT_PRESET_ID } = evalResult;
 

--- a/tests/voiceisolate_presets.test.js
+++ b/tests/voiceisolate_presets.test.js
@@ -254,7 +254,7 @@ describe('voiceisolate_presets — boundary and regression checks', () => {
 
   test('No preset outputGain reaches the upper boundary (6 dB)', () => {
     Object.entries(PRESETS).forEach(([, preset]) => {
-      expect(preset.params.outputGain).toBeLessThanOrEqual(6);
+      expect(preset.params.outputGain).toBeLessThan(6);
     });
   });
 

--- a/voiceisolate_presets.ts
+++ b/voiceisolate_presets.ts
@@ -1,0 +1,71 @@
+export interface DSPParams {
+  highPassFreq: number;
+  lowPassFreq: number;
+  compThreshold: number;
+  compRatio: number;
+  gateThreshold: number;
+  denoiseMix: number;
+  spectralGateDB: number;
+  outputGain: number;
+  clarityBoost: number;
+  dryWetMix: number;
+}
+
+export interface VoiceIsolatePreset {
+  id: string;
+  name: string;
+  params: DSPParams;
+}
+
+export const PRESETS: Record<string, VoiceIsolatePreset> = {
+  'podcast-clean': {
+    id: 'podcast-clean',
+    name: 'Podcast Clean',
+    params: {
+      highPassFreq: 80,
+      lowPassFreq: 16000,
+      compThreshold: -24,
+      compRatio: 3.5,
+      gateThreshold: -48,
+      denoiseMix: 0.35,
+      spectralGateDB: 8,
+      outputGain: 1.5,
+      clarityBoost: 2,
+      dryWetMix: 0.95
+    }
+  },
+  'voice-stream': {
+    id: 'voice-stream',
+    name: 'Voice Stream',
+    params: {
+      highPassFreq: 100,
+      lowPassFreq: 14000,
+      compThreshold: -20,
+      compRatio: 3,
+      gateThreshold: -44,
+      denoiseMix: 0.3,
+      spectralGateDB: 6,
+      outputGain: 1,
+      clarityBoost: 1.5,
+      dryWetMix: 0.9
+    }
+  },
+  'aggressive-isolation': {
+    id: 'aggressive-isolation',
+    name: 'Aggressive Isolation',
+    params: {
+      highPassFreq: 120,
+      lowPassFreq: 12000,
+      compThreshold: -18,
+      compRatio: 5,
+      gateThreshold: -38,
+      denoiseMix: 0.85,
+      spectralGateDB: 14,
+      outputGain: 2,
+      clarityBoost: 3,
+      dryWetMix: 1.0
+    }
+  }
+};
+
+export const DEFAULT_PRESET_ID = 'podcast-clean';


### PR DESCRIPTION
This PR introduces the base DSP preset pack `v1.0` via `voiceisolate_presets.ts` including presets for podcasting, streaming, and aggressive noise isolation, and establishes `.qodo/rules.md` dictating crucial DSP safety parameters to prevent clipping, feedback, and distortion.

**🎯 What:**
- Added `voiceisolate_presets.ts` defining standard VoiceIsolate preset structures and values.
- Added `.qodo/rules.md` establishing explicit bounds for DSP parameters (e.g. `gateThreshold <= -30 dBFS`, `compRatio` range `1-20`, etc.).

**💡 Why:**
- To streamline DSP configuration for different recording environments and enforce safety parameters during automated configuration tuning to prevent audio artifacts.

**✅ Verification:**
- Ensured no existing tests failed after adding the specific preset logic and documentation files.
- Manual file validation confirms all properties align perfectly with the required bounds.

**✨ Result:**
- Project now includes explicit parameter safety limits and standardized starting presets for isolated processing workflows.

---
*PR created automatically by Jules for task [2861296667691902966](https://jules.google.com/task/2861296667691902966) started by @Joker5514*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Three voice-isolation presets added: podcast-clean (default), voice-stream, and aggressive-isolation, each with tuned audio parameters for clearer vocal isolation.

* **Documentation**
  * Added safety rules document defining validated DSP parameter ranges, naming conventions, and a cross-preset rule requiring aggressive-isolation to have higher denoiseMix.

* **Tests**
  * Comprehensive tests validating presets, parameter shapes, numeric bounds, naming formats, and exact preset values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/joker5514/voiceisolate-pro/pull/183" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
