### PR TITLE
chore(audit): sync version + pipeline claims, tighten validator

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,13 +6,15 @@ This file provides AI assistants with everything needed to navigate, understand,
 
 ## Project Overview
 
-**VoiceIsolate Pro** (v23.1) is a **browser-based, 100% local audio processing platform** for professional voice isolation and audio enhancement. Key attributes:
+**VoiceIsolate Pro** (v24.0.0) is a **browser-based, 100% local audio processing platform** for professional voice isolation and audio enhancement. Key attributes:
 
 - **Zero cloud processing**: All audio is processed on-device using Web Audio API + ONNX Runtime Web
 - **Privacy-first**: No telemetry, no external API calls during audio processing
 - **32-Stage Deca-Pass Pipeline**: Advanced DSP + hybrid ML (10 passes, 32 stages total)
 - **Cross-platform**: Web (Vercel), native Android (API 23+), native iOS (14.1+) via Capacitor 7
 - **Engineer Mode UI**: 52 sliders across 8 tabs, 6-panel diagnostics, 3D spectrogram visualization
+
+> Canonical version lives in `package.json#version`. `server.js` reads it from `package.json` at startup; when bumping the version, update `package.json`, `README.md`, this file, `capacitor.config.json`, and the `mobile:version` script together.
 
 ---
 
@@ -118,11 +120,21 @@ These are non-negotiable architectural rules enforced by `scripts/validate.js` a
 
 ### 1. Single-Pass Spectral Architecture
 
-The pipeline has **exactly one forward STFT** (Stage 10) and **exactly one iSTFT** (Stage 20). All spectral operations (noise reduction, voice separation, EQ, etc.) occur **in-place** between these two transforms. Never add a second STFT/iSTFT pair.
+**Within any single processing path**, there is exactly one forward STFT and one iSTFT, with all spectral operations (noise reduction, voice separation, EQ, etc.) occurring **in-place** between them. Never add a second STFT/iSTFT pair to the same path.
 
 ```
 [Time Domain] → STFT (Stage 10) → [Spectral Ops Stages 11–19] → iSTFT (Stage 20) → [Time Domain]
 ```
+
+There are three independent processing paths, each honoring this rule:
+
+| Path | STFT call | iSTFT call |
+|------|-----------|------------|
+| Offline main thread | `app.js` → `DSP.forwardSTFT` | `app.js` → `DSP.inverseSTFT` |
+| Offline worker pool | `dsp-worker.js` → `dspCore.forwardSTFT` | `dsp-worker.js` → `dspCore.inverseSTFT` |
+| Real-time AudioWorklet | `voice-isolate-processor.js` → `_forwardSTFTFrame` | `voice-isolate-processor.js` → `_inverseSTFTFrame` |
+
+Both implementations live in `public/app/dsp-core.js` (`forwardSTFT`/`inverseSTFT`) — do not fork additional copies.
 
 ### 2. AudioWorklet Ownership
 
