### PR TITLE
fix: remove duplicate code blocks causing syntax errors in test suite

### DIFF
--- a/app.js
+++ b/app.js
@@ -1421,17 +1421,6 @@ class VoiceIsolatePro {
     return out;
   }
 
-    for (let ch = 0; ch < nCh; ch++) {
-      const d = dry.getChannelData(ch);
-      const w = wet.getChannelData(ch);
-      const o = out.getChannelData(ch);
-      for (let i = 0; i < len; i++) {
-        o[i] = d[i] * (1 - wAmt) + w[i] * wAmt;
-      }
-    }
-    return out;
-  }
-
   peakNorm(buf, tDb) {
     const c = this.ctx;
     const nCh = buf.numberOfChannels;

--- a/tests/voiceisolate_presets.test.js
+++ b/tests/voiceisolate_presets.test.js
@@ -29,25 +29,6 @@ const jsSource = stripTypeScriptTypes(tsSource)
 const evalResult = new Function(
   jsSource + '\nreturn { PRESETS, DEFAULT_PRESET_ID };'
 )();
-// Remove TypeScript interface blocks and type annotations, then expose exports.
-const jsSource = tsSource
-  // Remove interface declarations (export interface Foo { ... })
-  .replace(/export\s+interface\s+\w+\s*\{[^}]*\}/g, '')
-  // Remove type alias declarations (export type Foo = ...; or type Foo = ...;)
-  .replace(/^(export\s+)?type\s+\w+\s*=.+;?\s*$/gm, '')
-  // Remove generic type annotation on PRESETS: Record<string, VoiceIsolatePreset>
-  .replace(/:\s*Record<[^>]+>/g, '')
-  // Remove remaining TS type annotations on const declarations (e.g. `: PresetId`)
-  .replace(/:\s*\w+(?=\s*=)/g, '')
-  // Remove 'export' keywords so assignments become plain 'const' declarations
-  .replace(/^export\s+/gm, '');
-
-// Pull out the values we need to test
-const evalResult = (function () {
-  const src = jsSource + '\nreturn { PRESETS, DEFAULT_PRESET_ID };';
-  // eslint-disable-next-line no-new-func
-  return new Function(src)();
-})();
 
 // Pull out the values we need to test
 // They are plain 'const' in the eval scope; capture via the script returning them.


### PR DESCRIPTION
- app.js: remove orphaned for-loop block outside mixDW() that was a
  duplicate of the function body, causing SyntaxError in vm.runInContext
  and new Function() evals used by 7 test files
- tests/voiceisolate_presets.test.js: remove stale regex-based TS
  stripping code left after refactor to stripTypeScriptTypes(), which
  caused duplicate const declarations (jsSource, evalResult) and a
  parse-time failure

All 292 tests now pass (was 35 failures across 8 suites).

https://claude.ai/code/session_016XGwwrCKZzx9sNerBVz8mb
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/joker5514/voiceisolate-pro/pull/204" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed duplicate audio mixing code.

* **Tests**
  * Simplified preset validation test infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->