### PR TITLE
Implement usage recording for metered billing in POST /api/usage/record

### DIFF
--- a/api/monetization.js
+++ b/api/monetization.js
@@ -43,7 +43,7 @@ const db = {
   },
   usage: {
     record: async (data) => {
-      const entry = { ...data, recordedAt: Date.now() };
+      const entry = { ...data, recordedAt: Math.floor(Date.now() / 1000) };
       _usageStore.push(entry);
       return entry;
     },

--- a/api/monetization.js
+++ b/api/monetization.js
@@ -29,6 +29,7 @@ const router = express.Router();
 
 // ─── Simulated Database ───────────────────────────────────────────────────────
 const _licensesStore = new Map();
+const _usageStore = [];
 const db = {
   licenses: {
     upsert: async (data) => {
@@ -38,6 +39,16 @@ const db = {
     },
     get: async (customerId) => {
       return _licensesStore.get(customerId) || null;
+    }
+  },
+  usage: {
+    record: async (data) => {
+      const entry = { ...data, recordedAt: Date.now() };
+      _usageStore.push(entry);
+      return entry;
+    },
+    list: async (email) => {
+      return email ? _usageStore.filter(e => e.email === email) : [..._usageStore];
     }
   }
 };
@@ -274,7 +285,7 @@ router.get('/license/status', (req, res) => {
 });
 
 // ─── POST /api/usage/record ───────────────────────────────────────────────────
-router.post('/usage/record', (req, res) => {
+router.post('/usage/record', async (req, res) => {
   const { event: usageEvent, units = 1 } = req.body;
   const authHeader = req.headers.authorization;
 
@@ -286,8 +297,8 @@ router.post('/usage/record', (req, res) => {
   const payload = validateLicenseToken(token);
   if (!payload) return res.status(401).json({ error: 'Invalid token' });
 
-  // TODO: Record usage in database for metered billing
-  console.log(`[Usage] ${payload.email} — ${usageEvent} × ${units}`);
+  const entry = await db.usage.record({ email: payload.email, event: usageEvent, units });
+  console.log(`[Usage] ${entry.email} — ${entry.event} × ${entry.units}`);
   res.json({ recorded: true, event: usageEvent, units });
 });
 


### PR DESCRIPTION
Adds a _usageStore array and db.usage namespace (record/list methods) to the
simulated database, replacing the TODO comment with actual in-memory persistence.
Each usage event is stamped with recordedAt for future metered billing queries.

https://claude.ai/code/session_01XfVm7UdiasWeMHsd1cuiMq
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/joker5514/voiceisolate-pro/pull/350" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Usage recording now properly persists data entries with timestamps for accurate tracking and retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->