### PR TITLE
docs: update index.html to reflect v24 architecture

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,3 +4,6 @@
 ## 2024-04-14 - [Accessible Tabs]
 **Learning:** Custom UI tabs (e.g., `.tab` buttons) must implement explicit ARIA roles (`tablist`, `tab`, `tabpanel`) and dynamically synchronize the `aria-selected` attribute with their active visual state for screen reader accessibility. This includes adding `aria-controls` to the tabs and `aria-labelledby` to the tab panels.
 **Action:** When implementing custom tab UI, explicitly set `role="tablist"` on the container, `role="tab"` on the buttons, `role="tabpanel"` on the panels, and sync `aria-selected` in Javascript.
+## 2024-04-15 - [Index Updates]
+**Learning:** Remember to verify line numbers of specific text strings before applying them using python regex or replacing them, and correctly handle instances where multiple string hits match the criteria.
+**Action:** Always test the update steps to prevent failing later and verify with `git diff`.

--- a/public/index.html
+++ b/public/index.html
@@ -170,7 +170,7 @@ footer{border-top:1px solid var(--border);padding:2rem 1.5rem;text-align:center;
   <div class="hero-logo">VoiceIsolate.Pro</div>
 
   <h1>VoiceIsolate <em>Pro</em></h1>
-  <p class="hero-sub">Studio-grade voice isolation. 36-Stage Deca-Pass DSP pipeline. Hybrid ML + classical spectral processing. 100% local — zero data egress.</p>
+  <p class="hero-sub">Studio-grade voice isolation. 40-Stage Dodeca-Pass DSP pipeline. Hybrid ML + classical spectral processing. 100% local — zero data egress.</p>
 
   <!-- Animated stat counters -->
   <div class="hero-stats">
@@ -216,7 +216,7 @@ footer{border-top:1px solid var(--border);padding:2rem 1.5rem;text-align:center;
         <div class="step-icon" aria-hidden="true">
           <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
         </div>
-        <h3>36-Stage Pipeline</h3>
+        <h3>40-Stage Pipeline</h3>
         <p>Runs entirely inside your browser. Noise gate → Wiener NR → ERB spectral gate → harmonic reconstruction → dereverberation → ML VAD → dynamics chain.</p>
         <div class="step-formats">
           <span>Wiener NR</span><span>ERB Gate</span><span>VAD</span><span>Dereverb</span><span>De-ess</span><span>52 sliders</span>
@@ -330,9 +330,9 @@ footer{border-top:1px solid var(--border);padding:2rem 1.5rem;text-align:center;
         <div class="launch-text">
           <span class="launch-tag">Engineer Mode v24.0</span>
           <h2>Launch the App</h2>
-          <p>52 sliders. 6-panel diagnostic dashboard. A/B comparison. 3D spectrogram. 35-stage pipeline. Drop audio or video and get studio-clean output in seconds.</p>
+          <p>52 sliders. 6-panel diagnostic dashboard. A/B comparison. 3D spectrogram. 40-stage pipeline. Drop audio or video and get studio-clean output in seconds.</p>
           <div class="launch-pills">
-            <span>36-Stage DSP</span><span>ML VAD</span><span>52 Sliders</span><span>A/B Compare</span>
+            <span>40-Stage DSP</span><span>ML VAD</span><span>52 Sliders</span><span>A/B Compare</span>
             <span>3D Spectrogram</span><span>32-bit WAV</span><span>100% Local</span><span>Zero Upload</span>
           </div>
         </div>

--- a/public/index.html
+++ b/public/index.html
@@ -330,7 +330,7 @@ footer{border-top:1px solid var(--border);padding:2rem 1.5rem;text-align:center;
         <div class="launch-text">
           <span class="launch-tag">Engineer Mode v24.0</span>
           <h2>Launch the App</h2>
-          <p>52 sliders. 6-panel diagnostic dashboard. A/B comparison. 3D spectrogram. 40-stage pipeline. Drop audio or video and get studio-clean output in seconds.</p>
+          <p>52 sliders. 6-panel diagnostic dashboard. A/B comparison. 3D spectrogram. 40-Stage pipeline. Drop audio or video and get studio-clean output in seconds.</p>
           <div class="launch-pills">
             <span>40-Stage DSP</span><span>ML VAD</span><span>52 Sliders</span><span>A/B Compare</span>
             <span>3D Spectrogram</span><span>32-bit WAV</span><span>100% Local</span><span>Zero Upload</span>


### PR DESCRIPTION
🎯 **What:**
Updated `public/index.html` to reflect the latest "40-stage Dodeca-Pass" architecture according to the README for version 24.0.0.

💡 **Why:**
The landing page was still showing outdated text such as "36-Stage Deca-Pass" and "35-stage pipeline" rather than the actual v24 architecture. 

✅ **Verification:**
Ran project validation (`pnpm run validate`) and `pnpm test` (noting unrelated existing failures). The tests showed no regressions introduced by the textual updates.

✨ **Result:**
The homepage text matches the current v24 documentation accurately.

---
*PR created automatically by Jules for task [14643515793349502879](https://jules.google.com/task/14643515793349502879) started by @Joker5514*