### PR TITLE
perf(pipeline): cut per-hop allocations and soften ML warmup mask

### DIFF
--- a/public/app/dsp-core.js
+++ b/public/app/dsp-core.js
@@ -196,7 +196,11 @@ const DSPCore = {
   forwardSTFT(data, fftSize = 4096, hopSize = 1024) {
     const window = this.hannWindow(fftSize);
     const halfN = fftSize / 2 + 1;
-    const frameCount = Math.floor((data.length - fftSize) / hopSize) + 1;
+    // Guard: clips in shorter than one FFT window produce 0 frames rather
+    // than a negative frameCount (which would have overflowed downstream).
+    const frameCount = data.length >= fftSize
+      ? Math.floor((data.length - fftSize) / hopSize) + 1
+      : 0;
     const mag = [];
     const phase = [];
 

--- a/public/app/ml-worker.js
+++ b/public/app/ml-worker.js
@@ -690,7 +690,12 @@ async function buildMask(magnitudes, pcmChunk = null) {
 
   if (!warmupComplete) {
     updateNoiseProfile(magnitudes);
-    mask.fill(0);
+    // Ramp mask from near-silence up to full passthrough over the warmup
+    // window instead of clamping to 0. Users previously heard ~1.8s of dead
+    // silence before the noise profile was considered converged.
+    const ramp = Math.min(1, noiseFrames / NOISE_WARMUP_FRAMES);
+    const rampGain = 0.05 + 0.95 * ramp * ramp;
+    for (let k = 0; k < numBins; k++) mask[k] *= rampGain;
     return mask;
   }
 

--- a/public/app/voice-isolate-processor.js
+++ b/public/app/voice-isolate-processor.js
@@ -148,6 +148,13 @@ class VoiceIsolateProcessor extends AudioWorkletProcessor {
     this.fftReal = new Float32Array(this.FFT_SIZE);
     this.fftImag = new Float32Array(this.FFT_SIZE);
 
+    // Hot-path scratch buffers — reused every hop to avoid ~600KB/s GC churn
+    // at 48kHz/1024-hop. Resized together with fftReal/fftImag when FFT_SIZE
+    // is renegotiated via 'initRingBuffers'.
+    this._frameScratch    = new Float32Array(this.FFT_SIZE);
+    this._phaseScratch    = new Float32Array(this.HALF_N);
+    this._fallbackMagScratch = new Float32Array(this.HALF_N);
+
     // Hann window (precomputed)
     this.window = hannWindow(this.FFT_SIZE);
 
@@ -190,6 +197,9 @@ class VoiceIsolateProcessor extends AudioWorkletProcessor {
         this.window   = hannWindow(this.FFT_SIZE);
         this.fftReal  = new Float32Array(this.FFT_SIZE);
         this.fftImag  = new Float32Array(this.FFT_SIZE);
+        this._frameScratch       = new Float32Array(this.FFT_SIZE);
+        this._phaseScratch       = new Float32Array(this.HALF_N);
+        this._fallbackMagScratch = new Float32Array(this.HALF_N);
         // Re-size accumulation buffers if FFT_SIZE changed
         this.inputAccum      = new Float32Array(this.FFT_SIZE * 4);
         this.outputAccum     = new Float32Array(this.FFT_SIZE * 4);
@@ -255,8 +265,9 @@ class VoiceIsolateProcessor extends AudioWorkletProcessor {
   // ─── Single Forward STFT Frame ─────────────────────────────────────────
   // Populates fftReal[] and fftImag[] via in-place FFT.
   // Writes HALF_N magnitudes then HALF_N phases into inputSAB.
-  // Returns a NEW Float32Array containing the phase values so the caller
-  // can reconstruct the spectrum after iFFT clobbers fftReal/fftImag.
+  // Returns the cached phase scratch buffer so the caller can reconstruct
+  // the spectrum after iFFT clobbers fftReal/fftImag. The buffer is owned
+  // by the processor and must be consumed before the next STFT frame.
   _forwardSTFTFrame(audioData) {
     const N = this.FFT_SIZE;
     const halfN = this.HALF_N;
@@ -264,21 +275,30 @@ class VoiceIsolateProcessor extends AudioWorkletProcessor {
     const imag = this.fftImag;
     const w    = this.window;
 
-    for (let i = 0; i < N; i++) {
-      real[i] = (i < audioData.length) ? audioData[i] * w[i] : 0;
+    const audioLen = audioData.length;
+    const copyLen  = audioLen < N ? audioLen : N;
+    for (let i = 0; i < copyLen; i++) {
+      real[i] = audioData[i] * w[i];
+      imag[i] = 0;
+    }
+    for (let i = copyLen; i < N; i++) {
+      real[i] = 0;
       imag[i] = 0;
     }
 
     // ── SINGLE FORWARD FFT ──
     fft(real, imag, false);
 
-    const phase = new Float32Array(halfN);
+    const phase = this._phaseScratch;
     if (this.inputSAB) {
       for (let k = 0; k < halfN; k++) {
-        const mag = Math.sqrt(real[k] * real[k] + imag[k] * imag[k]);
+        const re = real[k];
+        const im = imag[k];
+        const mag = Math.sqrt(re * re + im * im);
+        const ph  = Math.atan2(im, re);
         this.inputSAB[k]         = mag;
-        this.inputSAB[halfN + k] = Math.atan2(imag[k], real[k]);
-        phase[k]                 = this.inputSAB[halfN + k];
+        this.inputSAB[halfN + k] = ph;
+        phase[k]                 = ph;
       }
       Atomics.store(this.ctrlIn, 2, 1);
       Atomics.notify(this.ctrlIn, 2, 1);
@@ -358,14 +378,16 @@ class VoiceIsolateProcessor extends AudioWorkletProcessor {
     // [BUG 1 FIX] Use inputProcessed (not outputHead/outputTail) to track
     // how many samples have been fed through the STFT pipeline.
     while (this.inputHead - this.inputProcessed >= this.HOP_SIZE) {
-      // Gather newest FFT_SIZE samples (the analysis frame)
-      const frame = new Float32Array(this.FFT_SIZE);
-      const base  = this.inputProcessed + this.HOP_SIZE - this.FFT_SIZE;
-
-      for (let i = 0; i < this.FFT_SIZE; i++) {
-        frame[i] = (base + i >= 0)
-          ? this.inputAccum[(base + i) % accumLen]
-          : 0;
+      // Gather newest FFT_SIZE samples (the analysis frame) into a reusable
+      // scratch buffer. Splitting into three regions removes a per-sample
+      // branch on (base + i >= 0).
+      const frame = this._frameScratch;
+      const N     = this.FFT_SIZE;
+      const base  = this.inputProcessed + this.HOP_SIZE - N;
+      const zeroPrefix = base < 0 ? -base : 0;
+      for (let i = 0; i < zeroPrefix; i++) frame[i] = 0;
+      for (let i = zeroPrefix; i < N; i++) {
+        frame[i] = this.inputAccum[(base + i) % accumLen];
       }
 
       // [ORDER LOCK — Bug 2]: _forwardSTFTFrame populates fftReal/fftImag.
@@ -374,12 +396,11 @@ class VoiceIsolateProcessor extends AudioWorkletProcessor {
       const fwdPhase = this._forwardSTFTFrame(frame);
 
       const halfN = this.HALF_N;
-      const fallbackMag = new Float32Array(halfN);
+      const fallbackMag = this._fallbackMagScratch;
       for (let k = 0; k < halfN; k++) {
-        fallbackMag[k] = Math.sqrt(
-          this.fftReal[k] * this.fftReal[k] +
-          this.fftImag[k] * this.fftImag[k]
-        );
+        const re = this.fftReal[k];
+        const im = this.fftImag[k];
+        fallbackMag[k] = Math.sqrt(re * re + im * im);
       }
       // fftReal/fftImag may now be safely overwritten by iFFT below.
 

--- a/tests/dsp-core.test.js
+++ b/tests/dsp-core.test.js
@@ -717,6 +717,14 @@ describe('DSPCore STFT/iSTFT roundtrip', () => {
     const expected = Math.floor((48000 - 4096) / 1024) + 1;
     expect(frameCount).toBe(expected);
   });
+
+  test('short clips smaller than fftSize produce zero frames with empty spectra', () => {
+    const data = new Float32Array(1024);
+    const { frameCount, mag, phase } = DSPCore.forwardSTFT(data, 4096, 1024);
+    expect(frameCount).toBe(0);
+    expect(mag).toEqual([]);
+    expect(phase).toEqual([]);
+  });
 });
 
 // ── calcRMS / calcPeak ────────────────────────────────────────────────────────

--- a/tests/ml-worker.test.js
+++ b/tests/ml-worker.test.js
@@ -183,6 +183,44 @@ describe('ml-worker.js', () => {
 
     await workerGlobal.self.onmessage({ data: { type: 'reset' } });
   });
+
+  it('applies non-zero warmup mask floor and ramps up during noise-profile warmup', async () => {
+    const vadRun = jest.fn().mockResolvedValue({ output: { data: new Float32Array([0.75]) } });
+    workerGlobal.self.ort.InferenceSession.create.mockResolvedValue({ run: vadRun });
+
+    await workerGlobal.self.onmessage({
+      data: {
+        type: 'init',
+        payload: {
+          allowedModels: ['vad'],
+          preferredProviders: ['wasm'],
+          modelBasePath: './models/',
+        },
+      },
+    });
+
+    const magnitudes = new Float32Array(16).fill(0.2);
+    const gains = [];
+    const sampleFrames = new Set([1, 45, 90]);
+
+    for (let frame = 1; frame <= 90; frame++) {
+      await workerGlobal.self.onmessage({ data: { type: 'process', payload: { magnitudes } } });
+      if (sampleFrames.has(frame)) {
+        const processed = postedMessages.filter((m) => m.type === 'processed').at(-1);
+        gains.push({ frame, gain: processed.output[0] });
+      }
+    }
+
+    const gainAt = (frame) => gains.find((g) => g.frame === frame).gain;
+    const expectedGain = (frame) => 0.05 + 0.95 * Math.pow(frame / 90, 2);
+
+    expect(gainAt(1)).toBeGreaterThanOrEqual(0.05);
+    expect(gainAt(1)).toBeLessThan(gainAt(45));
+    expect(gainAt(45)).toBeLessThan(gainAt(90));
+    expect(gainAt(1)).toBeCloseTo(expectedGain(1), 6);
+    expect(gainAt(45)).toBeCloseTo(expectedGain(45), 6);
+    expect(gainAt(90)).toBeCloseTo(1, 6);
+  });
 });
 
 // ============================================================


### PR DESCRIPTION
## Summary

Three targeted fixes to the 32-stage Deca-Pass processing pipeline, focused on realtime hot-path performance and correctness edge cases.

- **`public/app/voice-isolate-processor.js`** — The AudioWorklet `process()` loop was allocating three `Float32Array`s every hop (`frame` @ FFT_SIZE, `phase` @ HALF_N, `fallbackMag` @ HALF_N). At 48kHz with a 1024-sample hop that's ~47 allocations/s × ~20KB each ≈ 600KB/s of GC churn in the audio-rendering thread. Hoisted all three onto the processor instance as `_frameScratch`, `_phaseScratch`, `_fallbackMagScratch`, reuse each hop, and resize alongside `fftReal`/`fftImag` when FFT_SIZE is renegotiated via `initRingBuffers`. Also split the circular-frame copy into a zero-prefix region and a main region so the per-sample `base + i >= 0` branch inside the inner loop is gone.
- **`public/app/dsp-core.js`** — `forwardSTFT` computed `frameCount = floor((data.length - fftSize) / hopSize) + 1`, which goes negative for clips shorter than one analysis window and silently corrupts downstream consumers (empty-array loops, NaN propagation). Clamp to 0 when `data.length < fftSize` so short clips simply return empty `mag`/`phase` arrays.
- **`public/app/ml-worker.js`** — During the ~1.8s noise-profile warmup the mask was being hard-zeroed, so users heard dead silence for the opening of every session. Replaced with a quadratic ramp from a 5% floor up to unity across the warmup window — the noise profile still converges on the same frames, but the output stays audible while it does.

## Test plan

- [x] `pnpm validate` — all 32-stage structural checks pass
- [x] `pnpm lint` — clean
- [x] `pnpm test` — all 40 suites / 1508 tests pass (`tests/voice-isolate-processor.test.js`, `tests/dsp-core.test.js`, `tests/dsp.test.js`, `tests/ml-worker.test.js` all green)
- [ ] Smoke-test live mode in a browser — confirm the opening ~2s of a capture is no longer silent and that CPU usage in the audio thread is lower per the DevTools performance tab

https://claude.ai/code/session_017cXueBZikCg32KdKupPqzh
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/joker5514/voiceisolate-pro/pull/394" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Short audio inputs now produce zero frames instead of negative frame counts.

* **Performance**
  * Reduced per-frame heap allocations by reusing scratch buffers in the real-time audio pipeline.
  * Noise-profile warmup now preserves existing mask values and applies a smooth quadratic gain ramp.

* **Tests**
  * Added roundtrip test for sub-FFT-size inputs and a test verifying the warmup gain ramp.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->