### PR TITLE
fix: persist session state, auto-restore uploaded file, and cache processed output

### DIFF
--- a/public/app/app.js
+++ b/public/app/app.js
@@ -880,11 +880,25 @@ class VoiceIsolatePro {
   }
 
   async _rcPut(key, value) {
+    const MAX_ENTRIES = 5;
     try {
       const db = await this._rcOpen();
       await new Promise((res, rej) => {
         const tx = db.transaction('results', 'readwrite');
-        tx.objectStore('results').put(value, key);
+        const store = tx.objectStore('results');
+        store.put(value, key);
+        // Prune oldest entries when the store exceeds MAX_ENTRIES
+        const countReq = store.count();
+        countReq.onsuccess = () => {
+          if (countReq.result > MAX_ENTRIES) {
+            const cursorReq = store.openCursor();
+            let toDelete = countReq.result - MAX_ENTRIES;
+            cursorReq.onsuccess = e => {
+              const cursor = e.target.result;
+              if (cursor && toDelete > 0) { cursor.delete(); toDelete--; cursor.continue(); }
+            };
+          }
+        };
         tx.oncomplete = res;
         tx.onerror = () => rej(tx.error);
       });
@@ -901,7 +915,7 @@ class VoiceIsolatePro {
   _bufToRaw(buf) {
     const channels = [];
     for (let ch = 0; ch < buf.numberOfChannels; ch++) channels.push(buf.getChannelData(ch).slice());
-    return { channels, sampleRate: buf.sampleRate, length: buf.length, numberOfChannels: buf.numberOfChannels };
+    return { channels, sampleRate: buf.sampleRate, length: buf.length, numberOfChannels: buf.numberOfChannels, cachedAt: Date.now() };
   }
 
   _rawToBuf(raw) {
@@ -925,12 +939,13 @@ class VoiceIsolatePro {
     });
   }
 
-  async _saveFileToCache(file) {
+  async _saveFileToCache(file, preReadBuffer) {
+    if (this.isVideo) return; // video decode requires a user gesture; skip
     const MAX_BYTES = 500 * 1024 * 1024; // skip files over 500 MB
     if (file.size > MAX_BYTES) return;
     try {
-      const data = await file.arrayBuffer();
-      const entry = { data, name: file.name, type: file.type || '', lastModified: file.lastModified || Date.now(), isVideo: this.isVideo };
+      const data = preReadBuffer || await file.arrayBuffer();
+      const entry = { data, name: file.name, type: file.type || '', lastModified: file.lastModified || Date.now() };
       const db = await this._fcOpen();
       await new Promise((res, rej) => {
         const tx = db.transaction('file', 'readwrite');
@@ -954,6 +969,8 @@ class VoiceIsolatePro {
   }
 
   async _restoreSavedFile() {
+    // Skip if user already loaded a file before this async restore resolved
+    if (this.inputBuffer) return;
     try {
       const db = await this._fcOpen();
       const entry = await new Promise((res, rej) => {
@@ -963,6 +980,9 @@ class VoiceIsolatePro {
         req.onerror = () => rej(req.error);
       });
       if (!entry) return;
+      // Double-check after the async IDB read — user may have loaded a file in the meantime
+      if (this.inputBuffer) return;
+      if (this.dom.fileInfo) this.dom.fileInfo.textContent = '⏳ Restoring session…';
       const file = new File([entry.data], entry.name, { type: entry.type, lastModified: entry.lastModified });
       await this.handleFile(file);
     } catch { /* non-critical — user will just see empty state */ }
@@ -1095,10 +1115,11 @@ class VoiceIsolatePro {
       // Yield to browser paint cycle to prevent UI freeze on large files
       await new Promise(r => typeof requestAnimationFrame !== 'undefined' ? requestAnimationFrame(() => r()) : setTimeout(r, 0));
       let audioBuf = null;
+      let rawBuffer = null;
       if (this.isVideo) {
         audioBuf = await this.decodeViaVideoElement(file);
       } else {
-        const rawBuffer = await file.arrayBuffer();
+        rawBuffer = await file.arrayBuffer();
         const safeCopy = rawBuffer.slice(0);
         try {
           audioBuf = await this.ctx.decodeAudioData(safeCopy);
@@ -1123,7 +1144,8 @@ class VoiceIsolatePro {
       this.outputBuffer = null;
       this._lastLoadedFile = file;
       // Persist file so it auto-reloads after a page refresh (non-blocking)
-      this._saveFileToCache(file).catch(() => {});
+      // Pass the already-read rawBuffer to avoid a second file.arrayBuffer() call
+      this._saveFileToCache(file, rawBuffer).catch(() => {});
       // Check result cache — restore instantly if same file + same params were processed before
       try {
         const cacheKey = this._rcKey(file);
@@ -1189,7 +1211,8 @@ class VoiceIsolatePro {
               reject(new Error('Failed to decode video audio: ' + e.message));
             }
           };
-          recorder.start(); vid.play();
+          recorder.start();
+          vid.play().catch(e => { vid.pause(); recorder.stop(); reject(new Error('Video playback blocked: ' + e.message)); });
           vid.onended = () => { recorder.stop(); };
           setTimeout(() => { if (recorder.state === 'recording') { vid.pause(); recorder.stop(); } }, (duration + 2) * 1000);
         } catch (e) { cleanup(); reject(e); }

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -360,6 +360,24 @@ class VoiceIsolatePro {
     this.params = {};
     for (const tab of Object.values(SLIDERS)) for (const s of tab) this.params[s.id] = s.val;
     this.params.spectralFloor = this._mapSpectralFloor(this.params.nrFloor);
+    // Restore persisted slider params from previous session
+    try {
+      const savedParams = JSON.parse(localStorage.getItem('vip_params') || 'null');
+      if (savedParams && typeof savedParams === 'object') {
+        for (const tab of Object.values(SLIDERS)) {
+          for (const s of tab) {
+            const v = savedParams[s.id];
+            if (typeof v === 'number' && isFinite(v)) {
+              this.params[s.id] = Math.min(s.max, Math.max(s.min, v));
+            }
+          }
+        }
+        this.params.spectralFloor = this._mapSpectralFloor(this.params.nrFloor);
+      }
+    } catch { /* storage sandboxed */ }
+    this._paramSaveTimer = 0;
+    this._lastLoadedFile = null;
+    this._rcDB = null;
     this.three = {};
     try {
       this.customPresets = JSON.parse(localStorage.getItem('vip_custom_presets') || '{}');
@@ -537,20 +555,21 @@ class VoiceIsolatePro {
         inputEl.id = s.id;
         inputEl.min = s.min;
         inputEl.max = s.max;
-        inputEl.value = s.val;
+        const initVal = this.params[s.id] !== undefined ? this.params[s.id] : s.val;
+        inputEl.value = initVal;
         inputEl.step = s.step;
         inputEl.dataset.param = s.id;
         inputEl.setAttribute('aria-label', s.label);
         inputEl.setAttribute('aria-valuemin', s.min);
         inputEl.setAttribute('aria-valuemax', s.max);
-        inputEl.setAttribute('aria-valuenow', s.val);
+        inputEl.setAttribute('aria-valuenow', initVal);
         const range = s.max - s.min;
-        const initPct = range > 0 ? ((s.val - s.min) / range) * 100 : 0;
+        const initPct = range > 0 ? ((initVal - s.min) / range) * 100 : 0;
         inputEl.style.setProperty('--pct', `${initPct.toFixed(1)}%`);
         const valEl = document.createElement('span');
         valEl.className = 'sr-val';
         valEl.id = s.id + 'Val';
-        valEl.textContent = s.val + s.unit;
+        valEl.textContent = initVal + s.unit;
         row.appendChild(labelEl);
         row.appendChild(inputEl);
         row.appendChild(valEl);
@@ -822,9 +841,73 @@ class VoiceIsolatePro {
     const pct = range > 0 ? ((v - parseFloat(el.min)) / range) * 100 : 0;
     el.style.setProperty('--pct', `${pct.toFixed(1)}%`);
     if (el.classList.contains('realtime') && this.liveChainBuilt) this.updateLiveChain();
+    clearTimeout(this._paramSaveTimer);
+    this._paramSaveTimer = setTimeout(() => this._saveParams(), 500);
   }
 
+  _saveParams() {
+    try { localStorage.setItem('vip_params', JSON.stringify(this.params)); } catch { /* storage sandboxed */ }
+  }
 
+  // ---- Processed-result cache (IndexedDB) --------------------------------
+
+  async _rcOpen() {
+    if (this._rcDB) return this._rcDB;
+    return new Promise((res, rej) => {
+      const req = indexedDB.open('vip-results-v1', 1);
+      req.onupgradeneeded = e => {
+        const db = e.target.result;
+        if (!db.objectStoreNames.contains('results')) db.createObjectStore('results');
+      };
+      req.onsuccess = e => { this._rcDB = e.target.result; res(this._rcDB); };
+      req.onerror = () => rej(req.error);
+    });
+  }
+
+  async _rcGet(key) {
+    try {
+      const db = await this._rcOpen();
+      return new Promise((res, rej) => {
+        const tx = db.transaction('results', 'readonly');
+        const req = tx.objectStore('results').get(key);
+        req.onsuccess = () => res(req.result || null);
+        req.onerror = () => rej(req.error);
+      });
+    } catch { return null; }
+  }
+
+  async _rcPut(key, value) {
+    try {
+      const db = await this._rcOpen();
+      await new Promise((res, rej) => {
+        const tx = db.transaction('results', 'readwrite');
+        tx.objectStore('results').put(value, key);
+        tx.oncomplete = res;
+        tx.onerror = () => rej(tx.error);
+      });
+    } catch { /* non-critical */ }
+  }
+
+  _rcKey(file) {
+    const paramStr = JSON.stringify(
+      Object.keys(this.params).sort().reduce((o, k) => { o[k] = this.params[k]; return o; }, {})
+    );
+    return `${file.name}:${file.size}:${file.lastModified || 0}:${paramStr}`;
+  }
+
+  _bufToRaw(buf) {
+    const channels = [];
+    for (let ch = 0; ch < buf.numberOfChannels; ch++) channels.push(buf.getChannelData(ch).slice());
+    return { channels, sampleRate: buf.sampleRate, length: buf.length, numberOfChannels: buf.numberOfChannels };
+  }
+
+  _rawToBuf(raw) {
+    const buf = this.ctx.createBuffer(raw.numberOfChannels, raw.length, raw.sampleRate);
+    for (let ch = 0; ch < raw.numberOfChannels; ch++) buf.copyToChannel(raw.channels[ch], ch);
+    return buf;
+  }
+
+  // -------------------------------------------------------------------------
 
   renderCustomPresets() {
     const row = document.querySelector('.presets-row');
@@ -916,6 +999,7 @@ class VoiceIsolatePro {
       : this._mapSpectralFloor(this.params.nrFloor);
     document.querySelectorAll('.btn-preset').forEach(b => b.classList.toggle('active', b.dataset.preset === name));
     if (this.liveChainBuilt) this.updateLiveChain();
+    this._saveParams();
   }
 
   // ======== FILE HANDLING ========
@@ -976,6 +1060,29 @@ class VoiceIsolatePro {
       } else { this.dom.videoCard.style.display = 'none'; }
       this.inputBuffer = audioBuf;
       this.outputBuffer = null;
+      this._lastLoadedFile = file;
+      // Check result cache — restore instantly if same file + same params were processed before
+      try {
+        const cacheKey = this._rcKey(file);
+        const cached = await this._rcGet(cacheKey);
+        if (cached) {
+          this.outputBuffer = this._rawToBuf(cached);
+          await new Promise(r => (typeof requestAnimationFrame !== 'undefined' ? requestAnimationFrame : setTimeout)(r, 0));
+          this.onAudioLoaded(file.name);
+          this.resizeCanvas(this.dom.waveProcCanvas);
+          this.drawWaveform(this.outputBuffer, this.dom.waveProcCanvas, '#22d3ee');
+          this.resizeCanvas(this.dom.compCanvas);
+          this.drawComparison(this.inputBuffer, this.outputBuffer);
+          this.dom.saveProcBtn.disabled = false;
+          this.dom.tpAB.disabled = false;
+          this.dom.reprocessBtn.disabled = false;
+          if (this.dom.mobileReprocessBtn) this.dom.mobileReprocessBtn.disabled = false;
+          this.dom.tpABLabel.textContent = 'Restored — A/B';
+          this.setStatus('COMPLETE');
+          this.dom.pipeStage.textContent = 'Restored from cache';
+          return;
+        }
+      } catch { /* non-critical — fall through to normal load */ }
       await new Promise(r => (typeof requestAnimationFrame !== 'undefined' ? requestAnimationFrame : setTimeout)(r, 0));
       this.onAudioLoaded(file.name);
     } catch (err) {
@@ -1659,6 +1766,11 @@ class VoiceIsolatePro {
 
       this.dom.stProcTime.textContent = ((performance.now() - t0) / 1000).toFixed(2) + 's';
       this.outputBuffer = fin;
+      // Persist result so next load of same file + params is instant (non-blocking)
+      if (this._lastLoadedFile) {
+        const cacheKey = this._rcKey(this._lastLoadedFile);
+        this._rcPut(cacheKey, this._bufToRaw(fin)).catch(() => {});
+      }
       const snr = this.calcRMS(fin.getChannelData(0)) - this.calcRMS(this.inputBuffer.getChannelData(0));
       this.dom.hSNR.textContent = (snr >= 0 ? '+' : '') + snr.toFixed(1) + ' dB';
       this.resizeCanvas(this.dom.waveProcCanvas);

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -378,6 +378,7 @@ class VoiceIsolatePro {
     this._paramSaveTimer = 0;
     this._lastLoadedFile = null;
     this._rcDB = null;
+    this._fcDB = null;
     this.three = {};
     try {
       this.customPresets = JSON.parse(localStorage.getItem('vip_custom_presets') || '{}');
@@ -419,6 +420,8 @@ class VoiceIsolatePro {
     this._initVisualEngine();
     // ML worker ownership lives in PipelineOrchestrator to prevent
     // duplicate workers, duplicate ORT/model init, and race conditions.
+    // Restore last uploaded file (runs async, non-blocking)
+    this._restoreSavedFile().catch(() => {});
   }
 
   // ------------------------------------------------------------------
@@ -907,6 +910,64 @@ class VoiceIsolatePro {
     return buf;
   }
 
+  // ---- Uploaded file persistence (IndexedDB) ------------------------------
+
+  async _fcOpen() {
+    if (this._fcDB) return this._fcDB;
+    return new Promise((res, rej) => {
+      const req = indexedDB.open('vip-file-cache-v1', 1);
+      req.onupgradeneeded = e => {
+        const db = e.target.result;
+        if (!db.objectStoreNames.contains('file')) db.createObjectStore('file');
+      };
+      req.onsuccess = e => { this._fcDB = e.target.result; res(this._fcDB); };
+      req.onerror = () => rej(req.error);
+    });
+  }
+
+  async _saveFileToCache(file) {
+    const MAX_BYTES = 500 * 1024 * 1024; // skip files over 500 MB
+    if (file.size > MAX_BYTES) return;
+    try {
+      const data = await file.arrayBuffer();
+      const entry = { data, name: file.name, type: file.type || '', lastModified: file.lastModified || Date.now(), isVideo: this.isVideo };
+      const db = await this._fcOpen();
+      await new Promise((res, rej) => {
+        const tx = db.transaction('file', 'readwrite');
+        tx.objectStore('file').put(entry, 'current');
+        tx.oncomplete = res;
+        tx.onerror = () => rej(tx.error);
+      });
+    } catch { /* non-critical */ }
+  }
+
+  async _clearSavedFile() {
+    try {
+      const db = await this._fcOpen();
+      await new Promise((res, rej) => {
+        const tx = db.transaction('file', 'readwrite');
+        tx.objectStore('file').delete('current');
+        tx.oncomplete = res;
+        tx.onerror = () => rej(tx.error);
+      });
+    } catch { /* non-critical */ }
+  }
+
+  async _restoreSavedFile() {
+    try {
+      const db = await this._fcOpen();
+      const entry = await new Promise((res, rej) => {
+        const tx = db.transaction('file', 'readonly');
+        const req = tx.objectStore('file').get('current');
+        req.onsuccess = () => res(req.result || null);
+        req.onerror = () => rej(req.error);
+      });
+      if (!entry) return;
+      const file = new File([entry.data], entry.name, { type: entry.type, lastModified: entry.lastModified });
+      await this.handleFile(file);
+    } catch { /* non-critical — user will just see empty state */ }
+  }
+
   // -------------------------------------------------------------------------
 
   renderCustomPresets() {
@@ -1061,6 +1122,8 @@ class VoiceIsolatePro {
       this.inputBuffer = audioBuf;
       this.outputBuffer = null;
       this._lastLoadedFile = file;
+      // Persist file so it auto-reloads after a page refresh (non-blocking)
+      this._saveFileToCache(file).catch(() => {});
       // Check result cache — restore instantly if same file + same params were processed before
       try {
         const cacheKey = this._rcKey(file);
@@ -1305,6 +1368,8 @@ class VoiceIsolatePro {
     this.stop();
     this.inputBuffer = null;
     this.outputBuffer = null;
+    this._lastLoadedFile = null;
+    this._clearSavedFile().catch(() => {});
     this.abMode = 'original';
     if (this.videoUrl) {
       try { URL.revokeObjectURL(this.videoUrl); } catch {}

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -891,11 +891,23 @@ class VoiceIsolatePro {
         const countReq = store.count();
         countReq.onsuccess = () => {
           if (countReq.result > MAX_ENTRIES) {
+            const entries = [];
             const cursorReq = store.openCursor();
-            let toDelete = countReq.result - MAX_ENTRIES;
             cursorReq.onsuccess = e => {
               const cursor = e.target.result;
-              if (cursor && toDelete > 0) { cursor.delete(); toDelete--; cursor.continue(); }
+              if (cursor) {
+                const cachedAt = cursor.value && typeof cursor.value.cachedAt === 'number'
+                  ? cursor.value.cachedAt
+                  : 0;
+                entries.push({ key: cursor.key, cachedAt });
+                cursor.continue();
+                return;
+              }
+              const toDelete = countReq.result - MAX_ENTRIES;
+              entries
+                .sort((a, b) => a.cachedAt - b.cachedAt)
+                .slice(0, toDelete)
+                .forEach(entry => { store.delete(entry.key); });
             };
           }
         };

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -914,7 +914,7 @@ class VoiceIsolatePro {
 
   _bufToRaw(buf) {
     const channels = [];
-    for (let ch = 0; ch < buf.numberOfChannels; ch++) channels.push(buf.getChannelData(ch).slice());
+    for (let ch = 0; ch < buf.numberOfChannels; ch++) channels.push(buf.getChannelData(ch));
     return { channels, sampleRate: buf.sampleRate, length: buf.length, numberOfChannels: buf.numberOfChannels, cachedAt: Date.now() };
   }
 
@@ -922,6 +922,23 @@ class VoiceIsolatePro {
     const buf = this.ctx.createBuffer(raw.numberOfChannels, raw.length, raw.sampleRate);
     for (let ch = 0; ch < raw.numberOfChannels; ch++) buf.copyToChannel(raw.channels[ch], ch);
     return buf;
+  }
+
+  _scheduleIdle(fn) {
+    if (typeof requestIdleCallback === 'function') {
+      requestIdleCallback(fn, { timeout: 750 });
+      return;
+    }
+    setTimeout(fn, 0);
+  }
+
+  _cacheResultLater(file, buf) {
+    if (!file || !buf) return;
+    const MAX_CACHE_BYTES = 64 * 1024 * 1024;
+    const estimatedBytes = buf.numberOfChannels * buf.length * Float32Array.BYTES_PER_ELEMENT;
+    if (estimatedBytes > MAX_CACHE_BYTES) return;
+    const cacheKey = this._rcKey(file);
+    this._scheduleIdle(() => this._rcPut(cacheKey, this._bufToRaw(buf)).catch(() => {}));
   }
 
   // ---- Uploaded file persistence (IndexedDB) ------------------------------
@@ -1856,8 +1873,7 @@ class VoiceIsolatePro {
       this.outputBuffer = fin;
       // Persist result so next load of same file + params is instant (non-blocking)
       if (this._lastLoadedFile) {
-        const cacheKey = this._rcKey(this._lastLoadedFile);
-        this._rcPut(cacheKey, this._bufToRaw(fin)).catch(() => {});
+        this._cacheResultLater(this._lastLoadedFile, fin);
       }
       const snr = this.calcRMS(fin.getChannelData(0)) - this.calcRMS(this.inputBuffer.getChannelData(0));
       this.dom.hSNR.textContent = (snr >= 0 ? '+' : '') + snr.toFixed(1) + ' dB';

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -914,7 +914,7 @@ class VoiceIsolatePro {
 
   _bufToRaw(buf) {
     const channels = [];
-    for (let ch = 0; ch < buf.numberOfChannels; ch++) channels.push(buf.getChannelData(ch));
+    for (let ch = 0; ch < buf.numberOfChannels; ch++) channels.push(buf.getChannelData(ch).slice());
     return { channels, sampleRate: buf.sampleRate, length: buf.length, numberOfChannels: buf.numberOfChannels, cachedAt: Date.now() };
   }
 
@@ -938,7 +938,12 @@ class VoiceIsolatePro {
     const estimatedBytes = buf.numberOfChannels * buf.length * Float32Array.BYTES_PER_ELEMENT;
     if (estimatedBytes > MAX_CACHE_BYTES) return;
     const cacheKey = this._rcKey(file);
-    this._scheduleIdle(() => this._rcPut(cacheKey, this._bufToRaw(buf)).catch(() => {}));
+    const raw = this._bufToRaw(buf);
+    const serializedBytes = raw.channels.reduce((sum, ch) => sum + ((ch && ch.byteLength) || 0), 0);
+    if (serializedBytes > MAX_CACHE_BYTES) return;
+    this._scheduleIdle(() => this._rcPut(cacheKey, raw).catch(err => {
+      structuredLog('warn', 'Result cache write failed', { error: err instanceof Error ? err.message : String(err) });
+    }));
   }
 
   // ---- Uploaded file persistence (IndexedDB) ------------------------------

--- a/tests/mobile-ui.test.js
+++ b/tests/mobile-ui.test.js
@@ -99,7 +99,7 @@ describe('app.js — --pct CSS variable wiring', () => {
   test('initPct calculation present in slider render method', () => {
     expect(appJs).toContain('initPct');
     expect(appJs).toContain('const range = s.max - s.min');
-    expect(appJs).toContain('range > 0 ? ((s.val - s.min) / range) * 100 : 0');
+    expect(appJs).toContain('range > 0 ? ((initVal - s.min) / range) * 100 : 0');
   });
 
   test('initPct result applied via style.setProperty', () => {
@@ -600,7 +600,7 @@ describe('--pct formula — range variable approach (regression for removed asse
   test('app.js uses the range-variable form in the render loop (not inline division)', () => {
     // The render-loop formula stores denominator in `range` first
     expect(appJs).toContain('const range = s.max - s.min');
-    expect(appJs).toContain('range > 0 ? ((s.val - s.min) / range) * 100 : 0');
+    expect(appJs).toContain('range > 0 ? ((initVal - s.min) / range) * 100 : 0');
   });
 
   test('app.js guards against zero-range in render loop with range > 0 check', () => {


### PR DESCRIPTION
## Summary

Fixes two major UX pain points: all 52 slider settings and the uploaded audio file now survive page refreshes/navigation, and processed output is cached so the same file + settings never need to be re-processed.

---

## Changes

### Slider / param persistence (`localStorage`)
- All 52 slider values saved to `vip_params` with a 500 ms debounce after every change, and immediately on preset apply
- On next page load values are restored before `buildSliderPanels()` runs — every slider initialises at its last-used position

### Uploaded file persistence (`vip-file-cache-v1` IndexedDB)
- After a file is decoded its raw `ArrayBuffer` is stored in IDB (capped at 500 MB)
- On page load `_restoreSavedFile()` reconstructs a `File` object and runs the normal `handleFile()` path — all existing validation, error handling, and the result-cache lookup apply automatically
- Video files are excluded (autoplay policy blocks `vid.play()` without a user gesture; must be re-uploaded)
- Clicking **Clear** deletes the IDB entry so the next session starts clean
- Shows **"⏳ Restoring session…"** in the file-info label while restore is in progress

### Processed output cache (`vip-results-v1` IndexedDB)
- After the 32-stage pipeline completes the output `AudioBuffer` is serialised (channel `Float32Array`s + metadata + `cachedAt` timestamp) and stored under a key derived from the file fingerprint (`name:size:lastModified`) and a sorted-params hash
- On the next load of the same file with the same slider settings the result is restored instantly — status shows **"Restored from cache"**, zero pipeline time
- Store is pruned to a maximum of 5 entries on every write (oldest first) to prevent unbounded IDB growth

---

## Bug fixes

| Bug | Fix |
|---|---|
| Double `file.arrayBuffer()` read | Pass the buffer already read during decode into `_saveFileToCache()` — no second disk read |
| Unhandled `vid.play()` rejection | `decodeViaVideoElement` now `.catch()`es the play promise; autoplay blocks surface as a proper `Error` |
| Race condition in `_restoreSavedFile()` | `inputBuffer` checked before **and** after the async IDB read; a file loaded by the user during the round-trip is never overwritten |
| Unbounded result-cache growth | `_rcPut` prunes oldest entries when count exceeds 5 |
| Slider UI showed defaults on refresh | `buildSliderPanels()` now initialises each slider from `this.params[s.id]` (which includes restored values) instead of the static `s.val` default |

---

## Test plan

- [ ] Load an audio file, move several sliders, refresh — sliders restore to previous positions
- [ ] Load an audio file, run the pipeline, close the tab, reopen — file auto-loads and "Restored from cache" appears instantly
- [ ] Change a slider after loading, click **Process** — new result is cached under the updated params key
- [ ] Click **Clear**, refresh — no file is auto-restored
- [ ] Load a video file — processes normally; a subsequent refresh does **not** attempt auto-restore
- [ ] `pnpm test` — only the three pre-existing failures remain (mobile version-number mismatches)

https://claude.ai/code/session_01UMheuoovUnQT7h98JBbQjD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Slider settings are now automatically saved and restored between sessions.
  * The app restores your last uploaded file on startup for convenience.
  * Processing results are cached to skip redundant processing when using the same file and settings.

* **Bug Fixes**
  * Improved video playback error handling with better user feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->