### PR TITLE
fix: resolve 'ort' identifier redeclaration in ml-worker

### DIFF
--- a/ml-worker.js
+++ b/ml-worker.js
@@ -15,7 +15,6 @@
  * - Supports: Demucs v4, BSRNN, Silero VAD, ECAPA-TDNN
  */
 
-let ort = null;             // ONNX Runtime reference
 let sessions = {};          // { demucs, bsrnn, vad, ecapa }
 let provider = 'wasm';      // active execution provider
 let inputRing = null;        // SharedRingBuffer (read side)
@@ -99,9 +98,8 @@ async function initialize(msg) {
     if (msg.ortUrl) _bannedImport(msg.ortUrl);
 
     // Import ONNX Runtime from vendored local copy only
-    if (!ort) {
+    if (!self.ort) {
       importScripts('/lib/ort.min.js');
-      ort = self.ort;
     }
 
     // Detect best execution provider
@@ -121,7 +119,7 @@ async function initialize(msg) {
     for (const name of models) {
       const path = msg.modelPaths?.[name] || MODEL_PATHS[name];
       try {
-        sessions[name] = await ort.InferenceSession.create(path, sessionOpts);
+        sessions[name] = await self.ort.InferenceSession.create(path, sessionOpts);
         log('info', `Loaded model: ${name}`);
       } catch (err) {
         log('warn', `Model ${name} unavailable: ${err.message}`);
@@ -231,7 +229,7 @@ async function generateMask(frame) {
 
   // Demucs inference
   if (sessions.demucs && weights.demucs > 0) {
-    const tensor = new ort.Tensor('float32', frame, [1, 1, frameSize]);
+    const tensor = new self.ort.Tensor('float32', frame, [1, 1, frameSize]);
     try {
       const result = await sessions.demucs.run({ input: tensor });
       const output = result[Object.keys(result)[0]];
@@ -244,7 +242,7 @@ async function generateMask(frame) {
 
   // BSRNN inference
   if (sessions.bsrnn && weights.bsrnn > 0) {
-    const tensor = new ort.Tensor('float32', frame, [1, 1, frameSize]);
+    const tensor = new self.ort.Tensor('float32', frame, [1, 1, frameSize]);
     try {
       const result = await sessions.bsrnn.run({ input: tensor });
       const output = result[Object.keys(result)[0]];
@@ -303,9 +301,9 @@ async function handleVAD(msg) {
       const padded = new Float32Array(windowSize);
       padded.set(chunk);
 
-      const inputTensor = new ort.Tensor('float32', padded, [1, windowSize]);
-      const srTensor = new ort.Tensor('int64', BigInt64Array.from([BigInt(sr)]), [1]);
-      const stateTensor = new ort.Tensor('float32', state, [2, 1, stateSize]);
+      const inputTensor = new self.ort.Tensor('float32', padded, [1, windowSize]);
+      const srTensor = new self.ort.Tensor('int64', BigInt64Array.from([BigInt(sr)]), [1]);
+      const stateTensor = new self.ort.Tensor('float32', state, [2, 1, stateSize]);
 
       try {
         const result = await sessions.vad.run({
@@ -373,7 +371,7 @@ async function handleEnroll(msg) {
 
   try {
     const data = msg.data;
-    const tensor = new ort.Tensor('float32', data, [1, 1, data.length]);
+    const tensor = new self.ort.Tensor('float32', data, [1, 1, data.length]);
     try {
       const result = await sessions.ecapa.run({ input: tensor });
       const output = result[Object.keys(result)[0]];
@@ -413,7 +411,7 @@ async function handleDNS(msg) {
       const end = Math.min(start + chunkSize, data.length);
       const chunk = data.subarray(start, end);
 
-      const tensor = new ort.Tensor('float32', chunk, [1, 1, chunk.length]);
+      const tensor = new self.ort.Tensor('float32', chunk, [1, 1, chunk.length]);
       try {
         const out = await sessions.dns.run({ input: tensor });
         const output = out[Object.keys(out)[0]];

--- a/public/app/ml-worker.js
+++ b/public/app/ml-worker.js
@@ -18,7 +18,6 @@
  *             DNS v2 (conformer), noise classifier, ConvTasNet multi-speaker sep
  */
 
-let ort = null;             // ONNX Runtime reference
 let sessions = {};          // { demucs, bsrnn, vad, ecapa }
 let provider = 'wasm';      // active execution provider
 let inputRing = null;        // SharedRingBuffer (read side)
@@ -130,9 +129,8 @@ self.onmessage = async (e) => {
  */
 async function initialize(msg) {
   try {
-    if (!ort) {
+    if (!self.ort) {
       importScripts('/lib/ort.min.js');
-      ort = self.ort;
     }
 
     provider = await detectProvider();
@@ -149,7 +147,7 @@ async function initialize(msg) {
     for (const name of models) {
       const path = msg.modelPaths?.[name] || MODEL_PATHS[name];
       try {
-        sessions[name] = await ort.InferenceSession.create(path, sessionOpts);
+        sessions[name] = await self.ort.InferenceSession.create(path, sessionOpts);
         log('info', `Loaded model: ${name}`);
       } catch (err) {
         const displayName = name === 'vad' ? 'VAD' : name;
@@ -295,7 +293,7 @@ async function processChunkWithMask(chunk, session) {
   let gainMask;
   if (session) {
     try {
-      const tensor = new ort.Tensor('float32', mag, [1, 1, halfN]);
+      const tensor = new self.ort.Tensor('float32', mag, [1, 1, halfN]);
       const results = await session.run({ input: tensor });
       const outputKey = Object.keys(results)[0];
       const rawMask = results[outputKey];
@@ -346,7 +344,7 @@ async function generateMask(frame) {
     const stereo = new Float32Array(len * 2);
     stereo.set(frame, 0);
     stereo.set(frame, len);
-    const tensor = new ort.Tensor('float32', stereo, [1, 2, len]);
+    const tensor = new self.ort.Tensor('float32', stereo, [1, 2, len]);
     try {
       const result = await sessions.demucs.run({ input: tensor });
       const output = result[Object.keys(result)[0]];
@@ -366,7 +364,7 @@ async function generateMask(frame) {
     const stereo = new Float32Array(len * 2);
     stereo.set(frame, 0);
     stereo.set(frame, len);
-    const tensor = new ort.Tensor('float32', stereo, [1, 2, len]);
+    const tensor = new self.ort.Tensor('float32', stereo, [1, 2, len]);
     try {
       const result = await sessions.bsrnn.run({ input: tensor });
       const output = result[Object.keys(result)[0]];
@@ -427,9 +425,9 @@ async function handleVAD(msg) {
          chunk = padded;
       }
 
-      const inputTensor = new ort.Tensor('float32', chunk, [1, chunk.length]);
-      const srTensor = new ort.Tensor('int64', BigInt64Array.from([BigInt(sr)]), [1]);
-      const stateTensor = new ort.Tensor('float32', state, [2, 1, stateSize]);
+      const inputTensor = new self.ort.Tensor('float32', chunk, [1, chunk.length]);
+      const srTensor = new self.ort.Tensor('int64', BigInt64Array.from([BigInt(sr)]), [1]);
+      const stateTensor = new self.ort.Tensor('float32', state, [2, 1, stateSize]);
 
       try {
         const result = await sessions.vad.run({
@@ -518,7 +516,7 @@ async function handleEnroll(msg) {
 
   try {
     const data = msg.data;
-    const tensor = new ort.Tensor('float32', data, [1, 1, data.length]);
+    const tensor = new self.ort.Tensor('float32', data, [1, 1, data.length]);
     try {
       const result = await sessions.ecapa.run({ input: tensor });
       const output = result[Object.keys(result)[0]];
@@ -550,7 +548,7 @@ async function handleIdentify(msg) {
 
   try {
     const data = msg.data;
-    const tensor = new ort.Tensor('float32', data, [1, 1, data.length]);
+    const tensor = new self.ort.Tensor('float32', data, [1, 1, data.length]);
     try {
       const result = await sessions.ecapa.run({ input: tensor });
       const output = result[Object.keys(result)[0]];
@@ -589,7 +587,7 @@ async function handleDNS2(msg) {
   }
 
   try {
-    const tensor = new ort.Tensor('float32', magnitude, [1, 1, magnitude.length]);
+    const tensor = new self.ort.Tensor('float32', magnitude, [1, 1, magnitude.length]);
     try {
       const result = await sessions.dns2.run({ input: tensor });
       const output = result[Object.keys(result)[0]];
@@ -632,7 +630,7 @@ async function handleClassifyNoise(msg) {
   }
 
   try {
-    const tensor = new ort.Tensor('float32', features, [1, features.length]);
+    const tensor = new self.ort.Tensor('float32', features, [1, features.length]);
     try {
       const result = await sessions.noiseClassifier.run({ input: tensor });
       const output = result[Object.keys(result)[0]];
@@ -700,7 +698,7 @@ async function handleMultiSeparate(msg) {
   }
 
   try {
-    const tensor = new ort.Tensor('float32', data, [1, 1, data.length]);
+    const tensor = new self.ort.Tensor('float32', data, [1, 1, data.length]);
     let streams;
     try {
       const result = await sessions.convtasnet.run({ input: tensor });


### PR DESCRIPTION
ort.min.js declares `const ort` at the worker global scope. The
ml-worker also had `let ort = null` at the top level, causing
"Identifier 'ort' has already been declared" on importScripts.

Remove the top-level `let ort` declaration and reference the runtime
via `self.ort` (set by the library) throughout both ml-worker files.

https://claude.ai/code/session_018YT3YAFWXeh2fzR87dHxmv

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a worker crash caused by `ort` being declared twice. Removes the local `ort` and uses `self.ort` so ONNX Runtime loads without errors.

- **Bug Fixes**
  - Removed top-level `let ort` from both `ml-worker.js` files.
  - Load `/lib/ort.min.js` only when `self.ort` is missing.
  - Replaced all `ort.*` calls with `self.ort.*` for session creation and tensor ops.

<sup>Written for commit 2fdb7c98cdb6e1a67162754c15488b243dc8b2b2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/joker5514/voiceisolate-pro/pull/296" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
