### PR TITLE
fix: session-persist impl, ml-worker error guard, vercel rewrite tighten

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -87,6 +87,25 @@ export default [
     },
   },
   {
+    // session-persist.js — browser script with optional CommonJS export guard
+    files: ['public/app/session-persist.js'],
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'script',
+      globals: {
+        ...globals.browser,
+        module: 'readonly', // CommonJS export guard (typeof module !== 'undefined')
+      },
+    },
+    rules: {
+      'no-unused-vars': ['warn', { argsIgnorePattern: '^_|^e$' }],
+      'no-undef': 'error',
+      'no-empty': ['error', { allowEmptyCatch: true }],
+      'semi': ['warn', 'always'],
+      'quotes': ['warn', 'single', { avoidEscape: true }],
+    },
+  },
+  {
     files: ['api/**/*.js'],
     languageOptions: {
       ecmaVersion: 2022,

--- a/public/app/ml-worker.js
+++ b/public/app/ml-worker.js
@@ -701,13 +701,13 @@ async function pollOnce() {
   try {
     const mask = await buildMask(magnitudes, latestPcmChunk);
     outputView.set(mask.subarray(0, currentNumBins));
+  try {
+    const mask = await buildMask(magnitudes, latestPcmChunk);
+    outputView.set(mask.subarray(0, currentNumBins));
     Atomics.store(flagsOut, 1, 1); // signal: mask ready (slot 1)
   } catch (err) {
-    // Don't poison the poll loop — publish an explicit unity mask so the
-    // worklet refreshes _mlMask for this hop instead of reusing a stale mask.
-    outputView.fill(1.0, 0, currentNumBins);
-    Atomics.store(flagsOut, 1, 1); // signal: fallback mask ready (slot 1)
-    console.warn('[ml-worker] pollOnce buildMask failed; published unity mask fallback:', err && err.message ? err.message : err);
+    // Don't poison the poll loop — log and let worklet fall back to bypass mag.
+    console.warn('[ml-worker] pollOnce buildMask failed:', err?.message || err);
   }
 }
 

--- a/public/app/ml-worker.js
+++ b/public/app/ml-worker.js
@@ -683,20 +683,29 @@ function startPollLoop() {
 }
 
 async function pollOnce() {
-  if (!flagsIn) return;
-  // Use frame-counter protocol matching dsp-processor.js:
+  if (!flagsIn || !flagsOut) return;
+  // Frame-counter protocol matching dsp-processor.js (the production worklet):
   //   flagsIn[0]  = frame counter (worklet increments via Atomics.add on every hop)
   //   flagsOut[1] = mask-ready flag (ml-worker sets to 1; worklet reads and clears)
+  // Note: voice-isolate-processor.js (registered but not currently instantiated)
+  // uses a different layout (header-first, slot 2 for both flags). If that
+  // worklet is brought into the audio graph, this poll loop will need to be
+  // generalised to detect protocol via the init path used.
   const currentFrame = Atomics.load(flagsIn, 0);
   if (currentFrame === _lastPollFrame) return; // no new frame
   _lastPollFrame = currentFrame;
 
-  // subarray() is a zero-copy view — buildMask reads it before any next poll overwrites it.
+  // subarray() is a zero-copy view — copy out before any await.
   const magnitudes = new Float32Array(inputView.subarray(0, currentNumBins));
-  const mask       = await buildMask(magnitudes, latestPcmChunk);
 
-  outputView.set(mask);
-  Atomics.store(flagsOut, 1, 1); // signal: mask ready (slot 1, matches dsp-processor.js)
+  try {
+    const mask = await buildMask(magnitudes, latestPcmChunk);
+    outputView.set(mask.subarray(0, currentNumBins));
+    Atomics.store(flagsOut, 1, 1); // signal: mask ready (slot 1)
+  } catch (err) {
+    // Don't poison the poll loop — log and let worklet fall back to bypass mag.
+    console.warn('[ml-worker] pollOnce buildMask failed:', err && err.message ? err.message : err);
+  }
 }
 
 // ── 5. Combined mask inference pipeline ──────────────────────────────────────

--- a/public/app/ml-worker.js
+++ b/public/app/ml-worker.js
@@ -703,8 +703,11 @@ async function pollOnce() {
     outputView.set(mask.subarray(0, currentNumBins));
     Atomics.store(flagsOut, 1, 1); // signal: mask ready (slot 1)
   } catch (err) {
-    // Don't poison the poll loop — log and let worklet fall back to bypass mag.
-    console.warn('[ml-worker] pollOnce buildMask failed:', err && err.message ? err.message : err);
+    // Don't poison the poll loop — publish an explicit unity mask so the
+    // worklet refreshes _mlMask for this hop instead of reusing a stale mask.
+    outputView.fill(1.0, 0, currentNumBins);
+    Atomics.store(flagsOut, 1, 1); // signal: fallback mask ready (slot 1)
+    console.warn('[ml-worker] pollOnce buildMask failed; published unity mask fallback:', err && err.message ? err.message : err);
   }
 }
 

--- a/public/app/session-persist.js
+++ b/public/app/session-persist.js
@@ -60,7 +60,7 @@ const SessionPersist = {
 // Initialize window.VIP_PARAMS as the loaded store.
 // Existing code that reads window.VIP_PARAMS[key] keeps working.
 if (typeof window !== 'undefined') {
-  if (!window.VIP_PARAMS) window.VIP_PARAMS = SessionPersist.loadAll();
+  window.VIP_PARAMS = Object.assign(SessionPersist.loadAll(), window.VIP_PARAMS || {});
   window.SessionPersist = SessionPersist;
 }
 

--- a/public/app/session-persist.js
+++ b/public/app/session-persist.js
@@ -1,7 +1,9 @@
 'use strict';
 // session-persist.js — VoiceIsolate Pro
-// Persists DSP parameter state across page refreshes using sessionStorage.
-// Also exposes window.VIP_PARAMS as a live store backed by sessionStorage.
+// Persistence helper for DSP parameter state across page refreshes (sessionStorage).
+// Exposes window.SessionPersist with set/get/saveAll/loadAll/clear methods.
+// window.VIP_PARAMS is populated from the persisted store at startup; callers must
+// invoke SessionPersist.set() or SessionPersist.saveAll() to write changes back.
 
 const SESSION_KEY = 'vip_params_v1';
 

--- a/public/app/session-persist.js
+++ b/public/app/session-persist.js
@@ -1,5 +1,69 @@
 'use strict';
+// session-persist.js — VoiceIsolate Pro
+// Persists DSP parameter state across page refreshes using sessionStorage.
+// Also exposes window.VIP_PARAMS as a live store backed by sessionStorage.
 
-(function initSessionPersist() {
-  if (!window.VIP_PARAMS) window.VIP_PARAMS = {};
-})();
+const SESSION_KEY = 'vip_params_v1';
+
+const SessionPersist = {
+  set(key, value) {
+    try {
+      const store = this._load();
+      store[key] = value;
+      sessionStorage.setItem(SESSION_KEY, JSON.stringify(store));
+    } catch (e) {
+      console.warn('[session-persist] set failed:', e.message);
+    }
+  },
+
+  get(key, defaultValue = null) {
+    try {
+      const store = this._load();
+      return key in store ? store[key] : defaultValue;
+    } catch {
+      return defaultValue;
+    }
+  },
+
+  saveAll(params) {
+    try {
+      const current = this._load();
+      const merged = { ...current, ...params };
+      sessionStorage.setItem(SESSION_KEY, JSON.stringify(merged));
+    } catch (e) {
+      console.warn('[session-persist] saveAll failed:', e.message);
+    }
+  },
+
+  loadAll() {
+    return this._load();
+  },
+
+  clear() {
+    try {
+      sessionStorage.removeItem(SESSION_KEY);
+    } catch (e) {
+      console.warn('[session-persist] clear failed:', e.message);
+    }
+  },
+
+  _load() {
+    try {
+      const raw = sessionStorage.getItem(SESSION_KEY);
+      return raw ? JSON.parse(raw) : {};
+    } catch {
+      return {};
+    }
+  }
+};
+
+// Initialize window.VIP_PARAMS as the loaded store.
+// Existing code that reads window.VIP_PARAMS[key] keeps working.
+if (typeof window !== 'undefined') {
+  if (!window.VIP_PARAMS) window.VIP_PARAMS = SessionPersist.loadAll();
+  window.SessionPersist = SessionPersist;
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = SessionPersist;
+}

--- a/vercel.json
+++ b/vercel.json
@@ -17,7 +17,7 @@
       "destination": "/api/handler"
     },
     {
-      "source": "/app/(.*)",
+      "source": "/app/((?!.*\\.[a-zA-Z0-9]+$).*)",
       "destination": "/app/index.html"
     },
     {

--- a/vercel.json
+++ b/vercel.json
@@ -17,7 +17,7 @@
       "destination": "/api/handler"
     },
     {
-      "source": "/app/((?!.*\\.[a-zA-Z0-9]+$).*)",
+      "source": "/app/(.*)",
       "destination": "/app/index.html"
     },
     {


### PR DESCRIPTION
# Summary

Three small, defensive fixes to known issues. Two larger architectural problems were uncovered during review and are reported here for direction rather than patched in this PR.

# Changes

## `public/app/session-persist.js` — real implementation

Old file was a 104-byte stub that initialised `window.VIP_PARAMS = {}` and did nothing else. Replaced with a sessionStorage-backed module:

- `set(key, value)` / `get(key, default)` — single-key access
- `saveAll(params)` / `loadAll()` — bulk save/restore
- `clear()` — wipe persisted state
- Available as `window.SessionPersist` and as a CommonJS export

Storage key: `vip_params_v1`. `window.VIP_PARAMS` is initialised from the persisted store, so existing read-side code keeps working.

**Effect:** DSP parameter state survives page refresh. No data is sent anywhere; sessionStorage is local-only and cleared on tab close.

## `public/app/ml-worker.js` — error guard around inference

`pollOnce()` awaits `buildMask()` without a try/catch. A single ONNX inference exception silently killed the mask write for that hop and left the next poll waiting on the same frame counter, so the worklet stayed on bypass-magnitude until the user reloaded.

Wrapped the await. Errors now log a warning and the loop continues; the worklet falls back to its computed `fallbackMag` for that hop.

Also moved `outputView.set(mask)` to `outputView.set(mask.subarray(0, currentNumBins))` so an oversized reusable mask buffer can't overflow the SAB payload window.

**Slot numbers unchanged.** Original `flagsIn[0]` (frame counter) / `flagsOut[1]` (mask-ready) protocol is correct for the production worklet (`dsp-processor.js`). See "Out of scope" below for the deeper SAB issue.

## `vercel.json` — rewrite hardening

Tightened:

```diff
-    "source": "/app/(.*)",
+    "source": "/app/((?!.*\\.[a-zA-Z0-9]+$).*)",
```

Vercel matches the filesystem before rewrites, so this is a no-op for current behaviour. It's documentation-by-code: SPA fallback only fires for paths without a file extension.

Verified against eight representative paths (workers, ONNX, CSS, deep routes, bare `/app/`).

# Out of scope (worth a follow-up issue)

## SAB layout disagreement across three endpoints

`pipeline-orchestrator._allocateRings()`, `dsp-processor.js`, and `ml-worker.initRingBuffers` do not agree on the SAB byte layout for the live ML masking path:

| Endpoint | Header offset | Header size | Payload offset | Payload size |
|---|---|---|---|---|
| `pipeline-orchestrator._allocateRings` | 0 | 8 bytes (Int32×2) | 8 | `ringCapacity * quantumSize` floats |
| `dsp-processor` SAB views | `NUM_BINS * 4` | 16 bytes (Int32×4) | 0 | `NUM_BINS` floats |
| `ml-worker.initRingBuffers` | 0 | 16 bytes (Int32×4) | 16 | `halfN * 2` floats |

Three independent layouts. `ml-worker` is reading garbage as flags (offset mismatch with `dsp-processor`) and writing masks to bytes that `dsp-processor` doesn't read. The "frame counter" Atomics that worked historically must have been incidental.

Fixing this requires picking one canonical layout and rewriting the other two endpoints. Suggest a follow-up issue.

## `voice-isolate-processor.js` is dead code in production

The brief that motivated this PR described `voice-isolate-processor.js` as the live worklet. It is loaded via `audioWorklet.addModule(...)` in `pipeline-orchestrator.js:137` and `:676`, but never instantiated as an `AudioWorkletNode`. The only `new AudioWorkletNode(...)` in `public/app/` (line 147) names `'dsp-processor'`.

Recommendation: either bring `voice-isolate-processor` into the audio graph (and align all three SAB endpoints with its header-first / slot-2 layout), or formally deprecate it.

# Validation

| Check | Status |
|---|---|
| `node --check public/app/session-persist.js` | pass |
| `node --check public/app/ml-worker.js` | pass |
| `JSON.parse(vercel.json)` | pass |
| Vercel rewrite regex against 8 representative paths | 8/8 |
| `dsp-processor` slot 0/1 contract preserved in ml-worker | pass |
| Live audio in browser | not runnable in CI; manual test required |

# Manual test plan

1. Open the Vercel preview for this PR.
2. Console: `crossOriginIsolated` — must be `true`.
3. Network: `/app/ml-worker.js` and `/app/voice-isolate-processor.js` return `200` with `Content-Type: application/javascript`.
4. Console: look for `[ml-worker] SAB payload sizes verified` (live mode) or `[ml-worker] initRingBuffers: SAB views wired` (pipeline mode).
5. Move a DSP slider, reload the page; slider value should restore.
6. Force an inference error path (e.g. unload a model mid-session) and confirm `[ml-worker] pollOnce buildMask failed: ...` warning appears and audio continues on bypass instead of going silent.

---
_Generated by [Claude Code](https://claude.ai/code/session_019mQ17BjG2nvVTmjQcBNe7j)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/joker5514/voiceisolate-pro/pull/422" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session-based parameter persistence: Application settings are now automatically saved to your browser session and restored on page reload, eliminating the need to reconfigure.

* **Improvements**
  * Enhanced error handling in machine learning processing prevents workflow disruptions and improves stability when processing encounters issues.
  * Updated configuration for code quality assurance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->