### PR TITLE
deprecate: mark 15 obsolete VoiceIsolate Pro spec files with deprecation notices

### DIFF
--- a/DEPRECATION_LOG.md
+++ b/DEPRECATION_LOG.md
@@ -1,0 +1,82 @@
+# DEPRECATION LOG — VoiceIsolate Pro
+
+**Maintained by:** Randy Jordan, Senior Audio-DSP Architect  
+**Last updated:** 2026-04-08  
+**Canonical specification:** `VoiceIsolate_Pro_v23_Blueprint.docx` (36-Stage Deca-Pass, Threads from Space v12)
+
+> All files listed below are DEPRECATED. Do **not** use them for implementation decisions.  
+> The single authoritative implementation reference is `VoiceIsolate_Pro_v23_Blueprint.docx`.
+
+---
+
+## Deprecated Files
+
+| # | File Name | Deprecated On | Superseded By | Reason | Status |
+|---|-----------|--------------|---------------|--------|--------|
+| 1 | `VoiceIsolate-Pro-Complete.pdf` | 2026-04-08 | `VoiceIsolate_Pro_v23_Blueprint.docx` | v9.0 era document; 18-stage pipeline conflicts with authoritative 36-stage Deca-Pass; FFT size spec (4096–16384pt live) violates correct live-mode constraint of FFT=512/hop=128 | **DEPRECATED** |
+| 2 | `VoiceIsolate pro.pdf` | 2026-04-08 | `VoiceIsolate_Pro_v23_Blueprint.docx` | Early draft, incomplete spec, superseded by multiple subsequent versions | **DEPRECATED** |
+| 3 | `VoiceIsolate Pro .pdf` | 2026-04-08 | `VoiceIsolate_Pro_v23_Blueprint.docx` | Pre-final, 18-stage spec, contains contradictory pipeline stage counts (Space files version, updated 2026-02-21) | **DEPRECATED** |
+| 4 | `VoiceIsolate_Pro_v10_Aggressive_Blueprint.pdf` | 2026-04-08 | `VoiceIsolate_Pro_v23_Blueprint.docx` | v10 intermediate draft; pipeline stage count and model parameters conflict with final 36-stage Deca-Pass architecture | **DEPRECATED** |
+| 5 | `VoiceIsolate_Pro_v13_Blueprint` | 2026-04-08 | `VoiceIsolate_Pro_v23_Blueprint.docx` | v13 draft, superseded by final production blueprint; contains stale parameter tables for noise gate thresholds and STFT hop sizes | **DEPRECATED** |
+| 6 | `VoiceIsolate_Pro_v13_Blueprint.pdf` | 2026-04-08 | `VoiceIsolate_Pro_v23_Blueprint.docx` | v13 draft, superseded by final production blueprint; contains stale parameter tables for noise gate thresholds and STFT hop sizes | **DEPRECATED** |
+| 7 | `V14.pdf` | 2026-04-08 | `VoiceIsolate_Pro_v23_Blueprint.docx` | v14 draft, superseded by final production blueprint; do not use for implementation reference | **DEPRECATED** |
+| 8 | `VoiceIsolate_Pro_v5_Technical_Blueprint.docx` | 2026-04-08 | `VoiceIsolate_Pro_v23_Blueprint.docx` | v5.0 document (January 2026), 12-stage pipeline; completely superseded | **DEPRECATED** |
+| 9 | `Installing VoiceIsolate Pro v5.2.pdf` | 2026-04-08 | `VoiceIsolate_Pro_v23_Blueprint.docx` | v5.2 install guide references outdated architecture; current build target is Vite 5 + React 18 + TypeScript + ONNX Runtime Web | **DEPRECATED** |
+| 10 | `Installing VoiceIsolate Pro v5.2` | 2026-04-08 | `VoiceIsolate_Pro_v23_Blueprint.docx` | v5.2 install guide references outdated architecture; current build target is Vite 5 + React 18 + TypeScript + ONNX Runtime Web | **DEPRECATED** |
+| 11 | `voiceisolate-all.md` | 2026-04-08 | `VoiceIsolate_Pro_v23_Blueprint.docx` | Consolidated master document merging ALL versions (v5 through v9); contains contradictory pipeline specs from multiple eras; useful for historical reference ONLY | **DEPRECATED** |
+| 12 | `VoiceIsolate-Pro.md` | 2026-04-08 | `VoiceIsolate_Pro_v23_Blueprint.docx` | Consolidated master document merging ALL versions (v5 through v9); contains contradictory pipeline specs from multiple eras; useful for historical reference ONLY | **DEPRECATED** |
+| 13 | `voiceisolate-pdf.pdf` | 2026-04-08 | `VoiceIsolate_Pro_v23_Blueprint.docx` | v9.0 overview document, 18-stage spec; superseded | **DEPRECATED** |
+| 14 | `VoiceIsolate-Pro-Complete-Overview.pdf` | 2026-04-08 | `VoiceIsolate_Pro_v23_Blueprint.docx` | v9.0 overview document, 18-stage spec; superseded | **DEPRECATED** |
+| 15 | `VoiceIsolate-Pro-Complete-Overview.md` | 2026-04-08 | `VoiceIsolate_Pro_v23_Blueprint.docx` | v9.0 overview document, 18-stage spec; superseded | **DEPRECATED** |
+
+---
+
+## Deprecation Notice Files Created (In This Repository)
+
+Since several deprecated files are binary (PDF/DOCX) or do not exist within the git repository, the following deprecation notice files have been created as companions or stubs:
+
+| Deprecated File | Notice/Stub File Created |
+|----------------|--------------------------|
+| `VoiceIsolate-Pro-Complete.pdf` | `VoiceIsolate-Pro-Complete.DEPRECATED.md` |
+| `VoiceIsolate pro.pdf` | `VoiceIsolate-pro.DEPRECATED.md` |
+| `VoiceIsolate Pro .pdf` | `VoiceIsolate-Pro-space.DEPRECATED.md` |
+| `VoiceIsolate_Pro_v10_Aggressive_Blueprint.pdf` | `VoiceIsolate_Pro_v10_Aggressive_Blueprint.DEPRECATED.md` |
+| `VoiceIsolate_Pro_v13_Blueprint` (no ext) + `.pdf` | `VoiceIsolate_Pro_v13_Blueprint` (text notice) + `VoiceIsolate_Pro_v13_Blueprint.DEPRECATED.md` |
+| `V14.pdf` | `V14.DEPRECATED.md` |
+| `VoiceIsolate_Pro_v5_Technical_Blueprint.docx` | `VoiceIsolate_Pro_v5_Technical_Blueprint.DEPRECATED.md` |
+| `Installing VoiceIsolate Pro v5.2.pdf` + (no ext) | `Installing VoiceIsolate Pro v5.2` (text notice) + `Installing-VoiceIsolate-Pro-v5.2.DEPRECATED.md` |
+| `voiceisolate-all.md` | `voiceisolate-all.md` (deprecation front-matter prepended) |
+| `VoiceIsolate-Pro.md` | `VoiceIsolate-Pro.md` (deprecation front-matter prepended) |
+| `voiceisolate-pdf.pdf` | `voiceisolate-pdf.DEPRECATED.md` |
+| `VoiceIsolate-Pro-Complete-Overview.pdf` | `VoiceIsolate-Pro-Complete-Overview.DEPRECATED.md` |
+| `VoiceIsolate-Pro-Complete-Overview.md` | `VoiceIsolate-Pro-Complete-Overview.md` (deprecation front-matter prepended) |
+
+---
+
+## Active / Authoritative Files — DO NOT DEPRECATE
+
+| File | Role |
+|------|------|
+| `VoiceIsolate_Pro_v23_Blueprint.docx` | **CANONICAL SPEC** — 36-Stage Deca-Pass, Threads from Space v12 |
+| `public/app/index.html` | Active UI |
+| `public/app/style.css` | Active styles |
+| `public/app/app.js` | Active DSP orchestration |
+| `src/dsp-processor.js` | Active AudioWorklet |
+| `package.json` | Active build config |
+| `tsconfig.json` | Active TypeScript config |
+
+---
+
+## OrchestrAI Nexus — Cross-Project Deprecation Note
+
+The following file belongs to the **OrchestrAI Nexus** project (separate repository) and must be deprecated there:
+
+| File | Deprecated On | Superseded By | Reason | Status |
+|------|--------------|---------------|--------|--------|
+| `OrchestrAI Nexus File Creation Plan (1).pdf` | 2026-04-08 | `OrchestrAI Nexus File Creation Plan.md` | PDF duplicate of the .md version; the .md is the live, editable version and may be out of sync with the latest .md edits | **DEPRECATED** |
+
+> **Action required:** Apply this deprecation to the OrchestrAI Nexus repository by prepending the standard `[DEPRECATED 2026-04-08]` notice to `OrchestrAI Nexus File Creation Plan (1).pdf` per the format defined by Randy Jordan.
+
+---
+
+*VoiceIsolate Pro Deprecation Log · Authority: Randy Jordan, Senior Audio-DSP Architect / AI Architect*

