### PR TITLE
🧹 Remove leftover console.log from worker-pool.js

### DIFF
--- a/pr_description.md
+++ b/pr_description.md
@@ -1,9 +1,7 @@
-🧹 [code health improvement] Fix undefined variable in JS fallback DSP processor
+🎯 **What:** Removed a leftover `console.log` statement from `src/worker-pool.js` that printed "[Worker ID] Loading ONNX model with WebGPU EP..." during initialization.
 
-🎯 **What:** The `w` variable was referenced but undefined in the overlap-add loop within the `_processJS` method in `src/dsp-processor.js`. This has been resolved by correctly utilizing the pre-calculated window array directly using `win[i % N]`.
+💡 **Why:** `console.log` statements meant for debugging during development clutter up the console output in production. Removing it improves code health and cleanliness without impacting functionality.
 
-💡 **Why:** By referencing the intended variables within the loop properly, we guarantee that the JavaScript fallback code works if WASM goes unavailable, improving maintainability by eliminating a silent failure mode in the fallback logic. Unused variables were safely removed.
+✅ **Verification:** Verified by running the test suite (`pnpm test`), which passed perfectly. Inspected the code diff directly to ensure no other logic was disturbed.
 
-✅ **Verification:** Verified by ensuring the code lints without unused variable errors. No tests were broken and the change preserves all existing functionality and structure for the WASM fallback.
-
-✨ **Result:** The fallback processing will no longer crash due to `w is not defined` when evaluating overlap-add.
+✨ **Result:** A cleaner execution environment free from unnecessary debugging logs when the ML worker initializes.

--- a/src/worker-pool.js
+++ b/src/worker-pool.js
@@ -97,7 +97,6 @@ self.onmessage = async ({ data }) => {
       paramBuf = new Float32Array(data.paramSab);
       aesKey   = await generateKey();
 
-      console.log(`[Worker ${workerId}] Loading ONNX model with WebGPU EP...`);
       try {
         session_ecapa  = await ort.InferenceSession.create('/models/ecapa_tdnn_int8.onnx', {
           executionProviders: ['webgpu', 'wasm'],


### PR DESCRIPTION
🎯 **What:** Removed a leftover `console.log` statement from `src/worker-pool.js` that printed "[Worker ID] Loading ONNX model with WebGPU EP..." during initialization.

💡 **Why:** `console.log` statements meant for debugging during development clutter up the console output in production. Removing it improves code health and cleanliness without impacting functionality.

✅ **Verification:** Verified by running the test suite (`pnpm test`), which passed perfectly. Inspected the code diff directly to ensure no other logic was disturbed.

✨ **Result:** A cleaner execution environment free from unnecessary debugging logs when the ML worker initializes.

---
*PR created automatically by Jules for task [6318889966879934834](https://jules.google.com/task/6318889966879934834) started by @Joker5514*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/joker5514/voiceisolate-pro/pull/194" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed unnecessary startup logging from worker initialization to reduce console output.

* **Documentation**
  * Updated release documentation to reflect current changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->