### PR TITLE
feat(ui): persist UI scale with header Save button; trim Wiener GC

### DIFF
--- a/public/app/app.js
+++ b/public/app/app.js
@@ -359,6 +359,7 @@ class VoiceIsolatePro {
     this._rndBuf = new Uint32Array(4096);
     this._rndIdx = 0;
     this._sliderContextResumed = false;
+    this._uiScaleSaveTimer = 0;
     this.init();
   }
 
@@ -598,19 +599,28 @@ class VoiceIsolatePro {
   }
   _uiScaleApply(s) {
     const clamped = Math.max(this._uiScaleMin, Math.min(this._uiScaleMax, Math.round(s * 100) / 100));
+    const isSavedScale = clamped === this._uiScaleSaved;
     this._uiScale = clamped;
     document.documentElement.style.zoom = clamped === 1 ? '' : String(clamped);
     if (this.dom.uiScaleVal) this.dom.uiScaleVal.textContent = Math.round(clamped * 100) + '%';
-    if (this.dom.uiScaleSave) this.dom.uiScaleSave.classList.toggle('saved', clamped === this._uiScaleSaved);
+    if (!isSavedScale && this._uiScaleSaveTimer) {
+      clearTimeout(this._uiScaleSaveTimer);
+      this._uiScaleSaveTimer = 0;
+    }
+    if (this.dom.uiScaleSave) {
+      this.dom.uiScaleSave.classList.toggle('saved', isSavedScale);
+      this.dom.uiScaleSave.textContent = isSavedScale ? 'Saved' : 'Save';
+    }
   }
   _uiScaleSave() {
     try { localStorage.setItem('vip_ui_scale', String(this._uiScale)); } catch { /* storage sandboxed */ }
     this._uiScaleSaved = this._uiScale;
-    if (this.dom.uiScaleSave) {
-      this.dom.uiScaleSave.classList.add('saved');
-      this.dom.uiScaleSave.textContent = 'Saved';
-      setTimeout(() => { if (this.dom.uiScaleSave) this.dom.uiScaleSave.textContent = 'Save'; }, 1200);
-    }
+    this._uiScaleApply(this._uiScale);
+    if (this._uiScaleSaveTimer) clearTimeout(this._uiScaleSaveTimer);
+    this._uiScaleSaveTimer = setTimeout(() => {
+      this._uiScaleSaveTimer = 0;
+      this._uiScaleApply(this._uiScale);
+    }, 1200);
   }
 
   bindEvents() {

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -365,6 +365,7 @@ class VoiceIsolatePro {
   init() {
     this.buildSliderPanels();
     this.cacheDom();
+    this._uiScaleInit();
     this.bindEvents();
     this.initCanvases();
     this.init3D();
@@ -574,7 +575,42 @@ class VoiceIsolatePro {
       mobileStopBtn:g('mobileStopBtn'),
       statsToggle:g('statsToggle'),
       hdrStats:g('hdrStats'),
+      uiScaleDn:g('uiScaleDn'), uiScaleUp:g('uiScaleUp'),
+      uiScaleVal:g('uiScaleVal'), uiScaleSave:g('uiScaleSave'),
     };
+  }
+
+  // ── UI scale (screen stretching) ────────────────────────────────────────
+  // Persists across page refreshes via localStorage. Early-restore happens in
+  // an inline <script> in index.html so layout doesn't flash at 100% first.
+  _uiScaleInit() {
+    this._uiScaleMin = 0.5;
+    this._uiScaleMax = 2.0;
+    this._uiScaleStep = 0.1;
+    this._uiScaleDefault = 1.0;
+    let s = this._uiScaleDefault;
+    try {
+      const saved = parseFloat(localStorage.getItem('vip_ui_scale'));
+      if (isFinite(saved) && saved >= this._uiScaleMin && saved <= this._uiScaleMax) s = saved;
+    } catch { /* storage sandboxed */ }
+    this._uiScaleSaved = s;
+    this._uiScaleApply(s);
+  }
+  _uiScaleApply(s) {
+    const clamped = Math.max(this._uiScaleMin, Math.min(this._uiScaleMax, Math.round(s * 100) / 100));
+    this._uiScale = clamped;
+    document.documentElement.style.zoom = clamped === 1 ? '' : String(clamped);
+    if (this.dom.uiScaleVal) this.dom.uiScaleVal.textContent = Math.round(clamped * 100) + '%';
+    if (this.dom.uiScaleSave) this.dom.uiScaleSave.classList.toggle('saved', clamped === this._uiScaleSaved);
+  }
+  _uiScaleSave() {
+    try { localStorage.setItem('vip_ui_scale', String(this._uiScale)); } catch { /* storage sandboxed */ }
+    this._uiScaleSaved = this._uiScale;
+    if (this.dom.uiScaleSave) {
+      this.dom.uiScaleSave.classList.add('saved');
+      this.dom.uiScaleSave.textContent = 'Saved';
+      setTimeout(() => { if (this.dom.uiScaleSave) this.dom.uiScaleSave.textContent = 'Save'; }, 1200);
+    }
   }
 
   bindEvents() {
@@ -693,6 +729,9 @@ class VoiceIsolatePro {
         this.dom.statsToggle.textContent = expanded ? '▲' : '▼';
       });
     }
+    if (this.dom.uiScaleDn) this.dom.uiScaleDn.addEventListener('click', () => this._uiScaleApply(this._uiScale - this._uiScaleStep));
+    if (this.dom.uiScaleUp) this.dom.uiScaleUp.addEventListener('click', () => this._uiScaleApply(this._uiScale + this._uiScaleStep));
+    if (this.dom.uiScaleSave) this.dom.uiScaleSave.addEventListener('click', () => this._uiScaleSave());
   }
 
   onSlider(el) {

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -51,7 +51,19 @@
       try {
         var s = parseFloat(localStorage.getItem('vip_ui_scale'));
         if (isFinite(s) && s >= 0.5 && s <= 2) {
-          document.documentElement.style.zoom = s;
+          var rootStyle = document.documentElement.style;
+          var supportsZoom = typeof CSS !== 'undefined' && typeof CSS.supports === 'function' && CSS.supports('zoom', '1');
+          if (supportsZoom) {
+            rootStyle.zoom = String(s);
+            rootStyle.transform = '';
+            rootStyle.transformOrigin = '';
+            rootStyle.width = '';
+          } else {
+            rootStyle.zoom = '';
+            rootStyle.transform = 'scale(' + s + ')';
+            rootStyle.transformOrigin = 'top left';
+            rootStyle.width = (100 / s) + '%';
+          }
         }
       } catch(e) {}
     })();

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -38,7 +38,24 @@
     .auth-badge-admin{padding:1px 5px;border-radius:3px;font-size:0.5rem;font-weight:700;letter-spacing:0.1em;color:var(--red2);background:rgba(220,38,38,0.1);border:1px solid rgba(220,38,38,0.2)}
     .auth-logout-btn{background:none;border:none;color:var(--dim);cursor:pointer;font-size:0.8rem;padding:0 2px;line-height:1;transition:color 0.2s}
     .auth-logout-btn:hover{color:var(--red2)}