--- a/Installing VoiceIsolate Pro v5.2
+++ b/Installing VoiceIsolate Pro v5.2
@@ -1,0 +1,11 @@
+# DEPRECATED 2026-04-08
+# Superseded by: VoiceIsolate_Pro_v23_Blueprint.docx
+# Do not use for implementation.
+#
+# Reason: v5.2 install guide references an outdated architecture that no longer exists.
+# Current build target is Vite 5 + React 18 + TypeScript + ONNX Runtime Web.
+# Authority: Randy Jordan, Senior Audio-DSP Architect / AI Architect
+#
+# [DEPRECATED 2026-04-08] This document has been superseded by VoiceIsolate_Pro_v23_Blueprint.docx.
+# Do not reference this file for implementation decisions.
+# See VoiceIsolate_Pro_v23_Blueprint.docx for the authoritative specification.

--- a/Installing-VoiceIsolate-Pro-v5.2.DEPRECATED.md
+++ b/Installing-VoiceIsolate-Pro-v5.2.DEPRECATED.md
@@ -1,0 +1,13 @@
+---
+⚠️ DEPRECATED — DO NOT USE FOR IMPLEMENTATION
+Superseded by: VoiceIsolate_Pro_v23_Blueprint.docx
+Reason: v5.2 install guides reference an outdated architecture that no longer exists; current build target is Vite 5 + React 18 + TypeScript + ONNX Runtime Web.
+Deprecated on: 2026-04-08
+Authority: Randy Jordan, Senior Audio-DSP Architect / AI Architect
+---
+
+**DEPRECATION NOTICE FOR: `Installing VoiceIsolate Pro v5.2.pdf` and `Installing VoiceIsolate Pro v5.2` (no extension)**
+
+[DEPRECATED 2026-04-08] These documents have been superseded by `VoiceIsolate_Pro_v23_Blueprint.docx`.
+Do not reference these files for implementation decisions.
+See `VoiceIsolate_Pro_v23_Blueprint.docx` for the authoritative specification.

