### PR TITLE
fix(dsp): repair output sound quality across STFT, Wiener, mask, limiter

### DIFF
--- a/public/app/dsp-core.js
+++ b/public/app/dsp-core.js
@@ -111,36 +111,38 @@ class AdaptiveNoiseFloor {
   }
 }
 
-// Hardened Wiener filter — aggressive voice isolation
+// Wiener suppression gain in [beta, 1]. Pure attenuation — never amplifies.
+// Frequency-dependent boosting belongs in a separate post-stage (see voice mask),
+// not baked into the Wiener gain, where >1 multipliers re-introduce noise and clip.
 function wienerFilter(noiseMag, signalMag, params = {}) {
-  const alpha = params.noiseOverSubtract || 2.0; // over-subtraction factor (was 1.0)
-  const beta = params.spectralFloor || 0.001;   // spectral floor (was 0.01 — lower = cleaner)
-  const voiceBoost = params.voiceBoost || 1.5;   // boost voice band 80Hz-4kHz
+  const alpha = params.noiseOverSubtract || 1.2; // mild over-subtraction (was 2.0 — caused hollow voice)
+  const beta = params.spectralFloor || 0.02;     // -34 dB floor prevents musical noise (was 0.001)
 
   const noisePow = noiseMag * noiseMag;
   const sigPow = signalMag * signalMag;
   const snr = sigPow / (alpha * noisePow + 1e-10);
 
-  // Sigmoid-shaped suppression curve for sharper voice/noise boundary
-  const suppressionCurve = snr / (snr + 1.0);
-  const gain = Math.max(beta, suppressionCurve * suppressionCurve); // squared for aggression
-
-  return gain * voiceBoost;
+  // Wiener-style suppression curve, single-power (not squared). Squaring produced
+  // double the attenuation in dB and created spectral holes / chirping artifacts.
+  const gain = snr / (snr + 1.0);
+  return Math.max(beta, Math.min(1.0, gain));
 }
 
-// Voice frequency mask — boosts 80Hz-4kHz, hard-suppresses outside
-// binIndex: the FFT bin index, sampleRate: audio sample rate, fftSize: FFT size
+// Voice frequency mask — gentle bandpass weighting.
+// Brick-wall cuts (0.0 sub-bass, 0.05 high-band) made output sound like a
+// telephone line. Use a smooth weighting that preserves naturalness while
+// favouring the 200 Hz–5 kHz speech intelligibility range.
 function getVoiceMaskGain(binIndex, sampleRate, fftSize) {
   const freq = binIndex * sampleRate / fftSize;
 
-  if (freq < 60) return 0.0;           // sub-bass: kill
-  if (freq < 80) return 0.3;           // low rolloff
-  if (freq < 300) return 0.85;         // low voice fundamentals
-  if (freq <= 3400) return 1.0;        // CORE VOICE BAND — full pass
-  if (freq <= 4000) return 0.9;        // soft rolloff
-  if (freq <= 6000) return 0.6;        // sibilants — partial keep
-  if (freq <= 8000) return 0.25;       // high presence — attenuate
-  return 0.05;                         // ultra-high: near-kill
+  if (freq < 40)   return 0.30;        // very low: rumble — attenuate, don't kill
+  if (freq < 80)   return 0.60;        // bass / male fundamentals
+  if (freq < 200)  return 0.90;        // voice fundamentals: keep nearly full
+  if (freq <= 4000) return 1.0;        // CORE VOICE BAND
+  if (freq <= 6000) return 0.90;       // sibilants / presence — keep
+  if (freq <= 9000) return 0.75;       // upper presence / breath — preserve naturalness
+  if (freq <= 12000) return 0.55;      // air band
+  return 0.40;                         // ultra-high: gently attenuate (no near-kill)
 }
 
 /**
@@ -898,16 +900,21 @@ const DSPCore = {
     return { left: out_l, right: out_r };
   },
 
-  /** S32: True peak limiter with 4x oversampling */
+  /** S32: Soft-knee peak limiter. Output is strictly bounded by `ceiling`.
+   *  The knee starts ~3 dB below the ceiling so peaks compress smoothly
+   *  rather than slamming into a hard threshold (which created derivative
+   *  discontinuities and clicks on transients). */
   truePeakLimit(data, ceilingDb) {
     const ceiling = Math.pow(10, ceilingDb / 20);
-    // Simplified: hard clip with soft-knee
+    const knee = ceiling * 0.7079;             // -3 dB below ceiling
+    const range = ceiling - knee;
     for (let i = 0; i < data.length; i++) {
-      if (data[i] > ceiling) {
-        data[i] = ceiling * Math.tanh(data[i] / ceiling);
-      } else if (data[i] < -ceiling) {
-        data[i] = -ceiling * Math.tanh(data[i] / -ceiling);
-      }
+      const x = data[i];
+      const a = Math.abs(x);
+      if (a <= knee) continue;                 // linear region
+      const over = (a - knee) / range;         // ≥ 0
+      const compressed = knee + range * Math.tanh(over);
+      data[i] = (x < 0 ? -compressed : compressed);
     }
     return data;
   },

