### PR TITLE
fix: improve DSP audio quality — spectral subtraction, harmonic phase, noise floor, peak norm

### DIFF
--- a/public/app/app.js
+++ b/public/app/app.js
@@ -1494,9 +1494,9 @@ class VoiceIsolatePro {
       }
     }
 
-    if (peak === 0) return buf;
+    if (peak < 1e-8) return buf; // avoid huge gain on near-silence
 
-    const gain = Math.pow(10, tDb / 20) / peak;
+    const gain = Math.min(Math.pow(10, tDb / 20) / peak, 1e6);
     for (let ch = 0; ch < numChannels; ch++) {
       const inputData = buf.getChannelData(ch);
       const outputData = out.getChannelData(ch);

--- a/public/app/dsp-core.js
+++ b/public/app/dsp-core.js
@@ -367,7 +367,7 @@ const DSPCore = {
   /** S15: Wiener-MMSE spectral noise subtraction */
   wienerMMSE(mag, noiseProfile, amount) {
     const alpha = amount / 100;
-    const floor = 0.01; // spectral floor
+    const floor = 0.001; // spectral floor (~-60 dB, consistent with dsp-processor default)
     for (let f = 0; f < mag.length; f++) {
       for (let k = 0; k < mag[f].length; k++) {
         const noise = noiseProfile ? (noiseProfile[k] || 0) : 0;

--- a/public/app/dsp-processor.js
+++ b/public/app/dsp-processor.js
@@ -514,7 +514,7 @@ class DspProcessor extends AudioWorkletProcessor {
 
       // ── Spectral subtraction blend: higher subStrength → more aggressive
       //    Blends Log-MMSE with harder spectral subtraction gain
-      const subGain = Math.max(1 - (noiseScaled / (power + 1e-20)), specFloor);
+      const subGain = Math.max(1 - Math.sqrt(noiseScaled / (power + 1e-20)), specFloor);
       gain = (1 - subStrength) * gain + subStrength * Math.min(gain, subGain);
 
       // ── Apply user-controlled amount (blend between unity and full NR)
@@ -812,7 +812,11 @@ class DspProcessor extends AudioWorkletProcessor {
         const harmonicMag = mag[k] * recov / (h * h);
         if (harmonicMag > mag[hk]) {
           mag[hk] = harmonicMag;
-          phase[hk] = phase[k] * h; // phase-locked
+          // Wrap harmonic phase to [-π, π] to avoid discontinuities
+          const TWO_PI = 6.283185307179586;
+          let hp = phase[k] * h;
+          hp -= TWO_PI * Math.round(hp / TWO_PI);
+          phase[hk] = hp;
         }
       }
     }


### PR DESCRIPTION
- dsp-processor.js: Use sqrt(noise/signal) in spectral subtraction gain so
  attenuation is applied in the magnitude domain (not power), preventing
  over-aggressive noise removal at low SNR.

- dsp-processor.js: Wrap harmonic recovery phase (phase[k] * h) to [-π, π]
  to avoid phase discontinuities in synthesized harmonics.

- dsp-core.js: Lower wienerMMSE spectral floor from 0.01 (-40 dB) to 0.001
  (-60 dB), matching the real-time processor default and avoiding residual
  noise bleed in the offline pipeline.

- app.js: Guard peakNorm against near-silent buffers (peak < 1e-8) and clamp
  maximum gain to 1e6 to prevent arithmetic overflow on silent/near-silent input.

https://claude.ai/code/session_01DbShrNYpHfEYbEu1e39cv6
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/joker5514/voiceisolate-pro/pull/261" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved silence detection to prevent normalization on nearly-silent audio.
  * Added gain limiting to prevent distortion during signal processing.
  * Enhanced noise reduction effectiveness with adjusted subtraction parameters.
  * Reduced phase discontinuities in harmonic recovery to minimize audio artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->