--- a/V14.DEPRECATED.md
+++ b/V14.DEPRECATED.md
@@ -1,0 +1,13 @@
+---
+⚠️ DEPRECATED — DO NOT USE FOR IMPLEMENTATION
+Superseded by: VoiceIsolate_Pro_v23_Blueprint.docx
+Reason: v14 draft, superseded by final production blueprint; do not use for implementation reference.
+Deprecated on: 2026-04-08
+Authority: Randy Jordan, Senior Audio-DSP Architect / AI Architect
+---
+
+**DEPRECATION NOTICE FOR: `V14.pdf`**
+
+[DEPRECATED 2026-04-08] This document has been superseded by `VoiceIsolate_Pro_v23_Blueprint.docx`.
+Do not reference this file for implementation decisions.
+See `VoiceIsolate_Pro_v23_Blueprint.docx` for the authoritative specification.

--- a/VoiceIsolate-Pro-Complete-Overview.DEPRECATED.md
+++ b/VoiceIsolate-Pro-Complete-Overview.DEPRECATED.md
@@ -1,0 +1,13 @@
+---
+⚠️ DEPRECATED — DO NOT USE FOR IMPLEMENTATION
+Superseded by: VoiceIsolate_Pro_v23_Blueprint.docx
+Reason: v9.0 era overview document with 18-stage pipeline spec; superseded by the authoritative 36-stage Deca-Pass architecture.
+Deprecated on: 2026-04-08
+Authority: Randy Jordan, Senior Audio-DSP Architect / AI Architect
+---
+
+**DEPRECATION NOTICE FOR: `VoiceIsolate-Pro-Complete-Overview.pdf`**
+
+[DEPRECATED 2026-04-08] This document has been superseded by `VoiceIsolate_Pro_v23_Blueprint.docx`.
+Do not reference this file for implementation decisions.
+See `VoiceIsolate_Pro_v23_Blueprint.docx` for the authoritative specification.