@@ -183,7 +195,20 @@ All 52 sliders are defined in `app.js` as the `SLIDERS` array. Each slider objec
 }
 ```
 
-Sliders are organized into 8 tabs: Gate, Noise Reduction, EQ, Compression, Reverb/Echo, Stereo, Loudness, Advanced.
+Sliders are organized into 8 tab groups in the `SLIDERS` object:
+
+| Key    | Sliders | Purpose                                                  |
+|--------|---------|----------------------------------------------------------|
+| `gate` | 6       | Threshold, range, attack/release/hold, lookahead         |
+| `nr`   | 5       | Spectral noise reduction amount/sensitivity/floor/smoothing |
+| `eq`   | 10      | 10-band parametric EQ (Sub/Bass/Warmth/.../Brilliance)   |
+| `dyn`  | 8       | Compressor + brickwall limiter                           |
+| `spec` | 8       | HP/LP filters, de-esser, spectral tilt, formant shift    |
+| `adv`  | 6       | Dereverb, harmonic recovery, stereo width, phase correction |
+| `sep`  | 5       | Voice isolation, background suppress, focus band, crosstalk |
+| `out`  | 4       | Output gain, dry/wet, dither, output width               |
+
+Total: 6 + 5 + 10 + 8 + 8 + 6 + 5 + 4 = **52** (enforced by `scripts/validate.js` and `tests/sliders.test.js`).
 
 **When adding a new slider**:
 1. Add the object to `SLIDERS` in `app.js`
@@ -195,8 +220,8 @@ Sliders are organized into 8 tabs: Gate, Noise Reduction, EQ, Compression, Rever
 
 ## Preset System
 
-7 named presets defined in `app.js` as the `PRESETS` object:
-- `Podcast`, `Film`, `Interview`, `Forensic`, `Music`, `Broadcast`, `Restoration`
+8 named presets defined in `app.js` as the `PRESETS` object:
+- `Voice Clarity`, `Podcast Clean`, `Forensic Extract`, `Music Vocal`, `Whisper Boost`, `Phone/Radio`, `Live Performance`, `Surveillance`
 
 Each preset must define a value for **all 52 slider IDs**. The test `tests/presets.test.js` validates completeness. Applied via `applyPreset(presetName)`.
 
@@ -381,17 +406,19 @@ Node 24 + pnpm 9.0.0 on `ubuntu-latest`.
 
 ## Key Files Quick Reference
 
+Sizes are approximate; authoritative counts come from `wc -c`.
+
 | File | Size | Purpose |
 |------|------|---------|
-| `public/app/app.js` | 113KB | Main orchestrator: slider defs, presets, UI, transport |
-| `public/app/dsp-core.js` | 47KB | Pure DSP math: STFT, filters, spectral algorithms |
-| `public/app/pipeline-orchestrator.js` | 21KB | 36-stage Deca-Pass runner, AudioWorklet + ML worker init |
-| `public/app/pipeline-state.js` | 19KB | Centralized state, event bus |
-| `public/app/ml-worker.js` | 28KB | ONNX inference worker (Demucs, BSRNN, VAD) |
-| `public/app/ml-worker-fetch-cache.js` | 24KB | Model caching via IndexedDB |
-| `public/app/voice-isolate-processor.js` | 15KB | AudioWorklet real-time processor |
-| `public/app/batch-processor.js` | 14KB | Multi-file batch queue |
-| `public/app/visuals.js` | 20KB | Three.js 3D spectrogram |
+| `public/app/app.js` | ~128KB | Main orchestrator: slider defs, presets, UI, transport |
+| `public/app/dsp-core.js` | ~52KB | Pure DSP math: STFT, filters, spectral algorithms |
+| `public/app/pipeline-orchestrator.js` | ~29KB | 32-stage Deca-Pass runner, AudioWorklet + ML worker init |
+| `public/app/pipeline-state.js` | ~19KB | Centralized state, event bus |
+| `public/app/ml-worker.js` | ~32KB | ONNX inference worker (Demucs, BSRNN, VAD) |
+| `public/app/ml-worker-fetch-cache.js` | ~24KB | Model caching via IndexedDB |
+| `public/app/voice-isolate-processor.js` | ~19KB | AudioWorklet real-time processor |
+| `public/app/batch-processor.js` | ~14KB | Multi-file batch queue |
+| `public/app/visuals.js` | ~19KB | Three.js 3D spectrogram |
 | `server.js` | — | Express dev server with required COOP/COEP headers |
 | `api/monetization.js` | — | Stripe checkout, JWT license generation |
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # VoiceIsolate Pro · v24.0
 
-> **Browser-based, 100% local, 40-stage audio processing platform.**
+> **Browser-based, 100% local, 32-stage audio processing platform.**
 > Zero cloud. Zero telemetry. Privacy-first.
 
 [![Deploy](https://img.shields.io/badge/Vercel-live-brightgreen?logo=vercel)](https://voice-isolate-pro.vercel.app)
 [![Version](https://img.shields.io/badge/version-v24.0-blue)](#changelog)
-[![Pipeline](https://img.shields.io/badge/pipeline-40--stage-purple)](#pipeline)
+[![Pipeline](https://img.shields.io/badge/pipeline-32--stage-purple)](#pipeline)
 [![License](https://img.shields.io/badge/license-PROPRIETARY-red)](LICENSE)
 
 ---
@@ -33,22 +33,20 @@
 ┌─────────────────────────────────────────────────────────────┐
 │          PipelineOrchestrator (pipeline-orchestrator.js)    │
 │  ┌─ Single-Pass STFT (Critical for phase coherence)        │
-│  │  Forward FFT → 40-stage spectral ops (in-place)         │
-│  │  → Inverse iFFT → Overlap-Add                            │
+│  │  Forward FFT (S10) → spectral ops in-place (S11–S19)    │
+│  │  → Inverse iFFT (S20) → Overlap-Add                      │
 │  │                                                           │
-│  └─ 12 Passes, 40 Stages (Dodeca-Pass):                    │
-│     Pass  1: Ingestion & Normalization (S1–S4)             │
-│     Pass  2: Analysis & Classification (S5–S8)             │
-│     Pass  3: Classical DSP Annihilation (S9–S14)           │
-│     Pass  4: ML Source Separation (S15–S19)                │
-│     Pass  5: Spectral Refinement (S20–S22)                 │
-│     Pass  6: Room Correction (S23–S26)                     │
-│     Pass  7: Time-Domain Polish (S27–S29)                  │
-│     Pass  8: Neural Reconstruction (S30–S33)               │
-│     Pass  9: Stereo Recovery & Spatial (S34–S35)           │
-│     Pass 10: Perceptual QA (S36–S37)                       │
-│     Pass 11: Forensic Certification (S38)                  │
-│     Pass 12: Output Mastering (S39–S40)                    │
+│  └─ 10 Passes, 32 Stages (Deca-Pass):                      │
+│     Pass  1: Input & Normalization (S01–S04)               │
+│     Pass  2: Pre-Spectral Cleanup (S05–S09)                │
+│     Pass  3: Forward STFT (S10)                             │
+│     Pass  4: Wiener NR (S11–S12)                            │
+│     Pass  5: Spectral Refinement (S13–S19)                 │
+│     Pass  6: Inverse STFT (S20)                             │
+│     Pass  7: Offline Audio Graph (S21–S25)                 │
+│     Pass  8: Render & Mix (S26–S28)                         │
+│     Pass  9: Finalize & Metrics (S29–S31)                  │
+│     Pass 10: Forensic Export (S32)                          │
 └─────────────────────────────────────────────────────────────┘
 ```
 
