### PR TITLE
fix(pipeline): wire applyCrosstalkCancel into post-render stage

### DIFF
--- a/public/app/app.js
+++ b/public/app/app.js
@@ -1429,10 +1429,10 @@ class VoiceIsolatePro {
       await this.pip(27, total);
       if (p.dryWet < 100) fin = this.mixDW(this.inputBuffer, fin, p.dryWet / 100);
 
-      // Apply crosstalk cancellation, formant shift, phase correction, and dither
+      // Apply phase correction, crosstalk cancellation, formant shift, and dither
+      if (p.phaseCorr > 0) fin = this.applyPhaseCorr(fin, p.phaseCorr);
       if (p.crosstalkCancel > 0) fin = this.applyCrosstalkCancel(fin, p.crosstalkCancel);
       if (p.formantShift !== 0) fin = this.applyFormantShift(fin, p.formantShift);
-      if (p.phaseCorr > 0) fin = this.applyPhaseCorr(fin, p.phaseCorr);
       if (p.ditherAmt > 0) fin = this.applyDither(fin, p.ditherAmt);
 
       // Peak normalize to limiter ceiling

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -1429,7 +1429,8 @@ class VoiceIsolatePro {
       await this.pip(27, total);
       if (p.dryWet < 100) fin = this.mixDW(this.inputBuffer, fin, p.dryWet / 100);
 
-      // Apply formant shift, phase correction, and dither (p.formantShift, p.phaseCorr, p.ditherAmt)
+      // Apply crosstalk cancellation, formant shift, phase correction, and dither
+      if (p.crosstalkCancel > 0) fin = this.applyCrosstalkCancel(fin, p.crosstalkCancel);
       if (p.formantShift !== 0) fin = this.applyFormantShift(fin, p.formantShift);
       if (p.phaseCorr > 0) fin = this.applyPhaseCorr(fin, p.phaseCorr);
       if (p.ditherAmt > 0) fin = this.applyDither(fin, p.ditherAmt);


### PR DESCRIPTION
## Summary

- `applyCrosstalkCancel()` (M/S matrix cross-channel cancellation) was fully implemented but never called in the processing pipeline
- The `crosstalkCancel` slider had zero effect on output audio
- Wired the call into the post-render stage alongside the other buffer transforms (formant shift, phase correction, dither)

## Test plan

- [ ] All 1295 Jest tests pass (`pnpm test`)
- [ ] Structural validation passes (`pnpm validate`)
- [ ] Set `crosstalkCancel` slider > 0 and verify L/R channel bleed is reduced in output
- [ ] Verify mono files (< 2 channels) are passed through unchanged (guard in `applyCrosstalkCancel`)

https://claude.ai/code/session_01KH7C1Bb7W2mqkf4rgKnvcv
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/joker5514/voiceisolate-pro/pull/384" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added crosstalk cancellation effect to the mastering processing pipeline.

* **Chores**
  * Updated the processing order of audio effects in the offline mastering stage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->