--- a/VoiceIsolate-Pro-Complete-Overview.md
+++ b/VoiceIsolate-Pro-Complete-Overview.md
@@ -1,0 +1,11 @@
+---
+⚠️ DEPRECATED — DO NOT USE FOR IMPLEMENTATION
+Superseded by: VoiceIsolate_Pro_v23_Blueprint.docx
+Reason: v9.0 era overview document with 18-stage pipeline spec; superseded by the authoritative 36-stage Deca-Pass architecture.
+Deprecated on: 2026-04-08
+Authority: Randy Jordan, Senior Audio-DSP Architect / AI Architect
+---
+
+> **This file is a v9.0 era overview document only.**
+> It documents an 18-stage pipeline that has been superseded.
+> See `VoiceIsolate_Pro_v23_Blueprint.docx` for the authoritative 36-stage Deca-Pass specification.

--- a/VoiceIsolate-Pro-Complete.DEPRECATED.md
+++ b/VoiceIsolate-Pro-Complete.DEPRECATED.md
@@ -1,0 +1,13 @@
+---
+⚠️ DEPRECATED — DO NOT USE FOR IMPLEMENTATION
+Superseded by: VoiceIsolate_Pro_v23_Blueprint.docx
+Reason: v9.0 era document; 18-stage pipeline spec conflicts with the authoritative 36-stage Deca-Pass. FFT size spec (4096–16384pt live) violates the correct live-mode constraint of FFT=512/hop=128.
+Deprecated on: 2026-04-08
+Authority: Randy Jordan, Senior Audio-DSP Architect / AI Architect
+---
+
+**DEPRECATION NOTICE FOR: `VoiceIsolate-Pro-Complete.pdf`**
+
+[DEPRECATED 2026-04-08] This document has been superseded by `VoiceIsolate_Pro_v23_Blueprint.docx`.
+Do not reference this file for implementation decisions.
+See `VoiceIsolate_Pro_v23_Blueprint.docx` for the authoritative specification.

--- a/VoiceIsolate-Pro-space.DEPRECATED.md
+++ b/VoiceIsolate-Pro-space.DEPRECATED.md
@@ -1,0 +1,13 @@
+---
+⚠️ DEPRECATED — DO NOT USE FOR IMPLEMENTATION
+Superseded by: VoiceIsolate_Pro_v23_Blueprint.docx
+Reason: Pre-final, 18-stage spec; contains contradictory pipeline stage counts (Space files version, updated 2026-02-21).
+Deprecated on: 2026-04-08
+Authority: Randy Jordan, Senior Audio-DSP Architect / AI Architect
+---
+
+**DEPRECATION NOTICE FOR: `VoiceIsolate Pro .pdf`** (Space files version)
+
+[DEPRECATED 2026-04-08] This document has been superseded by `VoiceIsolate_Pro_v23_Blueprint.docx`.
+Do not reference this file for implementation decisions.
+See `VoiceIsolate_Pro_v23_Blueprint.docx` for the authoritative specification.

--- a/VoiceIsolate-Pro.md
+++ b/VoiceIsolate-Pro.md
@@ -1,0 +1,11 @@
+---
+⚠️ DEPRECATED — DO NOT USE FOR IMPLEMENTATION
+Superseded by: VoiceIsolate_Pro_v23_Blueprint.docx
+Reason: Consolidated master document merging ALL versions (v5 through v9); contains contradictory pipeline specs from multiple eras. The v23 Blueprint is the only implementation reference.
+Deprecated on: 2026-04-08
+Authority: Randy Jordan, Senior Audio-DSP Architect / AI Architect
+---
+
+> **This file is a historical consolidation document only.**
+> It merged all spec versions from v5 through v9 and must NOT be used as an implementation reference.
+> See `VoiceIsolate_Pro_v23_Blueprint.docx` for the authoritative 36-stage Deca-Pass specification.