+    /* UI scale (screen stretching) control */
+    .hdr-scale{display:inline-flex;align-items:center;gap:4px;margin-left:8px}
+    .hdr-scale .btn-xs{padding:3px 7px;font-size:0.7rem;line-height:1;background:var(--s3);color:var(--text2);border:1px solid var(--border);border-radius:var(--rs);cursor:pointer;font-family:var(--ff);font-weight:600}
+    .hdr-scale .btn-xs:hover:not(:disabled){border-color:var(--red);color:var(--text)}
+    .hdr-scale #uiScaleVal{font-family:var(--fm);font-size:0.7rem;color:var(--text2);min-width:40px;text-align:center}
+    .hdr-scale #uiScaleSave.saved{background:rgba(34,197,94,0.12);color:var(--green);border-color:rgba(34,197,94,0.3)}
   </style>
+  <!-- Restore saved UI scale before paint to avoid flash. Must stay in sync with uiScaleApply() in app.js. -->
+  <script data-role="ui-scale-restore">
+    (function(){
+      try {
+        var s = parseFloat(localStorage.getItem('vip_ui_scale'));
+        if (isFinite(s) && s >= 0.5 && s <= 2) {
+          document.documentElement.style.zoom = s;
+        }
+      } catch(e) {}
+    })();
+  </script>
 </head>
 <body>
   <!-- ── Startup diagnostic banner (shown only if server/model errors detected) ── -->
@@ -63,6 +80,12 @@
         <span class="hdr-badge">ENGINEER MODE</span>
         <span class="hdr-badge diag-badge">6-PANEL DIAGNOSTICS</span>
       </div>
