### PR TITLE
fix: restore working toggle with original btn-xs styling

### DIFF
--- a/public/app/index.html
+++ b/public/app/index.html
@@ -163,7 +163,7 @@
             <input type="range" id="tpVol" class="tp-vol-slider" min="0" max="1" step="0.01" value="1" aria-label="Volume" />
           </div>
           <div class="tp-ab">
-            <button id="tpAB" class="btn btn-ab" disabled title="Toggle Original / Processed">A/B</button>
+            <button id="tpAB" class="btn btn-xs" title="Toggle Original / Processed">A/B</button>
             <span id="tpABLabel" class="tp-ab-label">Original</span>
           </div>
         </div>


### PR DESCRIPTION
Revert to 452ba41 base, then fix the label-wrapping-button bug by
separating #tpAB and #tpABLabel into siblings inside a .tp-ab div.
Keeps the original btn-xs class so the button looks exactly as before.

https://claude.ai/code/session_01XMJkpDKb88pY4YLHyuxqUc
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/joker5514/voiceisolate-pro/pull/305" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore the A/B toggle with the original `btn-xs` styling and fix the label-wrapping bug.

Switch `#tpAB` back to `btn btn-xs` and keep `#tpABLabel` as a sibling in `.tp-ab` to prevent the label from wrapping the button.

<sup>Written for commit b5041fe39461d1f5bbbf2d4e401f15240b94c8b3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The A/B toggle button in transport controls is now enabled and interactive with updated visual styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->