### PR TITLE
Fix upload error + add login system with test accounts

### DIFF
--- a/api/auth.js
+++ b/api/auth.js
@@ -102,13 +102,16 @@ function seedUser(id, username, email, password, tier, role = 'user') {
 }
 
 // Admin account
-seedUser('usr_admin_001', 'joker5514', 'admin@voiceisolatepro.com', 'Admin8052', 'ENTERPRISE', 'admin');
+if (process.env.NODE_ENV !== 'production') {
+  // Admin account
+  seedUser('usr_admin_001', 'joker5514', 'admin@voiceisolatepro.com', 'Admin8052', 'ENTERPRISE', 'admin');
 
-// Test accounts per tier
-seedUser('usr_test_free', 'test_free', 'free@test.voiceisolatepro.com', 'TestFree123', 'FREE', 'user');
-seedUser('usr_test_pro', 'test_pro', 'pro@test.voiceisolatepro.com', 'TestPro123', 'PRO', 'user');
-seedUser('usr_test_studio', 'test_studio', 'studio@test.voiceisolatepro.com', 'TestStudio123', 'STUDIO', 'user');
-seedUser('usr_test_enterprise', 'test_enterprise', 'enterprise@test.voiceisolatepro.com', 'TestEnterprise123', 'ENTERPRISE', 'user');
+  // Test accounts per tier
+  seedUser('usr_test_free', 'test_free', 'free@test.voiceisolatepro.com', 'TestFree123', 'FREE', 'user');
+  seedUser('usr_test_pro', 'test_pro', 'pro@test.voiceisolatepro.com', 'TestPro123', 'PRO', 'user');
+  seedUser('usr_test_studio', 'test_studio', 'studio@test.voiceisolatepro.com', 'TestStudio123', 'STUDIO', 'user');
+  seedUser('usr_test_enterprise', 'test_enterprise', 'enterprise@test.voiceisolatepro.com', 'TestEnterprise123', 'ENTERPRISE', 'user');
+}
 
 // ─── POST /api/auth/login ────────────────────────────────────────────────────
 router.post('/login', (req, res) => {

--- a/api/auth.js
+++ b/api/auth.js
@@ -36,6 +36,13 @@ function verifyPassword(password, stored) {
 }
 
 // ─── JWT Utilities (reuses same secret as license tokens) ────────────────────
+if (!process.env.LICENSE_JWT_SECRET) {
+  if (process.env.NODE_ENV === 'production') {
+    throw new Error('LICENSE_JWT_SECRET environment variable is required');
+  }
+  process.env.LICENSE_JWT_SECRET = 'voiceisolate-dev-secret-key-minimum-32-chars';
+  console.warn('[auth] LICENSE_JWT_SECRET not set — using dev default. Do NOT use in production.');
+}
 const LICENSE_SECRET = process.env.LICENSE_JWT_SECRET;
 
 function createAuthToken(user) {

--- a/api/auth.js
+++ b/api/auth.js
@@ -40,8 +40,7 @@ if (!process.env.LICENSE_JWT_SECRET) {
   if (process.env.NODE_ENV === 'production') {
     throw new Error('LICENSE_JWT_SECRET environment variable is required');
   }
-  process.env.LICENSE_JWT_SECRET = 'voiceisolate-dev-secret-key-minimum-32-chars';
-  console.warn('[auth] LICENSE_JWT_SECRET not set — using dev default. Do NOT use in production.');
+  throw new Error('LICENSE_JWT_SECRET environment variable is required');
 }
 const LICENSE_SECRET = process.env.LICENSE_JWT_SECRET;
 

--- a/api/auth.js
+++ b/api/auth.js
@@ -1,0 +1,171 @@
+/**
+ * VoiceIsolate Pro — Authentication API v22
+ *
+ * Endpoints:
+ *   POST /api/auth/login   — Authenticate with username + password, returns JWT
+ *   GET  /api/auth/me      — Get current user info from Bearer token
+ *   POST /api/auth/logout  — Invalidate session (client-side only for now)
+ *
+ * Seeded accounts:
+ *   admin    — joker5514 (ENTERPRISE + admin)
+ *   test_free / test_pro / test_studio / test_enterprise — tier test accounts
+ *
+ * Passwords hashed with scrypt (Node.js built-in crypto).
+ */
+
+import express from 'express';
+import crypto from 'crypto';
+
+const router = express.Router();
+
+// ─── Password Hashing (scrypt) ───────────────────────────────────────────────
+const SCRYPT_KEYLEN = 64;
+const SCRYPT_COST = { N: 16384, r: 8, p: 1 };
+
+function hashPassword(password) {
+  const salt = crypto.randomBytes(16).toString('hex');
+  const derived = crypto.scryptSync(password, salt, SCRYPT_KEYLEN, SCRYPT_COST);
+  return `${salt}:${derived.toString('hex')}`;
+}
+
+function verifyPassword(password, stored) {
+  const [salt, hash] = stored.split(':');
+  const derived = crypto.scryptSync(password, salt, SCRYPT_KEYLEN, SCRYPT_COST);
+  const expected = Buffer.from(hash, 'hex');
+  return crypto.timingSafeEqual(derived, expected);
+}
+
+// ─── JWT Utilities (reuses same secret as license tokens) ────────────────────
+const LICENSE_SECRET = process.env.LICENSE_JWT_SECRET;
+
+function createAuthToken(user) {
+  const header = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64url');
+  const payload = Buffer.from(JSON.stringify({
+    sub: user.id,
+    username: user.username,
+    email: user.email,
+    tier: user.tier.toLowerCase(),
+    role: user.role,
+    iat: Math.floor(Date.now() / 1000),
+    exp: Math.floor(Date.now() / 1000) + (365 * 86400),
+    source: 'auth',
+    jti: crypto.randomBytes(8).toString('hex'),
+  })).toString('base64url');
+  const sig = crypto
+    .createHmac('sha256', LICENSE_SECRET)
+    .update(`${header}.${payload}`)
+    .digest('base64url');
+  return `${header}.${payload}.${sig}`;
+}
+
+function validateAuthToken(token) {
+  try {
+    const parts = token.split('.');
+    if (parts.length !== 3) return null;
+    const expectedSig = crypto
+      .createHmac('sha256', LICENSE_SECRET)
+      .update(`${parts[0]}.${parts[1]}`)
+      .digest('base64url');
+    if (!crypto.timingSafeEqual(
+      Buffer.from(expectedSig, 'base64url'),
+      Buffer.from(parts[2], 'base64url')
+    )) return null;
+    const payload = JSON.parse(Buffer.from(parts[1], 'base64url').toString());
+    if (Date.now() / 1000 > payload.exp) return null;
+    return payload;
+  } catch {
+    return null;
+  }
+}
+
+// ─── Seeded User Store ───────────────────────────────────────────────────────
+// In-memory store; production would use DATABASE_URL.
+const USERS = {};
+
+function seedUser(id, username, email, password, tier, role = 'user') {
+  USERS[username.toLowerCase()] = {
+    id,
+    username,
+    email,
+    passwordHash: hashPassword(password),
+    tier,
+    role,
+    createdAt: new Date().toISOString(),
+  };
+}
+
+// Admin account
+seedUser('usr_admin_001', 'joker5514', 'admin@voiceisolatepro.com', 'Admin8052', 'ENTERPRISE', 'admin');
+
+// Test accounts per tier
+seedUser('usr_test_free', 'test_free', 'free@test.voiceisolatepro.com', 'TestFree123', 'FREE', 'user');
+seedUser('usr_test_pro', 'test_pro', 'pro@test.voiceisolatepro.com', 'TestPro123', 'PRO', 'user');
+seedUser('usr_test_studio', 'test_studio', 'studio@test.voiceisolatepro.com', 'TestStudio123', 'STUDIO', 'user');
+seedUser('usr_test_enterprise', 'test_enterprise', 'enterprise@test.voiceisolatepro.com', 'TestEnterprise123', 'ENTERPRISE', 'user');
+
+// ─── POST /api/auth/login ────────────────────────────────────────────────────
+router.post('/login', (req, res) => {
+  const { username, password } = req.body || {};
+
+  if (!username || !password) {
+    return res.status(400).json({ error: 'Username and password are required.' });
+  }
+
+  const user = USERS[username.toLowerCase()];
+  if (!user) {
+    return res.status(401).json({ error: 'Invalid username or password.' });
+  }
+
+  if (!verifyPassword(password, user.passwordHash)) {
+    return res.status(401).json({ error: 'Invalid username or password.' });
+  }
+
+  const token = createAuthToken(user);
+
+  res.json({
+    success: true,
+    token,
+    user: {
+      id: user.id,
+      username: user.username,
+      email: user.email,
+      tier: user.tier,
+      role: user.role,
+    },
+  });
+});
+
+// ─── GET /api/auth/me ────────────────────────────────────────────────────────
+router.get('/me', (req, res) => {
+  const authHeader = req.headers.authorization;
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return res.status(401).json({ error: 'Not authenticated.' });
+  }
+
+  const payload = validateAuthToken(authHeader.slice(7));
+  if (!payload) {
+    return res.status(401).json({ error: 'Invalid or expired token.' });
+  }
+
+  const user = USERS[payload.username?.toLowerCase()];
+  res.json({
+    id: payload.sub,
+    username: payload.username,
+    email: payload.email,
+    tier: payload.tier.toUpperCase(),
+    role: payload.role,
+    expiresAt: payload.exp * 1000,
+    isAdmin: payload.role === 'admin',
+    ...(user ? { createdAt: user.createdAt } : {}),
+  });
+});
+
+// ─── POST /api/auth/logout ───────────────────────────────────────────────────
+router.post('/logout', (_req, res) => {
+  // Stateless JWT — logout is handled client-side by clearing the token.
+  // A production system would add the token to a revocation list.
+  res.json({ success: true, message: 'Logged out. Clear token on client.' });
+});
+
+export default router;
+export { validateAuthToken, USERS };

--- a/api/index.js
+++ b/api/index.js
@@ -11,6 +11,7 @@
  *   /api/license/*         → License validation and activation
  *   /api/usage/*           → Usage recording for metered billing
  *   /api/pricing           → Public pricing info
+ *   /api/auth/*            → Authentication (login, me, logout)
  *   /api/sync/*            → Cloud sync (Studio/Enterprise)
  *   /api/health            → Health check
  */
@@ -18,6 +19,7 @@
 import express from 'express';
 import monetizationRouter from './monetization.js';
 import syncRouter from './sync.js';
+import authRouter from './auth.js';
 
 const router = express.Router();
 
@@ -40,6 +42,9 @@ router.use(express.json());
 
 // ─── Monetization Routes ──────────────────────────────────────────────────────
 router.use('/', monetizationRouter);
+
+// ─── Authentication Routes ───────────────────────────────────────────────────
+router.use('/auth', authRouter);
 
 // ─── Cloud Sync Routes ────────────────────────────────────────────────────────
 router.use('/sync', syncRouter);

--- a/api/monetization.js
+++ b/api/monetization.js
@@ -37,7 +37,11 @@ function getStripe() {
 
 // ─── License Token Utilities ──────────────────────────────────────────────────
 if (!process.env.LICENSE_JWT_SECRET) {
-  throw new Error('LICENSE_JWT_SECRET environment variable is required');
+  if (process.env.NODE_ENV === 'production') {
+    throw new Error('LICENSE_JWT_SECRET environment variable is required');
+  }
+  process.env.LICENSE_JWT_SECRET = 'voiceisolate-dev-secret-key-minimum-32-chars';
+  console.warn('[monetization] LICENSE_JWT_SECRET not set — using dev default. Do NOT use in production.');
 }
 const LICENSE_SECRET = process.env.LICENSE_JWT_SECRET;
 

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -550,7 +550,7 @@ class VoiceIsolatePro {
       const LM = window.LicenseManager;
       if (LM && typeof LM.checkFileLimit === 'function') {
         const fileSizeMB = file.size / (1024 * 1024);
-        const check = LM.checkFileLimit(fileSizeMB, Infinity);
+        const check = LM.checkFileLimit(fileSizeMB, 0);
         if (!check.allowed) throw new Error(check.reason);
       }
 

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -543,6 +543,16 @@ class VoiceIsolatePro {
   async handleFile(file) {
     try {
       // 🛡️ Sentinel: Validate file size (max 200MB) and MIME type
+      const MAX_FILE_SIZE = 200 * 1024 * 1024; // 200 MB
+      if (file.size > MAX_FILE_SIZE) {
+        throw new Error('File too large (' + (file.size / (1024 * 1024)).toFixed(1) + ' MB). Maximum allowed size is 200 MB.');
+      }
+      const LM = window.LicenseManager;
+      if (LM && typeof LM.checkFileLimit === 'function') {
+        const fileSizeMB = file.size / (1024 * 1024);
+        const check = LM.checkFileLimit(fileSizeMB, Infinity);
+        if (!check.allowed) throw new Error(check.reason);
+      }
 
       const normalizedType = (file.type || '').toLowerCase();
       const normalizedName = (file.name || '').toLowerCase();

--- a/public/app/auth.js
+++ b/public/app/auth.js
@@ -1,0 +1,230 @@
+/**
+ * VoiceIsolate Pro — Client Auth Module v22
+ *
+ * Handles login UI, session persistence (localStorage), and LicenseManager integration.
+ * On successful login the JWT is passed to LicenseManager.activate() so the
+ * tier-based feature gates and file limits work automatically.
+ *
+ * Storage key: vip_auth_v22 (username, token)
+ */
+
+/* global LicenseManager */
+
+const VIPAuth = (() => {
+  'use strict';
+
+  const STORAGE_KEY = 'vip_auth_v22';
+  let _currentUser = null;
+
+  // ─── DOM helpers ─────────────────────────────────────────────────────────────
+  function $(id) { return document.getElementById(id); }
+
+  function _hide(el) { if (el) el.style.display = 'none'; }
+  function _show(el, display) { if (el) el.style.display = display || 'flex'; }
+
+  // ─── API calls ───────────────────────────────────────────────────────────────
+  async function _login(username, password) {
+    const res = await fetch('/api/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password }),
+    });
+    return res.json();
+  }
+
+  async function _fetchMe(token) {
+    const res = await fetch('/api/auth/me', {
+      headers: { 'Authorization': 'Bearer ' + token },
+    });
+    if (!res.ok) return null;
+    return res.json();
+  }
+
+  // ─── Session persistence ─────────────────────────────────────────────────────
+  function _saveSession(username, token) {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({ username, token }));
+    } catch { /* storage unavailable */ }
+  }
+
+  function _loadSession() {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      return raw ? JSON.parse(raw) : null;
+    } catch { return null; }
+  }
+
+  function _clearSession() {
+    try { localStorage.removeItem(STORAGE_KEY); } catch { /* ok */ }
+  }
+
+  // ─── UI rendering ───────────────────────────────────────────────────────────
+  function _renderLoginOverlay() {
+    // Don't duplicate
+    if ($('authOverlay')) return;
+
+    const overlay = document.createElement('div');
+    overlay.id = 'authOverlay';
+    overlay.innerHTML = `
+      <div class="auth-modal">
+        <div class="auth-icon">
+          <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+            <path d="M12 1v22M8 5v14M4 9v6M16 5v14M20 9v6"/>
+          </svg>
+        </div>
+        <h2 class="auth-title">VoiceIsolate Pro</h2>
+        <p class="auth-subtitle">Sign in to continue</p>
+        <form id="authForm" autocomplete="on">
+          <div class="auth-field">
+            <label for="authUser">Username</label>
+            <input type="text" id="authUser" name="username" autocomplete="username" spellcheck="false" required />
+          </div>
+          <div class="auth-field">
+            <label for="authPass">Password</label>
+            <input type="password" id="authPass" name="password" autocomplete="current-password" required />
+          </div>
+          <div id="authError" class="auth-error"></div>
+          <button type="submit" id="authSubmit" class="auth-btn">Sign In</button>
+        </form>
+      </div>
+    `;
+    document.body.appendChild(overlay);
+
+    $('authForm').addEventListener('submit', _handleLogin);
+  }
+
+  function _renderUserBadge(user) {
+    // Remove existing badge
+    const existing = $('authBadge');
+    if (existing) existing.remove();
+
+    const badge = document.createElement('div');
+    badge.id = 'authBadge';
+    badge.className = 'auth-badge';
+    const tierClass = 'auth-tier-' + (user.tier || 'free').toLowerCase();
+    badge.innerHTML = `
+      <span class="auth-badge-user">${_escHtml(user.username)}</span>
+      <span class="auth-badge-tier ${tierClass}">${(user.tier || 'FREE').toUpperCase()}</span>
+      ${user.role === 'admin' ? '<span class="auth-badge-admin">ADMIN</span>' : ''}
+      <button id="authLogoutBtn" class="auth-logout-btn" title="Sign out">&#x2715;</button>
+    `;
+
+    // Insert into header
+    const hdr = document.querySelector('.hdr');
+    if (hdr) {
+      const toggle = $('statsToggle');
+      if (toggle) hdr.insertBefore(badge, toggle);
+      else hdr.appendChild(badge);
+    }
+
+    $('authLogoutBtn').addEventListener('click', _handleLogout);
+  }
+
+  function _escHtml(str) {
+    const d = document.createElement('div');
+    d.textContent = str;
+    return d.innerHTML;
+  }
+
+  // ─── Event handlers ──────────────────────────────────────────────────────────
+  async function _handleLogin(e) {
+    e.preventDefault();
+    const btn = $('authSubmit');
+    const errEl = $('authError');
+    const username = $('authUser').value.trim();
+    const password = $('authPass').value;
+
+    if (!username || !password) {
+      errEl.textContent = 'Please enter username and password.';
+      return;
+    }
+
+    btn.disabled = true;
+    btn.textContent = 'Signing in...';
+    errEl.textContent = '';
+
+    try {
+      const data = await _login(username, password);
+      if (!data.success) {
+        errEl.textContent = data.error || 'Login failed.';
+        btn.disabled = false;
+        btn.textContent = 'Sign In';
+        return;
+      }
+
+      _currentUser = data.user;
+      _saveSession(data.user.username, data.token);
+
+      // Activate license via LicenseManager
+      if (window.LicenseManager && typeof window.LicenseManager.activate === 'function') {
+        window.LicenseManager.activate(data.token, data.user.email);
+      }
+
+      // Remove overlay, show badge
+      const overlay = $('authOverlay');
+      if (overlay) overlay.remove();
+      _renderUserBadge(data.user);
+
+    } catch (err) {
+      errEl.textContent = 'Network error. Is the server running?';
+      btn.disabled = false;
+      btn.textContent = 'Sign In';
+    }
+  }
+
+  function _handleLogout() {
+    _currentUser = null;
+    _clearSession();
+
+    // Deactivate license
+    if (window.LicenseManager && typeof window.LicenseManager.deactivate === 'function') {
+      window.LicenseManager.deactivate();
+    }
+
+    // Remove badge, show login
+    const badge = $('authBadge');
+    if (badge) badge.remove();
+    _renderLoginOverlay();
+  }
+
+  // ─── Init ────────────────────────────────────────────────────────────────────
+  async function init() {
+    const session = _loadSession();
+    if (session && session.token) {
+      // Try to restore session
+      try {
+        const me = await _fetchMe(session.token);
+        if (me && me.username) {
+          _currentUser = me;
+
+          // Re-activate license from stored token
+          if (window.LicenseManager && typeof window.LicenseManager.activate === 'function') {
+            window.LicenseManager.activate(session.token, me.email);
+          }
+
+          _renderUserBadge(me);
+          return;
+        }
+      } catch { /* server unavailable — fall through to login */ }
+    }
+
+    // No valid session — show login
+    _renderLoginOverlay();
+  }
+
+  // ─── Public API ──────────────────────────────────────────────────────────────
+  return {
+    init,
+    getUser() { return _currentUser; },
+    isLoggedIn() { return !!_currentUser; },
+    isAdmin() { return _currentUser && _currentUser.role === 'admin'; },
+    logout: _handleLogout,
+  };
+})();
+
+// Auto-init when DOM is ready
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', () => VIPAuth.init());
+} else {
+  VIPAuth.init();
+}

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -13,6 +13,32 @@
   <link rel="stylesheet" href="style.css" />
   <!-- Diagnostics log panel styles -->
   <link rel="stylesheet" href="style-diag-log.css" />
+  <!-- Auth overlay styles -->
+  <style>
+    #authOverlay{position:fixed;inset:0;z-index:10000;display:flex;align-items:center;justify-content:center;background:rgba(6,6,9,0.96);backdrop-filter:blur(12px)}
+    .auth-modal{width:340px;padding:32px 28px;background:var(--s2);border:1px solid var(--border2);border-radius:var(--r);text-align:center}
+    .auth-icon{width:48px;height:48px;margin:0 auto 12px;border-radius:10px;background:linear-gradient(135deg,var(--red),var(--red3));display:flex;align-items:center;justify-content:center;color:#fff;box-shadow:0 0 20px var(--red-glow)}
+    .auth-title{font-size:1.2rem;font-weight:700;margin-bottom:2px}
+    .auth-subtitle{font-size:0.75rem;color:var(--dim);margin-bottom:20px}
+    .auth-field{text-align:left;margin-bottom:12px}
+    .auth-field label{display:block;font-size:0.65rem;font-weight:600;color:var(--text2);text-transform:uppercase;letter-spacing:0.08em;margin-bottom:4px}
+    .auth-field input{width:100%;padding:8px 10px;background:var(--s1);border:1px solid var(--border);border-radius:var(--rs);color:var(--text);font-family:var(--fm);font-size:0.85rem;outline:none;transition:border-color 0.2s}
+    .auth-field input:focus{border-color:var(--red)}
+    .auth-error{font-size:0.72rem;color:var(--red2);min-height:18px;margin-bottom:4px}
+    .auth-btn{width:100%;padding:10px;background:linear-gradient(135deg,var(--red),var(--red3));color:#fff;font-family:var(--ff);font-size:0.85rem;font-weight:600;border:none;border-radius:var(--rs);cursor:pointer;transition:opacity 0.2s}
+    .auth-btn:hover{opacity:0.9}
+    .auth-btn:disabled{opacity:0.5;cursor:not-allowed}
+    .auth-badge{display:flex;align-items:center;gap:6px;padding:3px 8px;background:var(--s3);border:1px solid var(--border);border-radius:var(--rs);font-size:0.7rem;margin-right:8px}
+    .auth-badge-user{color:var(--text);font-weight:600;font-family:var(--fm)}
+    .auth-badge-tier{padding:1px 5px;border-radius:3px;font-size:0.55rem;font-weight:700;letter-spacing:0.08em}
+    .auth-tier-free{color:var(--dim);background:rgba(107,114,128,0.15)}
+    .auth-tier-pro{color:var(--cyan);background:rgba(34,211,238,0.1);border:1px solid rgba(34,211,238,0.2)}
+    .auth-tier-studio{color:var(--purple);background:rgba(168,85,247,0.1);border:1px solid rgba(168,85,247,0.2)}
+    .auth-tier-enterprise{color:var(--yellow);background:rgba(234,179,8,0.1);border:1px solid rgba(234,179,8,0.2)}
+    .auth-badge-admin{padding:1px 5px;border-radius:3px;font-size:0.5rem;font-weight:700;letter-spacing:0.1em;color:var(--red2);background:rgba(220,38,38,0.1);border:1px solid rgba(220,38,38,0.2)}
+    .auth-logout-btn{background:none;border:none;color:var(--dim);cursor:pointer;font-size:0.8rem;padding:0 2px;line-height:1;transition:color 0.2s}
+    .auth-logout-btn:hover{color:var(--red2)}
+  </style>
 </head>
 <body>
   <!-- HEADER -->
@@ -355,6 +381,7 @@
      4. batch-orchestrator       — batch queue
      5. analytics                — telemetry stub
      6. license-manager          — paywall gate
+     6b. auth.js                  — login overlay + session management
      7. app.js                   — defines VoiceIsolatePro class (includes merged patches)
      8. ai-engine-v2.js          — AI reasoning engine
      9. ai-intelligence.js       — AI analysis helpers
@@ -374,6 +401,7 @@
   <script src="./batch-orchestrator.js"></script>
   <script src="./analytics.js"></script>
   <script src="./license-manager.js"></script>
+  <script src="./auth.js"></script>
   <script src="./ai-engine-v2.js"></script>
   <script src="./ai-intelligence.js"></script>
   <script src="./ml-worker-models-patch.js"></script>

--- a/server.js
+++ b/server.js
@@ -10,6 +10,7 @@
 import express from 'express';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
+import apiRouter from './api/index.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = dirname(__filename);
@@ -45,6 +46,9 @@ app.use((_req, res, next) => {
 
   next();
 });
+
+// ── API Routes ──────────────────────────────────────────────────────────
+app.use('/api', apiRouter);
 
 // ── WASM MIME type & caching ─────────────────────────────────────────────
 app.use('/wasm', express.static(join(__dirname, 'wasm'), {

--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -1,0 +1,627 @@
+/**
+ * VoiceIsolate Pro — Authentication API Unit Tests
+ *
+ * Tests the JWT auth-token creation/validation logic and the HTTP route
+ * behaviour of the authentication API (api/auth.js).
+ *
+ * The core token functions (createAuthToken / validateAuthToken) are
+ * re-implemented here using the same algorithm as api/auth.js so the
+ * contract can be verified without importing the ESM module directly.
+ *
+ * Route-level tests use a minimal in-process Express app that mirrors the
+ * route handlers from api/auth.js.
+ */
+
+'use strict';
+
+const crypto  = require('crypto');
+const express = require('express');
+const request = require('supertest');
+
+// ── Test JWT secret (mirrors LICENSE_JWT_SECRET env var) ──────────────────────
+const TEST_SECRET = 'test-jwt-secret-for-auth-unit-tests-minimum-32-chars';
+
+// ── Token utility functions (same algorithm as api/auth.js) ──────────────────
+
+const SCRYPT_KEYLEN = 64;
+const SCRYPT_COST   = { N: 16384, r: 8, p: 1 };
+
+function hashPassword(password) {
+  const salt    = crypto.randomBytes(16).toString('hex');
+  const derived = crypto.scryptSync(password, salt, SCRYPT_KEYLEN, SCRYPT_COST);
+  return `${salt}:${derived.toString('hex')}`;
+}
+
+function verifyPassword(password, stored) {
+  const [salt, hash] = stored.split(':');
+  const derived      = crypto.scryptSync(password, salt, SCRYPT_KEYLEN, SCRYPT_COST);
+  const expected     = Buffer.from(hash, 'hex');
+  return crypto.timingSafeEqual(derived, expected);
+}
+
+function createAuthToken(user, secret = TEST_SECRET) {
+  const header  = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64url');
+  const payload = Buffer.from(JSON.stringify({
+    sub:      user.id,
+    username: user.username,
+    email:    user.email,
+    tier:     user.tier.toLowerCase(),
+    role:     user.role,
+    iat:      Math.floor(Date.now() / 1000),
+    exp:      Math.floor(Date.now() / 1000) + (365 * 86400),
+    source:   'auth',
+    jti:      crypto.randomBytes(8).toString('hex'),
+  })).toString('base64url');
+  const sig = crypto
+    .createHmac('sha256', secret)
+    .update(`${header}.${payload}`)
+    .digest('base64url');
+  return `${header}.${payload}.${sig}`;
+}
+
+function validateAuthToken(token, secret = TEST_SECRET) {
+  try {
+    const parts = token.split('.');
+    if (parts.length !== 3) return null;
+    const expectedSig = crypto
+      .createHmac('sha256', secret)
+      .update(`${parts[0]}.${parts[1]}`)
+      .digest('base64url');
+    if (!crypto.timingSafeEqual(
+      Buffer.from(expectedSig, 'base64url'),
+      Buffer.from(parts[2],    'base64url')
+    )) return null;
+    const payload = JSON.parse(Buffer.from(parts[1], 'base64url').toString());
+    if (Date.now() / 1000 > payload.exp) return null;
+    return payload;
+  } catch {
+    return null;
+  }
+}
+
+// ── Seeded user data (mirrors api/auth.js USERS) ──────────────────────────────
+function buildSeededUsers() {
+  const USERS = {};
+  function seedUser(id, username, email, password, tier, role = 'user') {
+    USERS[username.toLowerCase()] = {
+      id, username, email,
+      passwordHash: hashPassword(password),
+      tier, role,
+      createdAt: new Date().toISOString(),
+    };
+  }
+  seedUser('usr_admin_001',       'joker5514',         'admin@voiceisolatepro.com',             'Admin8052',         'ENTERPRISE', 'admin');
+  seedUser('usr_test_free',       'test_free',         'free@test.voiceisolatepro.com',          'TestFree123',       'FREE');
+  seedUser('usr_test_pro',        'test_pro',          'pro@test.voiceisolatepro.com',           'TestPro123',        'PRO');
+  seedUser('usr_test_studio',     'test_studio',       'studio@test.voiceisolatepro.com',        'TestStudio123',     'STUDIO');
+  seedUser('usr_test_enterprise', 'test_enterprise',   'enterprise@test.voiceisolatepro.com',    'TestEnterprise123', 'ENTERPRISE');
+  return USERS;
+}
+
+// ── Minimal Express app that mirrors api/auth.js route logic ──────────────────
+function buildApp(secret = TEST_SECRET) {
+  const app   = express();
+  const USERS = buildSeededUsers();
+
+  app.use(express.json());
+
+  // POST /login
+  app.post('/login', (req, res) => {
+    const { username, password } = req.body || {};
+    if (!username || !password) {
+      return res.status(400).json({ error: 'Username and password are required.' });
+    }
+    const user = USERS[username.toLowerCase()];
+    if (!user) {
+      return res.status(401).json({ error: 'Invalid username or password.' });
+    }
+    if (!verifyPassword(password, user.passwordHash)) {
+      return res.status(401).json({ error: 'Invalid username or password.' });
+    }
+    const token = createAuthToken(user, secret);
+    res.json({
+      success: true,
+      token,
+      user: {
+        id:       user.id,
+        username: user.username,
+        email:    user.email,
+        tier:     user.tier,
+        role:     user.role,
+      },
+    });
+  });
+
+  // GET /me
+  app.get('/me', (req, res) => {
+    const authHeader = req.headers.authorization;
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      return res.status(401).json({ error: 'Not authenticated.' });
+    }
+    const payload = validateAuthToken(authHeader.slice(7), secret);
+    if (!payload) {
+      return res.status(401).json({ error: 'Invalid or expired token.' });
+    }
+    const user = USERS[payload.username?.toLowerCase()];
+    res.json({
+      id:        payload.sub,
+      username:  payload.username,
+      email:     payload.email,
+      tier:      payload.tier.toUpperCase(),
+      role:      payload.role,
+      expiresAt: payload.exp * 1000,
+      isAdmin:   payload.role === 'admin',
+      ...(user ? { createdAt: user.createdAt } : {}),
+    });
+  });
+
+  // POST /logout
+  app.post('/logout', (_req, res) => {
+    res.json({ success: true, message: 'Logged out. Clear token on client.' });
+  });
+
+  return { app, USERS };
+}
+
+// ── createAuthToken() ─────────────────────────────────────────────────────────
+describe('createAuthToken()', () => {
+  const user = {
+    id: 'usr_test_1', username: 'testuser', email: 'test@example.com',
+    tier: 'PRO', role: 'user',
+  };
+
+  test('returns a three-part dot-separated string', () => {
+    const token = createAuthToken(user);
+    expect(token.split('.')).toHaveLength(3);
+  });
+
+  test('header decodes to correct JWT header fields', () => {
+    const token  = createAuthToken(user);
+    const header = JSON.parse(Buffer.from(token.split('.')[0], 'base64url').toString());
+    expect(header.alg).toBe('HS256');
+    expect(header.typ).toBe('JWT');
+  });
+
+  test('payload contains all expected fields', () => {
+    const token   = createAuthToken(user);
+    const payload = JSON.parse(Buffer.from(token.split('.')[1], 'base64url').toString());
+    expect(payload.sub).toBe('usr_test_1');
+    expect(payload.username).toBe('testuser');
+    expect(payload.email).toBe('test@example.com');
+    expect(payload.tier).toBe('pro');       // lowercased
+    expect(payload.role).toBe('user');
+    expect(payload.source).toBe('auth');
+    expect(typeof payload.jti).toBe('string');
+    expect(payload.iat).toBeLessThanOrEqual(Math.floor(Date.now() / 1000));
+    expect(payload.exp).toBeGreaterThan(Math.floor(Date.now() / 1000));
+  });
+
+  test('tier is stored lowercased in the payload', () => {
+    const token   = createAuthToken({ ...user, tier: 'ENTERPRISE' });
+    const payload = JSON.parse(Buffer.from(token.split('.')[1], 'base64url').toString());
+    expect(payload.tier).toBe('enterprise');
+  });
+
+  test('exp is approximately now + 365 days', () => {
+    const token       = createAuthToken(user);
+    const { exp }     = JSON.parse(Buffer.from(token.split('.')[1], 'base64url').toString());
+    const expectedExp = Math.floor(Date.now() / 1000) + 365 * 86400;
+    expect(Math.abs(exp - expectedExp)).toBeLessThan(5);
+  });
+
+  test('each call generates a unique jti', () => {
+    const t1 = createAuthToken(user);
+    const t2 = createAuthToken(user);
+    const p1 = JSON.parse(Buffer.from(t1.split('.')[1], 'base64url').toString());
+    const p2 = JSON.parse(Buffer.from(t2.split('.')[1], 'base64url').toString());
+    expect(p1.jti).not.toBe(p2.jti);
+  });
+
+  test('admin user token has role=admin in payload', () => {
+    const adminUser   = { ...user, role: 'admin' };
+    const token       = createAuthToken(adminUser);
+    const { role }    = JSON.parse(Buffer.from(token.split('.')[1], 'base64url').toString());
+    expect(role).toBe('admin');
+  });
+});
+
+// ── validateAuthToken() ───────────────────────────────────────────────────────
+describe('validateAuthToken()', () => {
+  const user = {
+    id: 'usr_v1', username: 'valuser', email: 'val@example.com',
+    tier: 'STUDIO', role: 'user',
+  };
+
+  test('returns payload for a valid unexpired token', () => {
+    const token   = createAuthToken(user);
+    const payload = validateAuthToken(token);
+    expect(payload).not.toBeNull();
+    expect(payload.sub).toBe('usr_v1');
+    expect(payload.username).toBe('valuser');
+    expect(payload.tier).toBe('studio');
+    expect(payload.source).toBe('auth');
+  });
+
+  test('returns null for a token signed with the wrong secret', () => {
+    const token = createAuthToken(user, 'wrong-secret-key-that-is-32-chars-long!!');
+    expect(validateAuthToken(token, TEST_SECRET)).toBeNull();
+  });
+
+  test('returns null for an expired token', () => {
+    const header  = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64url');
+    const payload = Buffer.from(JSON.stringify({
+      sub: 'u1', username: 'x', email: 'a@b.com', tier: 'pro',
+      role: 'user', iat: 0, exp: 1,
+    })).toString('base64url');
+    const sig = crypto
+      .createHmac('sha256', TEST_SECRET)
+      .update(`${header}.${payload}`)
+      .digest('base64url');
+    expect(validateAuthToken(`${header}.${payload}.${sig}`)).toBeNull();
+  });
+
+  test('returns null for a token with fewer than three parts', () => {
+    expect(validateAuthToken('only.twoparts')).toBeNull();
+    expect(validateAuthToken('singlepart')).toBeNull();
+  });
+
+  test('returns null for an empty string', () => {
+    expect(validateAuthToken('')).toBeNull();
+  });
+
+  test('returns null for a token with a tampered payload', () => {
+    const token   = createAuthToken(user);
+    const parts   = token.split('.');
+    const tampered = parts[1].slice(0, -1) + (parts[1].slice(-1) === 'a' ? 'b' : 'a');
+    expect(validateAuthToken(`${parts[0]}.${tampered}.${parts[2]}`)).toBeNull();
+  });
+
+  test('returns null for a completely invalid string', () => {
+    expect(validateAuthToken('not.a.jwt.at.all')).toBeNull();
+  });
+
+  test('roundtrip preserves all fields', () => {
+    const token   = createAuthToken(user);
+    const payload = validateAuthToken(token);
+    expect(payload.sub).toBe('usr_v1');
+    expect(payload.username).toBe('valuser');
+    expect(payload.email).toBe('val@example.com');
+    expect(payload.tier).toBe('studio');
+    expect(payload.source).toBe('auth');
+  });
+});
+
+// ── hashPassword / verifyPassword ─────────────────────────────────────────────
+describe('hashPassword() / verifyPassword()', () => {
+  test('produced hash verifies correctly against original password', () => {
+    const hash = hashPassword('mySecureP@ss1');
+    expect(verifyPassword('mySecureP@ss1', hash)).toBe(true);
+  });
+
+  test('wrong password does not verify', () => {
+    const hash = hashPassword('correctPassword');
+    expect(verifyPassword('wrongPassword', hash)).toBe(false);
+  });
+
+  test('hash format is salt:hex', () => {
+    const hash  = hashPassword('test');
+    const parts = hash.split(':');
+    expect(parts).toHaveLength(2);
+    expect(parts[0]).toHaveLength(32); // 16-byte hex
+    expect(parts[1]).toHaveLength(128); // 64-byte hex
+  });
+
+  test('two hashes of the same password use different salts', () => {
+    const h1 = hashPassword('samepass');
+    const h2 = hashPassword('samepass');
+    expect(h1.split(':')[0]).not.toBe(h2.split(':')[0]);
+  });
+});
+
+// ── Seeded USERS store ────────────────────────────────────────────────────────
+describe('Seeded USERS store', () => {
+  const USERS = buildSeededUsers();
+
+  test('contains all five seeded accounts', () => {
+    expect(Object.keys(USERS)).toHaveLength(5);
+    expect(USERS).toHaveProperty('joker5514');
+    expect(USERS).toHaveProperty('test_free');
+    expect(USERS).toHaveProperty('test_pro');
+    expect(USERS).toHaveProperty('test_studio');
+    expect(USERS).toHaveProperty('test_enterprise');
+  });
+
+  test('joker5514 has ENTERPRISE tier and admin role', () => {
+    expect(USERS['joker5514'].tier).toBe('ENTERPRISE');
+    expect(USERS['joker5514'].role).toBe('admin');
+  });
+
+  test('tier-named accounts have correct tiers', () => {
+    expect(USERS['test_free'].tier).toBe('FREE');
+    expect(USERS['test_pro'].tier).toBe('PRO');
+    expect(USERS['test_studio'].tier).toBe('STUDIO');
+    expect(USERS['test_enterprise'].tier).toBe('ENTERPRISE');
+  });
+
+  test('all test accounts have role=user', () => {
+    ['test_free', 'test_pro', 'test_studio', 'test_enterprise'].forEach((u) => {
+      expect(USERS[u].role).toBe('user');
+    });
+  });
+
+  test('user records have expected shape', () => {
+    const u = USERS['test_pro'];
+    expect(u).toHaveProperty('id');
+    expect(u).toHaveProperty('username');
+    expect(u).toHaveProperty('email');
+    expect(u).toHaveProperty('passwordHash');
+    expect(u).toHaveProperty('tier');
+    expect(u).toHaveProperty('role');
+    expect(u).toHaveProperty('createdAt');
+  });
+
+  test('passwords verify correctly for seeded accounts', () => {
+    expect(verifyPassword('Admin8052',         USERS['joker5514'].passwordHash)).toBe(true);
+    expect(verifyPassword('TestFree123',       USERS['test_free'].passwordHash)).toBe(true);
+    expect(verifyPassword('TestPro123',        USERS['test_pro'].passwordHash)).toBe(true);
+    expect(verifyPassword('TestStudio123',     USERS['test_studio'].passwordHash)).toBe(true);
+    expect(verifyPassword('TestEnterprise123', USERS['test_enterprise'].passwordHash)).toBe(true);
+  });
+});
+
+// ── POST /login ───────────────────────────────────────────────────────────────
+describe('POST /login', () => {
+  const { app } = buildApp();
+
+  test('returns 200 and a JWT on valid credentials', async () => {
+    const res = await request(app)
+      .post('/login')
+      .send({ username: 'test_pro', password: 'TestPro123' });
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(typeof res.body.token).toBe('string');
+    expect(res.body.token.split('.')).toHaveLength(3);
+  });
+
+  test('response user object has correct fields for test_pro', async () => {
+    const res = await request(app)
+      .post('/login')
+      .send({ username: 'test_pro', password: 'TestPro123' });
+    const u = res.body.user;
+    expect(u.username).toBe('test_pro');
+    expect(u.email).toBe('pro@test.voiceisolatepro.com');
+    expect(u.tier).toBe('PRO');
+    expect(u.role).toBe('user');
+    expect(u.id).toBe('usr_test_pro');
+  });
+
+  test('admin login returns role=admin and ENTERPRISE tier', async () => {
+    const res = await request(app)
+      .post('/login')
+      .send({ username: 'joker5514', password: 'Admin8052' });
+    expect(res.status).toBe(200);
+    expect(res.body.user.role).toBe('admin');
+    expect(res.body.user.tier).toBe('ENTERPRISE');
+  });
+
+  test('username matching is case-insensitive', async () => {
+    const res = await request(app)
+      .post('/login')
+      .send({ username: 'TEST_PRO', password: 'TestPro123' });
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  test('returns 401 for correct username but wrong password', async () => {
+    const res = await request(app)
+      .post('/login')
+      .send({ username: 'test_free', password: 'WrongPassword' });
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe('Invalid username or password.');
+  });
+
+  test('returns 401 for unknown username', async () => {
+    const res = await request(app)
+      .post('/login')
+      .send({ username: 'nobody', password: 'somepass' });
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe('Invalid username or password.');
+  });
+
+  test('returns 400 when username is missing', async () => {
+    const res = await request(app)
+      .post('/login')
+      .send({ password: 'TestPro123' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Username and password are required.');
+  });
+
+  test('returns 400 when password is missing', async () => {
+    const res = await request(app)
+      .post('/login')
+      .send({ username: 'test_pro' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Username and password are required.');
+  });
+
+  test('returns 400 when body is empty', async () => {
+    const res = await request(app).post('/login').send({});
+    expect(res.status).toBe(400);
+  });
+
+  test('all tier accounts can log in with correct passwords', async () => {
+    const accounts = [
+      { username: 'test_free',       password: 'TestFree123'       },
+      { username: 'test_pro',        password: 'TestPro123'        },
+      { username: 'test_studio',     password: 'TestStudio123'     },
+      { username: 'test_enterprise', password: 'TestEnterprise123' },
+    ];
+    for (const { username, password } of accounts) {
+      const res = await request(app).post('/login').send({ username, password });
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+    }
+  });
+
+  test('token payload source is "auth" (not "stripe")', async () => {
+    const res     = await request(app)
+      .post('/login')
+      .send({ username: 'test_pro', password: 'TestPro123' });
+    const payload = JSON.parse(Buffer.from(res.body.token.split('.')[1], 'base64url').toString());
+    expect(payload.source).toBe('auth');
+  });
+});
+
+// ── GET /me ───────────────────────────────────────────────────────────────────
+describe('GET /me', () => {
+  const { app } = buildApp();
+
+  async function loginAndGetToken(username, password) {
+    const res = await request(app).post('/login').send({ username, password });
+    return res.body.token;
+  }
+
+  test('returns 401 when no Authorization header is sent', async () => {
+    const res = await request(app).get('/me');
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe('Not authenticated.');
+  });
+
+  test('returns 401 when Authorization header lacks Bearer prefix', async () => {
+    const token = await loginAndGetToken('test_pro', 'TestPro123');
+    const res   = await request(app)
+      .get('/me')
+      .set('Authorization', token);          // missing "Bearer "
+    expect(res.status).toBe(401);
+  });
+
+  test('returns 401 for an invalid token string', async () => {
+    const res = await request(app)
+      .get('/me')
+      .set('Authorization', 'Bearer invalid.token.string');
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe('Invalid or expired token.');
+  });
+
+  test('returns user info for a valid Bearer token', async () => {
+    const token = await loginAndGetToken('test_studio', 'TestStudio123');
+    const res   = await request(app)
+      .get('/me')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body.username).toBe('test_studio');
+    expect(res.body.tier).toBe('STUDIO');
+    expect(res.body.email).toBe('studio@test.voiceisolatepro.com');
+    expect(res.body.isAdmin).toBe(false);
+  });
+
+  test('returns isAdmin=true for the admin token', async () => {
+    const token = await loginAndGetToken('joker5514', 'Admin8052');
+    const res   = await request(app)
+      .get('/me')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body.isAdmin).toBe(true);
+    expect(res.body.role).toBe('admin');
+  });
+
+  test('tier is uppercased in the /me response', async () => {
+    const token = await loginAndGetToken('test_pro', 'TestPro123');
+    const res   = await request(app)
+      .get('/me')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.body.tier).toBe('PRO');        // source stores 'pro', response uppercases it
+  });
+
+  test('response includes expiresAt as millisecond timestamp', async () => {
+    const token = await loginAndGetToken('test_free', 'TestFree123');
+    const res   = await request(app)
+      .get('/me')
+      .set('Authorization', `Bearer ${token}`);
+    expect(typeof res.body.expiresAt).toBe('number');
+    expect(res.body.expiresAt).toBeGreaterThan(Date.now());
+  });
+
+  test('response includes createdAt from the user store', async () => {
+    const token = await loginAndGetToken('test_enterprise', 'TestEnterprise123');
+    const res   = await request(app)
+      .get('/me')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.body).toHaveProperty('createdAt');
+    expect(typeof res.body.createdAt).toBe('string');
+  });
+
+  test('returns 401 for an expired token', async () => {
+    // Construct a token that is already expired
+    const header  = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64url');
+    const payload = Buffer.from(JSON.stringify({
+      sub: 'usr_test_pro', username: 'test_pro', email: 'pro@test.voiceisolatepro.com',
+      tier: 'pro', role: 'user', source: 'auth',
+      iat: 0, exp: 1,
+    })).toString('base64url');
+    const sig = crypto
+      .createHmac('sha256', TEST_SECRET)
+      .update(`${header}.${payload}`)
+      .digest('base64url');
+    const expiredToken = `${header}.${payload}.${sig}`;
+    const res = await request(app)
+      .get('/me')
+      .set('Authorization', `Bearer ${expiredToken}`);
+    expect(res.status).toBe(401);
+  });
+});
+
+// ── POST /logout ──────────────────────────────────────────────────────────────
+describe('POST /logout', () => {
+  const { app } = buildApp();
+
+  test('returns success:true regardless of auth state', async () => {
+    const res = await request(app).post('/logout');
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  test('response includes a message about clearing the token on client', async () => {
+    const res = await request(app).post('/logout');
+    expect(res.body.message).toMatch(/token/i);
+    expect(res.body.message).toMatch(/client/i);
+  });
+
+  test('returns success even when an Authorization header is present', async () => {
+    const res = await request(app)
+      .post('/logout')
+      .set('Authorization', 'Bearer some.random.token');
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+});
+
+// ── Full login → me flow ──────────────────────────────────────────────────────
+describe('Login → /me roundtrip', () => {
+  const { app } = buildApp();
+
+  test('token obtained from /login is accepted by /me', async () => {
+    const loginRes = await request(app)
+      .post('/login')
+      .send({ username: 'test_studio', password: 'TestStudio123' });
+    expect(loginRes.status).toBe(200);
+
+    const meRes = await request(app)
+      .get('/me')
+      .set('Authorization', `Bearer ${loginRes.body.token}`);
+    expect(meRes.status).toBe(200);
+    expect(meRes.body.username).toBe('test_studio');
+    expect(meRes.body.tier).toBe('STUDIO');
+  });
+
+  test('token from one user does not give access as a different user', async () => {
+    const loginRes = await request(app)
+      .post('/login')
+      .send({ username: 'test_free', password: 'TestFree123' });
+    const meRes = await request(app)
+      .get('/me')
+      .set('Authorization', `Bearer ${loginRes.body.token}`);
+    expect(meRes.body.username).toBe('test_free');
+    expect(meRes.body.tier).toBe('FREE');
+  });
+});

--- a/tests/auth_client.test.js
+++ b/tests/auth_client.test.js
@@ -1,0 +1,560 @@
+/**
+ * VoiceIsolate Pro — VIPAuth Client Module Tests
+ *
+ * Tests the browser-side auth module (public/app/auth.js):
+ *   - Session persistence helpers (_saveSession / _loadSession / _clearSession)
+ *   - _escHtml XSS protection
+ *   - VIPAuth public API: getUser(), isLoggedIn(), isAdmin(), logout()
+ *   - _renderLoginOverlay() / _renderUserBadge() DOM rendering
+ *   - _handleLogin() form submission logic
+ *   - init() session-restore and fallback-to-login flows
+ *
+ * Uses a jsdom-based environment (jest-environment-jsdom) for DOM APIs.
+ *
+ * @jest-environment jsdom
+ */
+
+'use strict';
+
+// ── Minimal stubs expected by auth.js at parse time ───────────────────────────
+// auth.js calls VIPAuth.init() immediately when document.readyState !== 'loading'.
+// We intercept fetch before loading the module so init() does not actually hit
+// the network.
+
+// Keep a handle on the fetch mock so individual tests can override the implementation.
+let fetchMock;
+
+beforeAll(() => {
+  fetchMock = jest.fn();
+  global.fetch = fetchMock;
+
+  // auth.js reads document.readyState to decide when to init. JSDOM typically
+  // sets it to 'complete' so the else-branch fires and calls VIPAuth.init()
+  // synchronously. We stub it to 'loading' so the module loads without
+  // triggering init() automatically.
+  Object.defineProperty(document, 'readyState', {
+    configurable: true,
+    get: () => 'loading',
+  });
+});
+
+afterEach(() => {
+  // Clean up any injected DOM elements between tests
+  const overlay = document.getElementById('authOverlay');
+  if (overlay) overlay.remove();
+  const badge = document.getElementById('authBadge');
+  if (badge) badge.remove();
+
+  localStorage.clear();
+  jest.clearAllMocks();
+  global.window.LicenseManager = undefined;
+});
+
+// ── Load VIPAuth module ───────────────────────────────────────────────────────
+// Use fs + eval so we can load the IIFE in the jsdom global scope.
+const fs   = require('fs');
+const path = require('path');
+
+const authSrc = fs.readFileSync(
+  path.join(__dirname, '../public/app/auth.js'),
+  'utf8'
+);
+
+// Evaluate in global scope once — the IIFE assigns to `const VIPAuth` at the
+// module top level so we must eval in global scope to access it from tests.
+// We strip the DOMContentLoaded auto-init block and call init() manually.
+const srcWithoutAutoInit = authSrc
+  .replace(/\/\/ Auto-init[\s\S]*$/, '');  // remove trailing auto-init block
+
+eval(srcWithoutAutoInit); // eslint-disable-line no-eval
+
+// VIPAuth is now available as a global in this test file's scope
+
+// ── localStorage session helpers (tested via VIPAuth behaviour) ───────────────
+describe('Session persistence', () => {
+  test('isLoggedIn() returns false when no session is stored', () => {
+    localStorage.clear();
+    expect(VIPAuth.isLoggedIn()).toBe(false);
+  });
+
+  test('getUser() returns null when not logged in', () => {
+    expect(VIPAuth.getUser()).toBeNull();
+  });
+
+  test('isAdmin() returns false when not logged in', () => {
+    expect(VIPAuth.isAdmin()).toBe(false);
+  });
+});
+
+// ── _renderLoginOverlay ───────────────────────────────────────────────────────
+describe('_renderLoginOverlay()', () => {
+  test('init() renders the auth overlay when no session exists', async () => {
+    localStorage.clear();
+    fetchMock.mockRejectedValue(new Error('no server'));
+
+    await VIPAuth.init();
+
+    expect(document.getElementById('authOverlay')).not.toBeNull();
+  });
+
+  test('overlay contains the login form elements', async () => {
+    localStorage.clear();
+    fetchMock.mockRejectedValue(new Error('no server'));
+
+    await VIPAuth.init();
+
+    expect(document.getElementById('authForm')).not.toBeNull();
+    expect(document.getElementById('authUser')).not.toBeNull();
+    expect(document.getElementById('authPass')).not.toBeNull();
+    expect(document.getElementById('authSubmit')).not.toBeNull();
+    expect(document.getElementById('authError')).not.toBeNull();
+  });
+
+  test('overlay is not duplicated on a second init() call', async () => {
+    localStorage.clear();
+    fetchMock.mockRejectedValue(new Error('no server'));
+
+    await VIPAuth.init();
+    await VIPAuth.init();
+
+    const overlays = document.querySelectorAll('#authOverlay');
+    expect(overlays.length).toBe(1);
+  });
+});
+
+// ── _handleLogin — form submission ────────────────────────────────────────────
+describe('_handleLogin()', () => {
+  async function renderAndGetForm() {
+    localStorage.clear();
+    fetchMock.mockRejectedValue(new Error('no server'));
+    await VIPAuth.init();
+    return {
+      form:     document.getElementById('authForm'),
+      userInput: document.getElementById('authUser'),
+      passInput: document.getElementById('authPass'),
+      submitBtn: document.getElementById('authSubmit'),
+      errEl:    document.getElementById('authError'),
+    };
+  }
+
+  test('shows validation error when username is empty', async () => {
+    const { form, userInput, passInput, errEl } = await renderAndGetForm();
+    userInput.value = '';
+    passInput.value = 'somepass';
+
+    form.dispatchEvent(new Event('submit'));
+    await Promise.resolve();
+
+    expect(errEl.textContent).toContain('Please enter username and password');
+  });
+
+  test('shows validation error when password is empty', async () => {
+    const { form, userInput, passInput, errEl } = await renderAndGetForm();
+    userInput.value = 'testuser';
+    passInput.value = '';
+
+    form.dispatchEvent(new Event('submit'));
+    await Promise.resolve();
+
+    expect(errEl.textContent).toContain('Please enter username and password');
+  });
+
+  test('disables submit button while signing in', async () => {
+    const { form, userInput, passInput, submitBtn } = await renderAndGetForm();
+    userInput.value = 'testuser';
+    passInput.value = 'testpass';
+
+    // Mock fetch to never resolve so we can observe the in-flight state
+    fetchMock.mockReturnValue(new Promise(() => {}));
+
+    form.dispatchEvent(new Event('submit'));
+    await Promise.resolve();   // let microtask queue flush
+
+    expect(submitBtn.disabled).toBe(true);
+    expect(submitBtn.textContent).toBe('Signing in...');
+  });
+
+  test('shows API error message on failed login', async () => {
+    const { form, userInput, passInput, errEl } = await renderAndGetForm();
+    userInput.value = 'baduser';
+    passInput.value = 'badpass';
+
+    fetchMock.mockResolvedValue({
+      json: () => Promise.resolve({ success: false, error: 'Invalid username or password.' }),
+    });
+
+    form.dispatchEvent(new Event('submit'));
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(errEl.textContent).toBe('Invalid username or password.');
+  });
+
+  test('re-enables submit button after failed login', async () => {
+    const { form, userInput, passInput, submitBtn } = await renderAndGetForm();
+    userInput.value = 'baduser';
+    passInput.value = 'badpass';
+
+    fetchMock.mockResolvedValue({
+      json: () => Promise.resolve({ success: false, error: 'Invalid username or password.' }),
+    });
+
+    form.dispatchEvent(new Event('submit'));
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(submitBtn.disabled).toBe(false);
+    expect(submitBtn.textContent).toBe('Sign In');
+  });
+
+  test('shows network error message when fetch throws', async () => {
+    const { form, userInput, passInput, errEl } = await renderAndGetForm();
+    userInput.value = 'testuser';
+    passInput.value = 'testpass';
+
+    fetchMock.mockRejectedValue(new Error('Network failure'));
+
+    form.dispatchEvent(new Event('submit'));
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(errEl.textContent).toContain('Network error');
+  });
+
+  test('removes overlay and renders badge on successful login', async () => {
+    const { form, userInput, passInput } = await renderAndGetForm();
+    userInput.value = 'test_pro';
+    passInput.value = 'TestPro123';
+
+    fetchMock.mockResolvedValue({
+      json: () => Promise.resolve({
+        success: true,
+        token:   'header.payload.sig',
+        user:    { id: 'usr_test_pro', username: 'test_pro', email: 'pro@test.com', tier: 'PRO', role: 'user' },
+      }),
+    });
+
+    form.dispatchEvent(new Event('submit'));
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(document.getElementById('authOverlay')).toBeNull();
+    expect(document.getElementById('authBadge')).not.toBeNull();
+  });
+
+  test('saves session to localStorage on successful login', async () => {
+    const { form, userInput, passInput } = await renderAndGetForm();
+    userInput.value = 'test_pro';
+    passInput.value = 'TestPro123';
+
+    fetchMock.mockResolvedValue({
+      json: () => Promise.resolve({
+        success: true,
+        token:   'mytoken123',
+        user:    { id: 'usr_test_pro', username: 'test_pro', email: 'pro@test.com', tier: 'PRO', role: 'user' },
+      }),
+    });
+
+    form.dispatchEvent(new Event('submit'));
+    await new Promise((r) => setTimeout(r, 50));
+
+    const stored = JSON.parse(localStorage.getItem('vip_auth_v22'));
+    expect(stored.username).toBe('test_pro');
+    expect(stored.token).toBe('mytoken123');
+  });
+
+  test('calls LicenseManager.activate with token and email on successful login', async () => {
+    const activate = jest.fn();
+    global.window.LicenseManager = { activate };
+
+    const { form, userInput, passInput } = await renderAndGetForm();
+    userInput.value = 'test_pro';
+    passInput.value = 'TestPro123';
+
+    fetchMock.mockResolvedValue({
+      json: () => Promise.resolve({
+        success: true,
+        token:   'mytoken456',
+        user:    { id: 'usr_test_pro', username: 'test_pro', email: 'pro@test.com', tier: 'PRO', role: 'user' },
+      }),
+    });
+
+    form.dispatchEvent(new Event('submit'));
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(activate).toHaveBeenCalledWith('mytoken456', 'pro@test.com');
+  });
+
+  test('updates _currentUser after successful login', async () => {
+    const { form, userInput, passInput } = await renderAndGetForm();
+    userInput.value = 'test_studio';
+    passInput.value = 'TestStudio123';
+
+    fetchMock.mockResolvedValue({
+      json: () => Promise.resolve({
+        success: true,
+        token:   'tok',
+        user:    { id: 'usr_test_studio', username: 'test_studio', email: 'studio@test.com', tier: 'STUDIO', role: 'user' },
+      }),
+    });
+
+    form.dispatchEvent(new Event('submit'));
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(VIPAuth.isLoggedIn()).toBe(true);
+    expect(VIPAuth.getUser().username).toBe('test_studio');
+  });
+});
+
+// ── _renderUserBadge DOM output ───────────────────────────────────────────────
+describe('_renderUserBadge()', () => {
+  async function loginSuccessfully(user) {
+    localStorage.clear();
+    fetchMock.mockRejectedValue(new Error('no session'));
+    await VIPAuth.init();
+
+    fetchMock.mockResolvedValue({
+      json: () => Promise.resolve({ success: true, token: 'tok', user }),
+    });
+
+    const form = document.getElementById('authForm');
+    document.getElementById('authUser').value = user.username;
+    document.getElementById('authPass').value = 'pass';
+    form.dispatchEvent(new Event('submit'));
+    await new Promise((r) => setTimeout(r, 50));
+  }
+
+  test('badge displays the correct username', async () => {
+    await loginSuccessfully({
+      id: 'u1', username: 'test_pro', email: 'p@t.com', tier: 'PRO', role: 'user',
+    });
+    const badge = document.getElementById('authBadge');
+    expect(badge).not.toBeNull();
+    expect(badge.innerHTML).toContain('test_pro');
+  });
+
+  test('badge displays uppercased tier', async () => {
+    await loginSuccessfully({
+      id: 'u2', username: 'test_studio', email: 's@t.com', tier: 'STUDIO', role: 'user',
+    });
+    const badge = document.getElementById('authBadge');
+    expect(badge.innerHTML).toContain('STUDIO');
+  });
+
+  test('badge shows ADMIN label for admin role', async () => {
+    await loginSuccessfully({
+      id: 'u3', username: 'joker5514', email: 'a@t.com', tier: 'ENTERPRISE', role: 'admin',
+    });
+    const badge = document.getElementById('authBadge');
+    expect(badge.innerHTML).toContain('ADMIN');
+  });
+
+  test('badge does not show ADMIN label for regular user', async () => {
+    await loginSuccessfully({
+      id: 'u4', username: 'test_free', email: 'f@t.com', tier: 'FREE', role: 'user',
+    });
+    const badge = document.getElementById('authBadge');
+    expect(badge.innerHTML).not.toContain('ADMIN');
+  });
+
+  test('_escHtml prevents XSS in username', async () => {
+    await loginSuccessfully({
+      id: 'u5', username: '<script>alert(1)</script>', email: 'x@t.com', tier: 'PRO', role: 'user',
+    });
+    const badge = document.getElementById('authBadge');
+    // Raw script tag must not appear unescaped in the badge HTML
+    expect(badge.innerHTML).not.toContain('<script>');
+    expect(badge.innerHTML).toContain('&lt;script&gt;');
+  });
+});
+
+// ── _handleLogout ─────────────────────────────────────────────────────────────
+describe('logout()', () => {
+  async function setupLoggedIn() {
+    localStorage.clear();
+    fetchMock.mockRejectedValue(new Error('no session'));
+    await VIPAuth.init();
+
+    fetchMock.mockResolvedValue({
+      json: () => Promise.resolve({
+        success: true, token: 'tok',
+        user: { id: 'u1', username: 'test_pro', email: 'p@t.com', tier: 'PRO', role: 'user' },
+      }),
+    });
+
+    const form = document.getElementById('authForm');
+    document.getElementById('authUser').value = 'test_pro';
+    document.getElementById('authPass').value = 'pass';
+    form.dispatchEvent(new Event('submit'));
+    await new Promise((r) => setTimeout(r, 50));
+  }
+
+  test('isLoggedIn() returns false after logout()', async () => {
+    await setupLoggedIn();
+    expect(VIPAuth.isLoggedIn()).toBe(true);
+    VIPAuth.logout();
+    expect(VIPAuth.isLoggedIn()).toBe(false);
+  });
+
+  test('getUser() returns null after logout()', async () => {
+    await setupLoggedIn();
+    VIPAuth.logout();
+    expect(VIPAuth.getUser()).toBeNull();
+  });
+
+  test('clears localStorage session on logout', async () => {
+    await setupLoggedIn();
+    expect(localStorage.getItem('vip_auth_v22')).not.toBeNull();
+    VIPAuth.logout();
+    expect(localStorage.getItem('vip_auth_v22')).toBeNull();
+  });
+
+  test('removes the badge from the DOM on logout', async () => {
+    await setupLoggedIn();
+    expect(document.getElementById('authBadge')).not.toBeNull();
+    VIPAuth.logout();
+    expect(document.getElementById('authBadge')).toBeNull();
+  });
+
+  test('renders login overlay again after logout', async () => {
+    await setupLoggedIn();
+    VIPAuth.logout();
+    expect(document.getElementById('authOverlay')).not.toBeNull();
+  });
+
+  test('calls LicenseManager.deactivate() on logout if available', async () => {
+    await setupLoggedIn();
+    const deactivate = jest.fn();
+    global.window.LicenseManager = { deactivate };
+    VIPAuth.logout();
+    expect(deactivate).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not throw when LicenseManager.deactivate is absent', () => {
+    global.window.LicenseManager = undefined;
+    expect(() => VIPAuth.logout()).not.toThrow();
+  });
+});
+
+// ── init() — session restore ──────────────────────────────────────────────────
+describe('init() — session restore', () => {
+  test('restores session from localStorage when /me returns valid user', async () => {
+    localStorage.setItem('vip_auth_v22', JSON.stringify({
+      username: 'test_pro',
+      token:    'valid-token',
+    }));
+
+    fetchMock.mockResolvedValue({
+      ok:   true,
+      json: () => Promise.resolve({
+        id: 'usr_test_pro', username: 'test_pro', email: 'pro@test.com',
+        tier: 'PRO', role: 'user', isAdmin: false, expiresAt: Date.now() + 999999,
+      }),
+    });
+
+    await VIPAuth.init();
+
+    expect(VIPAuth.isLoggedIn()).toBe(true);
+    expect(VIPAuth.getUser().username).toBe('test_pro');
+    expect(document.getElementById('authOverlay')).toBeNull();
+  });
+
+  test('shows login overlay when stored token is rejected by /me', async () => {
+    localStorage.setItem('vip_auth_v22', JSON.stringify({
+      username: 'test_pro',
+      token:    'expired-token',
+    }));
+
+    fetchMock.mockResolvedValue({
+      ok:   false,
+      json: () => Promise.resolve({ error: 'Invalid or expired token.' }),
+    });
+
+    await VIPAuth.init();
+
+    expect(document.getElementById('authOverlay')).not.toBeNull();
+  });
+
+  test('shows login overlay when localStorage has no session', async () => {
+    localStorage.clear();
+    await VIPAuth.init();
+    expect(document.getElementById('authOverlay')).not.toBeNull();
+  });
+
+  test('calls LicenseManager.activate on session restore', async () => {
+    const activate = jest.fn();
+    global.window.LicenseManager = { activate };
+
+    localStorage.setItem('vip_auth_v22', JSON.stringify({
+      username: 'test_enterprise',
+      token:    'stored-token',
+    }));
+
+    fetchMock.mockResolvedValue({
+      ok:   true,
+      json: () => Promise.resolve({
+        id: 'usr_test_enterprise', username: 'test_enterprise',
+        email: 'enterprise@test.com', tier: 'ENTERPRISE', role: 'user',
+        isAdmin: false, expiresAt: Date.now() + 999999,
+      }),
+    });
+
+    await VIPAuth.init();
+
+    expect(activate).toHaveBeenCalledWith('stored-token', 'enterprise@test.com');
+  });
+
+  test('falls through to login overlay when fetch throws (server down)', async () => {
+    localStorage.setItem('vip_auth_v22', JSON.stringify({
+      username: 'test_pro',
+      token:    'some-token',
+    }));
+
+    fetchMock.mockRejectedValue(new Error('ECONNREFUSED'));
+
+    await VIPAuth.init();
+
+    expect(document.getElementById('authOverlay')).not.toBeNull();
+  });
+});
+
+// ── isAdmin() ─────────────────────────────────────────────────────────────────
+describe('isAdmin()', () => {
+  test('returns false for a regular user', async () => {
+    localStorage.clear();
+    fetchMock.mockRejectedValue(new Error('no session'));
+    await VIPAuth.init();
+
+    fetchMock.mockResolvedValue({
+      json: () => Promise.resolve({
+        success: true, token: 'tok',
+        user: { id: 'u1', username: 'test_pro', email: 'p@t.com', tier: 'PRO', role: 'user' },
+      }),
+    });
+
+    const form = document.getElementById('authForm');
+    document.getElementById('authUser').value = 'test_pro';
+    document.getElementById('authPass').value = 'pass';
+    form.dispatchEvent(new Event('submit'));
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(VIPAuth.isAdmin()).toBe(false);
+  });
+
+  test('returns true for an admin user', async () => {
+    localStorage.clear();
+    fetchMock.mockRejectedValue(new Error('no session'));
+    await VIPAuth.init();
+
+    fetchMock.mockResolvedValue({
+      json: () => Promise.resolve({
+        success: true, token: 'tok',
+        user: { id: 'u3', username: 'joker5514', email: 'admin@t.com', tier: 'ENTERPRISE', role: 'admin' },
+      }),
+    });
+
+    const form = document.getElementById('authForm');
+    document.getElementById('authUser').value = 'joker5514';
+    document.getElementById('authPass').value = 'pass';
+    form.dispatchEvent(new Event('submit'));
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(VIPAuth.isAdmin()).toBe(true);
+  });
+});

--- a/tests/handle_file_validation.test.js
+++ b/tests/handle_file_validation.test.js
@@ -1,0 +1,303 @@
+/**
+ * VoiceIsolate Pro — handleFile() Validation Tests
+ *
+ * Tests the new file-size sentinel (200 MB hard cap) and LicenseManager
+ * checkFileLimit integration added to VoiceIsolatePro.handleFile() in
+ * public/app/app.js.
+ *
+ * Loads the class from public/app/app.js (not the root app.js, which is a
+ * different, smaller file) using the same VM + fake-globals technique as
+ * handle_file_decode.test.js.
+ */
+
+'use strict';
+
+const fs   = require('fs');
+const path = require('path');
+const vm   = require('vm');
+
+// ── Shared fixture: load VoiceIsolatePro.prototype.handleFile ─────────────────
+
+let handleFile;
+
+beforeAll(() => {
+  const appJsPath = path.join(__dirname, '../public/app/app.js');
+  const appJs     = fs.readFileSync(appJsPath, 'utf8');
+
+  const sandbox = {
+    document: {
+      addEventListener:   jest.fn(),
+      getElementById:     jest.fn(() => ({ addEventListener: jest.fn(), appendChild: jest.fn(), style: {} })),
+      createElement:      jest.fn(() => ({ textContent: '', innerHTML: '' })),
+      querySelector:      jest.fn(() => null),
+      querySelectorAll:   jest.fn(() => ({ forEach: jest.fn() })),
+      readyState:         'complete',
+      body:               { appendChild: jest.fn() },
+    },
+    window: {
+      LicenseManager: undefined, // overridden per-test in global.window
+    },
+    module:       { exports: {} },
+    Float32Array: Float32Array,
+    Math:         Math,
+    console:      { error: jest.fn(), warn: jest.fn(), log: jest.fn() },
+    parseFloat:   parseFloat,
+    parseInt:     parseInt,
+    URL: {
+      createObjectURL: jest.fn(() => 'blob:test'),
+      revokeObjectURL: jest.fn(),
+    },
+    setTimeout:   setTimeout,
+    clearTimeout: clearTimeout,
+    setInterval:  setInterval,
+    clearInterval: clearInterval,
+    Promise:      Promise,
+    localStorage: {
+      getItem:    jest.fn(() => null),
+      setItem:    jest.fn(),
+      removeItem: jest.fn(),
+    },
+    AudioContext:     jest.fn(() => ({})),
+    requestAnimationFrame: jest.fn(),
+    cancelAnimationFrame:  jest.fn(),
+    performance:      { now: jest.fn(() => Date.now()) },
+  };
+
+  // Redirect window.LicenseManager lookups into sandbox.window
+  Object.defineProperty(sandbox, 'window', {
+    get: () => sandbox._window,
+    set: (v) => { sandbox._window = v; },
+  });
+  sandbox._window = sandbox.window;
+
+  vm.createContext(sandbox);
+  vm.runInContext(appJs, sandbox);
+
+  const VoiceIsolatePro = sandbox.module.exports;
+  handleFile = VoiceIsolatePro.prototype.handleFile;
+});
+
+// ── Helper: build a minimal mockVip ──────────────────────────────────────────
+function makeMockVip(windowOverride = {}) {
+  return {
+    ensureCtx:   jest.fn(),
+    stop:        jest.fn(),
+    setStatus:   jest.fn(),
+    onAudioLoaded: jest.fn(),
+    decodeViaVideoElement: jest.fn().mockResolvedValue({ length: 100 }),
+    dom: {
+      fileInfo:   { textContent: '' },
+      videoPlayer: { src: '', onloadedmetadata: null, onerror: null },
+      videoCard:  { style: { display: '' } },
+    },
+    ctx: {
+      decodeAudioData: jest.fn().mockResolvedValue({ length: 100 }),
+    },
+    params: {},
+    _window: {
+      LicenseManager: windowOverride.LicenseManager || undefined,
+    },
+  };
+}
+
+// ── File-size validation (MAX 200 MB hard cap) ────────────────────────────────
+describe('handleFile() — file size validation (200 MB hard cap)', () => {
+  test('rejects a file larger than 200 MB with a descriptive error message', async () => {
+    const mockVip  = makeMockVip();
+    const overSize = 201 * 1024 * 1024; // 201 MB
+    const mockFile = {
+      name: 'huge.wav', size: overSize, type: 'audio/wav',
+      arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(10)),
+    };
+
+    await handleFile.call(mockVip, mockFile);
+
+    expect(mockVip.setStatus).toHaveBeenCalledWith('ERROR');
+    expect(mockVip.dom.fileInfo.textContent).toContain('File too large');
+    expect(mockVip.dom.fileInfo.textContent).toContain('201.0 MB');
+    expect(mockVip.dom.fileInfo.textContent).toContain('200 MB');
+  });
+
+  test('rejects a file at exactly 200 MB + 1 byte', async () => {
+    const mockVip  = makeMockVip();
+    const oneOver  = 200 * 1024 * 1024 + 1;
+    const mockFile = {
+      name: 'over.mp3', size: oneOver, type: 'audio/mpeg',
+      arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(10)),
+    };
+
+    await handleFile.call(mockVip, mockFile);
+
+    expect(mockVip.setStatus).toHaveBeenCalledWith('ERROR');
+    expect(mockVip.dom.fileInfo.textContent).toContain('File too large');
+  });
+
+  test('does not reject a file at exactly 200 MB', async () => {
+    const mockVip  = makeMockVip();
+    const exactly  = 200 * 1024 * 1024;
+    const mockFile = {
+      name: 'max.wav', size: exactly, type: 'audio/wav',
+      arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(10)),
+    };
+
+    await handleFile.call(mockVip, mockFile);
+
+    // Should NOT be called with 'ERROR' due to the size check
+    const errorCalls = mockVip.setStatus.mock.calls.filter(c => c[0] === 'ERROR');
+    // If ERROR was called it must not be because of size limit
+    if (errorCalls.length > 0) {
+      expect(mockVip.dom.fileInfo.textContent).not.toContain('File too large');
+    }
+  });
+
+  test('does not reject a normally-sized file (5 MB)', async () => {
+    const mockVip  = makeMockVip();
+    const mockFile = {
+      name: 'normal.wav', size: 5 * 1024 * 1024, type: 'audio/wav',
+      arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(10)),
+    };
+
+    await handleFile.call(mockVip, mockFile);
+
+    expect(mockVip.dom.fileInfo.textContent).not.toContain('File too large');
+  });
+
+  test('error message includes the actual file size in MB (two decimal places)', async () => {
+    const mockVip  = makeMockVip();
+    // 250.5 MB
+    const fileSize = Math.round(250.5 * 1024 * 1024);
+    const mockFile = {
+      name: 'big.wav', size: fileSize, type: 'audio/wav',
+      arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(10)),
+    };
+
+    await handleFile.call(mockVip, mockFile);
+
+    const msg = mockVip.dom.fileInfo.textContent;
+    // size displayed as X.X MB (one decimal)
+    expect(msg).toMatch(/\d+\.\d\s*MB/);
+  });
+});
+
+// ── LicenseManager.checkFileLimit integration ─────────────────────────────────
+describe('handleFile() — LicenseManager.checkFileLimit integration', () => {
+  test('calls checkFileLimit with fileSizeMB and 0 when LicenseManager is present', async () => {
+    const checkFileLimit = jest.fn().mockReturnValue({ allowed: true });
+    const mockVip  = makeMockVip({ LicenseManager: { checkFileLimit } });
+    const fileSize = 50 * 1024 * 1024; // 50 MB
+    const mockFile = {
+      name: 'audio.wav', size: fileSize, type: 'audio/wav',
+      arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(10)),
+    };
+
+    // Provide window.LicenseManager accessible to the handleFile code
+    mockVip.ctx.decodeAudioData = jest.fn().mockResolvedValue({ length: 100 });
+
+    // Patch global.window for this call so the code inside VM can read it
+    const savedWindow = global.window;
+    global.window = { LicenseManager: { checkFileLimit } };
+
+    await handleFile.call(mockVip, mockFile);
+
+    global.window = savedWindow;
+
+    // checkFileLimit should have been called with the file size in MB and 0
+    expect(checkFileLimit).toHaveBeenCalledWith(50, 0);
+  });
+
+  test('blocks the file when checkFileLimit returns allowed:false', async () => {
+    const checkFileLimit = jest.fn().mockReturnValue({
+      allowed: false,
+      reason: 'File size exceeds your plan limit of 25 MB.',
+    });
+    const mockVip  = makeMockVip();
+    const mockFile = {
+      name: 'big.wav', size: 30 * 1024 * 1024, type: 'audio/wav',
+      arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(10)),
+    };
+
+    const savedWindow = global.window;
+    global.window = { LicenseManager: { checkFileLimit } };
+
+    await handleFile.call(mockVip, mockFile);
+
+    global.window = savedWindow;
+
+    expect(mockVip.setStatus).toHaveBeenCalledWith('ERROR');
+    expect(mockVip.dom.fileInfo.textContent).toContain('File size exceeds your plan limit of 25 MB.');
+  });
+
+  test('uses check.reason as the error message when blocked by LicenseManager', async () => {
+    const reason        = 'Upgrade to PRO to process files larger than 25 MB.';
+    const checkFileLimit = jest.fn().mockReturnValue({ allowed: false, reason });
+    const mockVip  = makeMockVip();
+    const mockFile = {
+      name: 'medium.wav', size: 30 * 1024 * 1024, type: 'audio/wav',
+      arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(10)),
+    };
+
+    const savedWindow = global.window;
+    global.window = { LicenseManager: { checkFileLimit } };
+
+    await handleFile.call(mockVip, mockFile);
+
+    global.window = savedWindow;
+
+    expect(mockVip.dom.fileInfo.textContent).toContain(reason);
+  });
+
+  test('proceeds normally when LicenseManager is absent (window.LicenseManager undefined)', async () => {
+    const mockVip  = makeMockVip();
+    const mockFile = {
+      name: 'audio.wav', size: 5 * 1024 * 1024, type: 'audio/wav',
+      arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(10)),
+    };
+
+    const savedWindow = global.window;
+    global.window = {};    // no LicenseManager
+
+    await handleFile.call(mockVip, mockFile);
+
+    global.window = savedWindow;
+
+    expect(mockVip.dom.fileInfo.textContent).not.toContain('File too large');
+  });
+
+  test('proceeds normally when LicenseManager lacks checkFileLimit method', async () => {
+    const mockVip  = makeMockVip();
+    const mockFile = {
+      name: 'audio.wav', size: 5 * 1024 * 1024, type: 'audio/wav',
+      arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(10)),
+    };
+
+    const savedWindow = global.window;
+    global.window = { LicenseManager: { someOtherMethod: jest.fn() } };
+
+    await handleFile.call(mockVip, mockFile);
+
+    global.window = savedWindow;
+
+    expect(mockVip.dom.fileInfo.textContent).not.toContain('File too large');
+  });
+
+  test('size check runs before LicenseManager check (oversized file never calls LM)', async () => {
+    const checkFileLimit = jest.fn().mockReturnValue({ allowed: true });
+    const mockVip  = makeMockVip();
+    const mockFile = {
+      name: 'huge.wav', size: 300 * 1024 * 1024, type: 'audio/wav',
+      arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(10)),
+    };
+
+    const savedWindow = global.window;
+    global.window = { LicenseManager: { checkFileLimit } };
+
+    await handleFile.call(mockVip, mockFile);
+
+    global.window = savedWindow;
+
+    // The hard-cap error fires before the LM check
+    expect(mockVip.dom.fileInfo.textContent).toContain('File too large');
+    // LM checkFileLimit should NOT have been called since the hard cap triggered first
+    expect(checkFileLimit).not.toHaveBeenCalled();
+  });
+});

--- a/tests/monetization.test.js
+++ b/tests/monetization.test.js
@@ -421,3 +421,99 @@ describe('PRICE_TO_TIER mapping', () => {
     expect(PRICE_TO_TIER[PRICE_IDS.STUDIO_annual]).toBe('STUDIO');
   });
 });
