### PR TITLE
Redesign sliders to be more ergonomic & modern; complete mobile layout

### DIFF
--- a/build/app/app.js
+++ b/build/app/app.js
@@ -251,6 +251,11 @@ class VoiceIsolatePro {
           badge.textContent = 'RT';
           labelEl.appendChild(badge);
         }
+        const infoEl = document.createElement('span');
+        infoEl.className = 'sr-info';
+        infoEl.textContent = 'i';
+        infoEl.setAttribute('aria-hidden', 'true');
+        labelEl.appendChild(infoEl);
 
         const inputEl = document.createElement('input');
         inputEl.type = 'range';
@@ -265,6 +270,9 @@ class VoiceIsolatePro {
         inputEl.setAttribute('aria-valuemin', s.min);
         inputEl.setAttribute('aria-valuemax', s.max);
         inputEl.setAttribute('aria-valuenow', s.val);
+        // Set initial fill percentage for styled track
+        const initPct = ((s.val - s.min) / (s.max - s.min)) * 100;
+        inputEl.style.setProperty('--pct', `${initPct.toFixed(1)}%`);
 
         const valEl = document.createElement('span');
         valEl.className = 'sr-val';
@@ -286,6 +294,8 @@ class VoiceIsolatePro {
       uploadZone:g('uploadZone'), fileInput:g('fileInput'), fileBtn:g('fileBtn'),
       micBtn:g('micBtn'), micLabel:g('micLabel'), fileInfo:g('fileInfo'),
       processBtn:g('processBtn'), reprocessBtn:g('reprocessBtn'), stopProcBtn:g('stopProcBtn'),
+      mobileProcessBtn:g('mobileProcessBtn'), mobileReprocessBtn:g('mobileReprocessBtn'), mobileStopBtn:g('mobileStopBtn'),
+      statsToggle:g('statsToggle'), hdrStats:g('hdrStats'),
       saveOrigBtn:g('saveOrigBtn'), saveProcBtn:g('saveProcBtn'),
       auditLogBtn:g('auditLogBtn'), forensicToggle:g('forensicToggle'),
       videoCard:g('videoCard'), videoPlayer:g('videoPlayer'),
@@ -368,6 +378,18 @@ class VoiceIsolatePro {
     if (this.dom.auditLogBtn) {
       this.dom.auditLogBtn.addEventListener('click', () => this.downloadAuditLog());
     }
+    // Mobile action bar mirrors desktop process buttons
+    if (this.dom.mobileProcessBtn)   this.dom.mobileProcessBtn.addEventListener('click', () => this.runPipeline());
+    if (this.dom.mobileReprocessBtn) this.dom.mobileReprocessBtn.addEventListener('click', () => this.runPipeline());
+    if (this.dom.mobileStopBtn)      this.dom.mobileStopBtn.addEventListener('click', () => { this.abortFlag = true; });
+    // Mobile stats toggle
+    if (this.dom.statsToggle && this.dom.hdrStats) {
+      this.dom.statsToggle.addEventListener('click', () => {
+        const expanded = this.dom.hdrStats.classList.toggle('expanded');
+        this.dom.statsToggle.setAttribute('aria-expanded', String(expanded));
+        this.dom.statsToggle.textContent = expanded ? '▲' : '▼';
+      });
+    }
     window.addEventListener('resize', () => this.onResize());
   }
 
@@ -382,6 +404,9 @@ class VoiceIsolatePro {
     const ve = document.getElementById(id + 'Val');
     if (ve) ve.textContent = v + unit;
     el.setAttribute('aria-valuenow', v);
+    // Update filled-track CSS variable
+    const pct = ((v - parseFloat(el.min)) / (parseFloat(el.max) - parseFloat(el.min))) * 100;
+    el.style.setProperty('--pct', `${pct.toFixed(1)}%`);
     if (el.classList.contains('realtime') && this.liveChainBuilt) this.updateLiveChain();
   }
 
@@ -392,7 +417,7 @@ class VoiceIsolatePro {
     const actions = document.querySelector('.custom-preset-actions');
     if (!row || !actions) return;
 
-    for (const [id, preset] of Object.entries(this.customPresets)) {
+    for (const [id] of Object.entries(this.customPresets)) {
       if (document.querySelector(`.btn-preset[data-preset="${id}"]`)) continue;
       const name = id.split('-').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' ');
       const btn = document.createElement('button');
@@ -444,7 +469,13 @@ class VoiceIsolatePro {
       for (const s of sliders) {
         const el = document.getElementById(s.id);
         const ve = document.getElementById(s.id + 'Val');
-        if (el && this.params[s.id] !== undefined) { el.value = this.params[s.id]; el.setAttribute('aria-valuenow', this.params[s.id]); if (ve) ve.textContent = this.params[s.id] + s.unit; }
+        if (el && this.params[s.id] !== undefined) {
+          el.value = this.params[s.id];
+          el.setAttribute('aria-valuenow', this.params[s.id]);
+          if (ve) ve.textContent = this.params[s.id] + s.unit;
+          const pct = ((this.params[s.id] - s.min) / (s.max - s.min)) * 100;
+          el.style.setProperty('--pct', `${pct.toFixed(1)}%`);
+        }
       }
     }
     document.querySelectorAll('.btn-preset').forEach(b => b.classList.toggle('active', b.dataset.preset === name));
@@ -576,6 +607,8 @@ class VoiceIsolatePro {
     const dur = this.fmtDur(buf.duration);
     this.dom.fileInfo.textContent = (name || 'Recording') + ' (' + dur + ')';
     this.dom.processBtn.disabled = false;
+    if (this.dom.mobileProcessBtn) this.dom.mobileProcessBtn.disabled = false;
+    if (this.dom.mobileReprocessBtn) this.dom.mobileReprocessBtn.disabled = this.dom.reprocessBtn.disabled;
     this.dom.saveOrigBtn.disabled = false;
     this.dom.reprocessBtn.disabled = true;
     this.dom.saveProcBtn.disabled = true;
@@ -656,9 +689,9 @@ class VoiceIsolatePro {
   // ======== TRANSPORT ========
   play() {
     // Teardown previous playback state without resetting playOffset
-    this.teardownChain();
+    if (typeof this.teardownChain === 'function') this.teardownChain();
     if (this.isVideo && this.isPlaying) this.dom.videoPlayer.pause();
-    this.stopSpectro();
+    if (typeof this.stopSpectro === 'function') this.stopSpectro();
     if (typeof this.stopDiagnostics === 'function') this.stopDiagnostics();
     this.isPlaying = false;
 
@@ -839,6 +872,9 @@ class VoiceIsolatePro {
     if (!this.inputBuffer || this.isProcessing) return;
     this.isProcessing = true; this.abortFlag = false;
     this.dom.processBtn.style.display = 'none'; this.dom.stopProcBtn.style.display = 'inline-flex';
+    if (this.dom.mobileProcessBtn)   this.dom.mobileProcessBtn.style.display = 'none';
+    if (this.dom.mobileReprocessBtn) this.dom.mobileReprocessBtn.style.display = 'none';
+    if (this.dom.mobileStopBtn)      this.dom.mobileStopBtn.style.display = 'inline-flex';
     this.dom.saveProcBtn.disabled = true; this.dom.tpAB.disabled = true;
     this.setStatus('PROCESSING');
     if (this.forensicMode) { this.forensicLog = []; }
@@ -997,6 +1033,7 @@ class VoiceIsolatePro {
       this.drawWaveform(fin, this.dom.waveProcCanvas, '#22d3ee');
       this.dom.stVoices.textContent = this.estVoices(fin);
       this.dom.saveProcBtn.disabled = false; this.dom.tpAB.disabled = false; this.dom.reprocessBtn.disabled = false;
+      if (this.dom.mobileReprocessBtn) this.dom.mobileReprocessBtn.disabled = false;
       this.dom.tpABLabel.textContent = 'Ready — A/B';
       if (this.dom.fsBtnAB) this.dom.fsBtnAB.disabled = false;
       if (this.dom.auditLogBtn) this.dom.auditLogBtn.disabled = !this.forensicMode || this.forensicLog.length === 0;
@@ -1006,6 +1043,9 @@ class VoiceIsolatePro {
       else { structuredLog('error', 'Pipeline error', { error: e instanceof Error ? e.message : String(e) }); this.setStatus('ERROR'); this.dom.pipeDetail.textContent=e instanceof Error ? e.message : String(e); }
     } finally {
       this.isProcessing=false; this.dom.processBtn.style.display='inline-flex'; this.dom.stopProcBtn.style.display='none';
+      if (this.dom.mobileProcessBtn)   { this.dom.mobileProcessBtn.style.display='inline-flex'; }
+      if (this.dom.mobileReprocessBtn) { this.dom.mobileReprocessBtn.style.display='inline-flex'; this.dom.mobileReprocessBtn.disabled = this.dom.reprocessBtn.disabled; }
+      if (this.dom.mobileStopBtn)      this.dom.mobileStopBtn.style.display='none';
     }
   }
 

--- a/build/app/index.html
+++ b/build/app/index.html
@@ -36,7 +36,9 @@
         <span class="hdr-badge">ENGINEER MODE</span>
       </div>
     </div>
-    <div class="hdr-stats">
+    <!-- Mobile stats toggle (visible only on small screens via CSS) -->
+    <button class="hdr-stats-toggle" id="statsToggle" aria-label="Toggle stats" aria-expanded="false">&#9660;</button>
+    <div class="hdr-stats" id="hdrStats">
       <div class="hdr-stat"><span class="hs-val" id="hSNR">-- dB</span><span class="hs-lbl">SNR Gain</span></div>
       <div class="hdr-stat"><span class="hs-val" id="hDur">--</span><span class="hs-lbl">Duration</span></div>
       <div class="hdr-stat"><span class="hs-val" id="hSR">--</span><span class="hs-lbl">Sample Rate</span></div>
@@ -446,6 +448,16 @@
     <span>VoiceIsolate Pro v21.0 · Threads from Space v10 · Hybrid ML+DSP · 32-Stage Octa-Pass · Mobile-Ready</span>
     <span>100% Local Processing · Zero Data Transmission · Privacy First</span>
   </footer>
+
+  <!-- Mobile sticky action bar (hidden on desktop via CSS) -->
+  <div class="mobile-action-bar" id="mobileActionBar">
+    <button id="mobileProcessBtn" class="btn btn-primary" disabled>
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><polygon points="5 3 19 12 5 21"/></svg>
+      Process
+    </button>
+    <button id="mobileReprocessBtn" class="btn btn-reprocess" disabled>Re-run</button>
+    <button id="mobileStopBtn" class="btn btn-danger" style="display:none">Abort</button>
+  </div>
 
   <div id="tooltip" class="slider-tooltip"></div>
   <!-- v21 Modular Architecture: TFS v10 + Capacitor Mobile -->

--- a/build/app/style.css
+++ b/build/app/style.css
@@ -98,19 +98,56 @@ body::before{content:'';position:fixed;inset:0;background:linear-gradient(rgba(2
 .panel.active{display:block}
 
 /* ---- SLIDERS ---- */
-.sr{display:grid;grid-template-columns:1fr;gap:0;margin-bottom:2px}
-.sr-row{display:grid;grid-template-columns:130px 1fr 48px;align-items:center;gap:6px;padding:3px 0;border-bottom:1px solid rgba(255,255,255,0.02);position:relative}
-.sr-row:last-child{border-bottom:none}
-.sr-label{font-size:0.68rem;color:var(--text2);cursor:help;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;position:relative}
-.sr-label::after{content:'ⓘ';margin-left:4px;font-size:0.55rem;color:var(--dim);vertical-align:super}
-.sr-val{font-family:var(--fm);font-size:0.65rem;color:var(--red2);text-align:right}
-input[type="range"]{-webkit-appearance:none;appearance:none;width:100%;height:3px;border-radius:2px;background:var(--s4);outline:none}
-input[type="range"]::-webkit-slider-thumb{-webkit-appearance:none;width:12px;height:12px;border-radius:50%;background:var(--red);cursor:pointer;box-shadow:0 0 6px var(--red-glow);transition:transform 0.1s}
-input[type="range"]::-webkit-slider-thumb:hover{transform:scale(1.3);box-shadow:0 0 10px rgba(220,38,38,0.5)}
-input[type="range"]::-moz-range-thumb{width:12px;height:12px;border-radius:50%;background:var(--red);border:none;cursor:pointer}
-input[type="range"].realtime{background:linear-gradient(90deg,rgba(220,38,38,0.15),var(--s4))}
-input[type="range"].realtime::-webkit-slider-thumb{background:var(--cyan);box-shadow:0 0 6px rgba(34,211,238,0.4)}
-.rt-badge{display:inline-block;font-size:0.45rem;padding:0 3px;border-radius:2px;background:rgba(34,211,238,0.1);color:var(--cyan);font-weight:700;vertical-align:middle;margin-left:3px;letter-spacing:0.05em}
+.sr{display:grid;grid-template-columns:1fr;gap:1px;margin-bottom:2px}
+.sr-row{display:grid;grid-template-columns:118px 1fr 58px;align-items:center;gap:8px;padding:5px 6px;border-radius:7px;position:relative;transition:background 0.12s}
+.sr-row:hover{background:rgba(255,255,255,0.024)}
+.sr-label{font-size:0.67rem;font-weight:500;color:var(--text2);cursor:help;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;display:flex;align-items:center;gap:4px;min-width:0}
+.sr-info{display:inline-flex;align-items:center;justify-content:center;width:13px;height:13px;border-radius:50%;font-size:0.48rem;font-weight:700;color:var(--dim);border:1px solid rgba(255,255,255,0.1);flex-shrink:0;line-height:1;font-style:normal;pointer-events:none;margin-left:auto}
+.sr-val{font-family:var(--fm);font-size:0.62rem;font-weight:500;color:var(--red2);text-align:right;background:rgba(220,38,38,0.07);border:1px solid rgba(220,38,38,0.12);border-radius:5px;padding:2px 5px;white-space:nowrap;min-width:0;transition:border-color 0.15s,color 0.15s}
+.sr-row:hover .sr-val{border-color:rgba(220,38,38,0.22)}
+
+/* Track & thumb */
+.sr-row > input[type="range"]{
+  -webkit-appearance:none;appearance:none;
+  width:100%;height:5px;border-radius:3px;
+  background:linear-gradient(to right,var(--red) 0%,var(--red) var(--pct,50%),var(--s4) var(--pct,50%),var(--s4) 100%);
+  outline:none;cursor:pointer;transition:height 0.1s}
+.sr-row > input[type="range"]::-webkit-slider-runnable-track{height:5px;border-radius:3px}
+.sr-row > input[type="range"]::-webkit-slider-thumb{
+  -webkit-appearance:none;width:16px;height:16px;border-radius:50%;
+  background:#fff;border:2.5px solid var(--red);
+  cursor:pointer;margin-top:-5.5px;
+  box-shadow:0 1px 5px rgba(0,0,0,0.45),0 0 0 0 rgba(220,38,38,0);
+  transition:box-shadow 0.15s,transform 0.1s,border-color 0.1s}
+.sr-row > input[type="range"]::-webkit-slider-thumb:hover{
+  transform:scale(1.18);
+  box-shadow:0 2px 8px rgba(0,0,0,0.5),0 0 0 5px rgba(220,38,38,0.15)}
+.sr-row > input[type="range"]:active::-webkit-slider-thumb{
+  transform:scale(1.08);
+  box-shadow:0 2px 12px rgba(0,0,0,0.55),0 0 0 7px rgba(220,38,38,0.2)}
+.sr-row > input[type="range"]::-moz-range-track{height:5px;border-radius:3px;background:var(--s4);border:none}
+.sr-row > input[type="range"]::-moz-range-progress{height:5px;border-radius:3px;background:var(--red)}
+.sr-row > input[type="range"]::-moz-range-thumb{
+  width:16px;height:16px;border-radius:50%;
+  background:#fff;border:2.5px solid var(--red);
+  cursor:pointer;box-shadow:0 1px 5px rgba(0,0,0,0.45)}
+
+/* Realtime sliders — cyan accent */
+.sr-row > input[type="range"].realtime{
+  background:linear-gradient(to right,var(--cyan) 0%,var(--cyan) var(--pct,50%),var(--s4) var(--pct,50%),var(--s4) 100%)}
+.sr-row > input[type="range"].realtime::-webkit-slider-thumb{
+  border-color:var(--cyan);
+  box-shadow:0 1px 5px rgba(0,0,0,0.45),0 0 0 0 rgba(34,211,238,0)}
+.sr-row > input[type="range"].realtime::-webkit-slider-thumb:hover{
+  box-shadow:0 2px 8px rgba(0,0,0,0.5),0 0 0 5px rgba(34,211,238,0.2)}
+.sr-row > input[type="range"].realtime:active::-webkit-slider-thumb{
+  box-shadow:0 2px 12px rgba(0,0,0,0.55),0 0 0 7px rgba(34,211,238,0.25)}
+.sr-row > input[type="range"].realtime::-moz-range-progress{background:var(--cyan)}
+.sr-row > input[type="range"].realtime::-moz-range-thumb{border-color:var(--cyan)}
+.sr-row:hover input[type="range"].realtime + .sr-val{border-color:rgba(34,211,238,0.25);color:var(--cyan)}
+input[type="range"].realtime ~ .sr-val{color:var(--cyan);border-color:rgba(34,211,238,0.12);background:rgba(34,211,238,0.06)}
+
+.rt-badge{display:inline-block;font-size:0.44rem;padding:1px 4px;border-radius:3px;background:rgba(34,211,238,0.12);color:var(--cyan);font-weight:700;vertical-align:middle;margin-left:2px;letter-spacing:0.06em;border:1px solid rgba(34,211,238,0.2)}
 
 /* ---- PRESETS ---- */
 .presets-row{display:flex;align-items:center;gap:4px;margin-bottom:8px;flex-wrap:wrap}
@@ -176,6 +213,9 @@ input[type="range"].realtime::-webkit-slider-thumb{background:var(--cyan);box-sh
 .slider-tooltip.visible{opacity:1}
 
 /* ---- RESPONSIVE ---- */
+/* Stats toggle + mobile bar only visible on mobile (shown in mobile.css) */
+.hdr-stats-toggle{display:none}
+.mobile-action-bar{display:none}
 @media(max-width:960px){
   .main-grid{grid-template-columns:1fr}
   .col-left{order:2}.col-right{order:1}
@@ -270,19 +310,9 @@ input[type="range"].realtime::-webkit-slider-thumb{background:var(--cyan);box-sh
 .fs-xaxis-cv{width:100%;height:20px;display:block}
 
 /* ---- ACCESSIBILITY ---- */
-:focus-visible {
-  outline: 2px solid var(--cyan);
-  outline-offset: 2px;
-}
-input[type="range"]:focus-visible {
-  outline: 2px solid var(--cyan);
-  outline-offset: 4px;
-}
-input[type="range"]:focus-visible::-webkit-slider-thumb {
-  outline: 2px solid var(--cyan);
-  outline-offset: 2px;
-}
-input[type="range"]:focus-visible::-moz-range-thumb {
-  outline: 2px solid var(--cyan);
-  outline-offset: 2px;
-}
+:focus-visible{outline:2px solid var(--cyan);outline-offset:2px}
+input[type="range"]:focus-visible{outline:none}
+input[type="range"]:focus-visible::-webkit-slider-thumb{
+  box-shadow:0 0 0 3px var(--bg),0 0 0 5px var(--cyan),0 2px 8px rgba(0,0,0,0.5)}
+input[type="range"]:focus-visible::-moz-range-thumb{
+  box-shadow:0 0 0 3px var(--bg),0 0 0 5px var(--cyan)}

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -608,7 +608,7 @@ class VoiceIsolatePro {
     this.dom.fileInfo.textContent = (name || 'Recording') + ' (' + dur + ')';
     this.dom.processBtn.disabled = false;
     if (this.dom.mobileProcessBtn) this.dom.mobileProcessBtn.disabled = false;
-    if (this.dom.mobileReprocessBtn) this.dom.mobileReprocessBtn.disabled = true;
+    if (this.dom.mobileReprocessBtn) this.dom.mobileReprocessBtn.disabled = this.dom.reprocessBtn.disabled;
     this.dom.saveOrigBtn.disabled = false;
     this.dom.reprocessBtn.disabled = true;
     this.dom.saveProcBtn.disabled = true;
@@ -1044,7 +1044,7 @@ class VoiceIsolatePro {
     } finally {
       this.isProcessing=false; this.dom.processBtn.style.display='inline-flex'; this.dom.stopProcBtn.style.display='none';
       if (this.dom.mobileProcessBtn)   { this.dom.mobileProcessBtn.style.display='inline-flex'; }
-      if (this.dom.mobileReprocessBtn) { this.dom.mobileReprocessBtn.style.display='inline-flex'; }
+      if (this.dom.mobileReprocessBtn) { this.dom.mobileReprocessBtn.style.display='inline-flex'; this.dom.mobileReprocessBtn.disabled = this.dom.reprocessBtn.disabled; }
       if (this.dom.mobileStopBtn)      this.dom.mobileStopBtn.style.display='none';
     }
   }

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -251,6 +251,11 @@ class VoiceIsolatePro {
           badge.textContent = 'RT';
           labelEl.appendChild(badge);
         }
+        const infoEl = document.createElement('span');
+        infoEl.className = 'sr-info';
+        infoEl.textContent = 'i';
+        infoEl.setAttribute('aria-hidden', 'true');
+        labelEl.appendChild(infoEl);
 
         const inputEl = document.createElement('input');
         inputEl.type = 'range';
@@ -265,6 +270,9 @@ class VoiceIsolatePro {
         inputEl.setAttribute('aria-valuemin', s.min);
         inputEl.setAttribute('aria-valuemax', s.max);
         inputEl.setAttribute('aria-valuenow', s.val);
+        // Set initial fill percentage for styled track
+        const initPct = ((s.val - s.min) / (s.max - s.min)) * 100;
+        inputEl.style.setProperty('--pct', `${initPct.toFixed(1)}%`);
 
         const valEl = document.createElement('span');
         valEl.className = 'sr-val';
@@ -286,6 +294,8 @@ class VoiceIsolatePro {
       uploadZone:g('uploadZone'), fileInput:g('fileInput'), fileBtn:g('fileBtn'),
       micBtn:g('micBtn'), micLabel:g('micLabel'), fileInfo:g('fileInfo'),
       processBtn:g('processBtn'), reprocessBtn:g('reprocessBtn'), stopProcBtn:g('stopProcBtn'),
+      mobileProcessBtn:g('mobileProcessBtn'), mobileReprocessBtn:g('mobileReprocessBtn'), mobileStopBtn:g('mobileStopBtn'),
+      statsToggle:g('statsToggle'), hdrStats:g('hdrStats'),
       saveOrigBtn:g('saveOrigBtn'), saveProcBtn:g('saveProcBtn'),
       auditLogBtn:g('auditLogBtn'), forensicToggle:g('forensicToggle'),
       videoCard:g('videoCard'), videoPlayer:g('videoPlayer'),
@@ -368,6 +378,18 @@ class VoiceIsolatePro {
     if (this.dom.auditLogBtn) {
       this.dom.auditLogBtn.addEventListener('click', () => this.downloadAuditLog());
     }
+    // Mobile action bar mirrors desktop process buttons
+    if (this.dom.mobileProcessBtn)   this.dom.mobileProcessBtn.addEventListener('click', () => this.runPipeline());
+    if (this.dom.mobileReprocessBtn) this.dom.mobileReprocessBtn.addEventListener('click', () => this.runPipeline());
+    if (this.dom.mobileStopBtn)      this.dom.mobileStopBtn.addEventListener('click', () => { this.abortFlag = true; });
+    // Mobile stats toggle
+    if (this.dom.statsToggle && this.dom.hdrStats) {
+      this.dom.statsToggle.addEventListener('click', () => {
+        const expanded = this.dom.hdrStats.classList.toggle('expanded');
+        this.dom.statsToggle.setAttribute('aria-expanded', String(expanded));
+        this.dom.statsToggle.textContent = expanded ? '▲' : '▼';
+      });
+    }
     window.addEventListener('resize', () => this.onResize());
   }
 
@@ -382,6 +404,9 @@ class VoiceIsolatePro {
     const ve = document.getElementById(id + 'Val');
     if (ve) ve.textContent = v + unit;
     el.setAttribute('aria-valuenow', v);
+    // Update filled-track CSS variable
+    const pct = ((v - parseFloat(el.min)) / (parseFloat(el.max) - parseFloat(el.min))) * 100;
+    el.style.setProperty('--pct', `${pct.toFixed(1)}%`);
     if (el.classList.contains('realtime') && this.liveChainBuilt) this.updateLiveChain();
   }
 
@@ -444,7 +469,13 @@ class VoiceIsolatePro {
       for (const s of sliders) {
         const el = document.getElementById(s.id);
         const ve = document.getElementById(s.id + 'Val');
-        if (el && this.params[s.id] !== undefined) { el.value = this.params[s.id]; el.setAttribute('aria-valuenow', this.params[s.id]); if (ve) ve.textContent = this.params[s.id] + s.unit; }
+        if (el && this.params[s.id] !== undefined) {
+          el.value = this.params[s.id];
+          el.setAttribute('aria-valuenow', this.params[s.id]);
+          if (ve) ve.textContent = this.params[s.id] + s.unit;
+          const pct = ((this.params[s.id] - s.min) / (s.max - s.min)) * 100;
+          el.style.setProperty('--pct', `${pct.toFixed(1)}%`);
+        }
       }
     }
     document.querySelectorAll('.btn-preset').forEach(b => b.classList.toggle('active', b.dataset.preset === name));
@@ -576,6 +607,7 @@ class VoiceIsolatePro {
     const dur = this.fmtDur(buf.duration);
     this.dom.fileInfo.textContent = (name || 'Recording') + ' (' + dur + ')';
     this.dom.processBtn.disabled = false;
+    if (this.dom.mobileProcessBtn) this.dom.mobileProcessBtn.disabled = false;
     this.dom.saveOrigBtn.disabled = false;
     this.dom.reprocessBtn.disabled = true;
     this.dom.saveProcBtn.disabled = true;
@@ -839,6 +871,9 @@ class VoiceIsolatePro {
     if (!this.inputBuffer || this.isProcessing) return;
     this.isProcessing = true; this.abortFlag = false;
     this.dom.processBtn.style.display = 'none'; this.dom.stopProcBtn.style.display = 'inline-flex';
+    if (this.dom.mobileProcessBtn)   this.dom.mobileProcessBtn.style.display = 'none';
+    if (this.dom.mobileReprocessBtn) this.dom.mobileReprocessBtn.style.display = 'none';
+    if (this.dom.mobileStopBtn)      this.dom.mobileStopBtn.style.display = 'inline-flex';
     this.dom.saveProcBtn.disabled = true; this.dom.tpAB.disabled = true;
     this.setStatus('PROCESSING');
     if (this.forensicMode) { this.forensicLog = []; }
@@ -997,6 +1032,7 @@ class VoiceIsolatePro {
       this.drawWaveform(fin, this.dom.waveProcCanvas, '#22d3ee');
       this.dom.stVoices.textContent = this.estVoices(fin);
       this.dom.saveProcBtn.disabled = false; this.dom.tpAB.disabled = false; this.dom.reprocessBtn.disabled = false;
+      if (this.dom.mobileReprocessBtn) this.dom.mobileReprocessBtn.disabled = false;
       this.dom.tpABLabel.textContent = 'Ready — A/B';
       if (this.dom.fsBtnAB) this.dom.fsBtnAB.disabled = false;
       if (this.dom.auditLogBtn) this.dom.auditLogBtn.disabled = !this.forensicMode || this.forensicLog.length === 0;
@@ -1006,6 +1042,9 @@ class VoiceIsolatePro {
       else { structuredLog('error', 'Pipeline error', { error: e instanceof Error ? e.message : String(e) }); this.setStatus('ERROR'); this.dom.pipeDetail.textContent=e instanceof Error ? e.message : String(e); }
     } finally {
       this.isProcessing=false; this.dom.processBtn.style.display='inline-flex'; this.dom.stopProcBtn.style.display='none';
+      if (this.dom.mobileProcessBtn)   { this.dom.mobileProcessBtn.style.display='inline-flex'; }
+      if (this.dom.mobileReprocessBtn) { this.dom.mobileReprocessBtn.style.display='inline-flex'; this.dom.mobileReprocessBtn.disabled=false; }
+      if (this.dom.mobileStopBtn)      this.dom.mobileStopBtn.style.display='none';
     }
   }
 

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -1044,7 +1044,7 @@ class VoiceIsolatePro {
     } finally {
       this.isProcessing=false; this.dom.processBtn.style.display='inline-flex'; this.dom.stopProcBtn.style.display='none';
       if (this.dom.mobileProcessBtn)   { this.dom.mobileProcessBtn.style.display='inline-flex'; }
-      if (this.dom.mobileReprocessBtn) { this.dom.mobileReprocessBtn.style.display='inline-flex'; this.dom.mobileReprocessBtn.disabled=false; }
+      if (this.dom.mobileReprocessBtn) { this.dom.mobileReprocessBtn.style.display='inline-flex'; }
       if (this.dom.mobileStopBtn)      this.dom.mobileStopBtn.style.display='none';
     }
   }

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -608,6 +608,7 @@ class VoiceIsolatePro {
     this.dom.fileInfo.textContent = (name || 'Recording') + ' (' + dur + ')';
     this.dom.processBtn.disabled = false;
     if (this.dom.mobileProcessBtn) this.dom.mobileProcessBtn.disabled = false;
+    if (this.dom.mobileReprocessBtn) this.dom.mobileReprocessBtn.disabled = true;
     this.dom.saveOrigBtn.disabled = false;
     this.dom.reprocessBtn.disabled = true;
     this.dom.saveProcBtn.disabled = true;

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -36,7 +36,9 @@
         <span class="hdr-badge">ENGINEER MODE</span>
       </div>
     </div>
-    <div class="hdr-stats">
+    <!-- Mobile stats toggle (visible only on small screens via CSS) -->
+    <button class="hdr-stats-toggle" id="statsToggle" aria-label="Toggle stats" aria-expanded="false">&#9660;</button>
+    <div class="hdr-stats" id="hdrStats">
       <div class="hdr-stat"><span class="hs-val" id="hSNR">-- dB</span><span class="hs-lbl">SNR Gain</span></div>
       <div class="hdr-stat"><span class="hs-val" id="hDur">--</span><span class="hs-lbl">Duration</span></div>
       <div class="hdr-stat"><span class="hs-val" id="hSR">--</span><span class="hs-lbl">Sample Rate</span></div>
@@ -446,6 +448,16 @@
     <span>VoiceIsolate Pro v21.0 · Threads from Space v10 · Hybrid ML+DSP · 32-Stage Octa-Pass · Mobile-Ready</span>
     <span>100% Local Processing · Zero Data Transmission · Privacy First</span>
   </footer>
+
+  <!-- Mobile sticky action bar (hidden on desktop via CSS) -->
+  <div class="mobile-action-bar" id="mobileActionBar">
+    <button id="mobileProcessBtn" class="btn btn-primary" disabled>
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><polygon points="5 3 19 12 5 21"/></svg>
+      Process
+    </button>
+    <button id="mobileReprocessBtn" class="btn btn-reprocess" disabled>Re-run</button>
+    <button id="mobileStopBtn" class="btn btn-danger" style="display:none">Abort</button>
+  </div>
 
   <div id="tooltip" class="slider-tooltip"></div>
   <!-- v21 Modular Architecture: TFS v10 + Capacitor Mobile -->

--- a/public/app/mobile.css
+++ b/public/app/mobile.css
@@ -136,7 +136,7 @@ html {
     overflow-x: auto;
     -webkit-overflow-scrolling: touch;
     scrollbar-width: none;
-    flex-wrap: nowrap !important;
+    flex-wrap: nowrap;
     gap: 4px;
     padding-bottom: 2px;
   }

--- a/public/app/mobile.css
+++ b/public/app/mobile.css
@@ -2,6 +2,7 @@
    VoiceIsolate Pro v21.0 — Mobile Styles
    Capacitor Android/iOS native shell support
    Safe area insets, touch targets, gestures
+   Complete mobile UI layout
    ============================================ */
 
 /* ── Safe Area Insets (iPhone notch / Android cutout) ── */
@@ -10,6 +11,10 @@
   --safe-right: env(safe-area-inset-right, 0px);
   --safe-bottom: env(safe-area-inset-bottom, 0px);
   --safe-left: env(safe-area-inset-left, 0px);
+  /* Mobile-specific sizing */
+  --mob-slider-track: 6px;
+  --mob-slider-thumb: 24px;
+  --mob-touch-min: 44px;
 }
 
 /* ── Capacitor Native Shell Overrides ── */
@@ -23,109 +28,17 @@
 }
 
 .capacitor-native .hdr {
-  padding-top: calc(0.75rem + var(--safe-top));
+  padding-top: calc(0.5rem + var(--safe-top));
 }
 
 .capacitor-native .ftr {
-  padding-bottom: calc(1rem + var(--safe-bottom));
+  padding-bottom: calc(0.75rem + var(--safe-bottom));
 }
 
-/* ── Touch Target Minimum Size (WCAG 2.5.5) ── */
-@media (pointer: coarse) {
-  .btn,
-  .tab,
-  .btn-tp,
-  .btn-preset {
-    min-height: 44px;
-    min-width: 44px;
-  }
-
-  /* Larger sliders for touch */
-  input[type="range"] {
-    height: 32px;
-    cursor: pointer;
-  }
-
-  input[type="range"]::-webkit-slider-thumb {
-    width: 24px;
-    height: 24px;
-  }
-
-  input[type="range"]::-moz-range-thumb {
-    width: 24px;
-    height: 24px;
-  }
-}
-
-/* ── Mobile Layout Adjustments ── */
-@media (max-width: 768px) {
-  .main-grid {
-    grid-template-columns: 1fr !important;
-  }
-
-  .col-right {
-    order: -1; /* Show visualizations first on mobile */
-  }
-
-  .hdr-stats {
-    display: none; /* Hide stats bar on small screens */
-  }
-
-  .hdr-stats.expanded {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.5rem;
-  }
-
-  /* Collapsible stats toggle for mobile */
-  .hdr-stats-toggle {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 32px;
-    height: 32px;
-    background: rgba(255, 255, 255, 0.05);
-    border: 1px solid rgba(255, 255, 255, 0.1);
-    border-radius: 6px;
-    cursor: pointer;
-    color: var(--text-muted, #888);
-    font-size: 12px;
-  }
-
-  .tabs {
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
-    scrollbar-width: none;
-    flex-wrap: nowrap !important;
-  }
-
-  .tabs::-webkit-scrollbar {
-    display: none;
-  }
-
-  .presets-row {
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
-    scrollbar-width: none;
-    flex-wrap: nowrap !important;
-    padding-bottom: 4px;
-  }
-
-  .presets-row::-webkit-scrollbar {
-    display: none;
-  }
-
-  .wave-row {
-    grid-template-columns: 1fr !important;
-  }
-
-  .tech-features-grid {
-    grid-template-columns: 1fr !important;
-  }
-
-  .tech-stack-row {
-    flex-wrap: wrap;
-  }
+/* ── Smooth scrolling + font size lock ── */
+html {
+  scroll-behavior: smooth;
+  -webkit-text-size-adjust: 100%;
 }
 
 /* ── Prevent text selection on UI controls ── */
@@ -141,29 +54,382 @@
   -webkit-tap-highlight-color: transparent;
 }
 
-/* ── Smooth scrolling for mobile ── */
-html {
-  scroll-behavior: smooth;
-  -webkit-text-size-adjust: 100%;
-}
-
-/* ── Upload zone touch improvements ── */
 .upload-zone {
   -webkit-tap-highlight-color: transparent;
   touch-action: manipulation;
 }
 
-/* ── Haptic feedback visual cue ── */
+/* ═══════════════════════════════════════════
+   BREAKPOINT: Tablet / phablet  ≤ 960px
+   ═══════════════════════════════════════════ */
+@media (max-width: 960px) {
+  .main-grid {
+    grid-template-columns: 1fr;
+    margin: 6px auto;
+    padding: 0 8px 80px; /* room for mobile action bar */
+  }
+
+  /* Visualisations above controls on tablet */
+  .col-right { order: -1; }
+  .col-left  { order:  1; }
+
+  .wave-row { grid-template-columns: 1fr; }
+  .stats-row { grid-template-columns: repeat(2, 1fr); }
+  .ftr { flex-direction: column; text-align: center; gap: 2px; }
+}
+
+/* ═══════════════════════════════════════════
+   BREAKPOINT: Mobile  ≤ 768px
+   ═══════════════════════════════════════════ */
+@media (max-width: 768px) {
+
+  /* ── Header ── */
+  .hdr {
+    padding: 8px 12px;
+    gap: 8px;
+  }
+  .hdr-left { gap: 8px; }
+  .hdr-icon { width: 30px; height: 30px; border-radius: 6px; }
+  .hdr-title { font-size: 0.95rem; }
+  .hdr-ver   { font-size: 0.65rem; }
+  .hdr-badge { font-size: 0.5rem; padding: 1px 5px; }
+
+  /* Stats collapsed by default, toggled via JS .expanded */
+  .hdr-stats { display: none; width: 100%; }
+  .hdr-stats.expanded {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 4px 8px;
+    padding-top: 6px;
+    border-top: 1px solid rgba(255,255,255,0.06);
+  }
+  .hdr-stat { text-align: center; }
+  .hs-val   { font-size: 0.72rem; }
+  .hs-lbl   { font-size: 0.5rem; }
+
+  /* Stats toggle button (injected by app.js or present in HTML) */
+  .hdr-stats-toggle {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 30px;
+    height: 30px;
+    background: rgba(255,255,255,0.05);
+    border: 1px solid rgba(255,255,255,0.08);
+    border-radius: 6px;
+    cursor: pointer;
+    color: var(--dim);
+    font-size: 14px;
+    -webkit-tap-highlight-color: transparent;
+    flex-shrink: 0;
+  }
+  .hdr-stats-toggle:active { background: rgba(255,255,255,0.1); }
+
+  /* ── Cards ── */
+  .card { padding: 8px; border-radius: 8px; }
+
+  /* ── Upload ── */
+  .upload-zone { padding: 14px 10px; }
+
+  /* ── Tabs ── */
+  .tabs {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+    flex-wrap: nowrap !important;
+    gap: 4px;
+    padding-bottom: 2px;
+  }
+  .tabs::-webkit-scrollbar { display: none; }
+  .tab {
+    padding: 7px 12px;
+    font-size: 0.68rem;
+    border-radius: 8px;
+  }
+
+  /* ── Slider panels ── */
+  .panels {
+    max-height: none;
+    overflow-y: visible;
+    padding: 4px 6px 6px;
+    border-radius: 8px;
+  }
+
+  /* ── Slider rows: 2-row layout on mobile ──
+     Top row: label + value
+     Bottom row: full-width track              */
+  .sr-row {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    grid-template-rows: auto auto;
+    gap: 4px 8px;
+    padding: 9px 8px;
+    border-radius: 8px;
+  }
+  .sr-label {
+    grid-column: 1;
+    grid-row: 1;
+    font-size: 0.72rem;
+    font-weight: 600;
+    color: var(--text);
+    white-space: normal;
+    overflow: visible;
+    text-overflow: unset;
+    line-height: 1.3;
+  }
+  /* Hide the info icon on mobile — tooltip not useful on touch */
+  .sr-info { display: none; }
+
+  .sr-val {
+    grid-column: 2;
+    grid-row: 1;
+    font-size: 0.7rem;
+    padding: 3px 7px;
+    align-self: center;
+    min-width: 52px;
+    text-align: center;
+  }
+  input[type="range"] {
+    grid-column: 1 / -1;
+    grid-row: 2;
+    height: var(--mob-slider-track);
+    border-radius: calc(var(--mob-slider-track) / 2);
+    /* track gradient shape still driven by --pct */
+  }
+  input[type="range"]::-webkit-slider-runnable-track {
+    height: var(--mob-slider-track);
+  }
+  input[type="range"]::-webkit-slider-thumb {
+    width: var(--mob-slider-thumb);
+    height: var(--mob-slider-thumb);
+    margin-top: calc((var(--mob-slider-thumb) / -2) + (var(--mob-slider-track) / 2));
+    border-width: 3px;
+  }
+  input[type="range"]::-moz-range-thumb {
+    width: var(--mob-slider-thumb);
+    height: var(--mob-slider-thumb);
+    border-width: 3px;
+  }
+
+  /* RT badge sizing */
+  .rt-badge { font-size: 0.5rem; padding: 1px 5px; }
+
+  /* ── Presets row ── */
+  .presets-row {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+    flex-wrap: nowrap !important;
+    padding-bottom: 4px;
+    gap: 5px;
+  }
+  .presets-row::-webkit-scrollbar { display: none; }
+  .btn-preset {
+    padding: 6px 11px;
+    font-size: 0.65rem;
+    border-radius: 7px;
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+  .presets-label { flex-shrink: 0; }
+
+  /* Custom preset input area */
+  .custom-preset-actions {
+    flex-shrink: 0;
+    gap: 5px !important;
+  }
+
+  /* ── Action buttons ── */
+  .actions-row {
+    flex-direction: column;
+    gap: 6px;
+  }
+  .actions-row .btn {
+    width: 100%;
+    justify-content: center;
+    font-size: 0.78rem;
+    padding: 11px 14px;
+    border-radius: 9px;
+  }
+  /* Hide abort in actions-row; shown in sticky bar if needed */
+
+  /* ── Pipeline box ── */
+  .pipeline-box { padding: 8px 10px; }
+  .pipe-bar { height: 5px; border-radius: 3px; }
+  .pipe-fill { border-radius: 3px; }
+
+  /* ── Save row ── */
+  .save-row { flex-wrap: wrap; gap: 5px; }
+  .save-row .btn { flex: 1 1 auto; justify-content: center; }
+
+  /* ── Tech card ── */
+  .tech-features-grid { grid-template-columns: 1fr !important; }
+  .tech-stack-row { flex-wrap: wrap; }
+  .tech-pipeline-flow { flex-direction: column; align-items: flex-start; gap: 4px; }
+  .tpf-arrow { transform: rotate(90deg); margin-left: 8px; }
+
+  /* ── Stats row ── */
+  .stats-row { grid-template-columns: repeat(2, 1fr); gap: 5px; }
+
+  /* ── Footer ── */
+  .ftr { flex-direction: column; text-align: center; gap: 2px; font-size: 0.54rem; }
+}
+
+/* ═══════════════════════════════════════════
+   BREAKPOINT: Small phones  ≤ 480px
+   ═══════════════════════════════════════════ */
+@media (max-width: 480px) {
+  .hdr-stats.expanded {
+    grid-template-columns: repeat(3, 1fr);
+  }
+  /* Forensic toggle — move to bottom of stats on tiny screens */
+  .forensic-toggle-wrap {
+    grid-column: 1 / -1;
+    justify-content: center;
+    padding-top: 2px;
+  }
+  .sr-label { font-size: 0.7rem; }
+  .sr-val   { font-size: 0.67rem; min-width: 46px; }
+  .tab      { padding: 6px 10px; font-size: 0.65rem; }
+}
+
+/* ═══════════════════════════════════════════
+   TOUCH INPUT (pointer: coarse)
+   Applies to any touch device regardless of size
+   ═══════════════════════════════════════════ */
 @media (pointer: coarse) {
+  /* WCAG 2.5.5 — 44×44 px minimum touch targets */
+  .btn,
+  .tab,
+  .btn-tp,
+  .btn-preset {
+    min-height: var(--mob-touch-min);
+    min-width: var(--mob-touch-min);
+  }
+
+  /* Slider hit-area — invisible expansion */
+  input[type="range"] {
+    cursor: pointer;
+    padding: 14px 0; /* expands tap area without changing visual height */
+  }
+
+  /* Haptic visual cue on active */
   .btn:active {
-    transform: scale(0.97);
-    transition: transform 0.1s ease;
+    transform: scale(0.96);
+    transition: transform 0.08s ease;
+  }
+
+  /* Tap highlight removed */
+  .btn,
+  .tab,
+  input[type="range"] {
+    -webkit-tap-highlight-color: transparent;
   }
 }
 
-/* ── Status bar color for Android ── */
-@media (display-mode: standalone) {
-  body {
-    background-color: #0a0a0f;
+/* ═══════════════════════════════════════════
+   STICKY MOBILE ACTION BAR
+   Fixed bottom bar with primary action
+   ═══════════════════════════════════════════ */
+@media (max-width: 768px) {
+  .mobile-action-bar {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    z-index: 200;
+    background: rgba(6,6,9,0.97);
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+    border-top: 1px solid rgba(220,38,38,0.15);
+    padding: 8px 12px calc(8px + var(--safe-bottom));
+    display: flex;
+    gap: 8px;
+    align-items: center;
   }
+
+  .mobile-action-bar .btn-primary {
+    flex: 1;
+    justify-content: center;
+    font-size: 0.82rem;
+    padding: 12px 16px;
+    border-radius: 10px;
+  }
+  .mobile-action-bar .btn-reprocess,
+  .mobile-action-bar .btn-danger {
+    flex-shrink: 0;
+    padding: 12px 14px;
+    border-radius: 10px;
+  }
+
+  /* Hide the in-panel actions-row on mobile (moved to sticky bar) */
+  .actions-row { display: none; }
+}
+
+/* ═══════════════════════════════════════════
+   TRANSPORT CONTROLS  — mobile
+   ═══════════════════════════════════════════ */
+@media (max-width: 768px) {
+  .transport-card { padding: 8px; }
+  .transport-row {
+    display: grid;
+    grid-template-columns: repeat(5, auto) 1fr;
+    grid-template-rows: auto auto;
+    gap: 6px;
+    align-items: center;
+  }
+
+  /* Playback buttons row 1 */
+  .btn-tp {
+    padding: 8px;
+    border-radius: 8px;
+  }
+  #tpPlay, #tpPause, #tpStop, #tpRew, #tpFwd { grid-row: 1; }
+
+  /* Time display */
+  .tp-time {
+    grid-row: 1;
+    grid-column: 6;
+    text-align: right;
+    font-size: 0.65rem;
+  }
+
+  /* Seek slider full width row 2 */
+  .tp-seek {
+    grid-row: 2;
+    grid-column: 1 / -1;
+    width: 100%;
+    padding: 14px 0; /* touch area */
+  }
+
+  /* Speed + AB on row 2 — hide or compact */
+  .tp-speed { display: none; }
+  .tp-ab {
+    grid-row: 1;
+    grid-column: 5;
+    display: none; /* show via .transport-row.has-audio .tp-ab if desired */
+  }
+  .tp-ab-label { display: none; }
+}
+
+/* ═══════════════════════════════════════════
+   VISUALIZATIONS — mobile
+   ═══════════════════════════════════════════ */
+@media (max-width: 768px) {
+  .wave-row { grid-template-columns: 1fr !important; gap: 6px; }
+  .spectro3d-container { height: 160px; }
+  .spectro2d { height: 90px; }
+  .wave-cv   { height: 60px; }
+  .freq-cv   { height: 70px; }
+  .fs-wrap   { height: 130px; }
+  .viz-hdr   { flex-direction: column; align-items: flex-start; gap: 4px; }
+  .viz-actions { flex-wrap: wrap; gap: 4px; }
+}
+
+/* ═══════════════════════════════════════════
+   STATUS BAR (standalone/PWA mode)
+   ═══════════════════════════════════════════ */
+@media (display-mode: standalone) {
+  body { background-color: #0a0a0f; }
+  .hdr { padding-top: calc(0.5rem + var(--safe-top)); }
 }

--- a/public/app/style.css
+++ b/public/app/style.css
@@ -98,19 +98,56 @@ body::before{content:'';position:fixed;inset:0;background:linear-gradient(rgba(2
 .panel.active{display:block}
 
 /* ---- SLIDERS ---- */
-.sr{display:grid;grid-template-columns:1fr;gap:0;margin-bottom:2px}
-.sr-row{display:grid;grid-template-columns:130px 1fr 48px;align-items:center;gap:6px;padding:3px 0;border-bottom:1px solid rgba(255,255,255,0.02);position:relative}
-.sr-row:last-child{border-bottom:none}
-.sr-label{font-size:0.68rem;color:var(--text2);cursor:help;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;position:relative}
-.sr-label::after{content:'ⓘ';margin-left:4px;font-size:0.55rem;color:var(--dim);vertical-align:super}
-.sr-val{font-family:var(--fm);font-size:0.65rem;color:var(--red2);text-align:right}
-input[type="range"]{-webkit-appearance:none;appearance:none;width:100%;height:3px;border-radius:2px;background:var(--s4);outline:none}
-input[type="range"]::-webkit-slider-thumb{-webkit-appearance:none;width:12px;height:12px;border-radius:50%;background:var(--red);cursor:pointer;box-shadow:0 0 6px var(--red-glow);transition:transform 0.1s}
-input[type="range"]::-webkit-slider-thumb:hover{transform:scale(1.3);box-shadow:0 0 10px rgba(220,38,38,0.5)}
-input[type="range"]::-moz-range-thumb{width:12px;height:12px;border-radius:50%;background:var(--red);border:none;cursor:pointer}
-input[type="range"].realtime{background:linear-gradient(90deg,rgba(220,38,38,0.15),var(--s4))}
-input[type="range"].realtime::-webkit-slider-thumb{background:var(--cyan);box-shadow:0 0 6px rgba(34,211,238,0.4)}
-.rt-badge{display:inline-block;font-size:0.45rem;padding:0 3px;border-radius:2px;background:rgba(34,211,238,0.1);color:var(--cyan);font-weight:700;vertical-align:middle;margin-left:3px;letter-spacing:0.05em}
+.sr{display:grid;grid-template-columns:1fr;gap:1px;margin-bottom:2px}
+.sr-row{display:grid;grid-template-columns:118px 1fr 58px;align-items:center;gap:8px;padding:5px 6px;border-radius:7px;position:relative;transition:background 0.12s}
+.sr-row:hover{background:rgba(255,255,255,0.024)}
+.sr-label{font-size:0.67rem;font-weight:500;color:var(--text2);cursor:help;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;display:flex;align-items:center;gap:4px;min-width:0}
+.sr-info{display:inline-flex;align-items:center;justify-content:center;width:13px;height:13px;border-radius:50%;font-size:0.48rem;font-weight:700;color:var(--dim);border:1px solid rgba(255,255,255,0.1);flex-shrink:0;line-height:1;font-style:normal;pointer-events:none;margin-left:auto}
+.sr-val{font-family:var(--fm);font-size:0.62rem;font-weight:500;color:var(--red2);text-align:right;background:rgba(220,38,38,0.07);border:1px solid rgba(220,38,38,0.12);border-radius:5px;padding:2px 5px;white-space:nowrap;min-width:0;transition:border-color 0.15s,color 0.15s}
+.sr-row:hover .sr-val{border-color:rgba(220,38,38,0.22)}
+
+/* Track & thumb */
+input[type="range"]{
+  -webkit-appearance:none;appearance:none;
+  width:100%;height:5px;border-radius:3px;
+  background:linear-gradient(to right,var(--red) 0%,var(--red) var(--pct,50%),var(--s4) var(--pct,50%),var(--s4) 100%);
+  outline:none;cursor:pointer;transition:height 0.1s}
+input[type="range"]::-webkit-slider-runnable-track{height:5px;border-radius:3px}
+input[type="range"]::-webkit-slider-thumb{
+  -webkit-appearance:none;width:16px;height:16px;border-radius:50%;
+  background:#fff;border:2.5px solid var(--red);
+  cursor:pointer;margin-top:-5.5px;
+  box-shadow:0 1px 5px rgba(0,0,0,0.45),0 0 0 0 rgba(220,38,38,0);
+  transition:box-shadow 0.15s,transform 0.1s,border-color 0.1s}
+input[type="range"]::-webkit-slider-thumb:hover{
+  transform:scale(1.18);
+  box-shadow:0 2px 8px rgba(0,0,0,0.5),0 0 0 5px rgba(220,38,38,0.15)}
+input[type="range"]:active::-webkit-slider-thumb{
+  transform:scale(1.08);
+  box-shadow:0 2px 12px rgba(0,0,0,0.55),0 0 0 7px rgba(220,38,38,0.2)}
+input[type="range"]::-moz-range-track{height:5px;border-radius:3px;background:var(--s4);border:none}
+input[type="range"]::-moz-range-progress{height:5px;border-radius:3px;background:var(--red)}
+input[type="range"]::-moz-range-thumb{
+  width:16px;height:16px;border-radius:50%;
+  background:#fff;border:2.5px solid var(--red);
+  cursor:pointer;box-shadow:0 1px 5px rgba(0,0,0,0.45)}
+
+/* Realtime sliders — cyan accent */
+input[type="range"].realtime{
+  background:linear-gradient(to right,var(--cyan) 0%,var(--cyan) var(--pct,50%),var(--s4) var(--pct,50%),var(--s4) 100%)}
+input[type="range"].realtime::-webkit-slider-thumb{
+  border-color:var(--cyan);
+  box-shadow:0 1px 5px rgba(0,0,0,0.45),0 0 0 0 rgba(34,211,238,0)}
+input[type="range"].realtime::-webkit-slider-thumb:hover{
+  box-shadow:0 2px 8px rgba(0,0,0,0.5),0 0 0 5px rgba(34,211,238,0.2)}
+input[type="range"].realtime:active::-webkit-slider-thumb{
+  box-shadow:0 2px 12px rgba(0,0,0,0.55),0 0 0 7px rgba(34,211,238,0.25)}
+input[type="range"].realtime::-moz-range-progress{background:var(--cyan)}
+input[type="range"].realtime::-moz-range-thumb{border-color:var(--cyan)}
+.sr-row:hover input[type="range"].realtime + .sr-val{border-color:rgba(34,211,238,0.25);color:var(--cyan)}
+input[type="range"].realtime ~ .sr-val{color:var(--cyan);border-color:rgba(34,211,238,0.12);background:rgba(34,211,238,0.06)}
+
+.rt-badge{display:inline-block;font-size:0.44rem;padding:1px 4px;border-radius:3px;background:rgba(34,211,238,0.12);color:var(--cyan);font-weight:700;vertical-align:middle;margin-left:2px;letter-spacing:0.06em;border:1px solid rgba(34,211,238,0.2)}
 
 /* ---- PRESETS ---- */
 .presets-row{display:flex;align-items:center;gap:4px;margin-bottom:8px;flex-wrap:wrap}
@@ -176,6 +213,9 @@ input[type="range"].realtime::-webkit-slider-thumb{background:var(--cyan);box-sh
 .slider-tooltip.visible{opacity:1}
 
 /* ---- RESPONSIVE ---- */
+/* Stats toggle + mobile bar only visible on mobile (shown in mobile.css) */
+.hdr-stats-toggle{display:none}
+.mobile-action-bar{display:none}
 @media(max-width:960px){
   .main-grid{grid-template-columns:1fr}
   .col-left{order:2}.col-right{order:1}
@@ -270,19 +310,9 @@ input[type="range"].realtime::-webkit-slider-thumb{background:var(--cyan);box-sh
 .fs-xaxis-cv{width:100%;height:20px;display:block}
 
 /* ---- ACCESSIBILITY ---- */
-:focus-visible {
-  outline: 2px solid var(--cyan);
-  outline-offset: 2px;
-}
-input[type="range"]:focus-visible {
-  outline: 2px solid var(--cyan);
-  outline-offset: 4px;
-}
-input[type="range"]:focus-visible::-webkit-slider-thumb {
-  outline: 2px solid var(--cyan);
-  outline-offset: 2px;
-}
-input[type="range"]:focus-visible::-moz-range-thumb {
-  outline: 2px solid var(--cyan);
-  outline-offset: 2px;
-}
+:focus-visible{outline:2px solid var(--cyan);outline-offset:2px}
+input[type="range"]:focus-visible{outline:none}
+input[type="range"]:focus-visible::-webkit-slider-thumb{
+  box-shadow:0 0 0 3px var(--bg),0 0 0 5px var(--cyan),0 2px 8px rgba(0,0,0,0.5)}
+input[type="range"]:focus-visible::-moz-range-thumb{
+  box-shadow:0 0 0 3px var(--bg),0 0 0 5px var(--cyan)}

--- a/public/app/style.css
+++ b/public/app/style.css
@@ -107,43 +107,43 @@ body::before{content:'';position:fixed;inset:0;background:linear-gradient(rgba(2
 .sr-row:hover .sr-val{border-color:rgba(220,38,38,0.22)}
 
 /* Track & thumb */
-input[type="range"]{
+.sr-row > input[type="range"]{
   -webkit-appearance:none;appearance:none;
   width:100%;height:5px;border-radius:3px;
   background:linear-gradient(to right,var(--red) 0%,var(--red) var(--pct,50%),var(--s4) var(--pct,50%),var(--s4) 100%);
   outline:none;cursor:pointer;transition:height 0.1s}
-input[type="range"]::-webkit-slider-runnable-track{height:5px;border-radius:3px}
-input[type="range"]::-webkit-slider-thumb{
+.sr-row > input[type="range"]::-webkit-slider-runnable-track{height:5px;border-radius:3px}
+.sr-row > input[type="range"]::-webkit-slider-thumb{
   -webkit-appearance:none;width:16px;height:16px;border-radius:50%;
   background:#fff;border:2.5px solid var(--red);
   cursor:pointer;margin-top:-5.5px;
   box-shadow:0 1px 5px rgba(0,0,0,0.45),0 0 0 0 rgba(220,38,38,0);
   transition:box-shadow 0.15s,transform 0.1s,border-color 0.1s}
-input[type="range"]::-webkit-slider-thumb:hover{
+.sr-row > input[type="range"]::-webkit-slider-thumb:hover{
   transform:scale(1.18);
   box-shadow:0 2px 8px rgba(0,0,0,0.5),0 0 0 5px rgba(220,38,38,0.15)}
-input[type="range"]:active::-webkit-slider-thumb{
+.sr-row > input[type="range"]:active::-webkit-slider-thumb{
   transform:scale(1.08);
   box-shadow:0 2px 12px rgba(0,0,0,0.55),0 0 0 7px rgba(220,38,38,0.2)}
-input[type="range"]::-moz-range-track{height:5px;border-radius:3px;background:var(--s4);border:none}
-input[type="range"]::-moz-range-progress{height:5px;border-radius:3px;background:var(--red)}
-input[type="range"]::-moz-range-thumb{
+.sr-row > input[type="range"]::-moz-range-track{height:5px;border-radius:3px;background:var(--s4);border:none}
+.sr-row > input[type="range"]::-moz-range-progress{height:5px;border-radius:3px;background:var(--red)}
+.sr-row > input[type="range"]::-moz-range-thumb{
   width:16px;height:16px;border-radius:50%;
   background:#fff;border:2.5px solid var(--red);
   cursor:pointer;box-shadow:0 1px 5px rgba(0,0,0,0.45)}
 
 /* Realtime sliders — cyan accent */
-input[type="range"].realtime{
+.sr-row > input[type="range"].realtime{
   background:linear-gradient(to right,var(--cyan) 0%,var(--cyan) var(--pct,50%),var(--s4) var(--pct,50%),var(--s4) 100%)}
-input[type="range"].realtime::-webkit-slider-thumb{
+.sr-row > input[type="range"].realtime::-webkit-slider-thumb{
   border-color:var(--cyan);
   box-shadow:0 1px 5px rgba(0,0,0,0.45),0 0 0 0 rgba(34,211,238,0)}
-input[type="range"].realtime::-webkit-slider-thumb:hover{
+.sr-row > input[type="range"].realtime::-webkit-slider-thumb:hover{
   box-shadow:0 2px 8px rgba(0,0,0,0.5),0 0 0 5px rgba(34,211,238,0.2)}
-input[type="range"].realtime:active::-webkit-slider-thumb{
+.sr-row > input[type="range"].realtime:active::-webkit-slider-thumb{
   box-shadow:0 2px 12px rgba(0,0,0,0.55),0 0 0 7px rgba(34,211,238,0.25)}
-input[type="range"].realtime::-moz-range-progress{background:var(--cyan)}
-input[type="range"].realtime::-moz-range-thumb{border-color:var(--cyan)}
+.sr-row > input[type="range"].realtime::-moz-range-progress{background:var(--cyan)}
+.sr-row > input[type="range"].realtime::-moz-range-thumb{border-color:var(--cyan)}
 .sr-row:hover input[type="range"].realtime + .sr-val{border-color:rgba(34,211,238,0.25);color:var(--cyan)}
 input[type="range"].realtime ~ .sr-val{color:var(--cyan);border-color:rgba(34,211,238,0.12);background:rgba(34,211,238,0.06)}
 


### PR DESCRIPTION
Sliders (style.css + app.js):
- Filled track via CSS custom property --pct (updated live on input/preset)
- Track height 3px → 5px, rounded ends, gradient fill (red / cyan for RT)
- Thumb redesigned: white disc with 2.5px colored border, ring-shadow hover/focus/active states
- Slider rows get subtle hover background, gap and padding increased for better ergonomics
- sr-val chip styled as a pill badge; cyan tint for realtime sliders
- Accessible focus ring uses double box-shadow (bg ring + cyan ring) instead of outline
- Info icon rendered as inline <span class="sr-info"> per slider label
- applyPreset() now syncs --pct on all sliders

Mobile layout (mobile.css + index.html + app.js):
- Slider rows switch to 2-row layout on ≤768px (label+value on top, full-width track below)
- Touch target padding on range inputs for easy dragging
- Sticky mobile action bar (Process / Re-run / Abort) fixed to bottom of screen
- Desktop actions-row hidden on mobile; mobile bar mirrors enable/disable state from app.js
- Collapsible header stats with ▼/▲ toggle button (hdr-stats-toggle)
- Transport controls grid layout optimised for narrow screens
- Visualisation canvas heights tuned for mobile viewports
- Breakpoints: 960px (tablet), 768px (mobile), 480px (small phone)
- Capacitor safe-area insets and display-mode:standalone rules preserved

https://claude.ai/code/session_018FrM13STCeNt2sq9SKnjPW
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/joker5514/voiceisolate-pro/pull/225" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mobile sticky action bar with Process, Re-run and Stop controls.
  * Collapsible header stats toggle for mobile.

* **UI/UX Improvements**
  * Sliders show a dynamic filled track and an info icon; visuals stay in sync after presets and programmatic changes.
  * Major mobile/tablet layout overhaul with larger touch targets, improved spacing, and refined focus/hover feedback.

* **Bug Fixes**
  * Mobile pipeline controls now mirror desktop state for start/stop/reprocess flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->