### PR TITLE
Add test coverage for five previously untested modules

### DIFF
--- a/tests/batch-orchestrator.test.js
+++ b/tests/batch-orchestrator.test.js
@@ -1,0 +1,310 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const src = fs.readFileSync(path.join(__dirname, '../public/app/batch-orchestrator.js'), 'utf8');
+const BatchOrchestrator = (() => {
+  const exports = {};
+  const module = { exports };
+  const window = {};
+  eval(src); // eslint-disable-line no-eval
+  return module.exports;
+})();
+
+// ── constructor ───────────────────────────────────────────────────────────────
+
+describe('BatchOrchestrator constructor', () => {
+  test('default concurrency falls back to navigator.hardwareConcurrency or 4', () => {
+    const expected = (typeof navigator !== 'undefined' && navigator.hardwareConcurrency)
+      ? navigator.hardwareConcurrency : 4;
+    expect(new BatchOrchestrator({}).concurrency).toBe(expected);
+  });
+
+  test('concurrency option overrides default', () => {
+    expect(new BatchOrchestrator({ concurrency: 8 }).concurrency).toBe(8);
+  });
+
+  test('starts with empty queue and maps', () => {
+    const bo = new BatchOrchestrator();
+    expect(bo.queue.length).toBe(0);
+    expect(bo.active.size).toBe(0);
+    expect(bo.completed.length).toBe(0);
+    expect(bo.failed.length).toBe(0);
+  });
+
+  test('running is false initially', () => {
+    expect(new BatchOrchestrator().running).toBe(false);
+  });
+
+  test('default callbacks are no-ops that do not throw', () => {
+    const bo = new BatchOrchestrator();
+    expect(() => bo.onProgress({})).not.toThrow();
+    expect(() => bo.onJobComplete({})).not.toThrow();
+    expect(() => bo.onJobError({})).not.toThrow();
+    expect(() => bo.onBatchComplete({})).not.toThrow();
+  });
+
+  test('custom callbacks are stored', () => {
+    const onProgress = jest.fn();
+    const bo = new BatchOrchestrator({ onProgress });
+    bo.onProgress({ pct: 50 });
+    expect(onProgress).toHaveBeenCalledWith({ pct: 50 });
+  });
+});
+
+// ── enqueue ───────────────────────────────────────────────────────────────────
+
+describe('BatchOrchestrator.enqueue', () => {
+  test('returns incrementing integer IDs', () => {
+    const bo = new BatchOrchestrator();
+    const id1 = bo.enqueue({ name: 'a.wav' });
+    const id2 = bo.enqueue({ name: 'b.wav' });
+    expect(typeof id1).toBe('number');
+    expect(id2).toBe(id1 + 1);
+  });
+
+  test('adds a job to the queue', () => {
+    const bo = new BatchOrchestrator();
+    bo.enqueue({ name: 'test.wav' });
+    expect(bo.queue.length).toBe(1);
+  });
+
+  test('queue sorts by priority ascending (lower number = higher priority)', () => {
+    const bo = new BatchOrchestrator();
+    bo.enqueue({ name: 'low.wav' }, 10);
+    bo.enqueue({ name: 'high.wav' }, 1);
+    bo.enqueue({ name: 'mid.wav' }, 5);
+    expect(bo.queue.map(j => j.priority)).toEqual([1, 5, 10]);
+  });
+
+  test('default priority is 5', () => {
+    const bo = new BatchOrchestrator();
+    bo.enqueue({ name: 'test.wav' });
+    expect(bo.queue[0].priority).toBe(5);
+  });
+
+  test('initial job status is queued', () => {
+    const bo = new BatchOrchestrator();
+    bo.enqueue({ name: 'test.wav' });
+    expect(bo.queue[0].status).toBe('queued');
+  });
+
+  test('initial progress is 0', () => {
+    const bo = new BatchOrchestrator();
+    bo.enqueue({ name: 'test.wav' });
+    expect(bo.queue[0].progress).toBe(0);
+  });
+
+  test('per-file params override global params', () => {
+    const bo = new BatchOrchestrator({ params: { nrAmount: 50 } });
+    bo.enqueue({ name: 'test.wav' }, 5, { nrAmount: 80 });
+    expect(bo.queue[0].params.nrAmount).toBe(80);
+  });
+
+  test('uses global params when no per-file params provided', () => {
+    const bo = new BatchOrchestrator({ params: { nrAmount: 50 } });
+    bo.enqueue({ name: 'test.wav' });
+    expect(bo.queue[0].params.nrAmount).toBe(50);
+  });
+});
+
+// ── enqueueMany ───────────────────────────────────────────────────────────────
+
+describe('BatchOrchestrator.enqueueMany', () => {
+  test('enqueues all files and returns their IDs', () => {
+    const bo = new BatchOrchestrator();
+    const ids = bo.enqueueMany([{ name: 'a.wav' }, { name: 'b.wav' }, { name: 'c.wav' }]);
+    expect(ids.length).toBe(3);
+    expect(bo.queue.length).toBe(3);
+  });
+
+  test('all returned IDs are unique', () => {
+    const bo = new BatchOrchestrator();
+    const ids = bo.enqueueMany([{ name: 'a.wav' }, { name: 'b.wav' }]);
+    expect(new Set(ids).size).toBe(2);
+  });
+});
+
+// ── getProgress ───────────────────────────────────────────────────────────────
+
+describe('BatchOrchestrator.getProgress', () => {
+  test('empty state returns 100', () => {
+    expect(new BatchOrchestrator().getProgress()).toBe(100);
+  });
+
+  test('all queued, none done → 0', () => {
+    const bo = new BatchOrchestrator();
+    bo.enqueue({ name: 'a.wav' });
+    bo.enqueue({ name: 'b.wav' });
+    expect(bo.getProgress()).toBe(0);
+  });
+
+  test('half completed → 50', () => {
+    const bo = new BatchOrchestrator();
+    bo.enqueue({ name: 'a.wav' });
+    bo.enqueue({ name: 'b.wav' });
+    bo.completed.push(bo.queue.shift());
+    expect(bo.getProgress()).toBe(50);
+  });
+
+  test('all completed → 100', () => {
+    const bo = new BatchOrchestrator();
+    bo.enqueue({ name: 'a.wav' });
+    bo.completed.push(bo.queue.shift());
+    expect(bo.getProgress()).toBe(100);
+  });
+});
+
+// ── stop / cancel ─────────────────────────────────────────────────────────────
+
+describe('BatchOrchestrator.stop and cancel', () => {
+  test('stop() sets running=false', () => {
+    const bo = new BatchOrchestrator();
+    bo.running = true;
+    bo.stop();
+    expect(bo.running).toBe(false);
+  });
+
+  test('cancel() clears queue and sets running=false', () => {
+    const bo = new BatchOrchestrator();
+    bo.enqueue({ name: 'a.wav' });
+    bo.enqueue({ name: 'b.wav' });
+    bo.running = true;
+    bo.cancel();
+    expect(bo.running).toBe(false);
+    expect(bo.queue.length).toBe(0);
+  });
+
+  test('cancel() sends abort to active workers', () => {
+    const bo = new BatchOrchestrator();
+    const mockWorker = { postMessage: jest.fn() };
+    bo.active.set(1, { worker: mockWorker });
+    bo.cancel();
+    expect(mockWorker.postMessage).toHaveBeenCalledWith({ type: 'abort' });
+  });
+
+  test('cancel() handles active jobs without a worker reference gracefully', () => {
+    const bo = new BatchOrchestrator();
+    bo.active.set(1, { worker: null }); // no worker ref
+    expect(() => bo.cancel()).not.toThrow();
+  });
+});
+
+// ── _encodeWAV ────────────────────────────────────────────────────────────────
+
+describe('BatchOrchestrator._encodeWAV', () => {
+  const readStr = (v, off, len) =>
+    Array.from({ length: len }, (_, i) => String.fromCharCode(v.getUint8(off + i))).join('');
+
+  let bo;
+  beforeEach(() => { bo = new BatchOrchestrator(); });
+
+  test('produces valid RIFF/WAVE/fmt /data header', () => {
+    const buf = bo._encodeWAV(new Float32Array(10), 48000);
+    const v = new DataView(buf);
+    expect(readStr(v, 0, 4)).toBe('RIFF');
+    expect(readStr(v, 8, 4)).toBe('WAVE');
+    expect(readStr(v, 12, 4)).toBe('fmt ');
+    expect(readStr(v, 36, 4)).toBe('data');
+  });
+
+  test('buffer size = 44 + samples*2 for 16-bit', () => {
+    expect(bo._encodeWAV(new Float32Array(100), 48000, 16).byteLength).toBe(244);
+  });
+
+  test('sample rate written at offset 24', () => {
+    expect(new DataView(bo._encodeWAV(new Float32Array(1), 44100, 16)).getUint32(24, true)).toBe(44100);
+  });
+
+  test('RIFF chunk size = 36 + dataSize', () => {
+    const buf = bo._encodeWAV(new Float32Array(10), 48000, 16);
+    expect(new DataView(buf).getUint32(4, true)).toBe(36 + 10 * 2);
+  });
+
+  test('data size field = samples * 2', () => {
+    const buf = bo._encodeWAV(new Float32Array(20), 48000, 16);
+    expect(new DataView(buf).getUint32(40, true)).toBe(20 * 2);
+  });
+
+  test('over-range samples are clipped to ±32767', () => {
+    const buf = bo._encodeWAV(new Float32Array([2.0, -2.0]), 48000, 16);
+    const v = new DataView(buf);
+    expect(v.getInt16(44, true)).toBe(0x7FFF);
+    expect(v.getInt16(46, true)).toBeLessThanOrEqual(-0x7FFF);
+  });
+
+  test('format tag is 1 (PCM) for 16-bit', () => {
+    const buf = bo._encodeWAV(new Float32Array(1), 48000, 16);
+    expect(new DataView(buf).getUint16(20, true)).toBe(1);
+  });
+});
+
+// ── start() ───────────────────────────────────────────────────────────────────
+
+describe('BatchOrchestrator.start()', () => {
+  test('onBatchComplete fires after all jobs finish', async () => {
+    const completeCb = jest.fn();
+    const bo = new BatchOrchestrator({ concurrency: 2, onBatchComplete: completeCb });
+
+    bo._processJob = async (job) => {
+      job.status = 'complete';
+      bo.completed.push(job);
+      bo.active.delete(job.id);
+    };
+
+    bo.enqueue({ name: 'a.wav' });
+    bo.enqueue({ name: 'b.wav' });
+    await bo.start();
+
+    expect(completeCb).toHaveBeenCalledTimes(1);
+    const stats = completeCb.mock.calls[0][0];
+    expect(stats.completed).toBe(2);
+    expect(stats.failed).toBe(0);
+    expect(stats.total).toBe(2);
+  });
+
+  test('calling start() while already running is a no-op', async () => {
+    const bo = new BatchOrchestrator({ concurrency: 1 });
+    bo._processJob = async (job) => {
+      await new Promise(r => setTimeout(r, 10));
+      bo.completed.push(job);
+      bo.active.delete(job.id);
+    };
+    bo.enqueue({ name: 'a.wav' });
+    await Promise.all([bo.start(), bo.start()]);
+    expect(bo.completed.length).toBe(1);
+  });
+
+  test('failed jobs are tracked in failed array', async () => {
+    const bo = new BatchOrchestrator({ concurrency: 1 });
+    bo._processJob = async (job) => {
+      job.status = 'error';
+      job.error = 'Test error';
+      bo.failed.push(job);
+      bo.active.delete(job.id);
+    };
+    bo.enqueue({ name: 'fail.wav' });
+    await bo.start();
+    expect(bo.failed.length).toBe(1);
+    expect(bo.completed.length).toBe(0);
+  });
+
+  test('running resets to false after completion', async () => {
+    const bo = new BatchOrchestrator({ concurrency: 1 });
+    bo._processJob = async (job) => {
+      bo.completed.push(job);
+      bo.active.delete(job.id);
+    };
+    bo.enqueue({ name: 'a.wav' });
+    await bo.start();
+    expect(bo.running).toBe(false);
+  });
+
+  test('empty queue: onBatchComplete fires immediately with zeros', async () => {
+    const cb = jest.fn();
+    const bo = new BatchOrchestrator({ onBatchComplete: cb });
+    await bo.start();
+    expect(cb).toHaveBeenCalledWith({ completed: 0, failed: 0, total: 0 });
+  });
+});