+
+// ── LICENSE_JWT_SECRET dev-default fallback (monetization.js PR change) ────────
+// The change added: if LICENSE_JWT_SECRET is absent and NODE_ENV !== 'production',
+// set a well-known dev default instead of throwing.  We test the conditional
+// logic in isolation — the same conditions apply to api/auth.js which re-uses
+// the same env var.
+describe('LICENSE_JWT_SECRET dev-default fallback logic', () => {
+  const DEV_DEFAULT = 'voiceisolate-dev-secret-key-minimum-32-chars';
+
+  // Helper that mimics the monetization.js initialisation block
+  function applySecretFallback(envSecret, nodeEnv) {
+    const savedSecret  = process.env.LICENSE_JWT_SECRET;
+    const savedNodeEnv = process.env.NODE_ENV;
+
+    // Set up the environment as the test demands
+    if (envSecret === undefined) {
+      delete process.env.LICENSE_JWT_SECRET;
+    } else {
+      process.env.LICENSE_JWT_SECRET = envSecret;
+    }
+    process.env.NODE_ENV = nodeEnv || 'development';
+
+    let thrownError = null;
+    let warnEmitted = false;
+    const originalWarn = console.warn;
+    console.warn = (...args) => {
+      if (args[0] && String(args[0]).includes('LICENSE_JWT_SECRET')) warnEmitted = true;
+    };
+
+    try {
+      if (!process.env.LICENSE_JWT_SECRET) {
+        if (process.env.NODE_ENV === 'production') {
+          throw new Error('LICENSE_JWT_SECRET environment variable is required');
+        }
+        process.env.LICENSE_JWT_SECRET = DEV_DEFAULT;
+        console.warn('[monetization] LICENSE_JWT_SECRET not set — using dev default. Do NOT use in production.');
+      }
+    } catch (e) {
+      thrownError = e;
+    }
+
+    const resultSecret = process.env.LICENSE_JWT_SECRET;
+
+    // Restore
+    console.warn = originalWarn;
+    if (savedSecret === undefined) {
+      delete process.env.LICENSE_JWT_SECRET;
+    } else {
+      process.env.LICENSE_JWT_SECRET = savedSecret;
+    }
+    process.env.NODE_ENV = savedNodeEnv;
+
+    return { resultSecret, thrownError, warnEmitted };
+  }
+
+  test('sets dev default when LICENSE_JWT_SECRET is absent and NODE_ENV is development', () => {
+    const { resultSecret, thrownError } = applySecretFallback(undefined, 'development');
+    expect(thrownError).toBeNull();
+    expect(resultSecret).toBe(DEV_DEFAULT);
+  });
+
+  test('sets dev default when LICENSE_JWT_SECRET is absent and NODE_ENV is test', () => {
+    const { resultSecret, thrownError } = applySecretFallback(undefined, 'test');
+    expect(thrownError).toBeNull();
+    expect(resultSecret).toBe(DEV_DEFAULT);
+  });
+
+  test('sets dev default when LICENSE_JWT_SECRET is absent and NODE_ENV is not set', () => {
+    const { resultSecret, thrownError } = applySecretFallback(undefined, '');
+    expect(thrownError).toBeNull();
+    expect(resultSecret).toBe(DEV_DEFAULT);
+  });
+
+  test('throws in production when LICENSE_JWT_SECRET is absent', () => {
+    const { thrownError } = applySecretFallback(undefined, 'production');
+    expect(thrownError).not.toBeNull();
+    expect(thrownError.message).toContain('LICENSE_JWT_SECRET');
+  });
+
+  test('does not overwrite an existing LICENSE_JWT_SECRET', () => {
+    const mySecret = 'my-real-secret-key-with-enough-length-32chars';
+    const { resultSecret } = applySecretFallback(mySecret, 'development');
+    expect(resultSecret).toBe(mySecret);
+  });
+
+  test('dev default is at least 32 characters long (suitable as HMAC key)', () => {
+    expect(DEV_DEFAULT.length).toBeGreaterThanOrEqual(32);
+  });
+
+  test('tokens signed with the dev default secret validate correctly', () => {
+    const token   = createLicenseToken('u1', 'e@e.com', 'PRO', 365, DEV_DEFAULT);
+    const payload = validateLicenseToken(token, DEV_DEFAULT);
+    expect(payload).not.toBeNull();
+    expect(payload.tier).toBe('pro');
+  });
+});


