### PR TITLE
Give 3D spectrogram its own dedicated card

### DIFF
--- a/public/app/app.js
+++ b/public/app/app.js
@@ -318,7 +318,6 @@ class VoiceIsolatePro {
     this.isVideo = false;
     this.videoUrl = null;
     this.spectroRunning = false;
-    this.is3D = false;
     this.animId = null;
     this.diagRunning = false;
     this.diagAnimId = null;
@@ -546,8 +545,8 @@ class VoiceIsolatePro {
       tpRew:g('tpRew'), tpFwd:g('tpFwd'), tpCur:g('tpCur'), tpTotal:g('tpTotal'),
       tpSeek:g('tpSeek'), tpScrubTrack:g('tpScrubTrack'), tpScrubFill:g('tpScrubFill'), tpScrubThumb:g('tpScrubThumb'),
       tpSpeed:g('tpSpeed'), tpAB:g('tpAB'), tpABLabel:g('tpABLabel'),
-      spectro3DContainer:g('specCard'), spectro3DCanvas:g('spec3dCanvas'),
-      spectro3DReset:g('spec3dBtn'),
+      spectro3DContainer:g('spec3dContainer'), spectro3DCanvas:g('spec3dCanvas'),
+      spectro3DReset:g('spec3dResetBtn'),
       spectro2DCanvas:g('specCanvas'),
       waveOrigCanvas:g('waveformOrig'), waveProcCanvas:g('waveformCanvas'),
       freqCanvas:g('noiseCanvas'),
@@ -666,7 +665,7 @@ class VoiceIsolatePro {
       }
     });
     if (this.dom.spectro3DCanvas) this.dom.spectro3DCanvas.addEventListener('click', e => this.onSpectroClick(e));
-    if (this.dom.spectro3DReset) this.dom.spectro3DReset.addEventListener('click', () => this.toggle3DView());
+    if (this.dom.spectro3DReset) this.dom.spectro3DReset.addEventListener('click', () => this.reset3DView());
     window.addEventListener('resize', () => this.onResize());
 
     // Diagnostic bindings
@@ -2047,36 +2046,20 @@ class VoiceIsolatePro {
     cv.addEventListener('wheel',e=>{e.preventDefault();cam.position.z+=e.deltaY*0.05;cam.position.z=Math.max(20,Math.min(120,cam.position.z));},{passive:false});
     this.render3D();
   }
-  reset3DView(){if(this.three.cam){this.three.cam.position.set(0,40,60);this.three.cam.lookAt(0,0,0);}}
-  toggle3DView(){
-    this.is3D = !this.is3D;
-    const c2d = this.dom.spectro2DCanvas;
-    const c3d = this.dom.spectro3DCanvas;
-    const badge = document.getElementById('specModeBadge');
-    const btn = this.dom.spectro3DReset;
-    if (this.is3D) {
-      if (c2d) c2d.style.display = 'none';
-      if (c3d) c3d.style.display = 'block';
-      if (badge) badge.textContent = '3D';
-      if (btn) btn.textContent = 'Toggle 2D';
-      this.reset3DView();
-      if (this.three.ren) {
-        const ct = this.dom.spectro3DContainer;
-        if (ct) {
-          const w = ct.clientWidth;
-          const h = ct.clientHeight;
-          if (w > 0 && h > 0) {
-            this.three.ren.setSize(w, h);
-            this.three.cam.aspect = w / h;
-            this.three.cam.updateProjectionMatrix();
-          }
+  reset3DView(){
+    if(!this.three.cam)return;
+    this.three.cam.position.set(0,40,60);
+    this.three.cam.lookAt(0,0,0);
+    if(this.three.ren){
+      const ct = this.dom.spectro3DContainer;
+      if(ct){
+        const w = ct.clientWidth, h = ct.clientHeight;
+        if(w>0 && h>0){
+          this.three.ren.setSize(w,h);
+          this.three.cam.aspect = w/h;
+          this.three.cam.updateProjectionMatrix();
         }
       }
-    } else {
-      if (c3d) c3d.style.display = 'none';
-      if (c2d) c2d.style.display = 'block';
-      if (badge) badge.textContent = '2D';
-      if (btn) btn.textContent = 'Toggle 3D';
     }
   }
   update3D(freq){

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -247,13 +247,21 @@
         <canvas id="waveformOrig" class="viz-canvas" style="opacity:0.45" aria-label="Original audio waveform"></canvas>
       </div>
 
-      <!-- Spectrogram -->
+      <!-- Spectrogram (2D) -->
       <div class="card viz-card" id="specCard">
-        <div class="viz-hdr"><span>Spectrogram</span><span class="viz-badge">FFT 2048</span><span class="viz-badge" id="specModeBadge">2D</span>
-          <button id="spec3dBtn" class="btn btn-xs" style="margin-left:auto">Toggle 3D</button>
-        </div>
+        <div class="viz-hdr"><span>Spectrogram</span><span class="viz-badge">FFT 2048</span><span class="viz-badge">2D</span></div>
         <canvas id="specCanvas" class="viz-canvas" aria-label="Spectrogram visualization"></canvas>
-        <canvas id="spec3dCanvas" class="viz-canvas" style="display:none" aria-label="3D spectrogram visualization"></canvas>
+      </div>
+
+      <!-- 3D Spectrogram (dedicated space) -->
+      <div class="card viz-card" id="spec3dCard">
+        <div class="viz-hdr">
+          <span>3D Spectrogram</span><span class="viz-badge">Three.js</span>
+          <button id="spec3dResetBtn" class="btn btn-xs" style="margin-left:auto" title="Reset camera view">Reset View</button>
+        </div>
+        <div id="spec3dContainer" class="spectro3d-container">
+          <canvas id="spec3dCanvas" aria-label="3D spectrogram visualization"></canvas>
+        </div>
       </div>
 
       <!-- Comparison -->


### PR DESCRIPTION
Move the 3D spectrogram out from behind the "Toggle 3D" button on the
shared spectrogram card and into a dedicated #spec3dCard with its own
container, header and "Reset View" control. The 2D and 3D views are now
visible simultaneously.

- index.html: split specCard into a 2D-only card and a new spec3dCard
  containing #spec3dContainer/#spec3dCanvas.
- app.js: point spectro3DContainer at the new container, drop the
  is3D state and toggle3DView() (no longer needed), wire the reset
  button to reset3DView() which now also resyncs renderer size.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/joker5514/voiceisolate-pro/pull/388" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Reorganized spectrogram interface with dedicated 3D view card section
  * Replaced 3D view toggle with "Reset View" button for camera positioning
  * Streamlined 3D spectrogram reset functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->