@@ -60,7 +58,7 @@
 | `public/app/style.css` | Dark theme · CSS custom properties · Responsive |
 | `public/app/app.js` | Main-thread orchestration · UI ↔ pipeline bridge |
 | `public/app/dsp-core.js` | All DSP math (STFT, iSTFT, gates, EQ, dynamics, filters) |
-| `public/app/pipeline-orchestrator.js` | 40-stage pipeline runner · ONNX model init |
+| `public/app/pipeline-orchestrator.js` | 32-stage pipeline runner · ONNX model init |
 | `public/app/voice-isolate-processor.js` | AudioWorkletProcessor · real-time live mode |
 | `public/app/dsp-worker.js` | Worker thread · ML inference + CPU-heavy DSP |
 | `public/app/ml-worker.js` | ML worker · ONNX Runtime Web · model management |
@@ -73,35 +71,33 @@
 
 ### New in v24.0
 - **Threads from Space v13**: Upgraded architecture with adaptive ML routing and plugin bus
-- **40-Stage Dodeca-Pass Pipeline**: 12 processing passes (up from 10 passes / 36 stages)
-- **New Stages**: Micro-pitch correction (S28), spatial audio (S35), LUFS mastering (S39), scene classification (S08)
-- **<10ms Latency**: Reduced from <16ms via optimized AudioWorklet + ring buffer
-- **HiFi-GAN v2 Vocoder**: Neural speech resynthesis with natural breathiness
-- **Stereo Recovery Pass**: Mid-side decomposition and spatial cue preservation
+- **32-Stage Deca-Pass Pipeline**: 10 processing passes, enforced by `scripts/validate.js`
+- **Single-Pass STFT**: One forward STFT (S10) + one iSTFT (S20) per processing path, all spectral ops in-place
 - **Forensic Certification**: SHA-256 chain-of-custody with timestamped audit chain
+- **HiFi-GAN v2 Vocoder**: Neural speech resynthesis with natural breathiness
 - **Ensemble Fusion**: Demucs v4.1 + BS-RoFormer + BSRNN with learned per-band weights
+- **Stronger NR defaults** (v24 point releases): tuned noise-reduction and voice-isolation defaults to actually strip background noise in Engineer Mode
 
 ### Core Capabilities
