### PR TITLE
🧹 [code health improvement] Remove leftover debug logging from main.js

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -31,7 +31,6 @@ async function initAudio() {
 
 // ── Worker Pool (ONNX Demucs + ECAPA-TDNN) ───────────────────────────────────
 const POOL_SIZE = Math.max(2, (navigator.hardwareConcurrency || 4) - 2);
-console.log(`[VoiceIsolate] Spawning ${POOL_SIZE} inference workers`);
 
 const workerPool = Array.from({ length: POOL_SIZE }, (_, i) => {
   const w = new Worker(new URL('./worker-pool.js', import.meta.url), { type: 'module' });
@@ -42,7 +41,6 @@ const workerPool = Array.from({ length: POOL_SIZE }, (_, i) => {
       updateVisualizer(null, data.score);
     }
     if (data.type === 'ENROLLED') {
-      console.log('[VoiceIsolate] Voiceprint enrolled successfully');
       document.getElementById('btn-enroll').textContent = 'Voiceprint ✓';
     }
   };


### PR DESCRIPTION
🎯 **What:** Removed two leftover debug `console.log` statements from `src/main.js` (lines 34 and 45).
💡 **Why:** Debug logging can clutter the console output, which is generally bad for code health, maintainability, and production visibility. Removing them ensures the application runs quietly in production.
✅ **Verification:** Validated that syntax is correct by running validation script `pnpm run validate`, and ran the full suite via `pnpm test`. Both passed without issues. Checked the git diff manually to ensure only logging lines were affected.
✨ **Result:** Improved codebase cleanliness and removed console clutter.

---
*PR created automatically by Jules for task [16351454292509947000](https://jules.google.com/task/16351454292509947000) started by @Joker5514*