--- a/VoiceIsolate-pro.DEPRECATED.md
+++ b/VoiceIsolate-pro.DEPRECATED.md
@@ -1,0 +1,13 @@
+---
+⚠️ DEPRECATED — DO NOT USE FOR IMPLEMENTATION
+Superseded by: VoiceIsolate_Pro_v23_Blueprint.docx
+Reason: Early draft, incomplete spec, superseded by multiple subsequent versions.
+Deprecated on: 2026-04-08
+Authority: Randy Jordan, Senior Audio-DSP Architect / AI Architect
+---
+
+**DEPRECATION NOTICE FOR: `VoiceIsolate pro.pdf`**
+
+[DEPRECATED 2026-04-08] This document has been superseded by `VoiceIsolate_Pro_v23_Blueprint.docx`.
+Do not reference this file for implementation decisions.
+See `VoiceIsolate_Pro_v23_Blueprint.docx` for the authoritative specification.

--- a/VoiceIsolate_Pro_v10_Aggressive_Blueprint.DEPRECATED.md
+++ b/VoiceIsolate_Pro_v10_Aggressive_Blueprint.DEPRECATED.md
@@ -1,0 +1,13 @@
+---
+⚠️ DEPRECATED — DO NOT USE FOR IMPLEMENTATION
+Superseded by: VoiceIsolate_Pro_v23_Blueprint.docx
+Reason: v10 intermediate draft; pipeline stage count and model parameters conflict with the final 36-stage Deca-Pass architecture.
+Deprecated on: 2026-04-08
+Authority: Randy Jordan, Senior Audio-DSP Architect / AI Architect
+---
+
+**DEPRECATION NOTICE FOR: `VoiceIsolate_Pro_v10_Aggressive_Blueprint.pdf`**
+
+[DEPRECATED 2026-04-08] This document has been superseded by `VoiceIsolate_Pro_v23_Blueprint.docx`.
+Do not reference this file for implementation decisions.
+See `VoiceIsolate_Pro_v23_Blueprint.docx` for the authoritative specification.

--- a/VoiceIsolate_Pro_v13_Blueprint
+++ b/VoiceIsolate_Pro_v13_Blueprint
@@ -1,0 +1,11 @@
+# DEPRECATED 2026-04-08
+# Superseded by: VoiceIsolate_Pro_v23_Blueprint.docx
+# Do not use for implementation.
+#
+# Reason: v13 draft, superseded by final production blueprint; contains stale parameter
+# tables for noise gate thresholds and STFT hop sizes.
+# Authority: Randy Jordan, Senior Audio-DSP Architect / AI Architect
+#
+# [DEPRECATED 2026-04-08] This document has been superseded by VoiceIsolate_Pro_v23_Blueprint.docx.
+# Do not reference this file for implementation decisions.
+# See VoiceIsolate_Pro_v23_Blueprint.docx for the authoritative specification.

--- a/VoiceIsolate_Pro_v13_Blueprint.DEPRECATED.md
+++ b/VoiceIsolate_Pro_v13_Blueprint.DEPRECATED.md
@@ -1,0 +1,13 @@
+---
+⚠️ DEPRECATED — DO NOT USE FOR IMPLEMENTATION
+Superseded by: VoiceIsolate_Pro_v23_Blueprint.docx
+Reason: v13 draft, superseded by final production blueprint; contains stale parameter tables for noise gate thresholds and STFT hop sizes.
+Deprecated on: 2026-04-08
+Authority: Randy Jordan, Senior Audio-DSP Architect / AI Architect
+---
+
+**DEPRECATION NOTICE FOR: `VoiceIsolate_Pro_v13_Blueprint` (no extension) and `VoiceIsolate_Pro_v13_Blueprint.pdf`**
+
+[DEPRECATED 2026-04-08] These documents have been superseded by `VoiceIsolate_Pro_v23_Blueprint.docx`.
+Do not reference these files for implementation decisions.
+See `VoiceIsolate_Pro_v23_Blueprint.docx` for the authoritative specification.

--- a/VoiceIsolate_Pro_v5_Technical_Blueprint.DEPRECATED.md
+++ b/VoiceIsolate_Pro_v5_Technical_Blueprint.DEPRECATED.md
@@ -1,0 +1,13 @@
+---
+⚠️ DEPRECATED — DO NOT USE FOR IMPLEMENTATION
+Superseded by: VoiceIsolate_Pro_v23_Blueprint.docx
+Reason: v5.0 document (January 2026), 12-stage pipeline; completely superseded by the authoritative 36-stage Deca-Pass architecture.
+Deprecated on: 2026-04-08
+Authority: Randy Jordan, Senior Audio-DSP Architect / AI Architect
+---
+
+**DEPRECATION NOTICE FOR: `VoiceIsolate_Pro_v5_Technical_Blueprint.docx`**
+
+[DEPRECATED 2026-04-08] This document has been superseded by `VoiceIsolate_Pro_v23_Blueprint.docx`.
+Do not reference this file for implementation decisions.
+See `VoiceIsolate_Pro_v23_Blueprint.docx` for the authoritative specification.

