### PR TITLE
🎨 Palette: Fix global keyboard shortcut interception on UI controls and add scrubber keyboard nav

### DIFF
--- a/public/app/app.js
+++ b/public/app/app.js
@@ -724,10 +724,21 @@ class VoiceIsolatePro {
     bind('tpRew', this.dom.tpRew, 'click', () => this.seekDelta(-5));
     bind('tpFwd', this.dom.tpFwd, 'click', () => this.seekDelta(5));
     if (this.dom.tpSeek) bind('tpSeek', this.dom.tpSeek, 'input', () => this.seekTo(this.dom.tpSeek.value / CONSTANTS.MS_IN_SECOND));
-    if (this.dom.tpScrubTrack) bind('tpScrubTrack', this.dom.tpScrubTrack, 'pointerdown', e => {
-      const r = this.dom.tpScrubTrack.getBoundingClientRect();
-      this.seekTo((e.clientX - r.left) / r.width);
-    });
+    if (this.dom.tpScrubTrack) {
+      bind('tpScrubTrack', this.dom.tpScrubTrack, 'pointerdown', e => {
+        const r = this.dom.tpScrubTrack.getBoundingClientRect();
+        this.seekTo((e.clientX - r.left) / r.width);
+      });
+      bind('tpScrubTrackKey', this.dom.tpScrubTrack, 'keydown', e => {
+        if (e.key === 'ArrowLeft') {
+          e.preventDefault();
+          this.seekDelta(-5);
+        } else if (e.key === 'ArrowRight') {
+          e.preventDefault();
+          this.seekDelta(5);
+        }
+      });
+    }
     bind('tpSpeed', this.dom.tpSpeed, 'change', () => { const r = parseFloat(this.dom.tpSpeed.value); if (this.currentSource) this.currentSource.playbackRate.value = r; if (this.isVideo) this.dom.videoPlayer.playbackRate = r; });
     bind('tpAB', this.dom.tpAB, 'click', () => this.toggleAB());
     if (this.dom.waveProcCanvas) bind('waveformCanvas', this.dom.waveProcCanvas, 'click', e => {
@@ -875,7 +886,9 @@ class VoiceIsolatePro {
     const t = e.target;
     if (t && t.nodeType === 1) {
       const tag = t.tagName;
-      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || t.isContentEditable) return;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || tag === 'BUTTON' || t.isContentEditable) return;
+      const role = typeof t.getAttribute === 'function' ? t.getAttribute('role') : null;
+      if (role === 'button' || role === 'tab' || role === 'slider') return;
     }
     const auth = (typeof document !== 'undefined') ? document.getElementById('authOverlay') : null;
     if (auth && auth.offsetParent !== null) return;


### PR DESCRIPTION
💡 **What:** 
- Updated the global keydown listener to explicitly ignore key events (like Spacebar) when the active element is a `<button>` or an element with an ARIA role of `button`, `tab`, or `slider`.
- Added Left/Right Arrow keyboard navigation to the transport scrubber (`#tpScrubTrack`).

🎯 **Why:** 
- Previously, pressing Spacebar while focusing on a button (like the custom "A/B" or preset buttons) would both activate the button AND trigger the global playback toggle, causing a confusing double-action bug. This fix ensures native and custom UI components handle their own keyboard accessibility without interference.
- The playback scrubber lacked keyboard accessibility, preventing keyboard users from seeking forward/backward. It is now fully navigable via arrow keys.

♿ **Accessibility:**
- Restores proper keyboard interaction isolation for accessible buttons and tabs.
- Adds missing slider keyboard interaction support to the scrubber track.

---
*PR created automatically by Jules for task [18194844305759878244](https://jules.google.com/task/18194844305759878244) started by @Joker5514*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Timeline playback position can now be controlled using arrow keys for quick seeking.

* **Improvements**
  * Keyboard shortcuts now intelligently avoid triggering when focus is on interactive UI elements like buttons, tabs, or sliders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->