-- **Studio-Grade Voice Isolation**: -96dB noise floor, 32 ERB bands, forensic-grade
+- **Studio-Grade Voice Isolation**: low noise floor, 32 ERB bands, forensic-grade
 - **Multi-Band Noise Reduction**: Adaptive spectral gating with continuous noise tracking
 - **Overlapping Voice Separation**: Attention-based mask estimation per speaker via voiceprint
-- **Real-Time Processing**: <10ms end-to-end latency on desktop/mobile
-- **Offline High-Fidelity**: Full 40-stage pipeline, 4x oversampling, neural reconstruction
+- **Real-Time Processing**: low-latency AudioWorklet path with SharedArrayBuffer ring buffer
+- **Offline High-Fidelity**: Full 32-stage pipeline + neural reconstruction
 - **Artifact Suppression**: Temporal coherence + harmonic reconstruction + musical noise removal
 
 ---
 
-## Performance Metrics (v24)
+## Performance Targets (v24)
 
-| Metric | Value |
+> These are design targets, not measured guarantees. Benchmarks vary by device, model backend (WebGPU/WASM), and input material.
+
+| Metric | Target |
 |---|---|
-| **Real-Time Latency** | <10ms end-to-end (AudioWorklet) |
-| **Offline Throughput** | 6–8x real-time (GPU), 2–4x (CPU) |
-| **Noise Floor** | -96dB (offline), -72dB (real-time) |
-| **SNR Improvement** | +10–15 dB |
-| **PESQ Score** | >3.5 MOS |
-| **Intelligibility (STOI)** | >97% |
-| **ML Model Footprint** | ~50MB total (lazy loaded) |
+| **Real-Time Latency** | Low-latency AudioWorklet path (<20 ms end-to-end on desktop) |
+| **Offline Throughput** | Several× real-time on modern GPU/CPU |
+| **SNR Improvement** | +10–15 dB on typical speech-in-noise material |
+| **ML Model Footprint** | ~50 MB total (lazy loaded, cached in IndexedDB) |
 | **Supported Formats** | MP3, WAV, M4A, FLAC, OGG, OPUS, AAC, MP4, MOV, WEBM, MKV |
 
 ---
@@ -168,13 +164,13 @@ pnpm test
 
 ## Documentation
 
-**Complete Technical Blueprint**: See `VoiceIsolate_Pro_v24_Blueprint.docx`
+**Complete Technical Blueprint**: See `VoiceIsolate_Pro_v24_Blueprint.docx` for the long-form design doc. Note that the blueprint describes a target architecture; the shipped code currently implements the 32-stage Deca-Pass variant above. `CLAUDE.md` is the authoritative contributor reference — read it before editing.
 
-Sections:
+Blueprint sections:
 1. Executive Summary & Version Evolution
 2. Core Capabilities & Noise Classification Matrix
 3. System Architecture (Threads from Space v13)
-4. 40-Stage Dodeca-Pass Pipeline (all 12 passes detailed)
+4. 32-Stage Deca-Pass Pipeline
 5. Algorithms & Models (ensemble fusion, voiceprint gating, adaptive noise)
 6. Module-by-Module Breakdown with Critical Integration Points
 7. Pseudocode: Complete Pipeline (offline + real-time AudioWorklet)
@@ -191,21 +187,18 @@ Sections:
 
 ## Changelog
 
-### v24.0 (April 2026) — Threads from Space v13
-- **ARCHITECTURE**: Threads from Space v13 — adaptive ML routing, plugin bus, 7-layer system
-- **PIPELINE**: 40-stage Dodeca-Pass (12 passes, up from 36-stage/10-pass)
-- **NEW**: Micro-pitch correction (S28), spatial audio (S35), LUFS mastering (S39), scene classifier (S08)
+### v24.0 (2026) — Threads from Space v13
+- **ARCHITECTURE**: Threads from Space v13 — adaptive ML routing, plugin bus
+- **PIPELINE**: 32-stage Deca-Pass (10 passes), enforced by `scripts/validate.js`
 - **NEW**: HiFi-GAN v2 neural vocoder for speech resynthesis
