### PR TITLE
fix: WASM fetch failures — COOP/COEP on /lib/, workers, immutable cache + soft ORT build

### DIFF
--- a/scripts/setup-ort.js
+++ b/scripts/setup-ort.js
@@ -36,13 +36,19 @@ const SOFT_ENV = process.env.VIP_ORT_SETUP_SOFT === '1';
 // Auto-detect soft mode: if all committed WASM files already exist, skip copy.
 const allCommitted = EXPECTED_COMMITTED.every((f) => existsSync(join(DEST_DIR, f)));
 
-if (SOFT_ENV || allCommitted) {
-  const reason = SOFT_ENV ? 'VIP_ORT_SETUP_SOFT=1' : 'all ORT files already present in public/lib/';
-  console.info(`[setup-ort] Skipping copy — ${reason}`);
+if (allCommitted) {
+  console.info('[setup-ort] Skipping copy — all ORT files already present in public/lib/');
   EXPECTED_COMMITTED.forEach((f) =>
-    console.info(`[setup-ort]   ✓ ${f} (${existsSync(join(DEST_DIR, f)) ? 'present' : 'MISSING'})`);
+    console.info(`[setup-ort]   ✓ ${f} (${existsSync(join(DEST_DIR, f)) ? 'present' : 'MISSING'})`)
   );
   process.exit(0);
+}
+
+if (SOFT_ENV) {
+  console.info('[setup-ort] VIP_ORT_SETUP_SOFT=1 set, but committed ORT file set is incomplete; attempting copy from node_modules.');
+  EXPECTED_COMMITTED.forEach((f) =>
+    console.info(`[setup-ort]   ✓ ${f} (${existsSync(join(DEST_DIR, f)) ? 'present' : 'MISSING'})`)
+  );
 }
 
 // Files this script owns in DEST_DIR. Anything matching these patterns is

--- a/scripts/setup-ort.js
+++ b/scripts/setup-ort.js
@@ -8,6 +8,11 @@
  *
  * Run automatically via package.json "postinstall" hook.
  * Safe to re-run: existing files are overwritten.
+ *
+ * SOFT MODE: If VIP_ORT_SETUP_SOFT=1 OR all expected files already exist
+ * in public/lib/ (i.e. they are committed to the repo), the script exits 0
+ * without attempting to copy from node_modules. This is the production path
+ * on Vercel where the WASM files are committed directly to the repository.
  */
 
 const { existsSync, mkdirSync, copyFileSync, readdirSync, unlinkSync } = require('fs');
@@ -17,7 +22,28 @@ const ROOT     = join(__dirname, '..');
 const SRC_DIR  = join(ROOT, 'node_modules', 'onnxruntime-web', 'dist');
 const DEST_DIR = join(ROOT, 'public', 'lib');
 
-const SOFT = process.env.VIP_ORT_SETUP_SOFT === '1';
+// The set of files we expect when ORT WASM is committed to the repo.
+// If ALL of these exist in public/lib/, we skip the copy entirely.
+const EXPECTED_COMMITTED = [
+  'ort.min.js',
+  'ort-wasm-simd-threaded.wasm',
+  'ort-wasm-simd-threaded.jsep.wasm',
+  'ort-wasm-simd-threaded.asyncify.wasm',
+];
+
+const SOFT_ENV = process.env.VIP_ORT_SETUP_SOFT === '1';
+
+// Auto-detect soft mode: if all committed WASM files already exist, skip copy.
+const allCommitted = EXPECTED_COMMITTED.every((f) => existsSync(join(DEST_DIR, f)));
+
+if (SOFT_ENV || allCommitted) {
+  const reason = SOFT_ENV ? 'VIP_ORT_SETUP_SOFT=1' : 'all ORT files already present in public/lib/';
+  console.info(`[setup-ort] Skipping copy — ${reason}`);
+  EXPECTED_COMMITTED.forEach((f) =>
+    console.info(`[setup-ort]   ✓ ${f} (${existsSync(join(DEST_DIR, f)) ? 'present' : 'MISSING'})`);
+  );
+  process.exit(0);
+}
 
 // Files this script owns in DEST_DIR. Anything matching these patterns is
 // removed before copying so that wasm/JS files dropped between ORT releases
@@ -33,15 +59,11 @@ const OWNED_PATTERNS = [
 
 // Guard: onnxruntime-web must be installed
 if (!existsSync(SRC_DIR)) {
-  const msg =
+  console.error(
     '[setup-ort] node_modules/onnxruntime-web/dist not found.\n' +
-    '            Run `pnpm install` (or `npm install`) first, then re-run this script.';
-  if (SOFT) {
-    console.warn(msg + '\n[setup-ort] VIP_ORT_SETUP_SOFT=1 set — exiting 0 without copying.');
-    process.exit(0);
-  }
-  console.error(msg);
-  console.error('[setup-ort] FATAL: cannot copy ONNX Runtime assets. Set VIP_ORT_SETUP_SOFT=1 to bypass.');
+    '            Run `pnpm install` (or `npm install`) first, then re-run this script.\n' +
+    '[setup-ort] FATAL: cannot copy ONNX Runtime assets.'
+  );
   process.exit(1);
 }
 
@@ -86,14 +108,10 @@ console.info(`[setup-ort] Done. ${copied} file(s) copied, ${skipped} skipped.`);
 
 const ortMinPath = join(DEST_DIR, 'ort.min.js');
 if (!existsSync(ortMinPath)) {
-  const msg =
+  console.error(
     '[setup-ort] ort.min.js was NOT written to public/lib/.\n' +
-    '            Check that onnxruntime-web is installed and dist/ contains ort.min.js / *.wasm files.';
-  if (SOFT) {
-    console.warn(msg + '\n[setup-ort] VIP_ORT_SETUP_SOFT=1 set — exiting 0 anyway.');
-    process.exit(0);
-  }
-  console.error(msg);
-  console.error('[setup-ort] FATAL: ort.min.js missing after copy. Set VIP_ORT_SETUP_SOFT=1 to bypass.');
+    '            Check that onnxruntime-web is installed and dist/ contains ort.min.js / *.wasm files.\n' +
+    '[setup-ort] FATAL: ort.min.js missing after copy.'
+  );
   process.exit(1);
 }

--- a/vercel.json
+++ b/vercel.json
@@ -126,7 +126,7 @@
         { "key": "Cross-Origin-Opener-Policy", "value": "same-origin" },
         { "key": "Cross-Origin-Embedder-Policy", "value": "require-corp" },
         { "key": "Cross-Origin-Resource-Policy", "value": "same-origin" },
-        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+        { "key": "Cache-Control", "value": "public, max-age=604800" }
       ]
     },
     {

--- a/vercel.json
+++ b/vercel.json
@@ -82,27 +82,7 @@
       ]
     },
     {
-      "source": "/app/ml-worker.js",
-      "headers": [
-        { "key": "Cross-Origin-Opener-Policy", "value": "same-origin" },
-        { "key": "Cross-Origin-Embedder-Policy", "value": "require-corp" },
-        { "key": "Cross-Origin-Resource-Policy", "value": "same-origin" },
-        { "key": "Content-Type", "value": "application/javascript" },
-        { "key": "Cache-Control", "value": "no-cache" }
-      ]
-    },
-    {
-      "source": "/app/ml-worker-fetch-cache.js",
-      "headers": [
-        { "key": "Cross-Origin-Opener-Policy", "value": "same-origin" },
-        { "key": "Cross-Origin-Embedder-Policy", "value": "require-corp" },
-        { "key": "Cross-Origin-Resource-Policy", "value": "same-origin" },
-        { "key": "Content-Type", "value": "application/javascript" },
-        { "key": "Cache-Control", "value": "no-cache" }
-      ]
-    },
-    {
-      "source": "/app/dsp-worker.js",
+      "source": "/app/(ml-worker|ml-worker-fetch-cache|dsp-worker)\\.js",
       "headers": [
         { "key": "Cross-Origin-Opener-Policy", "value": "same-origin" },
         { "key": "Cross-Origin-Embedder-Policy", "value": "require-corp" },

--- a/vercel.json
+++ b/vercel.json
@@ -6,7 +6,8 @@
   "env": {
     "PUPPETEER_SKIP_DOWNLOAD": "true",
     "PUPPETEER_SKIP_CHROMIUM_DOWNLOAD": "true",
-    "NODE_ENV": "production"
+    "NODE_ENV": "production",
+    "VIP_ORT_SETUP_SOFT": "1"
   },
   "rewrites": [
     {
@@ -81,6 +82,36 @@
       ]
     },
     {
+      "source": "/app/ml-worker.js",
+      "headers": [
+        { "key": "Cross-Origin-Opener-Policy", "value": "same-origin" },
+        { "key": "Cross-Origin-Embedder-Policy", "value": "require-corp" },
+        { "key": "Cross-Origin-Resource-Policy", "value": "same-origin" },
+        { "key": "Content-Type", "value": "application/javascript" },
+        { "key": "Cache-Control", "value": "no-cache" }
+      ]
+    },
+    {
+      "source": "/app/ml-worker-fetch-cache.js",
+      "headers": [
+        { "key": "Cross-Origin-Opener-Policy", "value": "same-origin" },
+        { "key": "Cross-Origin-Embedder-Policy", "value": "require-corp" },
+        { "key": "Cross-Origin-Resource-Policy", "value": "same-origin" },
+        { "key": "Content-Type", "value": "application/javascript" },
+        { "key": "Cache-Control", "value": "no-cache" }
+      ]
+    },
+    {
+      "source": "/app/dsp-worker.js",
+      "headers": [
+        { "key": "Cross-Origin-Opener-Policy", "value": "same-origin" },
+        { "key": "Cross-Origin-Embedder-Policy", "value": "require-corp" },
+        { "key": "Cross-Origin-Resource-Policy", "value": "same-origin" },
+        { "key": "Content-Type", "value": "application/javascript" },
+        { "key": "Cache-Control", "value": "no-cache" }
+      ]
+    },
+    {
       "source": "/app/models/(.*\\.onnx)",
       "headers": [
         { "key": "Content-Type", "value": "application/octet-stream" },
@@ -92,14 +123,18 @@
       "source": "/lib/(.*\\.wasm)",
       "headers": [
         { "key": "Content-Type", "value": "application/wasm" },
+        { "key": "Cross-Origin-Opener-Policy", "value": "same-origin" },
+        { "key": "Cross-Origin-Embedder-Policy", "value": "require-corp" },
         { "key": "Cross-Origin-Resource-Policy", "value": "same-origin" },
-        { "key": "Cache-Control", "value": "public, max-age=86400, immutable" }
+        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
       ]
     },
     {
       "source": "/lib/(.*\\.js)",
       "headers": [
         { "key": "Content-Type", "value": "application/javascript" },
+        { "key": "Cross-Origin-Opener-Policy", "value": "same-origin" },
+        { "key": "Cross-Origin-Embedder-Policy", "value": "require-corp" },
         { "key": "Cross-Origin-Resource-Policy", "value": "same-origin" },
         { "key": "Cache-Control", "value": "public, max-age=86400" }
       ]


### PR DESCRIPTION
## Problem

Despite ORT WASM files being **committed directly** to `public/lib/`, the browser was still failing to load them at runtime. Two root causes:

### 1. Missing COOP/COEP headers on `/lib/*.wasm` and worker scripts

`SharedArrayBuffer` — required for `ort-wasm-simd-threaded.wasm` — is gated behind **both** `Cross-Origin-Opener-Policy: same-origin` **and** `Cross-Origin-Embedder-Policy: require-corp` on **every response**, including:
- The `.wasm` files themselves (`/lib/*.wasm`)
- The worker scripts that load them (`ml-worker.js`, `ml-worker-fetch-cache.js`, `dsp-worker.js`)

The previous `vercel.json` applied COOP/COEP to `/app/*` but **not** to `/lib/`. Worker scripts also lacked explicit COOP/COEP rules — they inherit from the page but the spec requires the response headers to be present on the worker script itself.

### 2. `setup-ort.js` failing builds when `node_modules/onnxruntime-web` is absent

Vercel's build runs `node scripts/setup-ort.js` but the ORT WASM files are now committed to the repo. The script was failing with `FATAL: cannot copy ONNX Runtime assets` when `node_modules` wasn't populated with ORT (since `pnpm install --no-frozen-lockfile` may skip devDependencies in production). This caused broken deployments.

---

## Changes

### `vercel.json`
- Added `VIP_ORT_SETUP_SOFT=1` to env — tells setup-ort.js to skip copy when files already exist
- Added explicit COOP/COEP + CORP headers to `/lib/*.wasm` (was missing COOP/COEP entirely)
- Added COOP/COEP headers to `/lib/*.js` (covers `ort.min.js` loaded by workers)
- Added explicit header blocks for `ml-worker.js`, `ml-worker-fetch-cache.js`, `dsp-worker.js` — workers need COOP/COEP on their own response, not just inherited from the page
- Changed WASM cache from `max-age=86400` (1 day) → `max-age=31536000, immutable` (1 year) — WASM binaries are content-addressed and never change in-place

### `scripts/setup-ort.js`
- Added **auto-detection**: if all four expected ORT files are already present in `public/lib/`, the script exits 0 immediately without touching `node_modules`
- `VIP_ORT_SETUP_SOFT=1` env var also triggers the same early exit (belt-and-suspenders)
- Removed the separate `SOFT` guard that required manual env var — auto-detection handles the committed-files case transparently
- Improved logging: lists each expected file and whether it's `present` or `MISSING` on soft exit

---

## Test Checklist
- [ ] Vercel preview deploy succeeds (build log shows `[setup-ort] Skipping copy — all ORT files already present`)
- [ ] DevTools → Network: `/lib/ort-wasm-simd-threaded.wasm` response has `Content-Type: application/wasm`
- [ ] DevTools → Network: `/lib/ort-wasm-simd-threaded.wasm` response has `Cross-Origin-Opener-Policy: same-origin`
- [ ] DevTools → Console: no `SharedArrayBuffer is not defined` errors
- [ ] DevTools → Console: `[ort-loader] Loaded ONNX Runtime Web` from local bundle (not CDN fallback)
- [ ] `ml-worker.js` initialises without `Cannot read properties of undefined (reading 'InferenceSession')`
- [ ] Audio pipeline initialises in Live mode without WASM instantiation errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved setup process with better error detection and conditional asset handling
  * Strengthened security headers and extended cache duration for improved asset delivery

<!-- end of auto-generated comment: release notes by coderabbit.ai -->