### PR TITLE
fix(ui): guard _uiScaleApply against missing document.documentElement

### DIFF
--- a/public/app/app.js
+++ b/public/app/app.js
@@ -601,7 +601,8 @@ class VoiceIsolatePro {
     const clamped = Math.max(this._uiScaleMin, Math.min(this._uiScaleMax, Math.round(s * 100) / 100));
     const isSavedScale = clamped === this._uiScaleSaved;
     this._uiScale = clamped;
-    document.documentElement.style.zoom = clamped === 1 ? '' : String(clamped);
+    const docEl = typeof document !== 'undefined' ? document.documentElement : null;
+    if (docEl && docEl.style) docEl.style.zoom = clamped === 1 ? '' : String(clamped);
     if (this.dom.uiScaleVal) this.dom.uiScaleVal.textContent = Math.round(clamped * 100) + '%';
     if (!isSavedScale && this._uiScaleSaveTimer) {
       clearTimeout(this._uiScaleSaveTimer);

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -601,7 +601,7 @@ class VoiceIsolatePro {
     const clamped = Math.max(this._uiScaleMin, Math.min(this._uiScaleMax, Math.round(s * 100) / 100));
     const isSavedScale = clamped === this._uiScaleSaved;
     this._uiScale = clamped;
-    const docEl = typeof document !== 'undefined' ? document.documentElement : null;
+    const docEl = document.documentElement;
     if (docEl && docEl.style) docEl.style.zoom = clamped === 1 ? '' : String(clamped);
     if (this.dom.uiScaleVal) this.dom.uiScaleVal.textContent = Math.round(clamped * 100) + '%';
     if (!isSavedScale && this._uiScaleSaveTimer) {


### PR DESCRIPTION
## Summary
- `_uiScaleApply` crashed with `TypeError: Cannot read properties of undefined (reading 'style')` when `document.documentElement` was unavailable, which aborted `VoiceIsolatePro` bootstrap (visible as `[app] Bootstrap failed:` in tests/dsp.test.js and similar partial-DOM environments).
- Added a null check for `document.documentElement` and its `.style` before assigning `zoom` in `public/app/app.js:604`.

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm validate` passes
- [x] `pnpm test` — all 40 suites / 1508 tests pass, previous `_uiScaleApply` bootstrap error no longer appears

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/joker5514/voiceisolate-pro/pull/393" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced application stability with conditional environment checks for improved robustness across various execution contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->