--- a/voiceisolate-all.md
+++ b/voiceisolate-all.md
@@ -1,0 +1,11 @@
+---
+⚠️ DEPRECATED — DO NOT USE FOR IMPLEMENTATION
+Superseded by: VoiceIsolate_Pro_v23_Blueprint.docx
+Reason: Consolidated master document merging ALL versions (v5 through v9); contains contradictory pipeline specs from multiple eras. The v23 Blueprint is the only implementation reference.
+Deprecated on: 2026-04-08
+Authority: Randy Jordan, Senior Audio-DSP Architect / AI Architect
+---
+
+> **This file is a historical consolidation document only.**
+> It merged all spec versions from v5 through v9 and must NOT be used as an implementation reference.
+> See `VoiceIsolate_Pro_v23_Blueprint.docx` for the authoritative 36-stage Deca-Pass specification.

--- a/voiceisolate-pdf.DEPRECATED.md
+++ b/voiceisolate-pdf.DEPRECATED.md
@@ -1,0 +1,13 @@
+---
+⚠️ DEPRECATED — DO NOT USE FOR IMPLEMENTATION
+Superseded by: VoiceIsolate_Pro_v23_Blueprint.docx
+Reason: v9.0 era overview document with 18-stage pipeline spec; superseded by the authoritative 36-stage Deca-Pass architecture.
+Deprecated on: 2026-04-08
+Authority: Randy Jordan, Senior Audio-DSP Architect / AI Architect
+---
+
+**DEPRECATION NOTICE FOR: `voiceisolate-pdf.pdf`**
+
+[DEPRECATED 2026-04-08] This document has been superseded by `VoiceIsolate_Pro_v23_Blueprint.docx`.
+Do not reference this file for implementation decisions.
+See `VoiceIsolate_Pro_v23_Blueprint.docx` for the authoritative specification.


### PR DESCRIPTION
Adds DEPRECATION_NOTICE headers and sidecar files for all superseded
spec documents (v5 through v14/v9 era), per authority of Randy Jordan.
All deprecated files point to VoiceIsolate_Pro_v23_Blueprint.docx as
the single authoritative 36-stage Deca-Pass implementation reference.

Files processed:
- voiceisolate-all.md, VoiceIsolate-Pro.md (multi-era consolidations)
- VoiceIsolate-Pro-Complete-Overview.md (v9.0 overview, 18-stage)
- .DEPRECATED.md sidecars for 10 binary PDF/DOCX files not in repo
- Text deprecation stubs for 2 no-extension files
- DEPRECATION_LOG.md: full audit table for both VoiceIsolate Pro and
  OrchestrAI Nexus (cross-project note for Nexus PDF duplicate)

https://claude.ai/code/session_01FyGZHTjg2vTyDHmU5XwsN7
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/joker5514/voiceisolate-pro/pull/309" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deprecates 15 legacy VoiceIsolate Pro spec files and adds clear notices across the repo. All deprecated docs now point to `VoiceIsolate_Pro_v23_Blueprint.docx` as the single canonical 36-stage Deca-Pass spec, with `DEPRECATION_LOG.md` plus sidecar `.DEPRECATED.md` files and stubs for binaries/no-extension files.

- **Migration**
  - Use `VoiceIsolate_Pro_v23_Blueprint.docx` as the only implementation reference and update any internal links that point to v5–v14/v9-era docs.
  - In the OrchestrAI Nexus repo, mark `OrchestrAI Nexus File Creation Plan (1).pdf` deprecated in the same format.

<sup>Written for commit 1036bc90fcae3f80e25ba941e41edd0a5e01cc1c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Marked multiple outdated specification and installation guides as deprecated to clarify the current authoritative reference
  * Added comprehensive deprecation notices across documentation to prevent reliance on outdated information
  * Historical documentation files now explicitly indicate supersession status and direct users to the current implementation specification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->