### PR TITLE
fix: strengthen default NR + voice-isolation params so background noise is actually removed

### DIFF
--- a/public/app/app.js
+++ b/public/app/app.js
@@ -20,7 +20,7 @@ function structuredLog(level, msg, data = {}) {
 // ---- SLIDER DEFINITIONS (52 total) ----
 const SLIDERS = {
   gate: [
-    { id:'gateThresh', label:'Threshold', min:-80, max:-5, val:-42, step:1, unit:' dB', rt:true, desc:'Signal level below which the gate closes. Lower values let quieter sounds through.' },
+    { id:'gateThresh', label:'Threshold', min:-80, max:-5, val:-55, step:1, unit:' dB', rt:true, desc:'Signal level below which the gate closes. Lower values let quieter sounds (whispers) through.' },
     { id:'gateRange', label:'Range', min:-90, max:0, val:-40, step:1, unit:' dB', rt:false, desc:'Maximum attenuation when gate is closed. -90dB = full silence, -20dB = gentle reduction.' },
     { id:'gateAttack', label:'Attack', min:0.1, max:50, val:2, step:0.1, unit:' ms', rt:true, desc:'How fast the gate opens when signal exceeds threshold.' },
     { id:'gateRelease', label:'Release', min:5, max:500, val:80, step:1, unit:' ms', rt:true, desc:'How fast the gate closes after signal drops below threshold.' },
@@ -28,11 +28,11 @@ const SLIDERS = {
     { id:'gateLookahead', label:'Lookahead', min:0, max:20, val:5, step:0.5, unit:' ms', rt:false, desc:'Pre-delay allowing the gate to open before transients arrive.' },
   ],
   nr: [
-    { id:'nrAmount', label:'Reduction Amount', min:0, max:100, val:55, step:1, unit:'%', rt:false, desc:'How much noise is removed. 40-60% is usually optimal.' },
-    { id:'nrSensitivity', label:'Sensitivity', min:0, max:100, val:50, step:1, unit:'%', rt:false, desc:'How aggressively noise is detected.' },
-    { id:'nrSpectralSub', label:'Spectral Subtract', min:0, max:100, val:40, step:1, unit:'%', rt:false, desc:'Subtracts estimated noise spectrum from signal.' },
-    { id:'nrFloor', label:'Noise Floor', min:-80, max:-20, val:-60, step:1, unit:' dB', rt:false, desc:'Estimated noise floor level.' },
-    { id:'nrSmoothing', label:'Smoothing', min:0, max:100, val:35, step:1, unit:'%', rt:false, desc:'Temporal smoothing of noise estimate.' },
+    { id:'nrAmount', label:'Reduction Amount', min:0, max:100, val:78, step:1, unit:'%', rt:false, desc:'How much noise is removed. 70-85% for voice/whisper isolation in noisy environments.' },
+    { id:'nrSensitivity', label:'Sensitivity', min:0, max:100, val:72, step:1, unit:'%', rt:false, desc:'How aggressively noise is detected.' },
+    { id:'nrSpectralSub', label:'Spectral Subtract', min:0, max:100, val:62, step:1, unit:'%', rt:false, desc:'Subtracts estimated noise spectrum from signal.' },
+    { id:'nrFloor', label:'Noise Floor', min:-80, max:-20, val:-55, step:1, unit:' dB', rt:false, desc:'Estimated noise floor level.' },
+    { id:'nrSmoothing', label:'Smoothing', min:0, max:100, val:45, step:1, unit:'%', rt:false, desc:'Temporal smoothing of noise estimate.' },
   ],
   eq: [
     { id:'eqSub', label:'Sub (40 Hz)', min:-12, max:6, val:-8, step:0.5, unit:' dB', rt:true, desc:'Sub-bass. Cut to remove rumble.' },
@@ -75,8 +75,8 @@ const SLIDERS = {
     { id:'phaseCorr', label:'Phase Correction', min:0, max:100, val:0, step:1, unit:'%', rt:false, desc:'Corrects phase issues between stereo channels.' },
   ],
   sep: [
-    { id:'voiceIso', label:'Voice Isolation', min:0, max:100, val:70, step:1, unit:'%', rt:false, desc:'Strength of voice/non-voice separation.' },
-    { id:'bgSuppress', label:'Background Suppress', min:0, max:100, val:50, step:1, unit:'%', rt:false, desc:'Attenuation of non-voice background.' },
+    { id:'voiceIso', label:'Voice Isolation', min:0, max:100, val:88, step:1, unit:'%', rt:false, desc:'Strength of voice/non-voice separation.' },
+    { id:'bgSuppress', label:'Background Suppress', min:0, max:100, val:80, step:1, unit:'%', rt:false, desc:'Attenuation of non-voice background.' },
     { id:'voiceFocusLo', label:'Voice Focus Low', min:80, max:500, val:120, step:5, unit:' Hz', rt:true, desc:'Lower bound of voice focus band.' },
     { id:'voiceFocusHi', label:'Voice Focus High', min:2000, max:12000, val:6000, step:100, unit:' Hz', rt:true, desc:'Upper bound of voice focus band.' },
     { id:'crosstalkCancel', label:'Crosstalk Cancel', min:0, max:100, val:0, step:1, unit:'%', rt:false, desc:'Reduces bleed between speakers.' },

--- a/public/app/dsp-core.js
+++ b/public/app/dsp-core.js
@@ -115,8 +115,8 @@ class AdaptiveNoiseFloor {
 // Frequency-dependent boosting belongs in a separate post-stage (see voice mask),
 // not baked into the Wiener gain, where >1 multipliers re-introduce noise and clip.
 function wienerFilter(noiseMag, signalMag, params = {}) {
-  const alphaRaw = Number.isFinite(params.noiseOverSubtract) ? params.noiseOverSubtract : 1.2; // mild over-subtraction (was 2.0 — caused hollow voice)
-  const betaRaw = Number.isFinite(params.spectralFloor) ? params.spectralFloor : 0.02;         // -34 dB floor prevents musical noise (was 0.001)
+  const alphaRaw = Number.isFinite(params.noiseOverSubtract) ? params.noiseOverSubtract : 1.5; // moderate over-subtraction — balances audible NR vs. hollow voice
+  const betaRaw = Number.isFinite(params.spectralFloor) ? params.spectralFloor : 0.008;        // -42 dB floor — suppresses residual noise without musical artifacts
   const alpha = Math.max(1e-6, alphaRaw);
   const beta = Math.min(1.0, Math.max(0.0, betaRaw));
 

--- a/public/app/dsp-processor.js
+++ b/public/app/dsp-processor.js
@@ -216,18 +216,18 @@ class DSPProcessor extends AudioWorkletProcessor {
     // Mirrors the 52-slider SLIDER_MAP keys that are relevant to live mode
     this._params = {
       // Gate
-      gateThresh:      -42,    // dB
+      gateThresh:      -55,    // dB  (low enough to pass whispers)
       gateRange:       -40,    // dB  (attenuation when gate closed)
       gateAttack:        2,    // ms
       gateRelease:      80,    // ms
       gateHold:         20,    // ms
       gateLookahead:     5,    // ms (lookahead ring buffer)
-      // NR
-      nrAmount:         55,    // %
-      nrSensitivity:    50,    // %
-      nrSpectralSub:    40,    // %
-      nrFloor:         -60,    // dB
-      nrSmoothing:      35,    // %
+      // NR — tuned for voice/whisper isolation against noisy backgrounds
+      nrAmount:         78,    // %
+      nrSensitivity:    72,    // %
+      nrSpectralSub:    62,    // %
+      nrFloor:         -55,    // dB
+      nrSmoothing:      45,    // %
       // De-ess
       deEssFreq:      7000,    // Hz
       deEssAmt:         30,    // %
@@ -236,8 +236,8 @@ class DSPProcessor extends AudioWorkletProcessor {
       // Voice focus
       voiceFocusLo:    120,    // Hz
       voiceFocusHi:   6000,    // Hz
-      voiceIso:         70,    // %
-      bgSuppress:       50,    // %
+      voiceIso:         88,    // %
+      bgSuppress:       80,    // %
       // Harmonic enhance
       harmRecov:        20,    // %
       harmOrder:         3,    // x
@@ -247,8 +247,8 @@ class DSPProcessor extends AudioWorkletProcessor {
       // Misc
       humReduce:        50,    // %
       vadThreshold:  0.005,
-      noiseOverSubtract: 1.2,
-      spectralFloor: 0.02,
+      noiseOverSubtract: 1.5,  // stronger over-subtraction for audible NR
+      spectralFloor: 0.008,    // -42 dB floor — suppresses residual noise without musical artifacts
       bypass:        false,
     };
     this._rebuildFilters(this._sampleRate);


### PR DESCRIPTION
## Summary

Out-of-box defaults were tuned for "subtle cleanup" rather than voice isolation — steady-state background noise was only attenuated a few dB, so users heard the noise instead of the voice/whisper the product is meant to isolate.

This PR raises the shipped defaults to values that actually suppress background noise while staying below the `Forensic Extract` / `Surveillance` preset strength (so presets remain meaningfully different).

### Changes

**`public/app/app.js`** — SLIDERS defaults:
| Slider | Before | After |
| --- | --- | --- |
| `gateThresh` | -42 dB | **-55 dB** (pass whispers) |
| `nrAmount` | 55 % | **78 %** |
| `nrSensitivity` | 50 % | **72 %** |
| `nrSpectralSub` | 40 % | **62 %** |
| `nrFloor` | -60 dB | **-55 dB** |
| `nrSmoothing` | 35 % | **45 %** |
| `voiceIso` | 70 % | **88 %** |
| `bgSuppress` | 50 % | **80 %** |

**`public/app/dsp-processor.js`** — AudioWorklet `_params` defaults mirror the SLIDERS changes, plus:
- `noiseOverSubtract`: 1.2 → **1.5** (audible over-subtraction)
- `spectralFloor`: 0.02 → **0.008** (-42 dB floor — suppresses residual noise without musical-noise artifacts)

**`public/app/dsp-core.js`** — `wienerFilter()` fallback defaults bumped to `noiseOverSubtract=1.5`, `spectralFloor=0.008` so offline and real-time paths agree when params are omitted.

### Why these numbers

- `spectralFloor=0.02` (-34 dB) was clamping Wiener gain too high, preserving residual noise. 0.008 (-42 dB) is aggressive enough to be audible but well above the 0.001 / 0.005 range where musical-noise artifacts start to dominate.
- `nrAmount=55%` × `nrSpectralSub=40%` was producing a combined β≈2.4 — half the strength used by `Voice Clarity` (82%) and well below `Forensic Extract` (95%). 78% × 62% brings the default into the "useful for real-world noisy input" band without crossing into forensic territory.
- `voiceIso=70%` / `bgSuppress=50%` gave ~1.35× voice boost and ~47% background attenuation. 88% / 80% gives ~1.44× boost and ~76% attenuation — clearly audible isolation.
- `gateThresh=-42 dB` was cutting off quiet voices/whispers. -55 dB matches `Live Performance` and still rejects room tone.

### Preset invariants preserved

- `Forensic Extract` still has the highest `voiceIso` (98) and `nrAmount` (95)
- `Surveillance` still has `nrAmount ≥ 88` (90)
- `Live Performance` still has lower `nrAmount` than `Forensic Extract`

## Test plan

- [x] `pnpm test` — 1517 tests across 41 suites, all passing
- [x] `pnpm lint` — clean
- [x] `pnpm validate` — structural checks pass
- [ ] Manual listen-test: load a noisy sample (fan/traffic/room tone), verify the default (un-preset) output has perceptibly less background noise and intelligible voice/whisper
- [ ] Verify the `Voice Clarity` and `Forensic Extract` presets still sound more aggressive than the new default (relative ordering preserved)
- [ ] Verify `Music Vocal` preset (which intentionally uses lower NR) is not clobbered — it sets its own values so defaults don't apply

https://claude.ai/code/session_0148L4X2XGpT95y8jHq94fm6
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/joker5514/voiceisolate-pro/pull/397" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced system sensitivity to reliably detect quiet and whispered speech with optimized threshold settings
  * Strengthened default noise reduction strength across all noise suppression controls for better clarity
  * Improved voice isolation and background suppression capabilities for noticeably clearer audio output
  * Optimized spectral noise attenuation for more aggressive and effective background noise reduction

<!-- end of auto-generated comment: release notes by coderabbit.ai -->