### PR TITLE
Speed up Deca-Pass pipeline hot paths

### DIFF
--- a/public/app/dsp-core.js
+++ b/public/app/dsp-core.js
@@ -235,6 +235,7 @@ const DSPCore = {
    */
   inverseSTFT(mag, phase, fftSize = 4096, hopSize = 1024, outputLength = 0) {
     const window = this.hannWindow(fftSize);
+    const windowSq = this._hannSqCache(fftSize, window);
     const frameCount = mag.length;
     const halfN = fftSize / 2 + 1;
     const len = outputLength || (frameCount - 1) * hopSize + fftSize;
@@ -247,13 +248,17 @@ const DSPCore = {
 
     for (let f = 0; f < frameCount; f++) {
       const offset = f * hopSize;
+      const magF = mag[f];
+      const phaseF = phase[f];
 
       // Reconstruct complex spectrum (clear only used region)
       for (let k = 0; k < halfN; k++) {
         // Guard NaN/Inf/negative magnitudes — any corrupt bin becomes silence for that bin
-        const m = (Number.isFinite(mag[f][k]) && mag[f][k] >= 0) ? mag[f][k] : 0;
-        real[k] = m * Math.cos(phase[f][k]);
-        imag[k] = m * Math.sin(phase[f][k]);
+        const rawM = magF[k];
+        const m = (rawM >= 0 && rawM < Infinity) ? rawM : 0;
+        const ph = phaseF[k];
+        real[k] = m * Math.cos(ph);
+        imag[k] = m * Math.sin(ph);
       }
       // Mirror for negative frequencies
       for (let k = halfN; k < fftSize; k++) {
@@ -264,12 +269,12 @@ const DSPCore = {
       // Inverse FFT
       this._fft(real, imag, true);
 
-      // Overlap-add with synthesis window
-      for (let i = 0; i < fftSize; i++) {
-        if (offset + i < len) {
-          output[offset + i] += real[i] * window[i];
-          windowSum[offset + i] += window[i] * window[i];
-        }
+      // Overlap-add with synthesis window — iterate only over the in-range slice
+      // so the per-sample bounds check inside the inner loop can be removed.
+      const nMax = Math.min(fftSize, len - offset);
+      for (let i = 0; i < nMax; i++) {
+        output[offset + i] += real[i] * window[i];
+        windowSum[offset + i] += windowSq[i];
       }
     }
 
@@ -281,45 +286,81 @@ const DSPCore = {
     return output;
   },
 
-  /** Cooley-Tukey radix-2 FFT (in-place) */
+  // Cache for window² arrays (used by iSTFT overlap-add normalisation).
+  _hannSqCacheMap: new Map(),
+  _hannSqCache(N, window) {
+    let sq = this._hannSqCacheMap.get(N);
+    if (sq) return sq;
+    sq = new Float32Array(N);
+    for (let i = 0; i < N; i++) sq[i] = window[i] * window[i];
+    this._hannSqCacheMap.set(N, sq);
+    return sq;
+  },
+
+  // Twiddle-factor cache keyed by signed size: +N for forward, -N for inverse.
+  // Each entry stores precomputed cos/sin for the full half-table (N/2 bins),
+  // allowing smaller butterfly stages to index via stride without recomputing trig.
+  _twiddleCache: new Map(),
+
+  _getTwiddles(N, inverse) {
+    const key = inverse ? -N : N;
+    let t = this._twiddleCache.get(key);
+    if (t) return t;
+    const half = N >> 1;
+    const cosT = new Float32Array(half);
+    const sinT = new Float32Array(half);
+    const dir = inverse ? 1 : -1;
+    const k0 = dir * 2 * Math.PI / N;
+    for (let k = 0; k < half; k++) {
+      const a = k0 * k;
+      cosT[k] = Math.cos(a);
+      sinT[k] = Math.sin(a);
+    }
+    t = { cosT, sinT };
+    this._twiddleCache.set(key, t);
+    return t;
+  },
+
+  /** Cooley-Tukey radix-2 FFT (in-place, cached twiddle tables) */
   _fft(real, imag, inverse) {
     const N = real.length;
-    // Bit-reversal permutation
+    // Bit-reversal permutation (temp-swap avoids array-destructure allocation)
     for (let i = 1, j = 0; i < N; i++) {
       let bit = N >> 1;
       for (; j & bit; bit >>= 1) j ^= bit;
       j ^= bit;
       if (i < j) {
-        [real[i], real[j]] = [real[j], real[i]];
-        [imag[i], imag[j]] = [imag[j], imag[i]];
+        const tr = real[i]; real[i] = real[j]; real[j] = tr;
+        const ti = imag[i]; imag[i] = imag[j]; imag[j] = ti;
       }
     }
 
-    // Butterfly stages
+    const { cosT, sinT } = this._getTwiddles(N, inverse);
+
+    // Butterfly stages — table lookup replaces per-inner-iter rotation accumulator
     for (let len = 2; len <= N; len <<= 1) {
       const halfLen = len >> 1;
-      const angle = (inverse ? 2 : -2) * Math.PI / len;
-      const wR = Math.cos(angle);
-      const wI = Math.sin(angle);
-
+      const stride = N / len;
       for (let i = 0; i < N; i += len) {
-        let curR = 1, curI = 0;
         for (let j = 0; j < halfLen; j++) {
-          const tR = curR * real[i + j + halfLen] - curI * imag[i + j + halfLen];
-          const tI = curR * imag[i + j + halfLen] + curI * real[i + j + halfLen];
+          const ti = j * stride;
+          const wR = cosT[ti];
+          const wI = sinT[ti];
+          const ar = real[i + j + halfLen];
+          const ai = imag[i + j + halfLen];
+          const tR = wR * ar - wI * ai;
+          const tI = wR * ai + wI * ar;
           real[i + j + halfLen] = real[i + j] - tR;
           imag[i + j + halfLen] = imag[i + j] - tI;
           real[i + j] += tR;
           imag[i + j] += tI;
-          const newCurR = curR * wR - curI * wI;
-          curI = curR * wI + curI * wR;
-          curR = newCurR;
         }
       }
     }
 
     if (inverse) {
-      for (let i = 0; i < N; i++) { real[i] /= N; imag[i] /= N; }
+      const inv = 1 / N;
+      for (let i = 0; i < N; i++) { real[i] *= inv; imag[i] *= inv; }
     }
   },
 
@@ -950,6 +991,10 @@ const DSPCore = {
 
     const framesPerVad = Math.floor(fftSize / 512); // VAD window ratio
 
+    // Reuse real/imag buffers across frames to avoid per-frame GC pressure.
+    const real = new Float32Array(fftSize);
+    const imag = new Float32Array(fftSize);
+
     for (let f = 0; ; f++) {
       const offset = f * hopSize;
       if (offset + fftSize > data.length) break;
@@ -959,8 +1004,7 @@ const DSPCore = {
       const confidence = vadConfidence ? vadConfidence[Math.floor(vadIdx)] : 0.5;
       if (confidence > 0.3) continue; // skip voiced frames
 
-      const real = new Float32Array(fftSize);
-      const imag = new Float32Array(fftSize);
+      imag.fill(0);
       for (let i = 0; i < fftSize; i++) {
         real[i] = data[offset + i] * window[i];
       }

--- a/public/app/dsp-worker.js
+++ b/public/app/dsp-worker.js
@@ -37,7 +37,12 @@ self.onmessage = async function (e) {
       case 'reset':      result = handleReset();                  break;
       default: throw new Error(`Unknown message type: ${type}`);
     }
-    self.postMessage({ type: 'result', id, result });
+    // Transfer any ArrayBuffer payload (processedData) instead of structured-cloning
+    // — this saves a full PCM copy on every processed block.
+    const transfers = (result && result.processedData instanceof ArrayBuffer)
+      ? [result.processedData]
+      : undefined;
+    self.postMessage({ type: 'result', id, result }, transfers);
   } catch (err) {
     self.postMessage({ type: 'error', id, error: err.message, stack: err.stack });
   }
@@ -118,7 +123,8 @@ async function handleProcess(payload) {
     try {
       const tensor = new self.ort.Tensor('float32', processed, [1, 1, processed.length]);
       const out = await runInference('demucs', tensor);
-      processed = new Float32Array(out[Object.keys(out)[0]].data);
+      // out[key].data is already a Float32Array — reference it directly instead of copying.
+      processed = out[Object.keys(out)[0]].data;
     } catch (err) {
       console.warn('[dsp-worker] Demucs failed, continuing classical DSP:', err.message);
     }

--- a/public/app/pipeline-orchestrator.js
+++ b/public/app/pipeline-orchestrator.js
@@ -483,12 +483,15 @@ class PipelineOrchestrator {
    * Safe to call before workletNode is created — updateParams() guards itself.
    */
   _bindSliders() {
-    document.querySelectorAll('input[type="range"][data-param]').forEach((el) => {
+    // Build the snapshot once up-front, then mutate the single changed field
+    // on each 'input' event. Re-querying all 52 sliders per-event was O(N)
+    // DOM work on every interaction; this drops it to O(1).
+    const sliders = document.querySelectorAll('input[type="range"][data-param]');
+    const snapshot = {};
+    sliders.forEach((s) => { snapshot[s.dataset.param] = parseFloat(s.value); });
+    sliders.forEach((el) => {
       el.addEventListener('input', () => {
-        const snapshot = {};
-        document.querySelectorAll('input[type="range"][data-param]').forEach((s) => {
-          snapshot[s.dataset.param] = parseFloat(s.value);
-        });
+        snapshot[el.dataset.param] = parseFloat(el.value);
         this.updateParams(snapshot);
       });
     });


### PR DESCRIPTION
Cache FFT twiddle factors (cos/sin) per-N so butterfly inner loops do
table lookups instead of accumulating rotations with 4 mul + 2 add per
iteration. Replace the inverse-FFT per-sample division with a single
reciprocal multiplication. Swap the bit-reversal destructuring pair
swap for plain temp-variable swaps to avoid transient allocations.

In inverseSTFT, precompute window² (cached per fftSize) and move the
offset-bounds check out of the per-sample inner loop. Hoist mag/phase
frame references so the V8 element-kind check fires once per frame,
not once per bin. Simplify the NaN/negative guard to a cheaper numeric
comparison.

In _computeNoiseProfile, hoist the real/imag Float32Array pair out of
the frame loop so the noise profiler stops churning GC on long files.

Collapse _bindSliders' O(N) DOM re-query into a cached snapshot that
only mutates the changed slider on each input event. Transfer the
processed-audio ArrayBuffer in dsp-worker's result postMessage instead
of structured-cloning it, and reference the ONNX tensor output buffer
directly instead of copying it after Demucs inference.

https://claude.ai/code/session_01BZSXqxcx5LuxcfNnbw6aj1
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/joker5514/voiceisolate-pro/pull/389" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
