### PR TITLE
Fix critical upload and DSP processing errors

### DIFF
--- a/public/app/batch-processor.js
+++ b/public/app/batch-processor.js
@@ -93,11 +93,11 @@ const BatchProcessor = (() => {
       job.progress = 10;
       _emit('job:progress', { job, progress: 10 });
 
-      // Decode audio
-      const audioCtx = new (window.OfflineAudioContext || window.webkitOfflineAudioContext)(
-        1, 44100, 44100
-      );
+      // Decode audio — use AudioContext (not OfflineAudioContext) so the native
+      // device sample rate is preserved and files are not silently resampled to 44100 Hz.
+      const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
       const audioBuffer = await audioCtx.decodeAudioData(arrayBuffer);
+      audioCtx.close().catch(() => {});
       const audioData = audioBuffer.getChannelData(0);
       const sampleRate = audioBuffer.sampleRate;
 

--- a/public/app/dsp-core.js
+++ b/public/app/dsp-core.js
@@ -130,11 +130,11 @@ const DSPCore = {
 
   // ===== WINDOWING =====
 
-  /** Generate Hann window of given length */
+  /** Generate periodic Hann window of given length (required for COLA at 75% overlap) */
   hannWindow(N) {
     const w = new Float32Array(N);
     for (let i = 0; i < N; i++) {
-      w[i] = 0.5 * (1 - Math.cos(2 * Math.PI * i / (N - 1)));
+      w[i] = 0.5 * (1 - Math.cos(2 * Math.PI * i / N));
     }
     return w;
   },

--- a/public/app/dsp-worker.js
+++ b/public/app/dsp-worker.js
@@ -44,9 +44,10 @@ self.onmessage = async function (e) {
 // Init
 // ---------------------------------------------------------------------------
 async function handleInit(payload) {
-  dspCore = new DSPCore(payload.sampleRate || 48000, payload.fftSize || 2048);
+  // DSPCore is a plain-object singleton, not a class — do not call with `new`
+  dspCore = DSPCore;
   isInitialized = true;
-  return { status: 'initialized', sampleRate: dspCore.sampleRate };
+  return { status: 'initialized', sampleRate: payload.sampleRate || 48000 };
 }
 
 // ---------------------------------------------------------------------------
@@ -109,10 +110,7 @@ async function handleProcess(payload) {
   const input = new Float32Array(audioData);
   let processed = input;
 
-  // Single Forward STFT — do not add a second one anywhere in this function
-  const { real, imag } = dspCore.forwardSTFT(processed);
-
-  // ML separation (operates in time domain before spectral ops)
+  // ML separation first (time-domain) — must run before STFT so spectral ops see ML output
   if (enabledModels?.includes('demucs') && ortSessions['demucs']) {
     try {
       const tensor = new self.ort.Tensor('float32', processed, [1, 1, processed.length]);
@@ -123,15 +121,21 @@ async function handleProcess(payload) {
     }
   }
 
-  // In-place spectral operations
+  // Single Forward STFT — do not add a second one anywhere in this function
+  const { mag, phase } = dspCore.forwardSTFT(processed);
+
+  // In-place spectral operations on mag/phase arrays
   if (params) {
-    dspCore.applySpectralGate(real, imag, params);
-    dspCore.applyNoiseReduction(real, imag, params);
-    dspCore.applyEQ(real, imag, params);
+    // ERB spectral gate using noise floor parameter
+    dspCore.spectralGate(mag, params.nrFloor ?? -60, sampleRate);
+    // Wiener noise subtraction (no pre-computed profile available at worker level)
+    if ((params.nrAmount ?? 0) > 0) {
+      dspCore.wienerMMSE(mag, null, params.nrAmount);
+    }
   }
 
   // Single Inverse STFT — do not add a second one anywhere
-  const output = dspCore.inverseSTFT(real, imag);
+  const output = dspCore.inverseSTFT(mag, phase);
 
   return {
     processedData: output.buffer,


### PR DESCRIPTION
dsp-worker.js:
- DSPCore is a plain-object singleton, not a class; calling `new DSPCore()`
  threw TypeError: DSPCore is not a constructor, preventing all worker init
- forwardSTFT returns {mag, phase}, not {real, imag}; wrong destructuring
  left both variables undefined for every subsequent spectral operation
- applySpectralGate / applyNoiseReduction / applyEQ do not exist on DSPCore;
  replaced with the actual methods spectralGate() and wienerMMSE()
- inverseSTFT was called with the undefined (real, imag) variables; fixed to
  pass (mag, phase)
- STFT was executed before the ML (Demucs) time-domain pass, so spectral ops
  ran on the original signal and the ML output was discarded; moved STFT
  after the ML block so both paths process the same audio

dsp-core.js:
- hannWindow used the symmetric formula (N-1 denominator) which fails the
  Constant Overlap-Add condition at 75% overlap, causing amplitude ripple
  and imperfect reconstruction; switched to the periodic formula (N denominator)

batch-processor.js:
- Batch decoding used OfflineAudioContext(1, 44100, 44100), which silently
  resamples all audio to 44100 Hz regardless of source sample rate; replaced
  with AudioContext so the native device rate is used (matching single-file
  behaviour) and the context is closed immediately after decoding

https://claude.ai/code/session_01MnKF1trqVQZccLsctDyMMw
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/joker5514/voiceisolate-pro/pull/301" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes upload failures and broken DSP processing by correcting worker init, STFT ordering, and windowing. Restores proper model output, cleaner audio, and preserves original sample rates in batch decoding.

- **Bug Fixes**
  - Worker: use DSPCore singleton (no `new`), read `{mag, phase}` from `forwardSTFT`, pass them to `inverseSTFT`, and run the ML pass before STFT.
  - Spectral ops: replace nonexistent methods with `spectralGate()` and `wienerMMSE()` on magnitude data.
  - Windowing: switch to periodic Hann to satisfy COLA at 75% overlap and reduce amplitude ripple.
  - Batch: decode with `AudioContext` to keep native sample rate and close context after decode.

<sup>Written for commit 906394a677def188c0cdb440307ea0a677349b93. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