+    </div>
+    <div class="hdr-scale" role="group" aria-label="UI scale">
+      <button id="uiScaleDn" type="button" class="btn-xs" title="Decrease UI scale" aria-label="Decrease UI scale">&minus;</button>
+      <span id="uiScaleVal" aria-live="polite">100%</span>
+      <button id="uiScaleUp" type="button" class="btn-xs" title="Increase UI scale" aria-label="Increase UI scale">+</button>
+      <button id="uiScaleSave" type="button" class="btn-xs" title="Save UI scale so it persists after refresh" aria-label="Save UI scale">Save</button>
     </div>
     <button id="statsToggle" class="hdr-stats-toggle" aria-label="Toggle stats" aria-expanded="false">&#9660;</button>
     <div class="hdr-stats" id="hdrStats">

--- a/public/app/ml-worker.js
+++ b/public/app/ml-worker.js
@@ -638,6 +638,9 @@ async function pollOnce() {
 // ── 5. Combined mask inference pipeline ──────────────────────────────────────
 // Reusable mask buffer — avoids one Float32Array allocation per inference call.
 let _maskBuffer = null;
+// Reusable 3-bin smoothing scratch — avoids a full-spectrum Float32Array
+// allocation per applyWienerFilter() call (~400KB/s GC churn at 50 Hz).
+let _smoothBuffer = null;
 
 async function buildMask(magnitudes, pcmChunk = null) {
   const numBins = magnitudes.length;
@@ -813,15 +816,19 @@ function applyWienerFilter(magnitudes, mask, isVoice) {
   }
 
   // 3-bin moving-average smoothing reduces isolated spectral holes (musical noise).
-  const smooth = new Float32Array(mask.length);
-  for (let k = 0; k < mask.length; k++) {
-    const a = mask[Math.max(0, k - 1)];
-    const b = mask[k];
-    const c = mask[Math.min(mask.length - 1, k + 1)];
-    smooth[k] = (a + b + c) / 3;
+  // Boundary-unrolled to avoid per-bin Math.max/Math.min; buffer is cached.
+  const len = mask.length;
+  if (!_smoothBuffer || _smoothBuffer.length < len) _smoothBuffer = new Float32Array(len);
+  const smooth = _smoothBuffer;
+  if (len > 0) {
+    smooth[0] = len > 1 ? (mask[0] + mask[0] + mask[1]) / 3 : mask[0];
+    const last = len - 1;
+    for (let k = 1; k < last; k++) smooth[k] = (mask[k - 1] + mask[k] + mask[k + 1]) / 3;
+    if (last > 0) smooth[last] = (mask[last - 1] + mask[last] + mask[last]) / 3;
   }
   const voiceFloor = isVoice ? spectralFloor : Math.min(1, spectralFloor * runtimeParams.nonVoiceSuppression);
-  for (let k = 0; k < mask.length; k++) {
-    mask[k] = Math.max(voiceFloor, Math.min(1, smooth[k]));
+  for (let k = 0; k < len; k++) {
+    const s = smooth[k];
+    mask[k] = s > 1 ? 1 : (s < voiceFloor ? voiceFloor : s);
   }
 }


### PR DESCRIPTION
Add a +/- UI scale control with a Save button to the engineer-mode header.
Scale is applied via document.documentElement.style.zoom and persisted to
localStorage under vip_ui_scale. An inline head-level <script> restores the
saved value before paint so the layout does not flash at 100% on refresh.
The Save button flips to a "Saved" state briefly so it is clear the value
was committed, and returns to "Save" when the current scale differs from
the stored one.

While profiling the pipeline for further wins on top of #389, replace the
per-frame Float32Array allocation inside applyWienerFilter's 3-bin moving
average with a cached module-scope scratch buffer, and fold the smoothing
boundary cases into an unrolled loop so the hot inner section drops the
per-bin Math.max/Math.min call pair. The follow-up clamp pass is rewritten
as straight comparisons instead of nested Math.min/Math.max calls for the
same reason.

https://claude.ai/code/session_01TLUHRVGvBaRn5PFqSwNHTP
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/joker5514/voiceisolate-pro/pull/390" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a persistent UI scale control with increase/decrease buttons, live percentage readout, save button, and startup application to avoid a visual flash — your preferred zoom persists across sessions.

* **Performance**
  * Reduced memory allocations in mask post-processing to lower per-inference garbage and improve inference efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->