-- **NEW**: Stereo recovery pass with mid-side decomposition
-- **NEW**: Comprehensive v24 blueprint (15 sections, full pseudocode, architecture diagrams)
-- **IMPROVED**: Real-time latency <10ms (down from <16ms)
-- **IMPROVED**: Noise floor -96dB offline (up from -80dB)
+- **NEW**: Comprehensive v24 blueprint (target architecture, pseudocode, diagrams)
 - **IMPROVED**: 3-model ensemble fusion (Demucs + BS-RoFormer + BSRNN) with learned per-band weights
-- **VERIFIED**: Single-pass STFT architecture enforced across all spectral operations
+- **IMPROVED**: Stronger default NR + voice-isolation parameters so background noise is actually removed
+- **IMPROVED**: Hardened playback controls + controls diagnostic script
+- **VERIFIED**: Single-pass STFT architecture enforced across all three processing paths (main thread, DSP worker, AudioWorklet)
 
 ### v23.0 (Previous)
 - Threads from Space v12 architecture
-- 36-stage Deca-Pass pipeline
 - Real-time + offline modes
 - WebAudio integration
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "voiceisolate-pro",
   "version": "24.0.0",
   "type": "module",
-  "description": "Studio-grade voice isolation platform. 36-stage Deca-Pass DSP pipeline with hybrid ML + classical spectral processing. Mobile-ready via Capacitor for Android & iOS.",
+  "description": "Studio-grade voice isolation platform. 32-stage Deca-Pass DSP pipeline with hybrid ML + classical spectral processing. Mobile-ready via Capacitor for Android & iOS.",
   "private": true,
   "keywords": [
     "audio",

--- a/scripts/validate.js
+++ b/scripts/validate.js
@@ -43,10 +43,12 @@ check(appJs.length > 10000, `Size: ${appJs.length} bytes (>10KB)`);
 const sliderGroups = ['gate', 'nr', 'eq'];
 sliderGroups.forEach(g => check(appJs.includes(`${g}:`), `Slider group: ${g}`));
 
-// Count slider definitions
-const sliderMatches = appJs.match(/id:\s*'/g);
+// Count slider definitions inside the SLIDERS literal only (avoid counting
+// EQ-band config objects and other `id:` occurrences elsewhere in app.js).
+const slidersBlock = appJs.match(/const SLIDERS\s*=\s*\{([\s\S]*?)\n\};/);
+const sliderMatches = slidersBlock ? slidersBlock[1].match(/\{\s*id\s*:\s*'/g) : null;
 const sliderCount = sliderMatches ? sliderMatches.length : 0;
-check(sliderCount >= 52, `Slider count: ${sliderCount} (>=52)`);
+check(sliderCount === 52, `Slider count: ${sliderCount} (must be 52)`);
 
 // Count STAGES
 const stagesMatch = appJs.match(/const STAGES = \[([\s\S]*?)\];/);
@@ -115,33 +117,6 @@ check(blueprint.includes('Threads from Space'), 'Threads from Space architecture
 
 // 5. Duplicate JSON key check
 console.log('\nJSON duplicate key check:');
-function checkDuplicateKeys(filePath) {
-  const raw = fs.readFileSync(path.resolve(__dirname, '..', filePath), 'utf8');
-  const dupes = [];
-  // Use a stack of Sets to track keys at each nesting level
-  const stack = [new Set()];
-  const lines = raw.split('\n');
-  const keyPattern = /^\s*"([^"]+)"\s*:/;
-  for (const line of lines) {
-    // Match key at the current depth before processing braces on this line
-    const match = line.match(keyPattern);
-    if (match) {
-      const key = match[1];
-      const currentLevel = stack[stack.length - 1];
-      if (currentLevel.has(key)) {
-        dupes.push(key);
-      }
-      currentLevel.add(key);
-    }
-    // Update depth after matching: opening braces push new scope, closing braces pop
-    for (const ch of line) {
-      if (ch === '{' || ch === '[') stack.push(new Set());
-      if ((ch === '}' || ch === ']') && stack.length > 1) stack.pop();
-    }
-  }
-  return dupes;
-}
-
 const { findDuplicateKeys } = require('./check-duplicate-keys.js');
 function checkDuplicateKeysWrapper(filePath) {
   const raw = fs.readFileSync(path.resolve(__dirname, '..', filePath), 'utf8');

--- a/scripts/validate.js
+++ b/scripts/validate.js
@@ -45,7 +45,7 @@ sliderGroups.forEach(g => check(appJs.includes(`${g}:`), `Slider group: ${g}`));
 
 // Count slider definitions inside the SLIDERS literal only (avoid counting
 // EQ-band config objects and other `id:` occurrences elsewhere in app.js).
-const slidersBlock = appJs.match(/const SLIDERS\s*=\s*\{([\s\S]*?)\n\};/);
+const slidersBlock = appJs.match(/const SLIDERS\s*=\s*\{([\s\S]*?)\s*\};/);
 const sliderMatches = slidersBlock ? slidersBlock[1].match(/\{\s*id\s*:\s*'/g) : null;
 const sliderCount = sliderMatches ? sliderMatches.length : 0;
 check(sliderCount === 52, `Slider count: ${sliderCount} (must be 52)`);

--- a/server.js
+++ b/server.js
@@ -8,6 +8,7 @@
 'use strict';
 
 import express from 'express';
+import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 import apiRouter from './api/index.js';
@@ -15,7 +16,7 @@ import apiRouter from './api/index.js';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = dirname(__filename);
 const PORT       = process.env.PORT || 3000;
-const APP_VERSION = '22.1.0'; // FIX 9: updated from 21.0.0
+const APP_VERSION = JSON.parse(readFileSync(join(__dirname, 'package.json'), 'utf8')).version;
 const app        = express();
 
 // ── Cross-Origin Isolation (required for SharedArrayBuffer) ──────────────


### PR DESCRIPTION
## Summary

Code audit findings, applied to docs + metadata so they match the code that actually ships.

- **`package.json`** — description `36-stage` → `32-stage` (the shipped `STAGES` array has exactly 32 entries).
- **`server.js`** — `APP_VERSION` now derived from `package.json` instead of hardcoded `'22.1.0'`. Single source of truth.
- **`scripts/validate.js`** — slider count check parses the `SLIDERS` literal and asserts exactly `=== 52` (previously `>= 52` counted across all `id:` occurrences in `app.js`, including EQ-band config objects — a future regression from 52→51 would have passed). Dead duplicate `checkDuplicateKeys` function removed.
- **`CLAUDE.md`** — version `23.1` → `24.0.0`; slider tab names corrected to the actual keys (`gate/nr/eq/dyn/spec/adv/sep/out`) with per-tab slider counts; preset list corrected from 7 fictitious names to the real 8 (`Voice Clarity`, `Podcast Clean`, `Forensic Extract`, `Music Vocal`, `Whisper Boost`, `Phone/Radio`, `Live Performance`, `Surveillance`); STFT constraint reworded to reflect the three independent processing paths (main thread / DSP worker / AudioWorklet), each with its own single STFT/iSTFT pair; file sizes refreshed.
- **`README.md`** — `40-stage Dodeca-Pass / 12 passes` → `32-stage Deca-Pass / 10 passes` (matches code + validator); unverified performance guarantees (`-96 dB` noise floor, `<10ms` latency, PESQ >3.5) replaced with "design targets" framing; changelog cleaned up.

No runtime behavior change. No source files under `public/app/` touched.

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm validate` — passes, slider count now reports `52 (must be 52)`
- [x] `pnpm test` — 41 suites / 1517 tests pass
- [ ] Spot-check `/health` returns `version: "24.0.0"` against local dev server
- [ ] Reviewer: confirm README wording for v24 matches intended positioning (shipped code vs. blueprint target)

## Out of scope (flagged in audit, not fixed here)

- CSP `'unsafe-inline'` in `vercel.json` + `server.js`
- Dead `STFT_COUNT` grep step in `.github/workflows/deploy.yml`
- `eslint-disable no-unused-vars` stubs in `public/app/ml-worker.js` (speaker registry)
- Both `playwright` and `puppeteer` in devDependencies
- No secret-scanning step in CI

https://claude.ai/code/session_011N1NksYJG3ou7t5Lh6PPmh
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/joker5514/voiceisolate-pro/pull/398" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Released v24.0.0 with updated pipeline architecture specifications.
  * Reorganized slider interface structure maintaining 52 sliders.
  * Expanded preset set from 7 to 8 options.
  * Updated performance targets and technical baseline documentation.

* **Chores**
  * Version now automatically synchronized from package configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->