### PR TITLE
Remove upload file size limits for all tiers

### DIFF
--- a/public/app/app-init.js
+++ b/public/app/app-init.js
@@ -506,14 +506,6 @@ function wireFileInput() {
     if (!file) return;
 
     const sizeMB = file.size / (1024 * 1024);
-    if (!checkFileSizeLimit(sizeMB)) {
-      showToast(
-        `File too large (${sizeMB.toFixed(1)} MB). ` +
-        `Your tier allows ${caps.maxFileSizeMB} MB max.`,
-        'error'
-      );
-      return;
-    }
 
     _pendingFileBuffer = await file.arrayBuffer();
     setFileLabel(file.name, sizeMB);

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -568,7 +568,9 @@ class VoiceIsolatePro {
       if (LM && typeof LM.checkFileLimit === 'function') {
         const fileSizeMB = file.size / (1024 * 1024);
         const check = LM.checkFileLimit(fileSizeMB, 0);
-        if (!check.allowed && check.reason && !check.reason.includes('size')) throw new Error(check.reason);
+        if (!check.allowed) {
+          throw new Error(check.reason || 'This file exceeds the limits for your current plan.');
+        }
       }
 
       const normalizedType = (file.type || '').toLowerCase();

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -564,16 +564,11 @@ class VoiceIsolatePro {
   // ======== FILE HANDLING ========
   async handleFile(file) {
     try {
-      const sizeCapMB = 200;
-      const fileSizeMB = file.size / (1024 * 1024);
-      if (fileSizeMB > sizeCapMB) {
-        throw new Error(`File too large: ${fileSizeMB.toFixed(1)} MB. The hard limit is ${sizeCapMB} MB.`);
-      }
       const LM = window.LicenseManager;
       if (LM && typeof LM.checkFileLimit === 'function') {
         const fileSizeMB = file.size / (1024 * 1024);
         const check = LM.checkFileLimit(fileSizeMB, 0);
-        if (!check.allowed) throw new Error(check.reason);
+        if (!check.allowed && check.reason && !check.reason.includes('size')) throw new Error(check.reason);
       }
 
       const normalizedType = (file.type || '').toLowerCase();

--- a/public/app/auth.js
+++ b/public/app/auth.js
@@ -81,7 +81,7 @@ const TIER_CAPS = {
     forensicMode:    false,
   },
   PRO: {
-    maxFileSizeMB:   500,
+    maxFileSizeMB:   Infinity,
     filesPerMonth:   50,
     maxStages:       18,
     mlModels:        ['silero-vad', 'rnnoise'],
@@ -92,7 +92,7 @@ const TIER_CAPS = {
     forensicMode:    false,
   },
   STUDIO: {
-    maxFileSizeMB:   2048,
+    maxFileSizeMB:   Infinity,
     filesPerMonth:   Infinity,
     maxStages:       32,
     mlModels:        ['silero-vad', 'rnnoise', 'demucs-v4', 'ecapa-tdnn'],

--- a/public/app/license-manager.js
+++ b/public/app/license-manager.js
@@ -23,7 +23,7 @@ const LicenseManager = (() => {
       color: '#6b7280',
       badge: null,
       limits: {
-        fileSizeMB: 50,
+        fileSizeMB: -1,
         durationMinutes: 5,
         exportsPerDay: 3,
         batchFiles: 0,
@@ -72,7 +72,7 @@ const LicenseManager = (() => {
       color: '#6366f1',
       badge: 'Most Popular',
       limits: {
-        fileSizeMB: 500,
+        fileSizeMB: -1,
         durationMinutes: 120,
         exportsPerDay: 50,
         batchFiles: 10,
@@ -121,7 +121,7 @@ const LicenseManager = (() => {
       color: '#f59e0b',
       badge: 'Best Value',
       limits: {
-        fileSizeMB: 2000,
+        fileSizeMB: -1,
         durationMinutes: -1,    // unlimited
         exportsPerDay: -1,
         batchFiles: 100,


### PR DESCRIPTION
- Remove the 200 MB hard cap in app.js handleFile()
- Remove the checkFileSizeLimit() gate in app-init.js wireFileInput()
- Set fileSizeMB to -1 (unlimited) for FREE, PRO, and STUDIO in license-manager.js
- Set maxFileSizeMB to Infinity for PRO and STUDIO in auth.js

https://claude.ai/code/session_01UBD3nLosX7hduSHJPfa128
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/joker5514/voiceisolate-pro/pull/357" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Unlimited file uploads are now available for FREE, PRO, and STUDIO account tiers. File size restrictions have been removed entirely for these subscription levels. Users no longer face upload limits that previously capped FREE tier at 50MB, PRO at 500MB, and STUDIO at 2GB, enabling seamless transfer of larger files across all tiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->