--- a/public/app/dsp-core.js
+++ b/public/app/dsp-core.js
@@ -115,8 +115,10 @@ class AdaptiveNoiseFloor {
 // Frequency-dependent boosting belongs in a separate post-stage (see voice mask),
 // not baked into the Wiener gain, where >1 multipliers re-introduce noise and clip.
 function wienerFilter(noiseMag, signalMag, params = {}) {
-  const alpha = params.noiseOverSubtract || 1.2; // mild over-subtraction (was 2.0 — caused hollow voice)
-  const beta = params.spectralFloor || 0.02;     // -34 dB floor prevents musical noise (was 0.001)
+  const alphaRaw = Number.isFinite(params.noiseOverSubtract) ? params.noiseOverSubtract : 1.2; // mild over-subtraction (was 2.0 — caused hollow voice)
+  const betaRaw = Number.isFinite(params.spectralFloor) ? params.spectralFloor : 0.02;         // -34 dB floor prevents musical noise (was 0.001)
+  const alpha = Math.max(1e-6, alphaRaw);
+  const beta = Math.min(1.0, Math.max(0.0, betaRaw));
 
   const noisePow = noiseMag * noiseMag;
   const sigPow = signalMag * signalMag;

--- a/public/app/dsp-processor.js
+++ b/public/app/dsp-processor.js
@@ -129,8 +129,10 @@ function processEnvFollower(ef, x) {
 // Wiener suppression gain in [beta, 1]. Pure attenuation — never amplifies.
 // Kept in sync with public/app/dsp-core.js (canonical).
 function wienerFilter(noiseMag, signalMag, params = {}) {
-  const alpha = params.noiseOverSubtract || 1.2;
-  const beta = params.spectralFloor || 0.02;
+  const alphaRaw = Number.isFinite(params.noiseOverSubtract) ? params.noiseOverSubtract : 1.2;
+  const betaRaw = Number.isFinite(params.spectralFloor) ? params.spectralFloor : 0.02;
+  const alpha = Math.max(1e-6, alphaRaw);
+  const beta = Math.min(1.0, Math.max(0.0, betaRaw));
 
   const noisePow = noiseMag * noiseMag;
   const sigPow = signalMag * signalMag;

--- a/public/app/dsp-processor.js
+++ b/public/app/dsp-processor.js
@@ -126,31 +126,30 @@ function processEnvFollower(ef, x) {
 // NOTE: duplicated intentionally from public/app/dsp-core.js (canonical helper).
 // AudioWorkletProcessor runs in an isolated global scope and this file is loaded
 // directly via addModule(); direct imports from dsp-core are not used here.
-// Hardened Wiener filter — aggressive voice isolation
+// Wiener suppression gain in [beta, 1]. Pure attenuation — never amplifies.
+// Kept in sync with public/app/dsp-core.js (canonical).
 function wienerFilter(noiseMag, signalMag, params = {}) {
-  const alpha = params.noiseOverSubtract || 2.0;
-  const beta = params.spectralFloor || 0.001;
-  const voiceBoost = params.voiceBoost || 1.5;
+  const alpha = params.noiseOverSubtract || 1.2;
+  const beta = params.spectralFloor || 0.02;
 
   const noisePow = noiseMag * noiseMag;
   const sigPow = signalMag * signalMag;
   const snr = sigPow / (alpha * noisePow + 1e-10);
-  const suppressionCurve = snr / (snr + 1.0);
-  const gain = Math.max(beta, suppressionCurve * suppressionCurve);
-  return gain * voiceBoost;
+  const gain = snr / (snr + 1.0);
+  return Math.max(beta, Math.min(1.0, gain));
 }
 
-// Voice frequency mask — boosts 80Hz-4kHz, hard-suppresses outside
+// Voice frequency mask — gentle bandpass weighting (kept in sync with dsp-core.js).
 function getVoiceMaskGain(binIndex, sampleRate, fftSize) {
   const freq = binIndex * sampleRate / fftSize;
-  if (freq < 60) return 0.0;
-  if (freq < 80) return 0.3;
-  if (freq < 300) return 0.85;
-  if (freq <= 3400) return 1.0;
-  if (freq <= 4000) return 0.9;
-  if (freq <= 6000) return 0.6;
-  if (freq <= 8000) return 0.25;
-  return 0.05;
+  if (freq < 40)    return 0.30;
+  if (freq < 80)    return 0.60;
+  if (freq < 200)   return 0.90;
+  if (freq <= 4000) return 1.0;
+  if (freq <= 6000) return 0.90;
+  if (freq <= 9000) return 0.75;
+  if (freq <= 12000) return 0.55;
+  return 0.40;
 }
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -245,9 +244,8 @@ class DSPProcessor extends AudioWorkletProcessor {
       // Misc
       humReduce:        50,    // %
       vadThreshold:  0.005,
-      noiseOverSubtract: 2.0,
-      spectralFloor: 0.001,
-      voiceBoost: 1.5,
+      noiseOverSubtract: 1.2,
+      spectralFloor: 0.02,
       bypass:        false,
     };
     this._rebuildFilters(this._sampleRate);

--- a/public/app/voice-isolate-processor.js
+++ b/public/app/voice-isolate-processor.js
@@ -63,7 +63,8 @@ const _hannCache = new Map();
 function hannWindow(N) {
   if (_hannCache.has(N)) return _hannCache.get(N);
   const w = new Float32Array(N);
-  for (let i = 0; i < N; i++) w[i] = 0.5 * (1 - Math.cos(2 * Math.PI * i / (N - 1)));
+  // Periodic Hann (divisor N, not N-1) — required for COLA at 75% overlap
+  for (let i = 0; i < N; i++) w[i] = 0.5 * (1 - Math.cos(2 * Math.PI * i / N));
   _hannCache.set(N, w);
   return w;
 }


### PR DESCRIPTION
- voice-isolate-processor.js: switch Hann window divisor from (N-1) to N
  so the periodic window satisfies Constant Overlap-Add at 75% hop. The
  symmetric form caused frame-rate amplitude modulation and clicks at
  overlap boundaries.

- dsp-core.js / dsp-processor.js wienerFilter(): a Wiener gain must lie in
  [0, 1]. The previous implementation multiplied the gain by voiceBoost=1.5
  (re-amplifying noise and pushing the signal into clip), squared the
  suppression curve (doubling attenuation in dB and producing spectral
  holes / chirping artifacts), and over-subtracted with alpha=2.0
  (hollow voice, lost consonants). Replaced with a clamped, single-power
  Wiener gain, alpha=1.2, floor at -34 dB.

- getVoiceMaskGain(): the prior mask hard-zeroed everything below 60 Hz
  and dropped to 0.05 above 8 kHz, leaving a thin "telephone voice"
  output. Replaced with a smooth weighting that preserves naturalness
  while still favouring the speech-intelligibility band.

- truePeakLimit(): the old "if above ceiling, multiply by tanh(x/c)" had a
  derivative discontinuity at the threshold and could still output above
  the ceiling for small overshoots. Replaced with a soft-knee starting
  3 dB below the ceiling, strictly bounded by it.

All 1295 tests pass; pnpm validate and pnpm lint clean.

https://claude.ai/code/session_01TtKqCwUdQmKyF9CTMdL6dL
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/joker5514/voiceisolate-pro/pull/383" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced overly aggressive noise suppression for clearer, non-amplifying output.
  * Soften peak limiting into a gentler soft-knee compressor for more natural peaks.
  * Smoothened voice-band weighting for more consistent frequency response.
  * Corrected window function computation to improve STFT/iSTFT overlap accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->