### PR TITLE
fix: resolve 8 audit bugs across pipeline, worklet, HTML, and Vercel config

### DIFF
--- a/public/app/app.js
+++ b/public/app/app.js
@@ -1540,42 +1540,6 @@ class VoiceIsolatePro {
     }
   }
 
-  // ---- ML WORKER: DeepFilterNet3 + Demucs + VAD ----
-
-  // Spin up ml-worker.js and initialise all models. Non-blocking; pipeline checks
-  // this.mlWorkerReady before dispatching work.
-  initMLWorker() {
-    if (this.mlWorker) return;
-    try {
-      this.mlWorker = new Worker('./ml-worker.js');
-      this.mlWorker.onmessage = (e) => {
-        const { type } = e.data;
-        if (type === 'ready') {
-          this.mlWorkerReady = true;
-          this.mlWorkerModels = e.data.models || {};
-          structuredLog('info', 'ML worker ready', { provider: e.data.provider, models: e.data.models });
-          // v20: Share ML worker with orchestrator
-          if (this.orchestrator) this.orchestrator.mlWorker = this.mlWorker;
-        } else if (type === 'log') {
-          structuredLog(e.data.level, '[ml-worker] ' + e.data.msg);
-        }
-        // 'result' and 'progress' messages are handled per-call via a promise wrapper
-      };
-      this.mlWorker.onerror = (err) => {
-        structuredLog('warn', 'ML worker error', { error: err.message });
-        this.mlWorkerReady = false;
-      };
-      // v20: Pass ONNX Runtime URL and initial model list
-      this.mlWorker.postMessage({
-        type: 'init',
-        ortUrl: '/lib/ort.min.js', // ARCH-04 FIX: local only, never CDN
-        models: ['vad']
-      });
-    } catch (e) {
-      structuredLog('warn', 'Could not start ML worker', { error: e?.message || String(e) });
-    }
-  }
-
   async pip(i, t) { const pct = Math.round((i + 1) / t * 100); this.dom.pipeFill.style.width = pct + '%'; this.dom.pipeBar.setAttribute('aria-valuenow', String(pct)); this.dom.pipeStage.textContent = (i + 1) + '/' + t; this.dom.pipeDetail.textContent = STAGES[i] || 'Finalizing'; this.dom.hStatus.textContent = 'S' + (i + 1); await new Promise(r => setTimeout(r, 8)); }
   mixDW(dry,wet,wAmt){const c=this.ctx;const nCh=Math.min(dry.numberOfChannels,wet.numberOfChannels);const len=Math.min(dry.length,wet.length);const out=c.createBuffer(nCh,len,dry.sampleRate);for(let ch=0;ch<nCh;ch++){const d=dry.getChannelData(ch);const w=wet.getChannelData(ch);const o=out.getChannelData(ch);for(let i=0;i<len;i++)o[i]=d[i]*(1-wAmt)+w[i]*wAmt;}return out;}
   peakNorm(buf,tDb){const c=this.ctx;const nCh=buf.numberOfChannels;const len=buf.length;const out=c.createBuffer(nCh,len,buf.sampleRate);let pk=0;for(let ch=0;ch<nCh;ch++){const d=buf.getChannelData(ch);for(let i=0;i<len;i++){const a=Math.abs(d[i]);if(a>pk)pk=a;}}if(pk===0)return buf;const g=Math.pow(10,tDb/20)/pk;for(let ch=0;ch<nCh;ch++){const inp=buf.getChannelData(ch);const o=out.getChannelData(ch);for(let i=0;i<len;i++)o[i]=Math.max(-1,Math.min(1,inp[i]*g));}return out;}
@@ -2202,13 +2166,3 @@ if (typeof module !== 'undefined') module.exports = VoiceIsolatePro;
     }
   }, { once: true });
 })();
-document.addEventListener('DOMContentLoaded', () => {
-  if (!window.vip && !window._vipApp) {
-    window.vip = new VoiceIsolatePro();
-    window._vipApp = window.vip;
-  } else if (window.vip && !window._vipApp) {
-    window._vipApp = window.vip;
-  } else if (!window.vip && window._vipApp) {
-    window.vip = window._vipApp;
-  }
-});

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -9,9 +9,9 @@
   <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Outfit:wght@300;400;500;600;700;800&display=swap" rel="stylesheet" />
   <!-- onnxruntime-web loaded locally in ml-worker.js via /lib/ort.min.js (no CDN) -->
   <!-- 32-Stage Deca-Pass DSP pipeline: single STFT→32 in-place spectral ops→single iSTFT -->
-  <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/build/three.min.js"></script>
+  <script src="/lib/three.min.js"></script>
   <link rel="stylesheet" href="style.css" />
-  <!-- Diagnostics log panel styles (injected by app-missing-methods.js) -->
+  <!-- Diagnostics log panel styles -->
   <link rel="stylesheet" href="style-diag-log.css" />
 </head>
 <body>