### PR DESCRIPTION
## Summary

- **Fix missing file size validation in `handleFile()`** — the sentinel comment documented a 200MB limit but no actual check existed, allowing arbitrarily large files to crash the browser with OOM errors. Now enforces a hard 200MB cap and integrates `LicenseManager.checkFileLimit()` for tier-based limits (FREE: 50MB, PRO: 500MB, etc.).
- **Add username/password login system** with scrypt-hashed passwords, JWT auth tokens that integrate with the existing `LicenseManager`, and a full-screen login overlay matching the dark industrial UI theme.
- **Seed admin and per-tier test accounts** for development/QA testing.

### Seeded Credentials

| Username | Password | Tier | Role |
|---|---|---|---|
| `joker5514` | `Admin8052` | ENTERPRISE | admin |
| `test_free` | `TestFree123` | FREE | user |
| `test_pro` | `TestPro123` | PRO | user |
| `test_studio` | `TestStudio123` | STUDIO | user |
| `test_enterprise` | `TestEnterprise123` | ENTERPRISE | user |

### Files Changed

- `public/app/app.js` — add file size validation in `handleFile()`
- `api/auth.js` — new auth router (login, me, logout endpoints)
- `api/index.js` — mount auth router at `/api/auth/*`
- `api/monetization.js` — graceful dev fallback for missing `LICENSE_JWT_SECRET`
- `public/app/auth.js` — client-side auth module (session, UI, LicenseManager integration)
- `public/app/index.html` — login overlay styles + auth.js script tag
- `server.js` — mount API router for `/api/*` routes

## Test plan

- [x] All 27 test suites pass (1114 tests)
- [x] ESLint lint passes
- [x] `pnpm validate` structural checks pass
- [ ] Manual: start dev server (`pnpm dev`), verify login overlay appears
- [ ] Manual: login as `joker5514` / `Admin8052`, verify ENTERPRISE badge + admin flag in header
- [ ] Manual: login as `test_free` / `TestFree123`, verify FREE tier badge and file size limit (50MB)
- [ ] Manual: logout, verify overlay reappears and license deactivates
- [ ] Manual: upload a file > 200MB, verify clear error message
- [ ] Manual: refresh page while logged in, verify session persists

https://claude.ai/code/session_01FUNLQahZS3qzNKTPjQhoB9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added user authentication endpoints and client login overlay with session persistence.
  * User status/tier badges and license activation tied to successful sign-in.
  * App now enforces a 200MB per-file upload limit.

* **Behavior Changes**
  * In non-production, a default license secret is used with a console warning; production still requires the secret.

* **Tests**
  * Extensive unit and integration tests for auth, client flows, file validation, and license behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->