### PR TITLE
feat(ux): visible error toasts and global keyboard shortcuts

### DIFF
--- a/public/app/app.js
+++ b/public/app/app.js
@@ -854,6 +854,37 @@ class VoiceIsolatePro {
     document.querySelectorAll('.sound-mute-btn').forEach(btn => {
       btn.addEventListener('click', () => this.toggleSoundCategory(btn.dataset.cat));
     });
+
+    // ── Global keyboard shortcuts ───────────────────────────────────────
+    // Space / K → play-pause toggle, Esc → stop / abort, X → A/B compare.
+    // Shortcuts are suppressed when typing in inputs, when modifier keys are
+    // held (so browser shortcuts like Ctrl+R / Cmd+S still work), or while a
+    // dialog/modal is open.
+    window.addEventListener('keydown', (e) => this._handleGlobalKeydown(e));
+  }
+
+  _handleGlobalKeydown(e) {
+    if (e.ctrlKey || e.metaKey || e.altKey) return;
+    const t = e.target;
+    if (t && t.nodeType === 1) {
+      const tag = t.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || t.isContentEditable) return;
+    }
+    const auth = (typeof document !== 'undefined') ? document.getElementById('authOverlay') : null;
+    if (auth && auth.offsetParent !== null) return;
+    const k = e.key;
+    if (k === ' ' || k === 'Spacebar' || k === 'k' || k === 'K') {
+      if (!this.inputBuffer) return;
+      e.preventDefault();
+      this.togglePlayback();
+    } else if (k === 'Escape') {
+      if (this.isProcessing) { this.abortFlag = true; e.preventDefault(); return; }
+      if (this.isPlaying) { e.preventDefault(); this.stop(); }
+    } else if (k === 'x' || k === 'X') {
+      if (!this.outputBuffer || !this.dom.tpAB || this.dom.tpAB.disabled) return;
+      e.preventDefault();
+      this.toggleAB();
+    }
   }
 
   onSlider(el) {
@@ -1239,6 +1270,7 @@ class VoiceIsolatePro {
     } catch (err) {
       console.error('File load error:', err);
       this.dom.fileInfo.textContent = 'Error: ' + err.message;
+      this.showNotification('Could not load file: ' + err.message, 'error', 6000);
       if (this.dom.processBtn && typeof previousProcessDisabled === 'boolean') this.dom.processBtn.disabled = previousProcessDisabled;
       if (this.dom.reprocessBtn && typeof previousReprocessDisabled === 'boolean') this.dom.reprocessBtn.disabled = previousReprocessDisabled;
       if (this.dom.mobileReprocessBtn && typeof previousMobileReprocessDisabled === 'boolean') this.dom.mobileReprocessBtn.disabled = previousMobileReprocessDisabled;
@@ -1965,8 +1997,14 @@ class VoiceIsolatePro {
       this.dom.tpABLabel.textContent = 'Ready — A/B';
       this.setStatus('COMPLETE');
     } catch(e) {
-      if (e==='abort') { this.setStatus('ABORTED'); this.dom.pipeStage.textContent='Aborted'; }
-      else { structuredLog('error', 'Pipeline error', { error: e instanceof Error ? e.message : String(e) }); this.setStatus('ERROR'); this.dom.pipeDetail.textContent=e instanceof Error ? e.message : String(e); }
+      if (e==='abort') { this.setStatus('ABORTED'); this.dom.pipeStage.textContent='Aborted'; this.showNotification('Processing aborted', 'warn'); }
+      else {
+        const msg = e instanceof Error ? e.message : String(e);
+        structuredLog('error', 'Pipeline error', { error: msg });
+        this.setStatus('ERROR');
+        this.dom.pipeDetail.textContent = msg;
+        this.showNotification('Processing failed: ' + msg, 'error', 6000);
+      }
     } finally {
       this.isProcessing=false; this.dom.processBtn.style.display='inline-flex'; this.dom.stopProcBtn.style.display='none';
       if (this.dom.mobileProcessBtn)   { this.dom.mobileProcessBtn.style.display='inline-flex'; }
@@ -3082,12 +3120,48 @@ class VoiceIsolatePro {
 
   showNotification(message, type = 'info', duration = 3500) {
     structuredLog(type === 'error' ? 'error' : 'info', '[notify] ' + message);
-    const toast = document.getElementById('toastMsg') || document.getElementById('notification');
-    if (!toast) return;
-    toast.textContent = message;
-    toast.className = 'toast toast-' + type + ' show';
-    clearTimeout(this._toastTimer);
-    this._toastTimer = setTimeout(() => { toast.classList.remove('show'); }, duration);
+    if (typeof document === 'undefined' || !document.body) return;
+    let region = document.getElementById('toastRegion');
+    if (!region) {
+      region = document.createElement('div');
+      region.id = 'toastRegion';
+      region.className = 'toast-region';
+      region.setAttribute('role', 'status');
+      region.setAttribute('aria-live', 'polite');
+      region.setAttribute('aria-atomic', 'true');
+      document.body.appendChild(region);
+    }
+    // Cap stack at 4 to avoid runaway accumulation if many errors fire at once.
+    while (region.children.length >= 4) region.removeChild(region.firstChild);
+    const toast = document.createElement('div');
+    toast.className = 'toast toast-' + type;
+    toast.setAttribute('role', type === 'error' ? 'alert' : 'status');
+    const text = document.createElement('span');
+    text.className = 'toast-msg';
+    text.textContent = String(message);
+    toast.appendChild(text);
+    const close = document.createElement('button');
+    close.type = 'button';
+    close.className = 'toast-close';
+    close.setAttribute('aria-label', 'Dismiss notification');
+    close.textContent = '×';
+    let removed = false;
+    const dismiss = () => {
+      if (removed) return;
+      removed = true;
+      toast.classList.remove('show');
+      setTimeout(() => { if (toast.parentNode) toast.parentNode.removeChild(toast); }, 220);
+    };
+    close.addEventListener('click', dismiss);
+    toast.appendChild(close);
+    region.appendChild(toast);
+    // Trigger CSS transition on next frame.
+    requestAnimationFrame(() => toast.classList.add('show'));
+    if (duration > 0) setTimeout(dismiss, duration);
+    return dismiss;
+  }
+  _showToast(message, type = 'info', duration = 3500) {
+    return this.showNotification(message, type, duration);
   }
 
   // ---- UTILITY ----

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -527,6 +527,9 @@
     <span>100% Local Processing · Zero Data Transmission · Privacy First</span>
   </footer>
 
+  <!-- Toast notification region for transient messages (errors, warnings, info) -->
+  <div id="toastRegion" class="toast-region" role="status" aria-live="polite" aria-atomic="true"></div>
+
   <div id="tooltip" class="slider-tooltip"></div>
 
   <!-- Mobile sticky action bar -->

--- a/public/app/style.css
+++ b/public/app/style.css
@@ -696,3 +696,59 @@ input[type="range"]:focus-visible::-moz-range-thumb{
 @media (max-width: 480px) {
   .sound-mute-grid { grid-template-columns: repeat(2, 1fr); }
 }
+
+/* ── Toast notification region ─────────────────────────────────────────── */
+.toast-region {
+  position: fixed;
+  top: 16px;
+  right: 16px;
+  z-index: 11000;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  pointer-events: none;
+  max-width: min(360px, calc(100vw - 32px));
+}
+.toast {
+  pointer-events: auto;
+  background: var(--s2);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-left-width: 3px;
+  border-radius: var(--rs);
+  padding: 10px 32px 10px 12px;
+  font-family: var(--ff);
+  font-size: 0.78rem;
+  line-height: 1.35;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.45);
+  position: relative;
+  opacity: 0;
+  transform: translateX(12px);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  word-wrap: break-word;
+}
+.toast.show { opacity: 1; transform: translateX(0); }
+.toast.toast-error   { border-left-color: var(--red);    color: #fecaca; }
+.toast.toast-warn    { border-left-color: #f59e0b;       color: #fde68a; }
+.toast.toast-warning { border-left-color: #f59e0b;       color: #fde68a; }
+.toast.toast-success { border-left-color: #10b981;       color: #a7f3d0; }
+.toast.toast-info    { border-left-color: var(--cyan);   color: var(--text); }
+.toast-close {
+  position: absolute;
+  top: 4px;
+  right: 6px;
+  width: 18px; height: 18px;
+  background: transparent;
+  border: none;
+  color: var(--dim);
+  font-size: 0.95rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0;
+  border-radius: 4px;
+}
+.toast-close:hover { color: var(--text); background: rgba(255,255,255,0.06); }
+.toast-close:focus-visible { outline: 2px solid var(--cyan); outline-offset: 1px; }
+@media (prefers-reduced-motion: reduce) {
+  .toast { transition: none; transform: none; }
+}

--- a/tests/handle_file_decode.test.js
+++ b/tests/handle_file_decode.test.js
@@ -65,6 +65,7 @@ describe('VoiceIsolatePro handleFile() Audio Decoding', () => {
       stop: jest.fn(),
       setStatus: jest.fn(),
       onAudioLoaded: jest.fn(),
+      showNotification: jest.fn(),
       decodeViaVideoElement: jest.fn().mockResolvedValue([1, 2, 3]), // Mock successful fallback decode
       dom: {
         fileInfo: {},
@@ -108,6 +109,7 @@ describe('VoiceIsolatePro handleFile() Audio Decoding', () => {
       stop: jest.fn(),
       setStatus: jest.fn(),
       onAudioLoaded: jest.fn(),
+      showNotification: jest.fn(),
       decodeViaVideoElement: jest.fn(),
       dom: {
         fileInfo: {},
@@ -143,6 +145,7 @@ describe('VoiceIsolatePro handleFile() Audio Decoding', () => {
       stop: jest.fn(),
       setStatus: jest.fn(),
       onAudioLoaded: jest.fn(),
+      showNotification: jest.fn(),
       decodeViaVideoElement: jest.fn(),
       dom: {
         fileInfo: {},

--- a/tests/handle_file_validation.test.js
+++ b/tests/handle_file_validation.test.js
@@ -81,6 +81,7 @@ function makeMockVip() {
     stop:        jest.fn(),
     setStatus:   jest.fn(),
     onAudioLoaded: jest.fn(),
+    showNotification: jest.fn(),
     decodeViaVideoElement: jest.fn().mockResolvedValue({ length: 100 }),
     dom: {
       fileInfo:   { textContent: '' },

--- a/tests/keyboard-shortcuts.test.js
+++ b/tests/keyboard-shortcuts.test.js
@@ -1,0 +1,128 @@
+const fs = require('fs');
+const path = require('path');
+
+const appJsPath = path.join(__dirname, '../public/app/app.js');
+const appJs = fs.readFileSync(appJsPath, 'utf8');
+
+// Same lightweight loader as tests/transport.test.js — the keyboard handler
+// is a plain method on the prototype, so we don't need a full DOM.
+let VoiceIsolatePro;
+try {
+  const safeCode = appJs.replace(/document\.addEventListener\('DOMContentLoaded'[\s\S]*\}\);/, '');
+  VoiceIsolatePro = new Function(
+    'window', 'document',
+    safeCode + '; return VoiceIsolatePro;'
+  )({}, { getElementById: () => null });
+} catch (e) {
+  console.error('Failed to load VoiceIsolatePro from app.js', e);
+}
+
+function makeEvent(key, opts = {}) {
+  return {
+    key,
+    ctrlKey: false,
+    metaKey: false,
+    altKey: false,
+    shiftKey: false,
+    target: { nodeType: 1, tagName: 'BODY', isContentEditable: false },
+    defaultPrevented: false,
+    preventDefault() { this.defaultPrevented = true; },
+    ...opts,
+  };
+}
+
+function makeInst(overrides = {}) {
+  return Object.assign(Object.create(VoiceIsolatePro.prototype), {
+    inputBuffer: { duration: 1 },
+    outputBuffer: { duration: 1 },
+    isProcessing: false,
+    isPlaying: false,
+    abortFlag: false,
+    dom: { tpAB: { disabled: false } },
+    togglePlayback: jest.fn(),
+    stop: jest.fn(),
+    toggleAB: jest.fn(),
+  }, overrides);
+}
+
+describe('global keyboard shortcuts', () => {
+  it('Space toggles playback when audio is loaded', () => {
+    const inst = makeInst();
+    const e = makeEvent(' ');
+    inst._handleGlobalKeydown(e);
+    expect(inst.togglePlayback).toHaveBeenCalledTimes(1);
+    expect(e.defaultPrevented).toBe(true);
+  });
+
+  it('K (lower or upper case) toggles playback', () => {
+    for (const key of ['k', 'K']) {
+      const inst = makeInst();
+      inst._handleGlobalKeydown(makeEvent(key));
+      expect(inst.togglePlayback).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  it('Space is ignored when no input buffer is loaded', () => {
+    const inst = makeInst({ inputBuffer: null });
+    const e = makeEvent(' ');
+    inst._handleGlobalKeydown(e);
+    expect(inst.togglePlayback).not.toHaveBeenCalled();
+    expect(e.defaultPrevented).toBe(false);
+  });
+
+  it('Space is ignored while focus is in a text input', () => {
+    const inst = makeInst();
+    const e = makeEvent(' ', { target: { nodeType: 1, tagName: 'INPUT', isContentEditable: false } });
+    inst._handleGlobalKeydown(e);
+    expect(inst.togglePlayback).not.toHaveBeenCalled();
+    expect(e.defaultPrevented).toBe(false);
+  });
+
+  it('Space is ignored when a modifier key is held (does not interfere with browser shortcuts)', () => {
+    const inst = makeInst();
+    const e = makeEvent(' ', { ctrlKey: true });
+    inst._handleGlobalKeydown(e);
+    expect(inst.togglePlayback).not.toHaveBeenCalled();
+    expect(e.defaultPrevented).toBe(false);
+  });
+
+  it('Escape sets abortFlag while processing', () => {
+    const inst = makeInst({ isProcessing: true });
+    inst._handleGlobalKeydown(makeEvent('Escape'));
+    expect(inst.abortFlag).toBe(true);
+    expect(inst.stop).not.toHaveBeenCalled();
+  });
+
+  it('Escape calls stop() while playing (and not processing)', () => {
+    const inst = makeInst({ isPlaying: true });
+    inst._handleGlobalKeydown(makeEvent('Escape'));
+    expect(inst.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it('X toggles A/B compare when output is ready', () => {
+    const inst = makeInst();
+    inst._handleGlobalKeydown(makeEvent('x'));
+    expect(inst.toggleAB).toHaveBeenCalledTimes(1);
+  });
+
+  it('X is ignored when A/B button is disabled', () => {
+    const inst = makeInst({ dom: { tpAB: { disabled: true } } });
+    inst._handleGlobalKeydown(makeEvent('x'));
+    expect(inst.toggleAB).not.toHaveBeenCalled();
+  });
+
+  it('X is ignored when no processed output exists', () => {
+    const inst = makeInst({ outputBuffer: null });
+    inst._handleGlobalKeydown(makeEvent('x'));
+    expect(inst.toggleAB).not.toHaveBeenCalled();
+  });
+
+  it('unrelated keys do nothing', () => {
+    const inst = makeInst();
+    inst._handleGlobalKeydown(makeEvent('a'));
+    inst._handleGlobalKeydown(makeEvent('Enter'));
+    expect(inst.togglePlayback).not.toHaveBeenCalled();
+    expect(inst.stop).not.toHaveBeenCalled();
+    expect(inst.toggleAB).not.toHaveBeenCalled();
+  });
+});

--- a/tests/notifications.test.js
+++ b/tests/notifications.test.js
@@ -1,0 +1,122 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+// We load app.js inside a vm sandbox so the `document` and `window` references
+// inside the source resolve to mocks we control per-test. Mirrors the loader
+// pattern in tests/handle_file_decode.test.js.
+function buildElementShim() {
+  return {
+    id: '',
+    className: '',
+    type: '',
+    textContent: '',
+    children: [],
+    attrs: {},
+    listeners: {},
+    parentNode: null,
+    get firstChild() { return this.children[0] || null; },
+    classList: (() => {
+      const set = new Set();
+      return {
+        add: (c) => set.add(c),
+        remove: (c) => set.delete(c),
+        contains: (c) => set.has(c),
+        toggle: (c) => { if (set.has(c)) { set.delete(c); return false; } set.add(c); return true; },
+      };
+    })(),
+    setAttribute(k, v) { this.attrs[k] = v; },
+    getAttribute(k) { return this.attrs[k]; },
+    appendChild(child) { this.children.push(child); child.parentNode = this; return child; },
+    removeChild(child) {
+      const i = this.children.indexOf(child);
+      if (i >= 0) this.children.splice(i, 1);
+      return child;
+    },
+    addEventListener(name, fn) { this.listeners[name] = fn; },
+  };
+}
+
+describe('showNotification / _showToast', () => {
+  let VoiceIsolatePro;
+  let mockDocument;
+  let region;
+
+  beforeEach(() => {
+    const body = buildElementShim();
+    region = buildElementShim();
+    region.id = 'toastRegion';
+    body.appendChild(region);
+    mockDocument = {
+      body,
+      getElementById: (id) => (id === 'toastRegion' ? region : null),
+      createElement: () => buildElementShim(),
+      addEventListener: () => {},
+    };
+
+    const sandbox = {
+      document: mockDocument,
+      window: {},
+      module: { exports: {} },
+      Float32Array,
+      Math,
+      console: { error: () => {}, warn: () => {}, log: () => {}, debug: () => {}, info: () => {} },
+      parseFloat,
+      URL: { createObjectURL: () => 'blob:test', revokeObjectURL: () => {} },
+      setTimeout,
+      clearTimeout,
+      Promise,
+      requestAnimationFrame: (cb) => { cb(); return 1; },
+    };
+    vm.createContext(sandbox);
+    const appJs = fs.readFileSync(path.join(__dirname, '../public/app/app.js'), 'utf8');
+    vm.runInContext(appJs, sandbox);
+    VoiceIsolatePro = sandbox.module.exports;
+  });
+
+  it('appends a toast element to the toastRegion', () => {
+    const inst = Object.create(VoiceIsolatePro.prototype);
+    inst.showNotification('Hello world', 'info', 0);
+    expect(region.children.length).toBe(1);
+    const toast = region.children[0];
+    expect(toast.className).toContain('toast');
+    expect(toast.className).toContain('toast-info');
+    // Message text node is the first child.
+    expect(toast.children[0].textContent).toBe('Hello world');
+  });
+
+  it('uses role=alert for error toasts so screen readers interrupt', () => {
+    const inst = Object.create(VoiceIsolatePro.prototype);
+    inst.showNotification('Decode failed', 'error', 0);
+    expect(region.children.length).toBe(1);
+    const toast = region.children[0];
+    expect(toast.getAttribute('role')).toBe('alert');
+    expect(toast.className).toContain('toast-error');
+  });
+
+  it('caps stacked toasts at 4', () => {
+    const inst = Object.create(VoiceIsolatePro.prototype);
+    for (let i = 0; i < 6; i++) inst.showNotification('msg ' + i, 'info', 0);
+    expect(region.children.length).toBeLessThanOrEqual(4);
+  });
+
+  it('_showToast is an alias for showNotification', () => {
+    const inst = Object.create(VoiceIsolatePro.prototype);
+    expect(typeof inst._showToast).toBe('function');
+    inst._showToast('Aliased', 'warn', 0);
+    expect(region.children.length).toBe(1);
+    const toast = region.children[0];
+    expect(toast.className).toContain('toast-warn');
+  });
+
+  it('returns a dismiss function that removes the toast', async () => {
+    const inst = Object.create(VoiceIsolatePro.prototype);
+    const dismiss = inst.showNotification('Bye', 'info', 0);
+    expect(typeof dismiss).toBe('function');
+    expect(region.children.length).toBe(1);
+    dismiss();
+    // Removal is queued via real setTimeout(220) — wait it out.
+    await new Promise(r => setTimeout(r, 260));
+    expect(region.children.length).toBe(0);
+  });
+});


### PR DESCRIPTION
Two small, high-leverage UX gaps surfaced during a codebase audit:

1. `showNotification()` existed but pointed at DOM ids (`toastMsg`,
   `notification`) that were never present in `index.html`, so every call
   silently no-oped. A separate `_showToast()` was referenced once but had
   never been defined. As a result, `handleFile()` decode failures and
   `runPipeline()` errors were logged to the console but invisible to the
   user — the only feedback was a status-bar text change.
2. There were no global keyboard shortcuts. Play/stop/A-B compare all
   required a mouse, which is awkward when iterating on settings.

Changes:

- Add a `#toastRegion` live region to `index.html` plus styles in
  `style.css` (stacked, dismissable, severity colors, reduced-motion safe).
- Rewrite `showNotification()` to create toasts dynamically, cap the stack
  at 4, return a dismiss handle, and use `role="alert"` for errors so
  screen readers interrupt. Add `_showToast()` as an alias so the existing
  call site works.
- Wire toasts into the `handleFile()` catch and the `runPipeline()` catch
  so decode/processing failures actually reach the user.
- Add a `_handleGlobalKeydown()` method bound to `window.keydown` in
  `bindEvents()`: Space/K toggles playback, Escape aborts processing or
  stops playback, X toggles A/B compare. Suppressed when focus is in a
  text field, when a modifier is held, or while the auth overlay is open.

Tests:

- New `tests/notifications.test.js` (5 tests) covers DOM construction,
  error role, stack cap, alias, and dismiss timing.
- New `tests/keyboard-shortcuts.test.js` (11 tests) covers Space/K/Esc/X
  paths and the input-focus / modifier-key suppression rules.
- Update existing handleFile mocks in `tests/handle_file_decode.test.js`
  and `tests/handle_file_validation.test.js` to include `showNotification`
  now that the catch path calls it.

All 1805 tests pass; `pnpm lint` and `pnpm validate` are clean.

https://claude.ai/code/session_013wibPxhZMCHvDeqruUbu9Q
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/joker5514/voiceisolate-pro/pull/413" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added global keyboard shortcuts: Space/K to toggle playback, Escape to stop processing, and X to toggle A/B comparison
  * Enhanced notification system with multiple dismissible toasts and auto-dismiss functionality (limited to 4 concurrent notifications)

* **Improvements**
  * Improved error reporting with better user feedback during file loading and processing failures
  * Enhanced accessibility with ARIA live regions for screen reader support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->