### PR TITLE
🧹 [Code health] Fix falsely flagged commented out code

### DIFF
--- a/public/app/ml-worker.js
+++ b/public/app/ml-worker.js
@@ -99,7 +99,7 @@ function buildErbFilterbank() {
   const hiErb = hzToErb(DF_SR / 2);
   const step  = (hiErb - loErb) / (DF_N_ERB + 1);
 
-  // For each bin, find its ERB band (−1 = unmapped)
+  // For each bin, find its ERB band (unmapped bins are marked as -1)
   const map = new Int16Array(nBins).fill(-1);
   const bands = Array.from({ length: DF_N_ERB }, () => []);
 


### PR DESCRIPTION
🎯 **What:** Reworded a comment in `public/app/ml-worker.js` that was triggering an automated "commented out code" heuristic.

💡 **Why:** The phrase `(-1 = unmapped)` contained an equals sign that looked like a variable assignment inside a comment, causing a false positive code health issue. Changing it to `(unmapped bins are marked as -1)` fixes the warning while keeping the exact same useful documentation intact.

✅ **Verification:** Tested the worker initialization logic and verified no syntax errors were introduced.

✨ **Result:** The code health tool no longer flags the comment, and documentation is perfectly preserved.

---
*PR created automatically by Jules for task [4586115178856359872](https://jules.google.com/task/4586115178856359872) started by @Joker5514*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/joker5514/voiceisolate-pro/pull/195" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code documentation for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->