--- a/tests/batch-processor.test.js
+++ b/tests/batch-processor.test.js
@@ -1,0 +1,359 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const src = fs.readFileSync(path.join(__dirname, '../public/app/batch-processor.js'), 'utf8');
+
+// Patch the source to expose private helpers alongside the public API so we
+// can unit-test them directly without changing the production file.
+const patchedSrc = src.replace(
+  /if \(typeof module !== 'undefined' && module\.exports\) module\.exports = BP;/,
+  `if (typeof module !== 'undefined' && module.exports) {
+    module.exports = BP;
+    module.exports._normalize = _normalize;
+    module.exports._encodeWAV = _encodeWAV;
+    module.exports._applyWatermark = _applyWatermark;
+  }`
+);
+
+// Browser globals required by the IIFE
+global.window = {
+  LicenseManager: null,
+  Paywall: null,
+  AudioContext: class {
+    decodeAudioData() {
+      return Promise.resolve({
+        getChannelData: () => new Float32Array(1024).fill(0.1),
+        sampleRate: 48000,
+      });
+    }
+    close() { return Promise.resolve(); }
+  },
+  webkitAudioContext: undefined,
+  VoiceIsolatePipeline: null,
+  JSZip: null,
+  URL: { createObjectURL: () => 'blob:mock', revokeObjectURL: () => {} },
+};
+global.document = {
+  createElement: () => ({ href: '', download: '', click: () => {} }),
+  body: { appendChild: () => {}, removeChild: () => {} },
+};
+global.AbortController = class {
+  constructor() { this.signal = { aborted: false, addEventListener: () => {} }; }
+  abort() { this.signal.aborted = true; }
+};
+global.FileReader = class {
+  readAsArrayBuffer() {
+    // Simulate async read via setTimeout so signal.abort can fire first
+    setTimeout(() => this.onload({ target: { result: new ArrayBuffer(1024) } }), 0);
+  }
+  abort() {}
+};
+global.Blob = class Blob {
+  constructor(parts = [], opts = {}) {
+    this.type = opts.type || '';
+    this.size = parts.reduce((a, b) => a + (b ? (b.byteLength || b.size || 0) : 0), 0);
+  }
+};
+
+/** Return a fresh BatchProcessor instance with clean internal state. */
+function freshBP() {
+  const exports = {};
+  const module = { exports };
+  eval(patchedSrc); // eslint-disable-line no-eval
+  return module.exports;
+}
+
+// ── _normalize ────────────────────────────────────────────────────────────────
+
+describe('BatchProcessor._normalize', () => {
+  test('scales peak to target dBFS', () => {
+    const bp = freshBP();
+    const data = new Float32Array([0.2, -0.4, 0.6, -0.1]);
+    const out = bp._normalize(data, -6);
+    const peak = Math.max(...Array.from(out).map(Math.abs));
+    expect(peak).toBeCloseTo(Math.pow(10, -6 / 20), 3);
+  });
+
+  test('all-zeros input is returned unchanged', () => {
+    const bp = freshBP();
+    const out = bp._normalize(new Float32Array(10), -1);
+    expect(out.every(v => v === 0)).toBe(true);
+  });
+
+  test('returns a new Float32Array (does not mutate input)', () => {
+    const bp = freshBP();
+    const data = new Float32Array([0.5, -0.5]);
+    const out = bp._normalize(data, -6);
+    expect(out).not.toBe(data);
+  });
+
+  test('output has the same length as input', () => {
+    const bp = freshBP();
+    const data = new Float32Array(100).fill(0.3);
+    expect(bp._normalize(data, -3).length).toBe(100);
+  });
+});
+
+// ── _encodeWAV ────────────────────────────────────────────────────────────────
+
+describe('BatchProcessor._encodeWAV', () => {
+  const readStr = (v, off, len) =>
+    Array.from({ length: len }, (_, i) => String.fromCharCode(v.getUint8(off + i))).join('');
+
+  test('produces valid RIFF/WAVE/fmt /data header', () => {
+    const bp = freshBP();
+    const buf = bp._encodeWAV(new Float32Array(4), 48000);
+    const v = new DataView(buf);
+    expect(readStr(v, 0, 4)).toBe('RIFF');
+    expect(readStr(v, 8, 4)).toBe('WAVE');
+    expect(readStr(v, 12, 4)).toBe('fmt ');
+    expect(readStr(v, 36, 4)).toBe('data');
+  });
+
+  test('buffer size = 44 + samples*2 (16-bit PCM)', () => {
+    const bp = freshBP();
+    expect(bp._encodeWAV(new Float32Array(100), 48000).byteLength).toBe(244);
+  });
+
+  test('sample rate written at offset 24', () => {
+    const bp = freshBP();
+    const v = new DataView(bp._encodeWAV(new Float32Array(1), 22050));
+    expect(v.getUint32(24, true)).toBe(22050);
+  });
+
+  test('RIFF chunk size = 36 + dataSize', () => {
+    const bp = freshBP();
+    const v = new DataView(bp._encodeWAV(new Float32Array(10), 48000));
+    expect(v.getUint32(4, true)).toBe(36 + 10 * 2);
+  });
+
+  test('data size field at offset 40 = samples*2', () => {
+    const bp = freshBP();
+    const v = new DataView(bp._encodeWAV(new Float32Array(20), 48000));
+    expect(v.getUint32(40, true)).toBe(20 * 2);
+  });
+
+  test('positive sample clips at +32767', () => {
+    const bp = freshBP();
+    const v = new DataView(bp._encodeWAV(new Float32Array([2.0]), 48000));
+    expect(v.getInt16(44, true)).toBe(0x7FFF);
+  });
+
+  test('channel count is 1 (mono)', () => {
+    const bp = freshBP();
+    const v = new DataView(bp._encodeWAV(new Float32Array(1), 48000));
+    expect(v.getUint16(22, true)).toBe(1);
+  });
+});
+
+// ── _applyWatermark ───────────────────────────────────────────────────────────
+
+describe('BatchProcessor._applyWatermark', () => {
+  test('output has the same length as input', () => {
+    const bp = freshBP();
+    const data = new Float32Array(4800).fill(0.3);
+    expect(bp._applyWatermark(data, 48000).length).toBe(4800);
+  });
+
+  test('watermark modifies the signal (output != input)', () => {
+    const bp = freshBP();
+    const data = new Float32Array(4800).fill(0.5);
+    const out = bp._applyWatermark(data, 48000);
+    let differs = false;
+    for (let i = 0; i < data.length; i++) {
+      if (Math.abs(out[i] - 0.5) > 1e-5) { differs = true; break; }
+    }
+    expect(differs).toBe(true);
+  });
+
+  test('watermark amplitude is small (< 0.02)', () => {
+    const bp = freshBP();
+    const data = new Float32Array(4800); // silence
+    const out = bp._applyWatermark(data, 48000);
+    for (const v of out) expect(Math.abs(v)).toBeLessThan(0.02);
+  });
+
+  test('output is always finite', () => {
+    const bp = freshBP();
+    const data = new Float32Array(48000).fill(0.9); // long signal
+    const out = bp._applyWatermark(data, 48000);
+    for (const v of out) expect(Number.isFinite(v)).toBe(true);
+  });
+});
+
+// ── event system ──────────────────────────────────────────────────────────────
+
+describe('BatchProcessor event system', () => {
+  test('on() returns an unsubscribe function', () => {
+    const bp = freshBP();
+    const unsub = bp.on('job:queued', () => {});
+    expect(typeof unsub).toBe('function');
+    expect(() => unsub()).not.toThrow();
+  });
+
+  test('pause() emits queue:paused', () => {
+    const bp = freshBP();
+    const cb = jest.fn();
+    bp.on('queue:paused', cb);
+    bp.pause();
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  test('resume() emits queue:resumed', () => {
+    const bp = freshBP();
+    const cb = jest.fn();
+    bp.on('queue:resumed', cb);
+    bp.resume();
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  test('wildcard (*) listener receives all events', () => {
+    const bp = freshBP();
+    const cb = jest.fn();
+    bp.on('*', cb);
+    bp.pause();
+    bp.resume();
+    expect(cb.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  test('unsubscribed listener no longer fires', () => {
+    const bp = freshBP();
+    const cb = jest.fn();
+    const unsub = bp.on('queue:paused', cb);
+    unsub();
+    bp.pause();
+    expect(cb).not.toHaveBeenCalled();
+  });
+});
+
+// ── pause / resume ────────────────────────────────────────────────────────────
+
+describe('BatchProcessor.pause and resume', () => {
+  test('pause() sets paused=true in stats', () => {
+    const bp = freshBP();
+    bp.pause();
+    expect(bp.getStats().paused).toBe(true);
+  });
+
+  test('resume() sets paused=false in stats', () => {
+    const bp = freshBP();
+    bp.pause();
+    bp.resume();
+    expect(bp.getStats().paused).toBe(false);
+  });
+});
+
+// ── getStats / getQueue ───────────────────────────────────────────────────────
+
+describe('BatchProcessor.getStats and getQueue', () => {
+  test('initial stats are all zero', () => {
+    const bp = freshBP();
+    const s = bp.getStats();
+    expect(s).toEqual({ total: 0, done: 0, processing: 0, queued: 0, errors: 0, paused: false });
+  });
+
+  test('getQueue returns empty array initially', () => {
+    expect(freshBP().getQueue()).toEqual([]);
+  });
+});
+
+// ── setConcurrency ────────────────────────────────────────────────────────────
+
+describe('BatchProcessor.setConcurrency', () => {
+  test('does not throw for valid values', () => {
+    const bp = freshBP();
+    expect(() => bp.setConcurrency(5)).not.toThrow();
+    expect(() => bp.setConcurrency(1)).not.toThrow();
+  });
+
+  test('clamps to minimum of 1', () => {
+    const bp = freshBP();
+    expect(() => bp.setConcurrency(0)).not.toThrow();
+    expect(() => bp.setConcurrency(-5)).not.toThrow();
+  });
+});
+
+// ── clearCompleted ────────────────────────────────────────────────────────────
+
+describe('BatchProcessor.clearCompleted', () => {
+  test('does not throw on empty queue', () => {
+    expect(() => freshBP().clearCompleted()).not.toThrow();
+  });
+});
+
+// ── addFiles ──────────────────────────────────────────────────────────────────
+
+describe('BatchProcessor.addFiles', () => {
+  afterEach(() => { global.window.LicenseManager = null; });
+
+  test('returns [] when LicenseManager is absent (maxBatch=0)', () => {
+    global.window.LicenseManager = null;
+    expect(freshBP().addFiles([{ name: 'test.wav', size: 100 }])).toEqual([]);
+  });
+
+  test('returns job IDs when unlimited batch is allowed', () => {
+    global.window.LicenseManager = { getTierDef: () => ({ limits: { batchFiles: -1 } }) };
+    const ids = freshBP().addFiles([{ name: 'a.wav', size: 100 }, { name: 'b.wav', size: 200 }]);
+    expect(ids.length).toBe(2);
+  });
+
+  test('respects maxBatch cap', () => {
+    global.window.LicenseManager = { getTierDef: () => ({ limits: { batchFiles: 2 } }) };
+    const files = [{ name: 'a.wav', size: 1 }, { name: 'b.wav', size: 1 }, { name: 'c.wav', size: 1 }];
+    expect(freshBP().addFiles(files).length).toBe(2);
+  });
+
+  test('queued jobs have correct name and state', () => {
+    global.window.LicenseManager = { getTierDef: () => ({ limits: { batchFiles: -1 } }) };
+    const bp = freshBP();
+    bp.addFiles([{ name: 'test.wav', size: 500 }]);
+    const q = bp.getQueue();
+    expect(q.length).toBe(1);
+    expect(q[0].state).toBe('queued');
+    expect(q[0].name).toBe('test.wav');
+    expect(q[0].size).toBe(500);
+  });
+
+  test('emits job:queued event per file', () => {
+    global.window.LicenseManager = { getTierDef: () => ({ limits: { batchFiles: -1 } }) };
+    const bp = freshBP();
+    const cb = jest.fn();
+    bp.on('job:queued', cb);
+    bp.addFiles([{ name: 'a.wav', size: 1 }, { name: 'b.wav', size: 2 }]);
+    expect(cb).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ── cancel / cancelAll ────────────────────────────────────────────────────────
+
+describe('BatchProcessor.cancel and cancelAll', () => {
+  afterEach(() => { global.window.LicenseManager = null; });
+
+  test('cancel on unknown ID does not throw', () => {
+    expect(() => freshBP().cancel('no_such_id')).not.toThrow();
+  });
+
+  test('cancelAll on empty queue does not throw', () => {
+    expect(() => freshBP().cancelAll()).not.toThrow();
+  });
+
+  test('cancel marks a queued job as cancelled', () => {
+    global.window.LicenseManager = { getTierDef: () => ({ limits: { batchFiles: -1 } }) };
+    const bp = freshBP();
+    const [id] = bp.addFiles([{ name: 'x.wav', size: 100 }]);
+    bp.cancel(id);
+    const job = bp.getQueue().find(j => j.id === id);
+    expect(job.state).toBe('cancelled');
+  });
+
+  test('cancelAll marks all non-terminal jobs as cancelled', () => {
+    global.window.LicenseManager = { getTierDef: () => ({ limits: { batchFiles: -1 } }) };
+    const bp = freshBP();
+    bp.addFiles([{ name: 'a.wav', size: 1 }, { name: 'b.wav', size: 2 }]);
+    bp.cancelAll();
+    const states = bp.getQueue().map(j => j.state);
+    expect(states.every(s => s === 'cancelled')).toBe(true);
+  });
+});

--- a/tests/dsp-core.test.js
+++ b/tests/dsp-core.test.js
@@ -1,0 +1,742 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const dspCoreJs = fs.readFileSync(path.join(__dirname, '../public/app/dsp-core.js'), 'utf8');
+const { DSPCore, AdaptiveNoiseFloor } = (() => {
+  const exports = {};
+  const module = { exports };
+  const window = {};
+  const self = {};
+  eval(dspCoreJs); // eslint-disable-line no-eval
+  return { DSPCore: module.exports, AdaptiveNoiseFloor: module.exports.AdaptiveNoiseFloor };
+})();
+
+// ── AdaptiveNoiseFloor ────────────────────────────────────────────────────────
+
+describe('AdaptiveNoiseFloor', () => {
+  test('constructor initializes to correct size and uninitialized state', () => {
+    const anf = new AdaptiveNoiseFloor(10);
+    expect(anf.numBins).toBe(10);
+    expect(anf.noiseEst.length).toBe(10);
+    expect(anf._initialized).toBe(false);
+  });
+
+  test('first update() seeds noiseEst from mag', () => {
+    const anf = new AdaptiveNoiseFloor(4);
+    const mag = new Float32Array([0.1, 0.2, 0.3, 0.4]);
+    anf.update(mag);
+    expect(anf._initialized).toBe(true);
+    for (let k = 0; k < 4; k++) expect(anf.noiseEst[k]).toBeCloseTo(mag[k], 5);
+  });
+
+  test('getFloor() returns zeros before any update (Infinity clamped)', () => {
+    const anf = new AdaptiveNoiseFloor(4);
+    const floor = anf.getFloor();
+    for (let k = 0; k < 4; k++) expect(floor[k]).toBe(0);
+  });
+
+  test('getFloor() retains initial low value within the sub-window lifetime', () => {
+    // Use a 2-second smoothing window so subWinLen ≈ 19 frames.
+    // Feeding only 5 high frames (< subWinLen) means no rotation yet:
+    // all 5 sub-windows still hold the initial low seed value.
+    const anf = new AdaptiveNoiseFloor(4, 2000, 1024, 48000);
+    anf.update(new Float32Array([0.01, 0.02, 0.03, 0.04]));
+    for (let i = 0; i < 5; i++) anf.update(new Float32Array([0.9, 0.9, 0.9, 0.9]));
+    const floor = anf.getFloor();
+    for (let k = 0; k < 4; k++) expect(floor[k]).toBeLessThan(0.1);
+  });
+
+  test('getFloor() accepts and returns a pre-allocated output buffer', () => {
+    const anf = new AdaptiveNoiseFloor(4);
+    anf.update(new Float32Array([0.1, 0.1, 0.1, 0.1]));
+    const out = new Float32Array(4);
+    const ret = anf.getFloor(out);
+    expect(ret).toBe(out);
+  });
+
+  test('reset() clears all state', () => {
+    const anf = new AdaptiveNoiseFloor(4);
+    anf.update(new Float32Array([0.5, 0.5, 0.5, 0.5]));
+    anf.reset();
+    expect(anf._initialized).toBe(false);
+    expect(anf._subFrameIdx).toBe(0);
+    expect(anf._subWinIdx).toBe(0);
+    const floor = anf.getFloor();
+    for (let k = 0; k < 4; k++) expect(floor[k]).toBe(0);
+  });
+
+  test('sub-window rotation increments _subWinIdx after subWinLen frames', () => {
+    const anf = new AdaptiveNoiseFloor(2, 100, 1024, 48000);
+    anf.update(new Float32Array([0.1, 0.1]));
+    const before = anf._subWinIdx;
+    for (let i = 0; i < anf._subWinLen + 1; i++) {
+      anf.update(new Float32Array([0.1, 0.1]));
+    }
+    expect(anf._subWinIdx).not.toBe(before);
+  });
+
+  test('noiseEst smoothing alpha is in (0, 1)', () => {
+    const anf = new AdaptiveNoiseFloor(2, 200, 1024, 48000);
+    expect(anf.alpha).toBeGreaterThan(0);
+    expect(anf.alpha).toBeLessThan(1);
+  });
+});
+
+// ── wienerFilter ─────────────────────────────────────────────────────────────
+
+describe('DSPCore.wienerFilter', () => {
+  test('returns gain in [beta, 1.0]', () => {
+    const g = DSPCore.wienerFilter(0.1, 0.5);
+    expect(g).toBeGreaterThanOrEqual(0.02);
+    expect(g).toBeLessThanOrEqual(1.0);
+  });
+
+  test('high SNR → gain near 1.0', () => {
+    expect(DSPCore.wienerFilter(0.001, 1.0)).toBeGreaterThan(0.95);
+  });
+
+  test('low SNR → gain near spectral floor', () => {
+    expect(DSPCore.wienerFilter(1.0, 0.001)).toBeLessThan(0.1);
+  });
+
+  test('zero signal returns finite gain', () => {
+    const g = DSPCore.wienerFilter(0.5, 0);
+    expect(Number.isFinite(g)).toBe(true);
+    expect(g).toBeGreaterThanOrEqual(0);
+  });
+
+  test('zero noise returns gain near 1.0', () => {
+    expect(DSPCore.wienerFilter(0, 0.5)).toBeCloseTo(1.0, 2);
+  });
+
+  test('custom spectralFloor is respected', () => {
+    const g = DSPCore.wienerFilter(1.0, 0.001, { spectralFloor: 0.5 });
+    expect(g).toBeGreaterThanOrEqual(0.5);
+  });
+
+  test('gain never exceeds 1.0 (no amplification) for random inputs', () => {
+    for (let i = 0; i < 50; i++) {
+      const g = DSPCore.wienerFilter(Math.random(), Math.random() * 2);
+      expect(g).toBeLessThanOrEqual(1.0 + 1e-9);
+    }
+  });
+});
+
+// ── getVoiceMaskGain ──────────────────────────────────────────────────────────
+
+describe('DSPCore.getVoiceMaskGain', () => {
+  const SR = 48000, FFT = 4096;
+
+  test('returns 0.3 for very low sub-bass (<40 Hz)', () => {
+    const bin = Math.floor(20 / (SR / FFT));
+    expect(DSPCore.getVoiceMaskGain(bin, SR, FFT)).toBe(0.30);
+  });
+
+  test('returns 1.0 for core voice band (200–4000 Hz)', () => {
+    const bin = Math.round(1000 / (SR / FFT));
+    expect(DSPCore.getVoiceMaskGain(bin, SR, FFT)).toBe(1.0);
+  });
+
+  test('returns 0.4 for frequencies above 12 kHz', () => {
+    const bin = Math.round(14000 / (SR / FFT));
+    expect(DSPCore.getVoiceMaskGain(bin, SR, FFT)).toBe(0.40);
+  });
+
+  test('all bin values are in [0, 1]', () => {
+    const halfN = FFT / 2 + 1;
+    for (let k = 0; k < halfN; k += 50) {
+      const g = DSPCore.getVoiceMaskGain(k, SR, FFT);
+      expect(g).toBeGreaterThanOrEqual(0);
+      expect(g).toBeLessThanOrEqual(1);
+    }
+  });
+});
+
+// ── hannWindow ────────────────────────────────────────────────────────────────
+
+describe('DSPCore.hannWindow', () => {
+  test('returns correct length', () => {
+    expect(DSPCore.hannWindow(256).length).toBe(256);
+  });
+
+  test('first sample is 0 (periodic Hann)', () => {
+    expect(DSPCore.hannWindow(512)[0]).toBeCloseTo(0, 6);
+  });
+
+  test('peak is 1.0 at midpoint', () => {
+    const w = DSPCore.hannWindow(512);
+    expect(w[256]).toBeCloseTo(1.0, 5);
+  });
+
+  test('caches result for same length (same reference)', () => {
+    expect(DSPCore.hannWindow(128)).toBe(DSPCore.hannWindow(128));
+  });
+});
+
+// ── peakNormalize ─────────────────────────────────────────────────────────────
+
+describe('DSPCore.peakNormalize', () => {
+  test('normalizes peak to target dBFS', () => {
+    const data = new Float32Array([0.1, -0.2, 0.3, -0.4]);
+    DSPCore.peakNormalize(data, -6);
+    const peak = Math.max(...data.map(Math.abs));
+    expect(peak).toBeCloseTo(Math.pow(10, -6 / 20), 4);
+  });
+
+  test('silent signal (all zeros) is left unchanged', () => {
+    const data = new Float32Array(8);
+    DSPCore.peakNormalize(data, -6);
+    expect(data.every(v => v === 0)).toBe(true);
+  });
+});
+
+// ── truePeakLimit ─────────────────────────────────────────────────────────────
+
+describe('DSPCore.truePeakLimit', () => {
+  test('output never exceeds ceiling (0 dBFS)', () => {
+    const data = new Float32Array([0.5, 1.5, -2.0, 0.9, -1.1]);
+    DSPCore.truePeakLimit(data, 0);
+    for (const v of data) expect(Math.abs(v)).toBeLessThanOrEqual(1.0 + 1e-6);
+  });
+
+  test('signal well below knee is unchanged', () => {
+    const data = new Float32Array([0.1, 0.2, -0.1]);
+    const copy = data.slice();
+    DSPCore.truePeakLimit(data, 0);
+    for (let i = 0; i < data.length; i++) expect(data[i]).toBeCloseTo(copy[i], 6);
+  });
+
+  test('polarity is preserved for large signals', () => {
+    const data = new Float32Array([2.0, -2.0]);
+    DSPCore.truePeakLimit(data, 0);
+    expect(data[0]).toBeGreaterThan(0);
+    expect(data[1]).toBeLessThan(0);
+  });
+});
+
+// ── deClip ────────────────────────────────────────────────────────────────────
+
+describe('DSPCore.deClip', () => {
+  test('interpolates clipped samples', () => {
+    const data = new Float32Array([0.1, 1.0, 0.1]);
+    DSPCore.deClip(data, 0.99);
+    expect(Math.abs(data[1])).toBeLessThan(1.0);
+    expect(data[1]).toBeCloseTo(0.1, 3);
+  });
+
+  test('normal samples are untouched', () => {
+    const data = new Float32Array([0.1, 0.5, 0.2, -0.3]);
+    const copy = data.slice();
+    DSPCore.deClip(data, 0.99);
+    for (let i = 1; i < data.length - 1; i++) expect(data[i]).toBeCloseTo(copy[i], 6);
+  });
+});
+
+// ── stereoWiden ───────────────────────────────────────────────────────────────
+
+describe('DSPCore.stereoWiden', () => {
+  test('null right channel → mono passthrough', () => {
+    const left = new Float32Array([1, 2, 3]);
+    const { left: outL, right: outR } = DSPCore.stereoWiden(left, null, 150);
+    expect(outL).toBe(left);
+    expect(outR).toBe(left);
+  });
+
+  test('width=100 returns channels unchanged', () => {
+    const left = new Float32Array([0.5, -0.3]);
+    const right = new Float32Array([0.2, 0.4]);
+    const { left: outL, right: outR } = DSPCore.stereoWiden(left, right, 100);
+    expect(outL).toBe(left);
+    expect(outR).toBe(right);
+  });
+
+  test('width=0 collapses to mono (L === R)', () => {
+    const left = new Float32Array([0.6, -0.4]);
+    const right = new Float32Array([0.2, 0.8]);
+    const { left: outL, right: outR } = DSPCore.stereoWiden(left, right, 0);
+    for (let i = 0; i < 2; i++) expect(outL[i]).toBeCloseTo(outR[i], 5);
+  });
+
+  test('output length matches input', () => {
+    const left = new Float32Array(8).fill(0.5);
+    const right = new Float32Array(8).fill(0.3);
+    const { left: outL, right: outR } = DSPCore.stereoWiden(left, right, 150);
+    expect(outL.length).toBe(8);
+    expect(outR.length).toBe(8);
+  });
+});
+
+// ── temporalSmooth ────────────────────────────────────────────────────────────
+
+describe('DSPCore.temporalSmooth', () => {
+  test('smoothing=0 leaves frames unchanged', () => {
+    const mag = [new Float32Array([1, 2, 3]), new Float32Array([4, 5, 6])];
+    const before = mag[1].slice();
+    DSPCore.temporalSmooth(mag, 0);
+    for (let k = 0; k < 3; k++) expect(mag[1][k]).toBeCloseTo(before[k], 6);
+  });
+
+  test('smoothing=100 replaces frame with previous', () => {
+    const mag = [new Float32Array([1, 1, 1]), new Float32Array([9, 9, 9])];
+    DSPCore.temporalSmooth(mag, 100);
+    for (let k = 0; k < 3; k++) expect(mag[1][k]).toBeCloseTo(1, 5);
+  });
+
+  test('smoothing=50 blends frames at 50/50', () => {
+    const mag = [new Float32Array([0, 0, 0]), new Float32Array([10, 10, 10])];
+    DSPCore.temporalSmooth(mag, 50);
+    for (let k = 0; k < 3; k++) expect(mag[1][k]).toBeCloseTo(5, 5);
+  });
+});
+
+// ── measureLUFS ───────────────────────────────────────────────────────────────
+
+describe('DSPCore.measureLUFS', () => {
+  test('silence returns -96', () => {
+    expect(DSPCore.measureLUFS(new Float32Array(48000), 48000)).toBe(-96);
+  });
+
+  test('full-scale 1kHz sine is in a reasonable LUFS range', () => {
+    const sr = 48000, N = sr * 2;
+    const data = new Float32Array(N);
+    for (let i = 0; i < N; i++) data[i] = Math.sin(2 * Math.PI * 1000 * i / sr);
+    const lufs = DSPCore.measureLUFS(data, sr);
+    expect(lufs).toBeGreaterThan(-10);
+    expect(lufs).toBeLessThan(5);
+  });
+
+  test('louder signal has higher LUFS than quieter', () => {
+    const sr = 48000, N = sr;
+    const loud = new Float32Array(N).fill(0.9);
+    const quiet = new Float32Array(N).fill(0.1);
+    expect(DSPCore.measureLUFS(loud, sr)).toBeGreaterThan(DSPCore.measureLUFS(quiet, sr));
+  });
+});
+
+// ── encodeWAV ─────────────────────────────────────────────────────────────────
+
+describe('DSPCore.encodeWAV', () => {
+  const readStr = (view, off, len) =>
+    Array.from({ length: len }, (_, i) => String.fromCharCode(view.getUint8(off + i))).join('');
+
+  test('produces valid RIFF/WAVE/fmt /data header', () => {
+    const buf = DSPCore.encodeWAV(new Float32Array(10), 48000, 16);
+    const v = new DataView(buf);
+    expect(readStr(v, 0, 4)).toBe('RIFF');
+    expect(readStr(v, 8, 4)).toBe('WAVE');
+    expect(readStr(v, 12, 4)).toBe('fmt ');
+    expect(readStr(v, 36, 4)).toBe('data');
+  });
+
+  test('16-bit: buffer size = 44 + samples*2', () => {
+    expect(DSPCore.encodeWAV(new Float32Array(100), 48000, 16).byteLength).toBe(244);
+  });
+
+  test('24-bit: buffer size = 44 + samples*3', () => {
+    expect(DSPCore.encodeWAV(new Float32Array(50), 48000, 24).byteLength).toBe(44 + 150);
+  });
+
+  test('32-bit: buffer size = 44 + samples*4', () => {
+    expect(DSPCore.encodeWAV(new Float32Array(100), 48000, 32).byteLength).toBe(444);
+  });
+
+  test('sample rate written correctly at offset 24', () => {
+    const buf = DSPCore.encodeWAV(new Float32Array(1), 44100, 16);
+    expect(new DataView(buf).getUint32(24, true)).toBe(44100);
+  });
+
+  test('RIFF chunk size = 36 + dataSize', () => {
+    const buf = DSPCore.encodeWAV(new Float32Array(10), 48000, 16);
+    expect(new DataView(buf).getUint32(4, true)).toBe(36 + 10 * 2);
+  });
+
+  test('16-bit clamps over-range samples to ±32767', () => {
+    const buf = DSPCore.encodeWAV(new Float32Array([2.0, -2.0]), 48000, 16);
+    const v = new DataView(buf);
+    expect(v.getInt16(44, true)).toBe(0x7FFF);
+    expect(v.getInt16(46, true)).toBe(-0x7FFF);
+  });
+});
+
+// ── wienerMMSE ────────────────────────────────────────────────────────────────
+
+describe('DSPCore.wienerMMSE', () => {
+  test('reduces magnitude when noiseProfile is strong', () => {
+    const mag = [new Float32Array(8).fill(0.5)];
+    DSPCore.wienerMMSE(mag, new Float32Array(8).fill(0.4), 100);
+    for (const v of mag[0]) expect(v).toBeLessThan(0.5);
+  });
+
+  test('null noiseProfile causes minimal change', () => {
+    const mag = [new Float32Array([0.5, 0.5])];
+    const before = mag[0].slice();
+    DSPCore.wienerMMSE(mag, null, 50);
+    for (let k = 0; k < 2; k++) expect(mag[0][k]).toBeGreaterThan(before[k] * 0.9);
+  });
+
+  test('amount=0 leaves magnitudes unchanged', () => {
+    const mag = [new Float32Array([0.3, 0.4, 0.5])];
+    const before = mag[0].slice();
+    DSPCore.wienerMMSE(mag, new Float32Array([0.2, 0.2, 0.2]), 0);
+    for (let k = 0; k < 3; k++) expect(mag[0][k]).toBeCloseTo(before[k], 6);
+  });
+});
+
+// ── applyAdaptiveWiener ───────────────────────────────────────────────────────
+
+describe('DSPCore.applyAdaptiveWiener', () => {
+  function frames(n, bins, val) {
+    return Array.from({ length: n }, () => new Float32Array(bins).fill(val));
+  }
+
+  test('silence frames (conf<0.3) update the tracker', () => {
+    const tracker = new AdaptiveNoiseFloor(4);
+    const mag = frames(5, 4, 0.1);
+    DSPCore.applyAdaptiveWiener(mag, new Float32Array(5).fill(0.0), tracker);
+    expect(tracker._initialized).toBe(true);
+  });
+
+  test('fully voiced frame (conf=1) passes through without suppression', () => {
+    const tracker = new AdaptiveNoiseFloor(4);
+    tracker.update(new Float32Array(4).fill(0.1));
+    const mag = [new Float32Array(4).fill(0.5)];
+    DSPCore.applyAdaptiveWiener(mag, new Float32Array([1.0]), tracker);
+    for (const v of mag[0]) expect(v).toBeCloseTo(0.5, 4);
+  });
+
+  test('returns the same mag array (in-place)', () => {
+    const tracker = new AdaptiveNoiseFloor(4);
+    const mag = frames(3, 4, 0.2);
+    const ret = DSPCore.applyAdaptiveWiener(mag, new Float32Array(3).fill(0.5), tracker);
+    expect(ret).toBe(mag);
+  });
+
+  test('no crash with empty vadConf', () => {
+    const tracker = new AdaptiveNoiseFloor(4);
+    const mag = frames(3, 4, 0.2);
+    expect(() => DSPCore.applyAdaptiveWiener(mag, null, tracker)).not.toThrow();
+  });
+});
+
+// ── AdaptiveNoiseEstimator ────────────────────────────────────────────────────
+
+describe('DSPCore.AdaptiveNoiseEstimator', () => {
+  test('constructor initializes noisePSD to zeros', () => {
+    const est = new DSPCore.AdaptiveNoiseEstimator(8);
+    expect(est.noisePSD.length).toBe(8);
+    expect(est.initialized).toBe(false);
+  });
+
+  test('first update() seeds PSD from magnitude²', () => {
+    const est = new DSPCore.AdaptiveNoiseEstimator(4);
+    const mag = new Float32Array([0.5, 0.3, 0.2, 0.1]);
+    est.update(mag);
+    expect(est.initialized).toBe(true);
+    for (let k = 0; k < 4; k++) expect(est.noisePSD[k]).toBeCloseTo(mag[k] * mag[k], 5);
+  });
+
+  test('attack smoothing when signal increases', () => {
+    const est = new DSPCore.AdaptiveNoiseEstimator(1, 0.9, 0.998);
+    est.update(new Float32Array([0.1]));
+    const prev = est.noisePSD[0];
+    est.update(new Float32Array([1.0]));
+    const expected = 0.9 * prev + 0.1 * 1.0;
+    expect(est.noisePSD[0]).toBeCloseTo(expected, 5);
+  });
+
+  test('release smoothing when signal decreases', () => {
+    const est = new DSPCore.AdaptiveNoiseEstimator(1, 0.9, 0.998);
+    est.update(new Float32Array([1.0]));
+    const prev = est.noisePSD[0];
+    est.update(new Float32Array([0.01]));
+    const expected = 0.998 * prev + 0.002 * 0.0001;
+    expect(est.noisePSD[0]).toBeCloseTo(expected, 4);
+  });
+
+  test('reset() clears state', () => {
+    const est = new DSPCore.AdaptiveNoiseEstimator(4);
+    est.update(new Float32Array(4).fill(0.5));
+    est.reset();
+    expect(est.initialized).toBe(false);
+    expect(est.noisePSD.every(v => v === 0)).toBe(true);
+  });
+
+  test('getProfile() returns the internal noisePSD reference', () => {
+    const est = new DSPCore.AdaptiveNoiseEstimator(4);
+    expect(est.getProfile()).toBe(est.noisePSD);
+  });
+});
+
+// ── MultibandWienerFilter ─────────────────────────────────────────────────────
+
+describe('DSPCore.MultibandWienerFilter', () => {
+  test('constructor defaults: 16 bands, 48kHz, 4096 fftSize', () => {
+    const wf = new DSPCore.MultibandWienerFilter();
+    expect(wf.numBands).toBe(16);
+    expect(wf.sr).toBe(48000);
+    expect(wf.fftSize).toBe(4096);
+    expect(wf.smoothGains.every(g => g === 1)).toBe(true);
+  });
+
+  test('process() returns same mag array (in-place)', () => {
+    const wf = new DSPCore.MultibandWienerFilter(4, 48000, 512);
+    const mag = new Float32Array(257).fill(0.5);
+    expect(wf.process(mag, null, 1)).toBe(mag);
+  });
+
+  test('process() reduces magnitudes when noisePSD is provided', () => {
+    const wf = new DSPCore.MultibandWienerFilter(4, 48000, 512);
+    const mag = new Float32Array(257).fill(0.5);
+    const noise = new Float32Array(257).fill(0.3);
+    const sumBefore = mag.reduce((a, b) => a + b, 0);
+    wf.process(mag, noise, 1);
+    expect(mag.reduce((a, b) => a + b, 0)).toBeLessThan(sumBefore);
+  });
+
+  test('process() output is always finite and non-negative', () => {
+    const wf = new DSPCore.MultibandWienerFilter(4, 48000, 512);
+    const mag = new Float32Array(257).fill(0.5);
+    wf.process(mag, null, 1);
+    for (const v of mag) {
+      expect(Number.isFinite(v)).toBe(true);
+      expect(v).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  test('reset() restores smoothGains to 1', () => {
+    const wf = new DSPCore.MultibandWienerFilter(4, 48000, 512);
+    wf.process(new Float32Array(257).fill(0.5), new Float32Array(257).fill(0.4), 1);
+    wf.reset();
+    expect(wf.smoothGains.every(g => g === 1)).toBe(true);
+  });
+
+  test('high temporal smoothing changes gains slowly between frames', () => {
+    const wf = new DSPCore.MultibandWienerFilter(2, 48000, 512);
+    const noise = new Float32Array(257).fill(0.05);
+    wf.process(new Float32Array(257).fill(0.1), noise, 1, 0.9);
+    const gains1 = wf.smoothGains.slice();
+    wf.process(new Float32Array(257).fill(0.9), noise, 1, 0.9);
+    for (let b = 0; b < wf.numBands; b++) {
+      expect(Math.abs(wf.smoothGains[b] - gains1[b])).toBeLessThan(0.5);
+    }
+  });
+});
+
+// ── VADProcessor ──────────────────────────────────────────────────────────────
+
+describe('DSPCore.VADProcessor', () => {
+  test('constructor stores sr and sensitivity', () => {
+    const vad = new DSPCore.VADProcessor(16000, 20, 0.8);
+    expect(vad.sr).toBe(16000);
+    expect(vad.sensitivity).toBe(0.8);
+  });
+
+  test('processFrame() returns 0 for silence', () => {
+    const vad = new DSPCore.VADProcessor(48000, 20, 0.5);
+    expect(vad.processFrame(new Float32Array(960))).toBe(0);
+  });
+
+  test('processFrame() returns 1 for loud tonal signal', () => {
+    const vad = new DSPCore.VADProcessor(48000, 20, 0.9);
+    const N = 960;
+    const frame = new Float32Array(N);
+    for (let i = 0; i < N; i++) frame[i] = 0.8 * Math.sin(2 * Math.PI * 300 * i / 48000);
+    expect(vad.processFrame(frame)).toBe(1);
+  });
+
+  test('processSignal() returns one value per frame', () => {
+    const vad = new DSPCore.VADProcessor(48000, 20, 0.5);
+    const result = vad.processSignal(new Float32Array(48000));
+    expect(result.length).toBe(Math.floor(48000 / vad.frameSize));
+  });
+
+  test('hangover returns 0.5 on first silence frame after speech', () => {
+    const vad = new DSPCore.VADProcessor(48000, 20, 0.9);
+    const N = 960;
+    const voiced = new Float32Array(N);
+    for (let i = 0; i < N; i++) voiced[i] = 0.8 * Math.sin(2 * Math.PI * 200 * i / 48000);
+    vad.processFrame(voiced);
+    expect(vad.processFrame(new Float32Array(N))).toBe(0.5);
+  });
+
+  test('setSensitivity() changes energyThreshDb', () => {
+    const vad = new DSPCore.VADProcessor(48000, 20, 0.5);
+    const before = vad.energyThreshDb;
+    vad.setSensitivity(0.9);
+    expect(vad.energyThreshDb).not.toBe(before);
+  });
+
+  test('reset() zeroes smoothedEnergy and hangover', () => {
+    const vad = new DSPCore.VADProcessor(48000, 20, 0.9);
+    const N = 960;
+    const voiced = new Float32Array(N);
+    for (let i = 0; i < N; i++) voiced[i] = 0.8 * Math.sin(2 * Math.PI * 200 * i / 48000);
+    vad.processFrame(voiced);
+    vad.reset();
+    expect(vad.hangover).toBe(0);
+    expect(vad.smoothedEnergy).toBe(0);
+  });
+});
+
+// ── classifyNoiseSpectral ─────────────────────────────────────────────────────
+
+describe('DSPCore.classifyNoiseSpectral', () => {
+  const VALID_CLASSES = ['music', 'white_noise', 'crowd', 'HVAC', 'keyboard', 'traffic', 'silence'];
+
+  test('empty input returns silence with confidence 1', () => {
+    const r = DSPCore.classifyNoiseSpectral([], 48000, 4096);
+    expect(r.noiseClass).toBe('silence');
+    expect(r.confidence).toBe(1);
+  });
+
+  test('near-zero magnitudes return silence', () => {
+    const mag = [new Float32Array(2049).fill(1e-8)];
+    expect(DSPCore.classifyNoiseSpectral(mag, 48000, 4096).noiseClass).toBe('silence');
+  });
+
+  test('returns a valid noiseClass string', () => {
+    const mag = Array.from({ length: 5 }, () => {
+      const m = new Float32Array(2049);
+      for (let k = 0; k < 2049; k++) m[k] = 0.01 + Math.random() * 0.02;
+      return m;
+    });
+    expect(VALID_CLASSES).toContain(DSPCore.classifyNoiseSpectral(mag, 48000, 4096).noiseClass);
+  });
+
+  test('confidence is in (0, 0.99]', () => {
+    const mag = Array.from({ length: 5 }, () => {
+      const m = new Float32Array(2049);
+      for (let k = 0; k < 2049; k++) m[k] = 0.01 + Math.random() * 0.02;
+      return m;
+    });
+    const r = DSPCore.classifyNoiseSpectral(mag, 48000, 4096);
+    expect(r.confidence).toBeGreaterThan(0);
+    expect(r.confidence).toBeLessThanOrEqual(0.99);
+  });
+
+  test('strong low-frequency energy leans toward HVAC or traffic', () => {
+    const numBins = 2049;
+    const binHz = 24000 / (numBins - 1);
+    const mag = Array.from({ length: 3 }, () => {
+      const m = new Float32Array(numBins).fill(1e-5);
+      for (let k = 0; k <= Math.round(120 / binHz); k++) m[k] = 1.0;
+      return m;
+    });
+    expect(['HVAC', 'traffic', 'music']).toContain(
+      DSPCore.classifyNoiseSpectral(mag, 48000, 4096).noiseClass
+    );
+  });
+});
+
+// ── removeClicks ──────────────────────────────────────────────────────────────
+
+describe('DSPCore.removeClicks', () => {
+  test('interpolates isolated spike', () => {
+    const data = new Float32Array(256);
+    data[64] = 999;
+    DSPCore.removeClicks(data, 3);
+    expect(Math.abs(data[64])).toBeLessThan(10);
+  });
+
+  test('leaves normal samples mostly untouched', () => {
+    const data = new Float32Array(256).fill(0.1);
+    const before = data.slice();
+    DSPCore.removeClicks(data, 3);
+    let unchanged = 0;
+    for (let i = 0; i < data.length; i++) {
+      if (Math.abs(data[i] - before[i]) < 1e-6) unchanged++;
+    }
+    expect(unchanged).toBeGreaterThan(data.length * 0.9);
+  });
+});
+
+// ── harmonicEnhanceV2 ─────────────────────────────────────────────────────────
+
+describe('DSPCore.harmonicEnhanceV2', () => {
+  test('amount=0 returns mag unchanged', () => {
+    const mag = [new Float32Array([0.1, 0.2, 0.3, 0.4, 0.5])];
+    const phase = [new Float32Array(5)];
+    const before = mag[0].slice();
+    DSPCore.harmonicEnhanceV2(mag, phase, 0);
+    for (let k = 0; k < 5; k++) expect(mag[0][k]).toBeCloseTo(before[k], 6);
+  });
+
+  test('no NaN or negative values in output', () => {
+    const N = 2049;
+    const mag = [Float32Array.from({ length: N }, () => Math.random() * 0.5)];
+    const phase = [Float32Array.from({ length: N }, () => (Math.random() - 0.5) * Math.PI * 2)];
+    DSPCore.harmonicEnhanceV2(mag, phase, 50, { sampleRate: 48000, fftSize: 4096 });
+    for (const v of mag[0]) {
+      expect(Number.isFinite(v)).toBe(true);
+      expect(v).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  test('returns mag array (in-place)', () => {
+    const mag = [new Float32Array(10).fill(0.2)];
+    const phase = [new Float32Array(10)];
+    expect(DSPCore.harmonicEnhanceV2(mag, phase, 20)).toBe(mag);
+  });
+});
+
+// ── STFT / iSTFT roundtrip ────────────────────────────────────────────────────
+
+describe('DSPCore STFT/iSTFT roundtrip', () => {
+  test('440 Hz sine reconstructed within 2% error in central region', () => {
+    const sr = 48000, N = sr;
+    const data = new Float32Array(N);
+    for (let i = 0; i < N; i++) data[i] = 0.5 * Math.sin(2 * Math.PI * 440 * i / sr);
+    const { mag, phase } = DSPCore.forwardSTFT(data, 4096, 1024);
+    const out = DSPCore.inverseSTFT(mag, phase, 4096, 1024, N);
+    let maxErr = 0;
+    for (let i = 4096; i < N - 4096; i++) {
+      const e = Math.abs(out[i] - data[i]);
+      if (e > maxErr) maxErr = e;
+    }
+    expect(maxErr).toBeLessThan(0.02);
+  });
+
+  test('iSTFT handles NaN/Inf magnitudes without producing non-finite output', () => {
+    const N = 8192;
+    const data = Float32Array.from({ length: N }, () => Math.random() * 0.1);
+    const { mag, phase } = DSPCore.forwardSTFT(data, 4096, 1024);
+    mag[0][0] = NaN;
+    mag[0][1] = Infinity;
+    mag[0][2] = -1;
+    // Corrupt phases too — iSTFT should handle gracefully
+    phase[0][0] = NaN;
+    // inverseSTFT guards rawM but not phases; just verify no crash and output exists
+    expect(() => DSPCore.inverseSTFT(mag, phase, 4096, 1024, N)).not.toThrow();
+  });
+
+  test('frameCount matches expected value', () => {
+    const data = new Float32Array(48000);
+    const { frameCount } = DSPCore.forwardSTFT(data, 4096, 1024);
+    const expected = Math.floor((48000 - 4096) / 1024) + 1;
+    expect(frameCount).toBe(expected);
+  });
+});
+
+// ── calcRMS / calcPeak ────────────────────────────────────────────────────────
+
+describe('DSPCore.calcRMS and calcPeak', () => {
+  test('calcRMS of all-zeros returns -96', () => {
+    expect(DSPCore.calcRMS(new Float32Array(100))).toBe(-96);
+  });
+
+  test('calcRMS of full-scale DC returns 0 dB', () => {
+    expect(DSPCore.calcRMS(new Float32Array(100).fill(1))).toBeCloseTo(0, 3);
+  });
+
+  test('calcPeak of all-zeros returns -96', () => {
+    expect(DSPCore.calcPeak(new Float32Array(100))).toBe(-96);
+  });
+
+  test('calcPeak detects largest absolute value', () => {
+    // calcPeak stores data[i]² then returns 10*log10(max²) = 20*log10(|max|)
+    const data = new Float32Array([0.1, 0.5, -0.9, 0.3]);
+    expect(DSPCore.calcPeak(data)).toBeCloseTo(10 * Math.log10(0.9 * 0.9), 2);
+  });
+});

--- a/tests/dsp-worker.test.js
+++ b/tests/dsp-worker.test.js
@@ -152,7 +152,7 @@ describe('dsp-worker: process', () => {
       audioData: audio.buffer, sampleRate: 48000, params: null
     }, 2);
     // Should not crash — STFT will have 0 frames; iSTFT returns empty buffer
-    expect(['result', 'error']).toContain(r.msg.type);
+    expect(r.msg.type).toBe('result');
   });
 });
 

--- a/tests/dsp-worker.test.js
+++ b/tests/dsp-worker.test.js
@@ -1,0 +1,247 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+// Load DSPCore to give the worker a real DSP implementation
+const dspCoreJs = fs.readFileSync(path.join(__dirname, '../public/app/dsp-core.js'), 'utf8');
+const DSPCore = (() => {
+  const exports = {};
+  const module = { exports };
+  const window = {};
+  const self = {};
+  eval(dspCoreJs); // eslint-disable-line no-eval
+  return module.exports;
+})();
+
+const workerSrc = fs.readFileSync(path.join(__dirname, '../public/app/dsp-worker.js'), 'utf8');
+
+/**
+ * Spin up a fresh worker instance by evaluating the source inside a mock
+ * self/importScripts environment. Returns the mock self (with .onmessage set)
+ * and a messages array that accumulates every postMessage call.
+ */
+function loadWorker() {
+  const messages = [];
+  const mockSelf = {
+    DSPCore,         // importScripts mock copies this onto self
+    ort: null,       // no ONNX runtime by default
+    onmessage: null,
+    postMessage(msg, transfers) { messages.push({ msg, transfers }); },
+  };
+
+  function importScripts() {
+    // dsp-core.js is already available as mockSelf.DSPCore — no-op
+  }
+
+  const fn = new Function('self', 'importScripts', 'module', workerSrc);
+  fn(mockSelf, importScripts, { exports: {} });
+
+  return { self: mockSelf, messages };
+}
+
+/** Dispatch a message and wait for the async handler to fully settle. */
+async function dispatch(mockSelf, messages, type, payload, id = 1) {
+  const before = messages.length;
+  await mockSelf.onmessage({ data: { type, id, payload } });
+  return messages.slice(before);
+}
+
+// ── message routing ───────────────────────────────────────────────────────────
+
+describe('dsp-worker message routing', () => {
+  test('unknown type posts an error response', async () => {
+    const { self: s, messages } = loadWorker();
+    const replies = await dispatch(s, messages, 'unknown_type', {});
+    expect(replies[0].msg.type).toBe('error');
+    expect(replies[0].msg.error).toMatch(/Unknown message type/);
+  });
+
+  test('reply id always mirrors request id', async () => {
+    const { self: s, messages } = loadWorker();
+    await dispatch(s, messages, 'init', { sampleRate: 48000 }, 42);
+    expect(messages[0].msg.id).toBe(42);
+  });
+});
+
+// ── init ──────────────────────────────────────────────────────────────────────
+
+describe('dsp-worker: init', () => {
+  test('returns status=initialized with provided sampleRate', async () => {
+    const { self: s, messages } = loadWorker();
+    const [r] = await dispatch(s, messages, 'init', { sampleRate: 44100 });
+    expect(r.msg.type).toBe('result');
+    expect(r.msg.result.status).toBe('initialized');
+    expect(r.msg.result.sampleRate).toBe(44100);
+  });
+
+  test('defaults sampleRate to 48000 when not provided', async () => {
+    const { self: s, messages } = loadWorker();
+    const [r] = await dispatch(s, messages, 'init', {});
+    expect(r.msg.result.sampleRate).toBe(48000);
+  });
+});
+
+// ── process ───────────────────────────────────────────────────────────────────
+
+describe('dsp-worker: process', () => {
+  test('process before init posts error', async () => {
+    const { self: s, messages } = loadWorker();
+    const audio = new Float32Array(8192).fill(0.1);
+    const [r] = await dispatch(s, messages, 'process', { audioData: audio.buffer, sampleRate: 48000 });
+    expect(r.msg.type).toBe('error');
+    expect(r.msg.error).toMatch(/not initialized/);
+  });
+
+  test('process after init returns result with processedData ArrayBuffer', async () => {
+    const { self: s, messages } = loadWorker();
+    await dispatch(s, messages, 'init', { sampleRate: 48000 }, 1);
+    messages.length = 0;
+    const audio = new Float32Array(8192).fill(0.1);
+    const [r] = await dispatch(s, messages, 'process', {
+      audioData: audio.buffer, sampleRate: 48000, params: null, enabledModels: []
+    }, 2);
+    expect(r.msg.type).toBe('result');
+    // Check byteLength rather than instanceof to avoid cross-realm constructor mismatch
+    expect(r.msg.result.processedData.byteLength).toBeGreaterThanOrEqual(0);
+  });
+
+  test('processedData result key is present and buffer-like', async () => {
+    const { self: s, messages } = loadWorker();
+    await dispatch(s, messages, 'init', { sampleRate: 48000 }, 1);
+    messages.length = 0;
+    const audio = new Float32Array(8192).fill(0.1);
+    const [r] = await dispatch(s, messages, 'process', {
+      audioData: audio.buffer, sampleRate: 48000, params: null
+    }, 2);
+    expect(r.msg.type).toBe('result');
+    expect(typeof r.msg.result.processedData.byteLength).toBe('number');
+  });
+
+  test('process with params applies spectral operations without crashing', async () => {
+    const { self: s, messages } = loadWorker();
+    await dispatch(s, messages, 'init', { sampleRate: 48000 }, 1);
+    messages.length = 0;
+    const audio = new Float32Array(8192).fill(0.2);
+    const [r] = await dispatch(s, messages, 'process', {
+      audioData: audio.buffer,
+      sampleRate: 48000,
+      params: { nrFloor: -60, nrAmount: 50 },
+      enabledModels: []
+    }, 2);
+    expect(r.msg.type).toBe('result');
+  });
+
+  test('process with all-zeros audio returns without error', async () => {
+    const { self: s, messages } = loadWorker();
+    await dispatch(s, messages, 'init', { sampleRate: 48000 }, 1);
+    messages.length = 0;
+    const audio = new Float32Array(8192); // all zeros
+    const [r] = await dispatch(s, messages, 'process', {
+      audioData: audio.buffer, sampleRate: 48000, params: null
+    }, 2);
+    expect(r.msg.type).toBe('result');
+  });
+
+  test('process with short (< fftSize) audio completes without error', async () => {
+    const { self: s, messages } = loadWorker();
+    await dispatch(s, messages, 'init', { sampleRate: 48000 }, 1);
+    messages.length = 0;
+    const audio = new Float32Array(512).fill(0.1); // shorter than fftSize=4096
+    const [r] = await dispatch(s, messages, 'process', {
+      audioData: audio.buffer, sampleRate: 48000, params: null
+    }, 2);
+    // Should not crash — STFT will have 0 frames; iSTFT returns empty buffer
+    expect(['result', 'error']).toContain(r.msg.type);
+  });
+});
+
+// ── loadModel ─────────────────────────────────────────────────────────────────
+
+describe('dsp-worker: loadModel', () => {
+  test('without ort available posts descriptive error', async () => {
+    const { self: s, messages } = loadWorker();
+    const [r] = await dispatch(s, messages, 'loadModel', {
+      modelName: 'vad', modelPath: '/models/silero_vad.onnx'
+    });
+    expect(r.msg.type).toBe('error');
+    expect(r.msg.error).toMatch(/onnxruntime/i);
+  });
+
+  test('with mock ort resolves successfully', async () => {
+    const { self: s, messages } = loadWorker();
+    s.ort = {
+      InferenceSession: {
+        create: jest.fn().mockResolvedValue({
+          inputNames: ['input'],
+          outputNames: ['output'],
+        }),
+      },
+    };
+    const [r] = await dispatch(s, messages, 'loadModel', {
+      modelName: 'test_model', modelPath: '/models/test.onnx'
+    });
+    expect(r.msg.type).toBe('result');
+    expect(r.msg.result.status).toBe('loaded');
+    expect(r.msg.result.modelName).toBe('test_model');
+    expect(r.msg.result.inputNames).toEqual(['input']);
+  });
+
+  test('ort.InferenceSession.create failure posts error', async () => {
+    const { self: s, messages } = loadWorker();
+    s.ort = {
+      InferenceSession: {
+        create: jest.fn().mockRejectedValue(new Error('model not found')),
+      },
+    };
+    const [r] = await dispatch(s, messages, 'loadModel', {
+      modelName: 'bad_model', modelPath: '/missing.onnx'
+    });
+    expect(r.msg.type).toBe('error');
+    expect(r.msg.error).toMatch(/model not found/);
+  });
+});
+
+// ── getMetrics / reset ────────────────────────────────────────────────────────
+
+describe('dsp-worker: getMetrics and reset', () => {
+  test('getMetrics before init returns empty object', async () => {
+    const { self: s, messages } = loadWorker();
+    const [r] = await dispatch(s, messages, 'getMetrics', {});
+    expect(r.msg.type).toBe('result');
+    expect(r.msg.result).toEqual({});
+  });
+
+  test('reset after init returns status=reset', async () => {
+    const { self: s, messages } = loadWorker();
+    await dispatch(s, messages, 'init', { sampleRate: 48000 }, 1);
+    messages.length = 0;
+    const [r] = await dispatch(s, messages, 'reset', {});
+    expect(r.msg.result.status).toBe('reset');
+  });
+
+  test('reset before init does not throw', async () => {
+    const { self: s, messages } = loadWorker();
+    const [r] = await dispatch(s, messages, 'reset', {});
+    expect(r.msg.type).toBe('result');
+  });
+});
+
+// ── demucs branch (enabled but no session) ───────────────────────────────────
+
+describe('dsp-worker: demucs graceful fallback', () => {
+  test('enabledModels includes demucs but session missing → falls back silently', async () => {
+    const { self: s, messages } = loadWorker();
+    await dispatch(s, messages, 'init', { sampleRate: 48000 }, 1);
+    messages.length = 0;
+    const audio = new Float32Array(8192).fill(0.1);
+    const [r] = await dispatch(s, messages, 'process', {
+      audioData: audio.buffer,
+      sampleRate: 48000,
+      params: null,
+      enabledModels: ['demucs'], // listed but not loaded
+    }, 2);
+    // Should fall back to classical DSP without error
+    expect(r.msg.type).toBe('result');
+  });
+});

--- a/tests/voice-isolate-processor.test.js
+++ b/tests/voice-isolate-processor.test.js
@@ -184,7 +184,7 @@ describe('VoiceIsolateProcessor._onMessage', () => {
   });
 
   test('initRingBuffers: posts error when inputSAB is too small', () => {
-    const tinyBuf = new SharedArrayBuffer ? (() => {
+    const tinyBuf = typeof SharedArrayBuffer !== 'undefined' ? (() => {
       try { return new SharedArrayBuffer(4); } catch { return null; }
     })() : null;
 

--- a/tests/voice-isolate-processor.test.js
+++ b/tests/voice-isolate-processor.test.js
@@ -1,0 +1,298 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+// ── AudioWorklet environment mock ─────────────────────────────────────────────
+const _registered = {};
+global.AudioWorkletProcessor = class AudioWorkletProcessor {
+  constructor() {
+    this.port = { postMessage: jest.fn(), onmessage: null };
+  }
+};
+global.registerProcessor = (name, cls) => { _registered[name] = cls; };
+global.sampleRate = 48000;
+
+// Load the processor file (defines HarmonicEnhancer, VoiceIsolateProcessor,
+// then calls registerProcessor at the bottom)
+const processorSrc = fs.readFileSync(
+  path.join(__dirname, '../public/app/voice-isolate-processor.js'), 'utf8'
+);
+eval(processorSrc); // eslint-disable-line no-eval
+
+const VoiceIsolateProcessor = _registered['voice-isolate-processor'];
+
+// Extract HarmonicEnhancer via the instance it creates inside the constructor
+const _sampleInst = new VoiceIsolateProcessor({});
+const HarmonicEnhancer = _sampleInst.harmonicEnhancer.constructor;
+
+// ── HarmonicEnhancer ──────────────────────────────────────────────────────────
+
+describe('HarmonicEnhancer', () => {
+  test('amount=0: enabled is false', () => {
+    const he = new HarmonicEnhancer(0);
+    expect(he.enabled).toBe(false);
+  });
+
+  test('amount=100: enabled is true, drive is 5', () => {
+    const he = new HarmonicEnhancer(100);
+    expect(he.enabled).toBe(true);
+    expect(he.drive).toBeCloseTo(5, 5);
+  });
+
+  test('processSample with amount=0 returns sample unchanged', () => {
+    const he = new HarmonicEnhancer(0);
+    expect(he.processSample(0.5)).toBe(0.5);
+    expect(he.processSample(-0.3)).toBe(-0.3);
+  });
+
+  test('processSample with amount>0 applies soft saturation', () => {
+    const he = new HarmonicEnhancer(50);
+    const out = he.processSample(0.5);
+    expect(Number.isFinite(out)).toBe(true);
+    expect(out).not.toBeCloseTo(0.5, 3);
+  });
+
+  test('processSample(0) returns 0 for any amount', () => {
+    for (const amt of [0, 25, 50, 100]) {
+      expect(new HarmonicEnhancer(amt).processSample(0)).toBeCloseTo(0, 6);
+    }
+  });
+
+  test('processSample preserves polarity', () => {
+    const he = new HarmonicEnhancer(50);
+    expect(he.processSample(0.3)).toBeGreaterThan(0);
+    expect(he.processSample(-0.3)).toBeLessThan(0);
+  });
+
+  test('setAmount clamps below 0 to 0', () => {
+    const he = new HarmonicEnhancer(50);
+    he.setAmount(-10);
+    expect(he.amount).toBe(0);
+    expect(he.enabled).toBe(false);
+  });
+
+  test('setAmount clamps above 100 to 100', () => {
+    const he = new HarmonicEnhancer(50);
+    he.setAmount(200);
+    expect(he.amount).toBe(100);
+  });
+
+  test('wetGain + dryGain sum to 1.0', () => {
+    const he = new HarmonicEnhancer(60);
+    expect(he.wetGain + he.dryGain).toBeCloseTo(1.0, 6);
+  });
+});
+
+// ── VoiceIsolateProcessor construction ───────────────────────────────────────
+
+describe('VoiceIsolateProcessor construction', () => {
+  test('instantiates without throwing', () => {
+    expect(() => new VoiceIsolateProcessor({})).not.toThrow();
+  });
+
+  test('default params are correct', () => {
+    const p = new VoiceIsolateProcessor({}).params;
+    expect(p.bypass).toBe(false);
+    expect(p.gateThresh).toBe(-42);
+    expect(p.dryWet).toBe(100);
+    expect(p.harmonicEnhance).toBe(0);
+    expect(p.outGain).toBe(0);
+  });
+
+  test('FFT_SIZE=4096, HOP_SIZE=1024, HALF_N=2049', () => {
+    const proc = new VoiceIsolateProcessor({});
+    expect(proc.FFT_SIZE).toBe(4096);
+    expect(proc.HOP_SIZE).toBe(1024);
+    expect(proc.HALF_N).toBe(2049);
+  });
+
+  test('accumulation buffers are 4× FFT_SIZE', () => {
+    const proc = new VoiceIsolateProcessor({});
+    expect(proc.inputAccum.length).toBe(proc.FFT_SIZE * 4);
+    expect(proc.outputAccum.length).toBe(proc.FFT_SIZE * 4);
+    expect(proc.outputWindowSum.length).toBe(proc.FFT_SIZE * 4);
+  });
+
+  test('all pointers start at 0', () => {
+    const proc = new VoiceIsolateProcessor({});
+    expect(proc.inputHead).toBe(0);
+    expect(proc.inputProcessed).toBe(0);
+    expect(proc.outputHead).toBe(0);
+    expect(proc.drainHead).toBe(0);
+    expect(proc.hopsSinceInit).toBe(0);
+  });
+
+  test('fft scratch buffers are FFT_SIZE long', () => {
+    const proc = new VoiceIsolateProcessor({});
+    expect(proc.fftReal.length).toBe(proc.FFT_SIZE);
+    expect(proc.fftImag.length).toBe(proc.FFT_SIZE);
+  });
+});
+
+// ── VoiceIsolateProcessor._onMessage ─────────────────────────────────────────
+
+describe('VoiceIsolateProcessor._onMessage', () => {
+  let proc;
+  beforeEach(() => { proc = new VoiceIsolateProcessor({}); });
+
+  test('param: updates a single known parameter', () => {
+    proc._onMessage({ type: 'param', key: 'gateThresh', value: -30 });
+    expect(proc.params.gateThresh).toBe(-30);
+  });
+
+  test('param: silently ignores unknown keys', () => {
+    expect(() => proc._onMessage({ type: 'param', key: 'nonexistent', value: 99 })).not.toThrow();
+    expect(proc.params.nonexistent).toBeUndefined();
+  });
+
+  test('param: harmonicEnhance also updates the HarmonicEnhancer', () => {
+    proc._onMessage({ type: 'param', key: 'harmonicEnhance', value: 75 });
+    expect(proc.harmonicEnhancer.amount).toBe(75);
+    expect(proc.harmonicEnhancer.enabled).toBe(true);
+  });
+
+  test('paramBulk: updates multiple params at once', () => {
+    proc._onMessage({ type: 'paramBulk', params: { gateThresh: -20, gateRange: -30, outGain: 3 } });
+    expect(proc.params.gateThresh).toBe(-20);
+    expect(proc.params.gateRange).toBe(-30);
+    expect(proc.params.outGain).toBe(3);
+  });
+
+  test('bypass: sets the bypass flag', () => {
+    proc._onMessage({ type: 'bypass', value: true });
+    expect(proc.params.bypass).toBe(true);
+    proc._onMessage({ type: 'bypass', value: false });
+    expect(proc.params.bypass).toBe(false);
+  });
+
+  test('initRingBuffers: resets all pointers to zero', () => {
+    proc.inputHead = 512;
+    proc.drainHead = 256;
+    proc._onMessage({ type: 'initRingBuffers', fftSize: 4096, hopSize: 1024 });
+    expect(proc.inputHead).toBe(0);
+    expect(proc.drainHead).toBe(0);
+    expect(proc.inputProcessed).toBe(0);
+    expect(proc.hopsSinceInit).toBe(0);
+  });
+
+  test('initRingBuffers: posts ready message', () => {
+    proc._onMessage({ type: 'initRingBuffers', fftSize: 4096, hopSize: 1024 });
+    expect(proc.port.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'ready', fftSize: 4096 })
+    );
+  });
+
+  test('initRingBuffers: posts error when inputSAB is too small', () => {
+    const tinyBuf = new SharedArrayBuffer ? (() => {
+      try { return new SharedArrayBuffer(4); } catch { return null; }
+    })() : null;
+
+    if (!tinyBuf) { expect(true).toBe(true); return; } // SAB not available in env
+
+    proc._onMessage({ type: 'initRingBuffers', fftSize: 4096, hopSize: 1024, inputSAB: tinyBuf });
+    expect(proc.port.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'error' })
+    );
+  });
+});
+
+// ── VoiceIsolateProcessor.process() ──────────────────────────────────────────
+
+describe('VoiceIsolateProcessor.process()', () => {
+  function mkBufs(size = 128, fill = 0.1) {
+    const inBuf = new Float32Array(size).fill(fill);
+    const outBuf = new Float32Array(size);
+    return { inputs: [[inBuf]], outputs: [[outBuf]], inBuf, outBuf };
+  }
+
+  test('returns true (keep-alive signal)', () => {
+    const proc = new VoiceIsolateProcessor({});
+    const { inputs, outputs } = mkBufs();
+    expect(proc.process(inputs, outputs)).toBe(true);
+  });
+
+  test('returns true when inputs/outputs are empty', () => {
+    const proc = new VoiceIsolateProcessor({});
+    expect(proc.process([[]], [[]])).toBe(true);
+  });
+
+  test('bypass mode: output == input', () => {
+    const proc = new VoiceIsolateProcessor({});
+    proc.params.bypass = true;
+    const { inputs, outputs, inBuf, outBuf } = mkBufs();
+    proc.process(inputs, outputs);
+    for (let i = 0; i < 128; i++) expect(outBuf[i]).toBe(inBuf[i]);
+  });
+
+  test('output is silent during latency window (hopsSinceInit < 4)', () => {
+    const proc = new VoiceIsolateProcessor({});
+    const { inputs, outputs, outBuf } = mkBufs(128, 0.5);
+    proc.process(inputs, outputs);
+    expect(outBuf.every(v => v === 0)).toBe(true);
+  });
+
+  test('inputHead advances by 128 each render', () => {
+    const proc = new VoiceIsolateProcessor({});
+    const { inputs, outputs } = mkBufs();
+    proc.process(inputs, outputs);
+    expect(proc.inputHead).toBe(128);
+    proc.process(inputs, outputs);
+    expect(proc.inputHead).toBe(256);
+  });
+
+  test('inputProcessed advances after HOP_SIZE samples are fed', () => {
+    const proc = new VoiceIsolateProcessor({});
+    const { inputs, outputs } = mkBufs();
+    // 8 × 128 = 1024 = HOP_SIZE
+    for (let i = 0; i < 8; i++) proc.process(inputs, outputs);
+    expect(proc.inputProcessed).toBeGreaterThanOrEqual(proc.HOP_SIZE);
+  });
+
+  test('output is finite after enough renders to exit latency window', () => {
+    const proc = new VoiceIsolateProcessor({});
+    const inBuf = new Float32Array(128).fill(0.3);
+    const outBuf = new Float32Array(128);
+    // Feed 40 quanta (40×128=5120 samples, well past 4× HOP latency)
+    for (let i = 0; i < 40; i++) proc.process([[inBuf]], [[outBuf]]);
+    for (const v of outBuf) expect(Number.isFinite(v)).toBe(true);
+  });
+});
+
+// ── VoiceIsolateProcessor._forwardSTFTFrame ───────────────────────────────────
+
+describe('VoiceIsolateProcessor._forwardSTFTFrame', () => {
+  let proc;
+  beforeEach(() => { proc = new VoiceIsolateProcessor({}); });
+
+  test('returns Float32Array of length HALF_N', () => {
+    const frame = Float32Array.from({ length: proc.FFT_SIZE }, () => Math.random() * 0.1);
+    const phase = proc._forwardSTFTFrame(frame);
+    expect(phase).toBeInstanceOf(Float32Array);
+    expect(phase.length).toBe(proc.HALF_N);
+  });
+
+  test('phase values are in [-π, π]', () => {
+    const frame = Float32Array.from({ length: proc.FFT_SIZE }, () => Math.random() - 0.5);
+    const phase = proc._forwardSTFTFrame(frame);
+    for (const p of phase) {
+      expect(p).toBeGreaterThanOrEqual(-Math.PI - 1e-6);
+      expect(p).toBeLessThanOrEqual(Math.PI + 1e-6);
+    }
+  });
+
+  test('zero-valued frame produces zero magnitudes in fftReal/fftImag', () => {
+    const frame = new Float32Array(proc.FFT_SIZE); // all zeros
+    proc._forwardSTFTFrame(frame);
+    // DC bin of a zero-input FFT is 0
+    expect(proc.fftReal[0]).toBeCloseTo(0, 6);
+  });
+});
+
+// ── parameterDescriptors ──────────────────────────────────────────────────────
+
+describe('VoiceIsolateProcessor.parameterDescriptors', () => {
+  test('is an empty array', () => {
+    expect(VoiceIsolateProcessor.parameterDescriptors).toEqual([]);
+  });
+});


### PR DESCRIPTION
- tests/dsp-core.test.js (148 tests): AdaptiveNoiseFloor, wienerFilter,
  getVoiceMaskGain, hannWindow, peakNormalize, truePeakLimit, deClip,
  stereoWiden, temporalSmooth, measureLUFS, encodeWAV, wienerMMSE,
  applyAdaptiveWiener, AdaptiveNoiseEstimator, MultibandWienerFilter,
  VADProcessor, classifyNoiseSpectral, removeClicks, harmonicEnhanceV2,
  STFT/iSTFT roundtrip, calcRMS/calcPeak

- tests/voice-isolate-processor.test.js (37 tests): HarmonicEnhancer
  (amount clamping, saturation, polarity) and VoiceIsolateProcessor
  (construction, _onMessage param/bypass/bulk/initRingBuffers,
  process bypass/latency/pointer advancement, _forwardSTFTFrame)

- tests/dsp-worker.test.js (17 tests): message routing, init/process/
  loadModel/getMetrics/reset handlers, ArrayBuffer transfer, demucs
  fallback when session is missing, ort absence error

- tests/batch-orchestrator.test.js (33 tests): constructor defaults,
  enqueue/enqueueMany priority sorting, getProgress, stop/cancel,
  _encodeWAV RIFF header correctness, start() lifecycle callbacks

- tests/batch-processor.test.js (41 tests): _normalize, _encodeWAV,
  _applyWatermark (via patched internals), event system (on/unsub/
  wildcard), pause/resume, addFiles with LicenseManager mocks,
  cancel/cancelAll, getStats/getQueue

https://claude.ai/code/session_01W5eLDaGg6wNSyaHkkWMPM8
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/joker5514/voiceisolate-pro/pull/392" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for batch orchestration, audio processing, DSP operations, worker processes, and voice isolation functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->