### PR TITLE
🧹 Fix ml-worker syntax, file size validation, and license limits

### DIFF
--- a/public/app/app.js
+++ b/public/app/app.js
@@ -562,6 +562,11 @@ class VoiceIsolatePro {
   // ======== FILE HANDLING ========
   async handleFile(file) {
     try {
+      const sizeCapMB = 200;
+      const fileSizeMB = file.size / (1024 * 1024);
+      if (fileSizeMB > sizeCapMB) {
+        throw new Error(`File too large: ${fileSizeMB.toFixed(1)} MB. The hard limit is ${sizeCapMB} MB.`);
+      }
       const LM = window.LicenseManager;
       if (LM && typeof LM.checkFileLimit === 'function') {
         const fileSizeMB = file.size / (1024 * 1024);

--- a/public/app/license-manager.js
+++ b/public/app/license-manager.js
@@ -23,9 +23,9 @@ const LicenseManager = (() => {
       color: '#6b7280',
       badge: null,
       limits: {
-        fileSizeMB: -1,
-        durationMinutes: -1,
-        exportsPerDay: -1,
+        fileSizeMB: 50,
+        durationMinutes: 5,
+        exportsPerDay: 3,
         batchFiles: 0,
         apiCallsPerMonth: 0,
         concurrentJobs: 1,

--- a/public/app/ml-worker.js
+++ b/public/app/ml-worker.js
@@ -158,19 +158,19 @@ self.onmessage = async (ev) => {
 };
 
 // ── 2. Multi-speaker separation ───────────────────────────────────────────────
-// async function handleMultiSeparate(streams) {
-//   if (!streams || !streams.length) {
-//     self.postMessage({ type: 'multi_done', streams: [] });
-//     return;
-//   }
+async function handleMultiSeparate(streams) {
+  if (!streams || !streams.length) {
+    self.postMessage({ type: 'multi_done', streams: [] });
+    return;
+  }
 //
-//   // Null-guard: filter out invalid stream entries before extracting buffers
-//   const transferables = streams
-//     .map(s => s && s.data && s.data.buffer)
-//     .filter(Boolean);
+  // Null-guard: filter out invalid stream entries before extracting buffers
+  const transferables = streams
+    .map(s => s && s.data && s.data.buffer)
+    .filter(Boolean);
 //
-//   self.postMessage({ type: 'multi_done', streams }, transferables);
-// }
+  self.postMessage({ type: 'multi_done', streams }, transferables);
+}
 
 // ── 3. Model loader ───────────────────────────────────────────────────────────
 async function loadModels(basePath, providers, modelList) {


### PR DESCRIPTION
🎯 **What:**
- Uncommented the `handleMultiSeparate` function and its related logic in `public/app/ml-worker.js`.
- Added a 200MB hard limit check to `handleFile` within `public/app/app.js` with appropriate error messaging.
- Adjusted the FREE tier limits in `public/app/license-manager.js` to correctly enforce a 50 MB file size limit, 5 minutes duration, and 3 exports per day.

💡 **Why:**
- The `handleMultiSeparate` logic was commented out, causing ESLint errors and functional regressions in the worker context.
- Without a hard file size cap, users could attempt to process excessively large files, causing Out-Of-Memory (OOM) errors in the browser.
- The `LicenseManager` limits were incorrectly configured with `-1` defaults, meaning the FREE tier was effectively unlimited.

✅ **Verification:**
- `pnpm run lint` passes successfully.
- `pnpm run test` passes (specifically `handle_file_validation.test.js`, `license-manager.test.js`, and `ml-worker.test.js`).
- `pnpm run validate` structure checks pass.

✨ **Result:**
- ESLint syntax errors are resolved.
- App robustly limits local uploads to 200MB.
- `LicenseManager` properly restricts the FREE tier.

---
*PR created automatically by Jules for task [5802971438810258326](https://jules.google.com/task/5802971438810258326) started by @Joker5514*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multi-speaker audio stream processing is now active.
  * File size restriction implemented: 200MB hard limit for all users; 50MB for Free tier.
  * Free tier usage limits enforced: 5-minute audio duration, 3 daily exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->