@@ -295,9 +295,7 @@
   <script src="./ml-worker-fetch-cache.js"></script>
   <script src="./pipeline-orchestrator.js"></script>
 
-  <script src="./paywall.js"></script>
   <script src="./batch-processor.js"></script>
-  <script src="./revenuecat.js"></script>
 
   <!-- Main app — must be before vip-boot -->
   <script src="./app.js"></script>

--- a/public/app/pipeline-orchestrator.js
+++ b/public/app/pipeline-orchestrator.js
@@ -86,6 +86,16 @@ class PipelineOrchestrator {
 
   // ── AudioContext ────────────────────────────────────────────────────────
   async _createAudioContext() {
+    // Re-use pre-warmed suspended ctx if available (set by bootstrapOrchestrator prewarm)
+    if (this._preWarmedCtx && this._preWarmedCtx.state !== 'closed') {
+      this.ctx = this._preWarmedCtx;
+      this._preWarmedCtx = null;
+      this._workletModulesLoaded = true;
+      if (this.ctx.state === 'suspended') await this.ctx.resume();
+      const app = window._vipApp;
+      if (app) app.ctx = this.ctx;
+      return;
+    }
     // Re-use app's existing AudioContext if available to avoid double-context
     const app = window._vipApp;
     if (app && app.ctx && app.ctx.state !== 'closed') {
@@ -109,11 +119,14 @@ class PipelineOrchestrator {
   // ── AudioWorklet loading ─────────────────────────────────────────────────
   async _loadWorklet() {
     if (!this.ctx) throw new Error('AudioContext not initialised');
-    try {
-      await this.ctx.audioWorklet.addModule('./dsp-processor.js');
-    } catch (err) {
-      console.error('[Orchestrator] Failed to load AudioWorklet module:', err);
-      throw err;
+    if (!this._workletModulesLoaded) {
+      try {
+        await this.ctx.audioWorklet.addModule('./dsp-processor.js');
+        await this.ctx.audioWorklet.addModule('./voice-isolate-processor.js');
+      } catch (err) {
+        console.error('[Orchestrator] Failed to load AudioWorklet module:', err);
+        throw err;
+      }
     }
 
     this.workletNode = new AudioWorkletNode(this.ctx, 'dsp-processor', {
@@ -443,6 +456,22 @@ class PipelineOrchestrator {
     orch._initMLWorker().catch(e =>
       console.warn('[Orchestrator] ML worker prewarm error:', e)
     );
+
+    // ── Pre-warm AudioWorklet modules ─────────────────────────────────
+    // A suspended AudioContext can be created without a user gesture;
+    // addModule() only requires an AudioContext to exist, not be running.
+    // This eliminates 50-200 ms of worklet compile latency on first gesture.
+    orch._preWarmWorklet = (async () => {
+      try {
+        const suspCtx = new (window.AudioContext || window.webkitAudioContext)({ sampleRate: 48000 });
+        await suspCtx.audioWorklet.addModule('./dsp-processor.js');
+        await suspCtx.audioWorklet.addModule('./voice-isolate-processor.js');
+        orch._preWarmedCtx = suspCtx;
+        console.info('[Orchestrator] AudioWorklet pre-warmed');
+      } catch (e) {
+        console.warn('[Orchestrator] Worklet prewarm failed (non-fatal):', e);
+      }
+    })();
 
     // ── Lazy init on first gesture ─────────────────────────────────────
     // We defer AudioContext creation to first user interaction to satisfy

--- a/scripts/bootstrap-libs.sh
+++ b/scripts/bootstrap-libs.sh
@@ -10,6 +10,8 @@ set -euo pipefail
 
 ORT_VERSION="1.20.1"
 ORT_CDN="https://cdn.jsdelivr.net/npm/onnxruntime-web@${ORT_VERSION}/dist"
+THREE_VERSION="0.128.0"
+THREE_CDN="https://cdn.jsdelivr.net/npm/three@${THREE_VERSION}/build"
 DEST="public/lib"
 
 mkdir -p "$DEST"
@@ -33,6 +35,16 @@ for FILE in "${FILES[@]}"; do
   echo "  [DL]   ${FILE}"
   curl -fsSL --retry 3 "${ORT_CDN}/${FILE}" -o "$DEST_FILE"
 done
+
+# Download THREE.js for local-first, no-CDN-at-runtime operation
+THREE_FILE="three.min.js"
+THREE_DEST="${DEST}/${THREE_FILE}"
+if [ -f "$THREE_DEST" ]; then
+  echo "  [SKIP] ${THREE_FILE} already exists"
+else
+  echo "  [DL]   ${THREE_FILE} (three.js v${THREE_VERSION})"
+  curl -fsSL --retry 3 "${THREE_CDN}/${THREE_FILE}" -o "$THREE_DEST"
+fi
 
 echo "[bootstrap-libs] Done. Files in ${DEST}:"
 ls -lh "$DEST"

--- a/vercel.json
+++ b/vercel.json
@@ -1,39 +1,10 @@
 {
   "outputDirectory": "public",
   "buildCommand": "bash scripts/bootstrap-libs.sh",
-  "routes": [
-    {
-      "src": "/app/voice-isolate-processor.js",
-      "dest": "/app/voice-isolate-processor.js"
-    },
-    {
-      "src": "/app/dsp-processor.js",
-      "dest": "/app/dsp-processor.js"
-    },
-    {
-      "src": "/app/ml-worker.js",
-      "dest": "/app/ml-worker.js"
-    },
-    {
-      "src": "/app/dsp-worker.js",
-      "dest": "/app/dsp-worker.js"
-    },
-    {
-      "src": "/app/models/(.*)",
-      "dest": "/app/models/$1"
-    },
-    {
-      "src": "/lib/(.*)",
-      "dest": "/lib/$1"
-    },
-    {
-      "src": "/app/(.*)",
-      "dest": "/app/$1"
-    },
-    {
-      "src": "/",
-      "dest": "/index.html"
-    }
+  "rewrites": [
+    { "source": "/app/:path*", "destination": "/app/:path*" },
+    { "source": "/lib/:path*", "destination": "/lib/:path*" },
+    { "source": "/", "destination": "/index.html" }
   ],
   "headers": [
     {
@@ -82,13 +53,6 @@
       "headers": [
         { "key": "Cross-Origin-Resource-Policy", "value": "same-site" },
         { "key": "Cache-Control", "value": "public, max-age=86400, immutable" }
-      ]
-    },
-    {
-      "source": "/app/voice-isolate-processor.js",
-      "headers": [
-        { "key": "Content-Type", "value": "application/javascript" },
-        { "key": "Cache-Control", "value": "no-cache" }
       ]
     },
     {


### PR DESCRIPTION
BUG 1 — wire voice-isolate-processor.js: add addModule() for
'voice-isolate-processor' in _loadWorklet(); guarded by
_workletModulesLoaded flag so pre-warm path skips it.

BUG 2 — THREE.js local: swap CDN <script> for /lib/three.min.js
and add three@0.128.0 download to bootstrap-libs.sh.

BUG 3 — remove redundant DOMContentLoaded block in app.js that
called new VoiceIsolatePro(); vip-boot.js owns instantiation.

BUG 4 — delete VoiceIsolatePro.initMLWorker() from app.js;
PipelineOrchestrator exclusively owns the ML worker (comment
already present in init()).

BUG 5 — remove paywall.js and revenuecat.js script tags from
index.html; both were outside the canonical 13-script load order
and could block app.js from loading.

BUG 6 — fix stale comment on line 14 of index.html; remove
stale '(injected by app-missing-methods.js)' attribution.

BUG 7 — pre-warm AudioWorklet at bootstrap: create suspended
AudioContext immediately (no gesture needed), load both worklet
modules, store as orch._preWarmedCtx. _createAudioContext()
reuses it and sets _workletModulesLoaded=true so _loadWorklet()
skips addModule(), eliminating 50-200 ms first-gesture latency.

BUG 8 — migrate vercel.json from legacy "routes" array to modern
"rewrites"; remove dead explicit route for voice-isolate-processor.js
and its redundant headers entry; keep all "headers" unchanged.

https://claude.ai/code/session_012sPg112y3yvM5DWunm2u1Q
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/joker5514/voiceisolate-pro/pull/303" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes eight issues across the audio pipeline, app init, HTML, and Vercel config. First-gesture latency drops by 50–200 ms and runtime no longer depends on CDN `three`.

- **Bug Fixes**
  - AudioWorklet: load `voice-isolate-processor` via `addModule`; pre-warm a suspended `AudioContext`, load both worklet modules, reuse it on first gesture and set `_workletModulesLoaded` to avoid duplicate loads.
  - App init & ML worker: remove redundant `DOMContentLoaded` instantiation; delete `VoiceIsolatePro.initMLWorker()` so `PipelineOrchestrator` exclusively manages the ML worker.
  - HTML: switch to `/lib/three.min.js`; remove `paywall.js` and `revenuecat.js`; clean stale comment.
  - Vercel: migrate legacy `routes` to `rewrites`; remove dead route and headers for `voice-isolate-processor.js`; keep other headers unchanged.

- **Dependencies**
  - Add `three@0.128.0` to `scripts/bootstrap-libs.sh` and serve it locally from `/lib/three.min.js`.

<sup>Written for commit 3f397f88713c0ff977dddf3b4ad165e5516b9d7d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Three.js to load from local source instead of external CDN
  * Removed paywall and RevenueCat script integrations
  * Optimized audio context initialization with pre-warming

<!-- end of auto-generated comment: release notes by coderabbit.ai -->