### PR TITLE
docs: update README to v22.1.0 with accurate content

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Single forward STFT → all spectral ops in-place → single inverse STFT. No ph
 | BS-RoFormer | Ensemble separation | ~30 MB | Studio+ |
 | ECAPA-TDNN | Speaker embeddings (256-dim) | ~2–3 MB | Pro+ |
 | HiFi-GAN v2 | Neural vocoder | ~4 MB | Studio+ |
-| Conformer-S | Residual artifact cleanup | ~8 MB | Forensic+ |
+| Conformer-S | Residual artifact cleanup | ~8 MB | Enterprise |
 
 The classical DSP pipeline (passes 1–10 above) operates independently without ML for lightweight deployments. All models are optional and lazily downloaded on first use.
 

--- a/README.md
+++ b/README.md
@@ -3,41 +3,41 @@
 [![CI](https://github.com/Joker5514/VoiceIsolate-Pro/actions/workflows/ci.yml/badge.svg)](https://github.com/Joker5514/VoiceIsolate-Pro/actions/workflows/ci.yml)
 [![Android Build](https://github.com/Joker5514/VoiceIsolate-Pro/actions/workflows/android-build.yml/badge.svg)](https://github.com/Joker5514/VoiceIsolate-Pro/actions/workflows/android-build.yml)
 [![Deploy](https://github.com/Joker5514/VoiceIsolate-Pro/actions/workflows/deploy.yml/badge.svg)](https://github.com/Joker5514/VoiceIsolate-Pro/actions/workflows/deploy.yml)
-![Version](https://img.shields.io/badge/version-22.0.0-blue)
+![Version](https://img.shields.io/badge/version-22.1.0-blue)
 ![License](https://img.shields.io/badge/license-All%20Rights%20Reserved-red)
 ![Platform](https://img.shields.io/badge/platform-browser%20%7C%20android%20%7C%20ios-lightgrey)
 ![Privacy](https://img.shields.io/badge/privacy-100%25%20local-brightgreen)
 
-> **Studio-grade voice isolation and audio enhancement — 100% local, zero cloud inference. Now with Monetization, AI Engine v2, and Cloud Sync.**
-> **v22.0** — Studio-grade voice isolation powered by real STFT spectral processing, adaptive Wiener filtering, and a 35-stage deca-pass DSP pipeline. 100% browser-native. Zero cloud egress.
+> **Studio-grade voice isolation and audio enhancement — 100% local, zero cloud inference.**
+> **v22.1** — Powered by real STFT spectral processing, adaptive Wiener filtering, and a 35-stage deca-pass DSP pipeline. Fully browser-native. Zero cloud egress.
 
 ---
 
 ## Overview
 
-VoiceIsolate Pro is a production-grade audio processing platform that isolates voices from any audio or video source — music, crowd noise, HVAC, reverb, hum — using real spectral math, not toy filters. Built on the **Threads from Space v11** architecture: a multi-threaded, GPU-acceleratable DSP engine running entirely in the browser via Web Audio API, AudioWorklet, and ONNX Runtime Web.
+VoiceIsolate Pro is a production-grade, privacy-first audio processing platform that isolates voices from any audio or video source — music, crowd noise, HVAC, reverb, hum — using real spectral math, not toy filters. Built on the **Threads from Space v11** architecture: a multi-threaded, GPU-acceleratable DSP engine running entirely in the browser via Web Audio API, AudioWorklet, and ONNX Runtime Web.
 
-**Live:** Deployed via Vercel auto-deploy on push to `main`.
+**Live:** Auto-deployed to Vercel on push to `main`.
 
 ---
 
-- **Resume Playback**: Pause and resume from exactly where you left off — no restart needed.
-- **Original/Processed Toggle**: Visual toggle switch in the transport bar to instantly switch between original and processed audio, synced with the spectrogram view.
-- **Improved Presets**: All 9 presets (Podcast, Film, Interview, Forensic, Music, Broadcast, Restoration, Whisper, Crystal Voice) have been professionally retuned for better results out of the box.
-- **Spectrogram Sync**: A/B toggle in transport, spectrogram, and source toggle are all bidirectionally synced.
-- **File Uploads Fixed**: Solved strict MIME type validation bugs that previously prevented common audio/video types (like MP3s and MKVs) from uploading correctly.
-- **Engineer Mode Refined**: Removed the clunky "How It Works" card from the main app interface to streamline the mobile UI and save space.
-- **CI/CD Fixes**: Deploy workflow now triggers on pull requests, CSP hardened (removed `wasm-unsafe-eval`, added `cdnjs.cloudflare.com`).
-## Current Version: v22.0.0 — Monetization & AI Engine v2 Upgrade
+## What's New in v22.1.0
 
-**Version 22** introduces a comprehensive monetization architecture and major AI upgrades:
+- **Resume Playback** — Pause and resume from exactly where you left off. No restart needed.
+- **A/B Toggle** — Instantly switch between original and processed audio in the transport bar, synced with the spectrogram view.
+- **Improved Presets** — All 9 presets professionally retuned for better out-of-the-box results.
+- **Spectrogram Sync** — A/B toggle, spectrogram, and source selector are bidirectionally synced.
+- **File Upload Fixes** — Resolved strict MIME type validation bugs blocking MP3, MKV, and other common formats.
+- **UI Streamlined** — Removed the "How It Works" card from the main interface to clean up the mobile layout.
+- **CI/CD Hardened** — Deploy workflow now triggers on pull requests; CSP tightened (removed `wasm-unsafe-eval`, added `cdnjs.cloudflare.com`).
+- **Monetization System** — Freemium tiers (Free / Pro / Studio / Enterprise) with offline JWT licensing, Stripe, and RevenueCat IAP.
+- **AI Engine v2** — Voice fingerprinting, gradient-descent auto-tune, per-speaker noise profile library, multi-speaker detection.
+- **Batch Processing** — Concurrent multi-file queue with ZIP export (Studio+ tier).
+- **Cloud Sync** — Cross-device preset and profile sync via REST API (Studio+ tier).
+- **Privacy-First Analytics** — Local-only usage tracking by default; server reporting is strictly opt-in and never includes audio data.
 
-- **Freemium Monetization System**: Free, Pro ($12/mo), Studio ($29/mo), and Enterprise tiers.
-- **Paywall & Licensing**: Secure offline JWT license validation, feature gating, and Stripe/RevenueCat integration.
-- **AI Engine v2**: Voice fingerprinting, advanced auto-tune via gradient descent, noise profile library, and multi-speaker detection.
-- **Batch Processing**: Process multiple files concurrently with ZIP export (Studio/Enterprise feature).
-- **Cloud Sync**: Sync presets, noise profiles, and history across devices (Studio/Enterprise feature).
-- **Privacy-First Analytics**: Local-only usage tracking by default. Server reporting is strictly opt-in and never includes audio data or content.
+---
+
 ## Architecture
 
 ```
@@ -45,7 +45,7 @@ Threads from Space v11 — Browser-Native DSP Engine
 
 ┌─ Main Thread ──────────────────────────────────────────┐
 │  UI · Transport · Sliders · 3D Spectrogram (Three.js)  │
-└────────────┬───────────────────────────────────────────-┘
+└────────────┬───────────────────────────────────────────┘
              │ SharedArrayBuffer / MessageChannel
 ┌────────────┴───────────────────────────────────────────┐
 │  AudioWorklet (RT)    │  DSP Workers (CPU-0..N)        │
@@ -54,7 +54,7 @@ Threads from Space v11 — Browser-Native DSP Engine
 ├───────────────────────┼────────────────────────────────┤
 │  ML Workers (GPU-0..N)│  Batch Orchestrator            │
 │  ONNX Runtime Web     │  Priority queue · Progress     │
-│  Demucs · BSRoFormer  │  1-1000+ files concurrent      │
+│  Demucs · BSRoFormer  │  1–1000+ files concurrent      │
 └───────────────────────┴────────────────────────────────┘
 ```
 
@@ -62,34 +62,27 @@ Threads from Space v11 — Browser-Native DSP Engine
 
 | File | Purpose |
 |------|---------|
-| `index.html` | Root app shell — 52-slider engineer panel, 6-panel diagnostics, 3D spectrogram |
-| `app.js` | Main application — 35-stage pipeline, transport, visualizations, presets |
-| `dsp-core.js` | Pure DSP math — STFT/iSTFT, biquad filters, adaptive Wiener, ERB gate, VAD, harmonic v2, deverb, temporal smoothing, noise classifier |
-| `dsp-worker.js` | Web Worker wrapper for DSPCore offload |
-| `ml-worker.js` | ONNX Runtime Web inference (Demucs, BSRoFormer, ECAPA-TDNN, Silero VAD) |
-| `pipeline-orchestrator.js` | DAG-based pipeline execution, stage dependencies, error propagation |
-| `pipeline-state.js` | Shared state management across pipeline stages |
-| `ring-buffer.js` | Lock-free SharedArrayBuffer ring buffer for AudioWorklet ↔ Worker exchange |
-| `batch-orchestrator.js` | Multi-file batch processing with priority queue |
-| `voice-isolate-processor.js` | AudioWorklet processor for real-time path |
-| `style.css` | Dark engineer UI theme |
-| `vercel.json` | COOP/COEP/CSP headers for SharedArrayBuffer support |
+| `public/app/index.html` | App shell — 52-slider engineer panel, 6-panel diagnostics, 3D spectrogram |
+| `public/app/app.js` | Main application — pipeline wiring, transport, visualizations, presets (2121 lines) |
+| `public/app/dsp-core.js` | Pure DSP math — STFT/iSTFT, biquad filters, adaptive Wiener, ERB gate, harmonic v2, deverb (1373 lines) |
+| `public/app/dsp-worker.js` | Web Worker wrapper for DSPCore offload (504 lines) |
+| `public/app/dsp-processor.js` | AudioWorklet processor for real-time streaming < 10ms (1013 lines) |
+| `public/app/ml-worker.js` | ONNX Runtime Web inference — Demucs, BSRoFormer, ECAPA-TDNN, Silero VAD (697 lines) |
+| `public/app/pipeline-orchestrator.js` | DAG-based pipeline execution, stage dependencies, error propagation |
+| `public/app/pipeline-state.js` | Centralized reactive state for all pipeline parameters |
+| `public/app/ring-buffer.js` | Lock-free SharedArrayBuffer ring buffer for AudioWorklet ↔ Worker exchange |
+| `public/app/ai-engine-v2.js` | Voice fingerprinting, gradient-descent auto-tune, multi-speaker detection |
+| `public/app/batch-orchestrator.js` | Multi-file batch processing with priority queue and ZIP export |
+| `public/app/license-manager.js` | Offline JWT license validation and tier enforcement |
+| `public/app/paywall.js` | Feature gating and Stripe/RevenueCat integration |
+| `public/app/cloud-sync.js` | Cross-device preset and profile synchronization via REST API |
+| `vercel.json` | COOP/COEP/CSP headers required for SharedArrayBuffer |
 
 ---
 
 ## 35-Stage Deca-Pass Pipeline
 
-| Feature | Detail |
-|---------|--------|
-| **36-stage Deca-Pass DSP** | 10 passes × 4 stages: Ingest → Analysis → Filter → Spectral NR → EQ → Spectral Processing → Dynamics → Master → Export |
-| **AI Engine v2** | Voice fingerprinting, noise profile library, adaptive spectral masking, and PESQ-inspired quality estimation |
-| **Monetization Tiers** | Flexible pricing with feature gates, usage quotas, and trial support |
-| **Batch Processing** | Concurrent processing queue with progress tracking and ZIP export |
-| **Cloud Sync** | Cross-device synchronization of presets and profiles via REST API |
-| **Mobile Native** | Runs as a native app on Android and iOS using Capacitor, with RevenueCat IAP support |
-| **Hybrid ML + Classical** | Demucs v4.1, BSRNN, DeepFilterNet3 working alongside Wiener filtering and spectral subtraction |
-| **100% Local Processing** | Audio never leaves your device. No server uploads. No cloud inference. |
-The core processing engine. Single forward STFT → all spectral ops in-place → single inverse STFT. No phase smearing.
+Single forward STFT → all spectral ops in-place → single inverse STFT. No phase smearing.
 
 | Pass | Stages | Operations |
 |------|--------|------------|
@@ -110,7 +103,7 @@ The core processing engine. Single forward STFT → all spectral ops in-place �
 
 - **Adaptive Wiener Filter** — Martin 2001 minimum statistics noise estimation with VAD-gated profiling, per-bin Speech Presence Probability weighting
 - **32-Band ERB Spectral Gate** — Psychoacoustic Equivalent Rectangular Bandwidth bands, per-band SNR-adaptive thresholds
-- **Temporal Smoothing** — Cross-frame gain smoothing eliminates musical noise / garbled artifacts
+- **Temporal Smoothing** — Cross-frame gain smoothing eliminates musical noise and garbled artifacts
 - **Dereverberation** — Late reflection estimation via exponential decay model, spectral subtraction
 - **Harmonic Enhancement v2** — Spectral Band Replication above 8kHz, formant F1/F2 detection and protection, breathiness control via spectral flatness
 - **Cascaded Notch Hum Removal** — 60Hz + 5 harmonics at Q=35
@@ -121,31 +114,31 @@ The core processing engine. Single forward STFT → all spectral ops in-place �
 
 ---
 
-## ML Models (Roadmap / Lazy-Loaded)
+## ML Models (Lazy-Loaded via ONNX Runtime Web)
 
-| Model | Task | Size (ONNX INT8) | Status |
-|-------|------|-------------------|--------|
-| Demucs v4.1 | Primary source separation | ~150 MB | Planned (Studio tier) |
-| BS-RoFormer | Ensemble separation | ~30 MB | Planned (Studio tier) |
-| ECAPA-TDNN | Speaker embeddings (192-dim) | ~2-3 MB | Planned (Pro tier) |
-| Silero VAD v5 | Voice activity detection | ~350 KB | Planned (Pro tier) |
-| HiFi-GAN v2 | Neural vocoder | ~4 MB | Planned (Studio tier) |
-| Conformer-S | Residual artifact cleanup | ~8 MB | Planned (Forensic tier) |
+| Model | Task | Size (ONNX INT8) | Tier |
+|-------|------|-------------------|------|
+| Silero VAD v5 | Voice activity detection | ~350 KB | Pro+ |
+| DeepFilterNet3 | Speech denoising + dereverberation | ~35 MB | Studio+ |
+| Demucs v4.1 | Primary source separation | ~150 MB | Studio+ |
+| BS-RoFormer | Ensemble separation | ~30 MB | Studio+ |
+| ECAPA-TDNN | Speaker embeddings (256-dim) | ~2–3 MB | Pro+ |
+| HiFi-GAN v2 | Neural vocoder | ~4 MB | Studio+ |
+| Conformer-S | Residual artifact cleanup | ~8 MB | Forensic+ |
 
-Classical DSP pipeline operates independently without ML for lightweight deployments.
+The classical DSP pipeline (passes 1–10 above) operates independently without ML for lightweight deployments. All models are optional and lazily downloaded on first use.
 
 ---
 
 ## UI Features
 
-- **52 Sliders** across 8 tabbed panels (Gate, Noise, EQ, Dynamics, Spectral, Advanced, Separation, Output)
-- **9 Presets** — Podcast, Film, Interview, Forensic, Music, Broadcast, Restoration, Whisper, Crystal Voice + custom save
-- **6-Panel Diagnostic Dashboard** — A/B waveform, oscilloscope (wave/mirror/XY), spectrogram with noise/ERB/ML overlays, LUFS meter, ML saliency heatmap, speaker PCA cluster
+- **52 Sliders** across 8 tabbed panels (Gate, Noise Reduction, EQ, Dynamics, Spectral, Advanced, Separation, Output)
+- **9 Presets** — Podcast, Film, Interview, Forensic, Music, Broadcast, Restoration, Whisper, Crystal Voice + custom save/load
+- **6-Panel Diagnostic Dashboard** — A/B waveform comparison, oscilloscope (wave/mirror/XY), spectrogram with noise/ERB/ML overlays, LUFS meter, ML saliency heatmap, speaker PCA cluster
 - **3D Spectrogram** — Three.js rendered, drag-to-orbit, scroll-to-zoom, click-band-to-mute
-- **2D Real-Time Spectrogram** — Scrolling frequency analysis
-- **Full Transport** — Play/pause/stop, seek, speed control (0.25x–2x), A/B toggle
+- **Full Transport** — Play/pause/stop, seek bar, speed control (0.25x–2x), A/B original/processed toggle
 - **Video Support** — MP4/MOV/WEBM with synced processed audio playback
-- **Recording** — Direct microphone capture with real-time visualization
+- **Live Recording** — Direct microphone capture with real-time visualization
 
 ---
 
@@ -153,7 +146,7 @@ Classical DSP pipeline operates independently without ML for lightweight deploym
 
 | Preset | Use Case | Key Settings |
 |--------|----------|-------------|
-| Podcast | Spoken word content | NR 60%, voice focus, presence boost, -16 LUFS |
+| Podcast | Spoken word content | NR 60%, voice focus, presence boost, –16 LUFS |
 | Film | Dialogue preservation | Light NR, room tone kept, natural dynamics |
 | Interview | Multi-speaker | Crosstalk cancel, balanced NR, mono focus |
 | Forensic | Evidence-grade | Minimal destructive processing, max clarity boost |
@@ -165,19 +158,56 @@ Classical DSP pipeline operates independently without ML for lightweight deploym
 
 ---
 
+## Monetization Tiers
+
+| Tier | Price | Features |
+|------|-------|----------|
+| **Free** | $0 | Classical DSP pipeline, 5-min processing limit, watermarked exports |
+| **Pro** | $12/mo | Full 35-stage pipeline, ML models (VAD, ECAPA-TDNN), unlimited duration, no watermark |
+| **Studio** | $29/mo | Pro + batch processing (up to 1000 files), Cloud Sync, ZIP export, API access |
+| **Enterprise** | $199/mo | White-label, custom models, SLA, dedicated support |
+
+Licensing uses offline JWT validation — no network call required to gate features. Mobile purchases handled via RevenueCat (iOS/Android).
+
+---
+
 ## Privacy & Security
 
 - **100% Local Processing** — All audio stays in the browser. Zero network requests during processing.
-- **Zero Audio Telemetry** — No audio data, content, or fingerprints are ever transmitted. Usage analytics (e.g., session counts) are local-only by default; server reporting requires explicit opt-in.
+- **Zero Audio Telemetry** — No audio data, content, or fingerprints are ever transmitted. Usage analytics are local-only by default; server reporting requires explicit opt-in.
 - **COOP/COEP Headers** — Required for SharedArrayBuffer, configured in `vercel.json`.
-- **Strict CSP** — Only allows self, cdnjs.cloudflare.com (Three.js), and blob/data URIs.
+- **Strict CSP** — Allows only self, `cdnjs.cloudflare.com` (Three.js), and blob/data URIs. No `wasm-unsafe-eval`.
+- **Offline JWT Licensing** — License validation works without an internet connection.
 
-### Tiers
+---
 
-- **Free**: Basic noise reduction, 5-min limit, watermarked exports.
-- **Pro ($12/mo)**: Full 36-stage pipeline, ML models, unlimited duration, no watermark.
-- **Studio ($29/mo)**: Pro features + Batch processing, Cloud Sync, API access.
-- **Enterprise ($199/mo)**: White-label, custom models, SLA.
+## Browser Support
+
+| Platform | Support |
+|----------|---------|
+| Chrome 90+ | Full (WebGPU where available) |
+| Firefox 88+ | Full (WebGL2 fallback) |
+| Safari 15.4+ | Full (WASM fallback) |
+| Edge 90+ | Full |
+| iOS / Android | Native app via Capacitor; responsive web layout also supported |
+
+---
+
+## Getting Started
+
+```bash
+git clone https://github.com/Joker5514/VoiceIsolate-Pro.git
+cd VoiceIsolate-Pro
+npm install
+npm run dev        # serves public/ on localhost:3000
+```
+
+For mobile builds:
+
+```bash
+npm run android:build   # Android APK via Gradle + Capacitor
+npm run ios:build       # iOS via Capacitor (requires macOS + Xcode)
+```
 
 ---
 
@@ -185,24 +215,19 @@ Classical DSP pipeline operates independently without ML for lightweight deploym
 
 | Command | Description |
 |---------|-------------|
-| `npm run dev` | Serve `public/` on port 3000 with CORS |
-| `npm run build` | Copy `public/` into `build/` directory |
+| `npm run dev` | Serve `public/` on port 3000 with CORS headers |
+| `npm run build` | Copy `public/` into `build/` for alternate deployment |
 | `npm run lint` | Run ESLint on core pipeline files |
-| `npm test` | Run Jest test suite |
-| `npm run validate` | Run custom pipeline validation script |
+| `npm test` | Run Jest unit test suite |
+| `npm run validate` | Run structural pipeline validation script |
+| `npm run android:build` | Build Android APK |
+| `npm run ios:build` | Build iOS app (macOS + Xcode required) |
+
+---
+
 ## Deployment
 
-Auto-deploys to Vercel on push to `main` via GitHub integration.
-
-```bash
-# Local development
-git clone https://github.com/Joker5514/VoiceIsolate-Pro.git
-cd VoiceIsolate-Pro
-npm install
-npm start          # serves on localhost:3000
-```
-
-Output directory: `public/` (Vercel) / `build/` (alternate).
+Auto-deploys to Vercel on push to `main` via GitHub integration. Output directory: `public/` (Vercel) or `build/` (alternate).
 
 ---
 
@@ -217,34 +242,15 @@ Output directory: `public/` (Vercel) / `build/` (alternate).
 | v16 | 28-stage hexa-pass | 28 | BSRNN ensemble, smart logic, 40+ sliders |
 | v18 | 32-stage octa-pass | 32 | Conformer refiner, forensic audit chain |
 | v20 | Modular vanilla JS | 32 | Threads from Space v10, modular build |
-| **v22** | **35-stage deca-pass** | **35** | **Real STFT pipeline, adaptive Wiener, anti-garble, harmonic v2** |
+| v22.0 | 35-stage deca-pass | 35 | Real STFT pipeline, adaptive Wiener, anti-garble, harmonic v2 |
+| **v22.1** | **35-stage deca-pass** | **35** | **Monetization, AI Engine v2, batch processing, Cloud Sync, privacy analytics** |
 
 ---
 
-## Monetization Tiers (Planned)
-
-| Tier | Price | Features |
-|------|-------|---------|
-| Free | $0 | Classical DSP pipeline, one-tap clean, WAV export |
-| Creator Pro | $9/mo | + Demucs separation, voiceprint, batch (10 files) |
-| Studio | $29/mo | + Ensemble fusion, HiFi-GAN vocoder, batch (1000 files) |
-| Forensic | $79/mo | + Chain-of-custody, Conformer-S, unlimited batch |
-
----
-
-## Browser Support
-
-| Platform | Support |
-|----------|---------|
-| Chrome 90+ | ✅ Full (WebGPU where available) |
-| Firefox 88+ | ✅ Full (WebGL2 fallback) |
-| Safari 15.4+ | ✅ Full (WASM fallback) |
-| Edge 90+ | ✅ Full |
-| Mobile (iOS/Android) | ✅ Responsive layout |
-
----
-
-**VoiceIsolate Pro v22.0.0** · Threads from Space v10 · Privacy-First · Updated March 2026
 ## License
 
-[MIT](LICENSE)
+All Rights Reserved. See [LICENSE](LICENSE) for details.
+
+---
+
+**VoiceIsolate Pro v22.1.0** · Threads from Space v11 · Privacy-First · Updated April 2026


### PR DESCRIPTION
- Bump version badge from 22.0.0 to 22.1.0
- Fix Threads from Space version (v10 → v11) throughout
- Consolidate duplicate/conflicting Monetization Tiers sections
- Add DeepFilterNet3 to ML Models table
- Fix Pro tier stage count (36 → 35)
- Correct dev command (npm start → npm run dev)
- Fix file paths to include public/app/ prefix
- Add mobile build commands and ECAPA-TDNN dimension correction
- Remove loose/orphaned content blocks and clean up structure

https://claude.ai/code/session_01WfNJifgaTn9A4yMaftjDfv
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/joker5514/voiceisolate-pro/pull/285" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the README to v22.1.0 to match current features, architecture, and licensing. Cleans structure, fixes inaccurate details, and adds missing paths, scripts, and browser support.

- **Bug Fixes**
  - Bumped version badge/footer to 22.1.0; fixed engine reference to Threads from Space v11.
  - Corrected Pro stage count (35) and ECAPA-TDNN embedding size (256-dim).
  - Fixed dev command (`npm run dev`), paths under `public/app/`, and processor filename (`dsp-processor.js`).
  - Clarified CSP (drop `wasm-unsafe-eval`; allow `cdnjs.cloudflare.com`) and corrected license to All Rights Reserved.

- **Refactors**
  - Consolidated Monetization Tiers into one table with pricing and offline JWT/RevenueCat notes.
  - Updated ML Models table (added DeepFilterNet3, tier labels) and noted lazy-loading.
  - Added mobile build scripts and Browser Support; tightened Getting Started/Deployment.
  - Standardized key file list under `public/app/` (added `ai-engine-v2.js`, licensing/paywall/cloud-sync modules) and removed duplicate/orphaned content.

<sup>Written for commit 01ef3f93db2ab0d1045d34f99376880c55f784c6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

