### PR TITLE
fix: reduce hum-notch Q from 30-35 to 5 to eliminate bell ringing artifact

### DIFF
--- a/public/app/app.js
+++ b/public/app/app.js
@@ -1705,7 +1705,7 @@ class VoiceIsolatePro {
         await this.pip(6, total);
         data = DSP.removeClicks(data, 3);
 
-        // S08: Hum removal (50/60 Hz + harmonics)
+        // S08: Hum removal (60 Hz + harmonics)
         await this.pip(7, total);
         const humFreqs = [60, 120, 180, 240, 300, 360];
         DSP.cascadedNotch(data, humFreqs, 5, sr);

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -1708,7 +1708,7 @@ class VoiceIsolatePro {
         // S08: Hum removal (50/60 Hz + harmonics)
         await this.pip(7, total);
         const humFreqs = [60, 120, 180, 240, 300, 360];
-        DSP.cascadedNotch(data, humFreqs, 35, sr);
+        DSP.cascadedNotch(data, humFreqs, 5, sr);
 
         // S09: De-essing (time-domain)
         await this.pip(8, total);

--- a/public/app/dsp-processor.js
+++ b/public/app/dsp-processor.js
@@ -311,9 +311,9 @@ class DSPProcessor extends AudioWorkletProcessor {
   _rebuildFilters(sr) {
     // Hum notch
     for (let ch = 0; ch < 2; ch++) {
-      setBiquadNotch(this._notch60[ch],   60, 30, sr);
-      setBiquadNotch(this._notch120[ch], 120, 30, sr);
-      setBiquadNotch(this._notch180[ch], 180, 30, sr);
+      setBiquadNotch(this._notch60[ch],   60, 5, sr);
+      setBiquadNotch(this._notch120[ch], 120, 5, sr);
+      setBiquadNotch(this._notch180[ch], 180, 5, sr);
     }
     // De-ess sidechain: narrow peak at deEssFreq with gain = -deEssAmt*0.15 dB
     const deEssGainDb = -(this._params.deEssAmt / 100) * 15;

--- a/public/app/ml-worker.js
+++ b/public/app/ml-worker.js
@@ -701,9 +701,6 @@ async function pollOnce() {
   try {
     const mask = await buildMask(magnitudes, latestPcmChunk);
     outputView.set(mask.subarray(0, currentNumBins));
-  try {
-    const mask = await buildMask(magnitudes, latestPcmChunk);
-    outputView.set(mask.subarray(0, currentNumBins));
     Atomics.store(flagsOut, 1, 1); // signal: mask ready (slot 1)
   } catch (err) {
     // Don't poison the poll loop — log and let worklet fall back to bypass mag.

--- a/tests/voice-isolate-processor.test.js
+++ b/tests/voice-isolate-processor.test.js
@@ -185,6 +185,8 @@ describe('VoiceIsolateProcessor._onMessage', () => {
     proc.inputHead = 512;
     proc.drainHead = 256;
 
+    proc._onMessage({ type: 'initRingBuffers', fftSize: 4096, hopSize: 1024 });
+
     expect(proc.inputHead).toBe(0);
     expect(proc.drainHead).toBe(0);
     expect(proc.inputProcessed).toBe(0);


### PR DESCRIPTION
IIR notch filters with Q=30–35 have extremely narrow bandwidth and a
correspondingly long impulse response — they ring at 60/120/180 Hz like
a struck bell whenever a transient passes through. Reducing Q to 5 is
sufficient to attenuate mains hum while keeping the filter response
brief enough to be inaudible on voice.

Fixes offline path (app.js cascadedNotch Q=35→5) and live AudioWorklet
path (dsp-processor.js setBiquadNotch Q=30→5 on all three hum harmonics).

https://claude.ai/code/session_011W65NabrRM1Bfn74hWgxXE
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/joker5514/voiceisolate-pro/pull/423" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized hum removal filtering for improved audio quality and noise reduction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->