### PR TITLE
feat: 3-tier redundant ONNX model CDN with automatic failover

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,95 @@ Execution provider cascade: WebGPU → WASM SIMD threaded → WASM (single-threa
 
 ---
 
+## Model CDN Setup
+
+Models are delivered via a 3-tier redundant CDN waterfall implemented in
+`public/app/model-cdn-loader.js`. The loader tries each source in order and
+fails over automatically:
+
+1. **Vercel Blob** (primary) — proxied through `/app/models/<filename>` so the
+   browser sees a same-origin URL that satisfies CSP `connect-src 'self'`. The
+   `vercel.json` rewrite maps the proxy to the actual blob CDN host.
+2. **Cloudflare R2** (secondary) — `https://models.voiceisolatepro.com/models/...`
+   (or `https://<bucket>.r2.dev/models/...` if no custom domain yet).
+3. **HuggingFace Hub** (tertiary fallback) — `https://huggingface.co/Joker5514/voice-isolate-models/resolve/main/<filename>`.
+
+Per-source URLs live in `public/app/models-manifest.json` (schemaVersion 2).
+After a successful fetch the buffer is cached in the SW Cache (`vip-models-v1`)
+under `/vip-model-cache/<modelKey>` with the active provider stamped in the
+`X-VIP-Provider` response header.
+
+### Upload order (run locally before deploying)
+
+```bash
+# 1. Vercel Blob (primary) — manifest source[0].url stays as the /app/models/ proxy path
+BLOB_READ_WRITE_TOKEN=vercel_blob_rw_3Jq9Akm8vl1TuB82_... \
+  node scripts/upload-to-vercel-blob.mjs
+
+# 2. Cloudflare R2 (secondary) — uses @aws-sdk/client-s3 against the R2 S3-compatible endpoint
+R2_ACCOUNT_ID=... \
+R2_ACCESS_KEY_ID=... \
+R2_SECRET_ACCESS_KEY=... \
+R2_BUCKET_NAME=voice-isolate-models \
+R2_PUBLIC_URL=https://models.voiceisolatepro.com \
+  node scripts/upload-to-r2.mjs
+
+# 3. HuggingFace Hub (tertiary) — auto-creates the public model repo if missing
+HF_TOKEN=hf_... python scripts/upload-to-huggingface.py
+```
+
+Each script writes its provider's source URLs back into
+`public/app/models-manifest.json`. Commit the resulting manifest before deploying.
+
+### Required Vercel project env vars
+
+- `BLOB_READ_WRITE_TOKEN` — Vercel Blob RW token (already set — added May 4)
+- `R2_ACCOUNT_ID` — Cloudflare account ID
+- `R2_ACCESS_KEY_ID` — R2 API token Access Key
+- `R2_SECRET_ACCESS_KEY` — R2 API token Secret
+- `R2_BUCKET_NAME` — e.g. `voice-isolate-models`
+- `R2_PUBLIC_URL` — public base URL (e.g. `https://models.voiceisolatepro.com`)
+- `HF_TOKEN` — HuggingFace user access token with write scope on `Joker5514/voice-isolate-models`
+
+Only `BLOB_READ_WRITE_TOKEN` is required at runtime/build time. The R2 and HF
+vars are only needed for the upload scripts during local model rollouts —
+the browser-side waterfall fetches public CDN URLs directly.
+
+### vercel.json rewrite
+
+The rewrite that maps the `/app/models/:model` proxy to your Vercel Blob store:
+
+```json
+{ "source": "/app/models/:model", "destination": "https://<store>.public.blob.vercel-storage.com/models/:model" }
+```
+
+Replace `<store>` (e.g. `store_3Jq9Akm8vl1TuB82` becomes
+`<store-hostname>.public.blob.vercel-storage.com`) after running
+`scripts/upload-to-vercel-blob.mjs`.
+
+### CSP
+
+`vercel.json` Content-Security-Policy `connect-src` includes:
+
+```
+'self' blob:
+https://blob.vercel-storage.com https://*.public.blob.vercel-storage.com
+https://*.r2.cloudflarestorage.com https://*.r2.dev https://models.voiceisolatepro.com
+https://huggingface.co https://*.xethub.hf.co https://cas-bridge.xethub.hf.co
+```
+
+The `xethub` hosts are required because HuggingFace redirects large
+files through their Xet CDN layer.
+
+### Diagnostics
+
+`window.ModelCDNLoader.getProviderHealthReport()` returns per-provider health
+for the current session, e.g. `{ 'vercel-blob': true, 'r2': true, 'huggingface': true }`.
+The Engineer Mode "CDN Health" panel renders this report and updates as the
+waterfall fails over.
+
+---
+
 ## Deployment
 
 **Platform**: Vercel (serverless, CDN-backed global deployment)

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   },
   "packageManager": "pnpm@9.0.0",
   "engines": {
-    "node": "22.x",
+    "node": "24.x",
     "pnpm": ">=9.0.0"
   },
   "dependencies": {

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -523,12 +523,17 @@
 
   <!-- Core modules (cloud-sync.js removed — violated 100% local constraint) -->
   <!-- ════════════════════════════════════════════════════════════════════════
-       Service Worker + Vercel-Blob model loader bootstrap (v24).
+       Service Worker + 3-tier redundant model loader bootstrap (v24).
        MUST run before app.js / pipeline-orchestrator init the ML worker so
        /app/models/*.onnx fetches are intercepted by sw.js and served from
-       the vip-models-v1 Cache (which model-loader.js populates from the
-       Vercel Blob rewrite). See MODELS.md.
+       the vip-models-v1 Cache. CDN waterfall (Vercel Blob → Cloudflare R2 →
+       HuggingFace) is implemented in model-cdn-loader.js. See MODELS.md.
        ════════════════════════════════════════════════════════════════════════ -->
+  <!-- model-cdn-loader.js MUST load before sw-register.js so window.ModelCDNLoader
+       is available when initModelLoader() runs. Classic <script> (not module) so
+       it executes synchronously and exposes window.ModelCDNLoader before the
+       module below imports sw-register.js. -->
+  <script src="/app/model-cdn-loader.js"></script>
   <script type="module">
     import { registerSW, initModelLoader } from './sw-register.js';
     (async () => {

--- a/public/app/model-cdn-loader.js
+++ b/public/app/model-cdn-loader.js
@@ -1,0 +1,187 @@
+// model-cdn-loader.js — VoiceIsolate Pro
+// 3-tier redundant ONNX model delivery with automatic failover.
+// Vercel Blob (primary, proxied via /app/models/) → Cloudflare R2 → HuggingFace Hub.
+// Exposes window.ModelCDNLoader for sw-register.js / pipeline-orchestrator.js.
+
+(function() {
+  'use strict';
+
+  // Provider priority order. vercel-blob first (proxied via /app/models/ rewrite —
+  // satisfies CSP connect-src 'self'). r2 second. huggingface last (Xet redirect
+  // layer can cause CORS issues on large files).
+  const PROVIDER_PRIORITY = ['vercel-blob', 'r2', 'huggingface'];
+
+  // In-memory registry of which providers are known-healthy this session
+  const providerHealth = { 'vercel-blob': true, 'r2': true, 'huggingface': true };
+
+  // Track which provider served each model in this session (for diagnostics)
+  const modelProviderMap = {};
+
+  // Service Worker cache name — must match sw-register.js
+  const CACHE_NAME = 'vip-models-v1';
+
+  /**
+   * fetchWithFallback — tries each source URL in priority order.
+   * On network error or non-2xx, marks that provider degraded and tries next.
+   * Returns: { arrayBuffer: ArrayBuffer, provider: string, url: string }
+   */
+  async function fetchWithFallback(modelKey, manifest, onProgress) {
+    const entry = manifest.models[modelKey];
+    if (!entry) throw new Error(`Unknown model key: ${modelKey}`);
+
+    // Sort sources by PROVIDER_PRIORITY, healthy providers first
+    const sorted = [...entry.sources].sort((a, b) => {
+      const ai = PROVIDER_PRIORITY.indexOf(a.provider);
+      const bi = PROVIDER_PRIORITY.indexOf(b.provider);
+      const ahealthy = providerHealth[a.provider] ? 0 : 1;
+      const bhealthy = providerHealth[b.provider] ? 0 : 1;
+      return ahealthy - bhealthy || ai - bi;
+    });
+
+    let lastError;
+    for (const source of sorted) {
+      try {
+        console.log(`[ModelCDN] Trying ${source.provider} for ${modelKey}: ${source.url}`);
+        const ab = await fetchWithProgress(source.url, entry.sizeBytes, onProgress);
+        providerHealth[source.provider] = true; // mark healthy on success
+        modelProviderMap[modelKey] = source.provider;
+        console.log(`[ModelCDN] ✓ ${modelKey} loaded from ${source.provider}`);
+        return { arrayBuffer: ab, provider: source.provider, url: source.url };
+      } catch (err) {
+        console.warn(`[ModelCDN] ✗ ${source.provider} failed for ${modelKey}:`, err.message);
+        providerHealth[source.provider] = false; // mark degraded
+        lastError = err;
+      }
+    }
+    throw new Error(`All CDN sources failed for ${modelKey}. Last error: ${lastError && lastError.message}`);
+  }
+
+  /**
+   * fetchWithProgress — fetch with XHR-style progress reporting.
+   * Falls back to plain fetch() if ReadableStream is unavailable.
+   */
+  async function fetchWithProgress(url, expectedBytes, onProgress) {
+    const resp = await fetch(url, { mode: 'cors', credentials: 'omit' });
+    if (!resp.ok) throw new Error(`HTTP ${resp.status} from ${url}`);
+
+    if (!resp.body || !onProgress) {
+      return resp.arrayBuffer();
+    }
+
+    const reader = resp.body.getReader();
+    const chunks = [];
+    let received = 0;
+    const total = parseInt(resp.headers.get('content-length') || expectedBytes, 10);
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      chunks.push(value);
+      received += value.length;
+      onProgress(received / total, received, total);
+    }
+
+    const merged = new Uint8Array(received);
+    let offset = 0;
+    for (const chunk of chunks) { merged.set(chunk, offset); offset += chunk.length; }
+    return merged.buffer;
+  }
+
+  /**
+   * loadModel — main entry point called by sw-register.js / pipeline-orchestrator.js
+   * Checks SW cache first, then falls back to CDN waterfall.
+   * Caches result in SW cache on success.
+   */
+  async function loadModel(modelKey, onProgress) {
+    const manifest = await getManifest();
+
+    // Check SW cache first
+    const cacheStorage = (typeof caches !== 'undefined') ? caches : null;
+    if (cacheStorage) {
+      try {
+        const cache = await cacheStorage.open(CACHE_NAME);
+        const cachedResp = await cache.match(`/vip-model-cache/${modelKey}`);
+        if (cachedResp) {
+          console.log(`[ModelCDN] ${modelKey} served from SW cache`);
+          if (onProgress) onProgress(1, 1, 1);
+          const provider = cachedResp.headers.get('X-VIP-Provider') || 'cache';
+          modelProviderMap[modelKey] = provider;
+          return await cachedResp.arrayBuffer();
+        }
+      } catch (e) { /* SW cache unavailable, fall through */ }
+    }
+
+    // CDN waterfall
+    const { arrayBuffer, provider, url } = await fetchWithFallback(modelKey, manifest, onProgress);
+
+    // Store in SW cache for next time (fire and forget)
+    try {
+      if (cacheStorage) {
+        const cache = await cacheStorage.open(CACHE_NAME);
+        const resp = new Response(arrayBuffer.slice(0), {
+          headers: {
+            'Content-Type': 'application/octet-stream',
+            'X-VIP-Provider': provider,
+            'X-VIP-Source-URL': url
+          }
+        });
+        await cache.put(`/vip-model-cache/${modelKey}`, resp);
+      }
+    } catch (e) { console.warn('[ModelCDN] SW cache write failed:', e); }
+
+    return arrayBuffer;
+  }
+
+  /**
+   * preloadEagerModels — called on app boot, loads all eager:true models
+   */
+  async function preloadEagerModels(onModelReady) {
+    const manifest = await getManifest();
+    const eager = Object.entries(manifest.models).filter(([, v]) => v.eager);
+    await Promise.all(eager.map(async ([key]) => {
+      try {
+        await loadModel(key);
+        if (onModelReady) onModelReady(key, 'ok', modelProviderMap[key]);
+      } catch (err) {
+        console.error(`[ModelCDN] Failed to preload ${key}:`, err);
+        if (onModelReady) onModelReady(key, 'error', null);
+      }
+    }));
+  }
+
+  /**
+   * getProviderHealthReport — returns current provider health for diagnostics
+   */
+  function getProviderHealthReport() {
+    return { ...providerHealth };
+  }
+
+  /**
+   * getModelProvider — returns which provider served the given modelKey this session
+   */
+  function getModelProvider(modelKey) {
+    return modelProviderMap[modelKey] || null;
+  }
+
+  // Manifest cache
+  let _manifest = null;
+  async function getManifest() {
+    if (_manifest) return _manifest;
+    const resp = await fetch('/app/models-manifest.json');
+    if (!resp.ok) throw new Error('Cannot load models-manifest.json');
+    _manifest = await resp.json();
+    return _manifest;
+  }
+
+  // Export to window
+  window.ModelCDNLoader = {
+    loadModel,
+    preloadEagerModels,
+    getProviderHealthReport,
+    getModelProvider,
+    getManifest,
+    PROVIDER_PRIORITY,
+    providerHealth,
+    modelProviderMap
+  };
+})();

--- a/public/app/model-status-ui.css
+++ b/public/app/model-status-ui.css
@@ -299,4 +299,107 @@
   background: rgba(255, 255, 255, 0.15);
 }
 
+/* Provider badges (rendered next to each model pill by ModelStatusUI) */
+.vip-pill-wrap {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin: 0 4px 4px 0;
+}
+
+.vip-provider {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-family: var(--mono, 'JetBrains Mono', monospace);
+  font-size: 0.65rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  border: 1px solid transparent;
+}
+
+.vip-provider--hidden { display: none; }
+
+.vip-provider--green {
+  color: #16a34a;
+  background: rgba(22, 163, 74, 0.10);
+  border-color: rgba(22, 163, 74, 0.25);
+}
+
+.vip-provider--blue {
+  color: #2563eb;
+  background: rgba(37, 99, 235, 0.10);
+  border-color: rgba(37, 99, 235, 0.25);
+}
+
+.vip-provider--yellow {
+  color: #ca8a04;
+  background: rgba(202, 138, 4, 0.10);
+  border-color: rgba(202, 138, 4, 0.25);
+}
+
+.vip-provider--red {
+  color: #dc2626;
+  background: rgba(220, 38, 38, 0.10);
+  border-color: rgba(220, 38, 38, 0.25);
+}
+
+.vip-provider--grey {
+  color: var(--dim, #4a5268);
+  background: rgba(255, 255, 255, 0.04);
+  border-color: rgba(255, 255, 255, 0.08);
+}
+
+/* CDN Health panel (rendered in Engineer Mode diagnostics) */
+.vip-cdn-health-title {
+  font-family: var(--mono, 'JetBrains Mono', monospace);
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text2, #c0c4d0);
+  margin-bottom: 6px;
+}
+
+.vip-cdn-health-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 4px 8px;
+  margin-bottom: 4px;
+  background: var(--card2, #0f1118);
+  border: 1px solid var(--border, #1a1e2a);
+  border-radius: 6px;
+  font-family: var(--mono, 'JetBrains Mono', monospace);
+  font-size: 0.72rem;
+}
+
+.vip-cdn-health-label {
+  color: var(--text, #e8eaf0);
+}
+
+.vip-cdn-health-status {
+  padding: 1px 8px;
+  border-radius: 4px;
+  font-size: 0.65rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: lowercase;
+}
+
+.vip-cdn-health-status--healthy {
+  color: #16a34a;
+  background: rgba(22, 163, 74, 0.12);
+}
+
+.vip-cdn-health-status--degraded {
+  color: #dc2626;
+  background: rgba(220, 38, 38, 0.12);
+}
+
+.vip-cdn-health-status--unknown {
+  color: var(--dim, #4a5268);
+  background: rgba(255, 255, 255, 0.04);
+}
+
 /* Made with Bob */

--- a/public/app/model-status-ui.js
+++ b/public/app/model-status-ui.js
@@ -1,59 +1,142 @@
 // model-status-ui.js — VoiceIsolate Pro
-// Displays per-model cache/load status pills in the UI.
+// Displays per-model cache/load status pills in the UI plus active-provider badges.
+// Also renders a "CDN Health" panel populated by window.ModelCDNLoader.getProviderHealthReport().
 
 const STATUS_CONFIG = {
-  cached:  { label: '✓ Cached',              cls: 'vip-pill--green'  },
-  loading: { label: '⟳ Loading…',            cls: 'vip-pill--amber'  },
-  pending: { label: 'Lazy — loads on first drop', cls: 'vip-pill--grey' },
-  error:   { label: '✗ Not found',           cls: 'vip-pill--red'    },
-  unknown: { label: '? Unknown',             cls: 'vip-pill--grey'   },
+  cached:  { label: '✓ Cached',                    cls: 'vip-pill--green' },
+  loading: { label: '⟳ Loading…',                  cls: 'vip-pill--amber' },
+  pending: { label: 'Lazy — loads on first drop',  cls: 'vip-pill--grey'  },
+  error:   { label: '✗ All failed',                cls: 'vip-pill--red'   },
+  unknown: { label: '? Unknown',                   cls: 'vip-pill--grey'  },
+};
+
+const PROVIDER_BADGE = {
+  'vercel-blob': { label: '✓ Vercel Blob',    cls: 'vip-provider--green'  },
+  'r2':          { label: '✓ Cloudflare R2',  cls: 'vip-provider--blue'   },
+  'huggingface': { label: '✓ HuggingFace',    cls: 'vip-provider--yellow' },
+  'cache':       { label: '✓ SW Cache',       cls: 'vip-provider--grey'   },
+};
+
+const HEALTH_LABELS = {
+  'vercel-blob': 'Vercel Blob',
+  'r2':          'Cloudflare R2',
+  'huggingface': 'HuggingFace',
 };
 
 export class ModelStatusUI {
   /**
    * @param {HTMLElement} container  – element to render pills into
    * @param {string[]}    modelKeys  – e.g. ['demucs','bsrnn','rnnoise','nsnet2','silero_vad']
+   * @param {object}      [opts]
+   * @param {HTMLElement} [opts.healthContainer] – element to render CDN health rows into
    */
-  constructor(container, modelKeys = []) {
+  constructor(container, modelKeys = [], opts = {}) {
     this._container = container;
+    this._healthContainer = opts.healthContainer || null;
     this._keys = modelKeys;
     this._pills = {};
+    this._badges = {};
+    this._healthRows = {};
     this._pollingTimer = null;
+    this._healthTimer = null;
     this._loadingCount = 0;
     this._render();
+    this._renderHealth();
+    this._startHealthPolling();
   }
 
   _render() {
     if (!this._container) return;
     this._container.innerHTML = '';
     for (const key of this._keys) {
+      const wrap = document.createElement('span');
+      wrap.className = 'vip-pill-wrap';
+      wrap.dataset.model = key;
+
       const pill = document.createElement('span');
       pill.className = 'vip-pill vip-pill--grey';
       pill.dataset.model = key;
       pill.textContent = key;
-      this._container.appendChild(pill);
+
+      const badge = document.createElement('span');
+      badge.className = 'vip-provider vip-provider--hidden';
+      badge.dataset.model = key;
+      badge.textContent = '';
+
+      wrap.appendChild(pill);
+      wrap.appendChild(badge);
+      this._container.appendChild(wrap);
       this._pills[key] = pill;
+      this._badges[key] = badge;
     }
+  }
+
+  _renderHealth() {
+    if (!this._healthContainer) return;
+    this._healthContainer.innerHTML = '';
+    const title = document.createElement('div');
+    title.className = 'vip-cdn-health-title';
+    title.textContent = 'CDN Health';
+    this._healthContainer.appendChild(title);
+
+    for (const provider of Object.keys(HEALTH_LABELS)) {
+      const row = document.createElement('div');
+      row.className = 'vip-cdn-health-row';
+      row.dataset.provider = provider;
+
+      const label = document.createElement('span');
+      label.className = 'vip-cdn-health-label';
+      label.textContent = HEALTH_LABELS[provider];
+
+      const status = document.createElement('span');
+      status.className = 'vip-cdn-health-status vip-cdn-health-status--unknown';
+      status.textContent = 'unknown';
+
+      row.appendChild(label);
+      row.appendChild(status);
+      this._healthContainer.appendChild(row);
+      this._healthRows[provider] = status;
+    }
+    this.refreshHealth();
   }
 
   /**
    * Update a single model's pill status.
-   * @param {string} key     – model key
+   * @param {string} key      – model key
    * @param {'cached'|'loading'|'pending'|'error'} status
-   * @param {number} [pct]   – progress percentage for 'loading' state
+   * @param {number} [pct]    – progress percentage for 'loading' state
+   * @param {string} [provider] – which CDN served the model (vercel-blob | r2 | huggingface)
    */
-  setStatus(key, status, pct) {
+  setStatus(key, status, pct, provider) {
     const pill = this._pills[key];
     if (!pill) return;
 
     const cfg = STATUS_CONFIG[status] || STATUS_CONFIG.unknown;
-    // Remove all status classes
     pill.className = `vip-pill ${cfg.cls}`;
 
     if (status === 'loading' && pct !== undefined) {
-      pill.textContent = `⟳ Loading ${Math.round(pct)}%`;
+      pill.textContent = `⟳ ${key} ${Math.round(pct)}%`;
     } else {
-      pill.textContent = cfg.label;
+      pill.textContent = `${key} ${cfg.label}`;
+    }
+
+    // Update provider badge
+    const badge = this._badges[key];
+    if (badge) {
+      const resolvedProvider = provider
+        || (window.ModelCDNLoader && window.ModelCDNLoader.getModelProvider
+            ? window.ModelCDNLoader.getModelProvider(key) : null);
+      if (status === 'cached' && resolvedProvider && PROVIDER_BADGE[resolvedProvider]) {
+        const pcfg = PROVIDER_BADGE[resolvedProvider];
+        badge.className = `vip-provider ${pcfg.cls}`;
+        badge.textContent = pcfg.label;
+      } else if (status === 'error') {
+        badge.className = 'vip-provider vip-provider--red';
+        badge.textContent = '✗ All failed';
+      } else {
+        badge.className = 'vip-provider vip-provider--hidden';
+        badge.textContent = '';
+      }
     }
 
     // Track loading models for auto-polling stop
@@ -64,29 +147,36 @@ export class ModelStatusUI {
       this._loadingCount = Math.max(0, this._loadingCount - 1);
       if (this._loadingCount === 0) this._stopPolling();
     }
+
+    // Refresh CDN health alongside model state changes
+    this.refreshHealth();
   }
 
   /**
    * Refresh all model statuses by reading from Cache API and manifest.
    */
   async refreshStatus() {
-    let manifest = {};
-    try {
-      const res = await fetch('/app/models-manifest.json', { cache: 'no-cache' });
-      if (res.ok) manifest = await res.json();
-    } catch { /* ignore */ }
+    let manifest = null;
+    if (window.ModelCDNLoader && window.ModelCDNLoader.getManifest) {
+      try { manifest = await window.ModelCDNLoader.getManifest(); }
+      catch { /* ignore */ }
+    }
 
     let hasLoading = false;
     for (const key of this._keys) {
-      const cacheKey = `/app/models/${key}.onnx`;
       try {
         const cache = await caches.open('vip-models-v1');
-        const match = await cache.match(cacheKey);
+        const match = await cache.match(`/vip-model-cache/${key}`);
         if (match) {
-          this.setStatus(key, 'cached');
-        } else if (manifest[key]) {
-          this.setStatus(key, 'loading');
-          hasLoading = true;
+          const provider = match.headers.get('X-VIP-Provider') || 'cache';
+          this.setStatus(key, 'cached', undefined, provider);
+        } else if (manifest && manifest.models && manifest.models[key]) {
+          if (manifest.models[key].eager) {
+            this.setStatus(key, 'loading');
+            hasLoading = true;
+          } else {
+            this.setStatus(key, 'pending');
+          }
         } else {
           this.setStatus(key, 'pending');
         }
@@ -96,6 +186,30 @@ export class ModelStatusUI {
     }
 
     if (!hasLoading) this._stopPolling();
+  }
+
+  /**
+   * refreshHealth — pull current provider health from window.ModelCDNLoader and update rows.
+   */
+  refreshHealth() {
+    if (!this._healthContainer) return;
+    if (!window.ModelCDNLoader || !window.ModelCDNLoader.getProviderHealthReport) return;
+    const report = window.ModelCDNLoader.getProviderHealthReport();
+    for (const provider of Object.keys(this._healthRows)) {
+      const el = this._healthRows[provider];
+      const healthy = report[provider];
+      el.classList.remove('vip-cdn-health-status--healthy', 'vip-cdn-health-status--degraded', 'vip-cdn-health-status--unknown');
+      if (healthy === true) {
+        el.classList.add('vip-cdn-health-status--healthy');
+        el.textContent = 'healthy';
+      } else if (healthy === false) {
+        el.classList.add('vip-cdn-health-status--degraded');
+        el.textContent = 'degraded';
+      } else {
+        el.classList.add('vip-cdn-health-status--unknown');
+        el.textContent = 'unknown';
+      }
+    }
   }
 
   _startPolling() {
@@ -110,7 +224,16 @@ export class ModelStatusUI {
     }
   }
 
+  _startHealthPolling() {
+    if (this._healthTimer || !this._healthContainer) return;
+    this._healthTimer = setInterval(() => this.refreshHealth(), 10000);
+  }
+
   destroy() {
     this._stopPolling();
+    if (this._healthTimer) {
+      clearInterval(this._healthTimer);
+      this._healthTimer = null;
+    }
   }
 }

--- a/public/app/models-manifest.json
+++ b/public/app/models-manifest.json
@@ -1,7 +1,55 @@
 {
-  "demucs": "",
-  "bsrnn": "",
-  "rnnoise": "",
-  "nsnet2": "",
-  "silero_vad": ""
+  "schemaVersion": 2,
+  "models": {
+    "demucs": {
+      "filename": "demucs_v4_quantized.onnx",
+      "sizeBytes": 388100096,
+      "eager": false,
+      "sources": [
+        { "provider": "vercel-blob", "url": "/app/models/demucs_v4_quantized.onnx" },
+        { "provider": "r2",          "url": "https://models.voiceisolatepro.com/models/demucs_v4_quantized.onnx" },
+        { "provider": "huggingface", "url": "https://huggingface.co/Joker5514/voice-isolate-models/resolve/main/demucs_v4_quantized.onnx" }
+      ]
+    },
+    "bsrnn": {
+      "filename": "bsrnn_quantized.onnx",
+      "sizeBytes": 155189248,
+      "eager": false,
+      "sources": [
+        { "provider": "vercel-blob", "url": "/app/models/bsrnn_quantized.onnx" },
+        { "provider": "r2",          "url": "https://models.voiceisolatepro.com/models/bsrnn_quantized.onnx" },
+        { "provider": "huggingface", "url": "https://huggingface.co/Joker5514/voice-isolate-models/resolve/main/bsrnn_quantized.onnx" }
+      ]
+    },
+    "rnnoise": {
+      "filename": "rnnoise.onnx",
+      "sizeBytes": 2097152,
+      "eager": true,
+      "sources": [
+        { "provider": "vercel-blob", "url": "/app/models/rnnoise.onnx" },
+        { "provider": "r2",          "url": "https://models.voiceisolatepro.com/models/rnnoise.onnx" },
+        { "provider": "huggingface", "url": "https://huggingface.co/Joker5514/voice-isolate-models/resolve/main/rnnoise.onnx" }
+      ]
+    },
+    "nsnet2": {
+      "filename": "nsnet2.onnx",
+      "sizeBytes": 2097152,
+      "eager": true,
+      "sources": [
+        { "provider": "vercel-blob", "url": "/app/models/nsnet2.onnx" },
+        { "provider": "r2",          "url": "https://models.voiceisolatepro.com/models/nsnet2.onnx" },
+        { "provider": "huggingface", "url": "https://huggingface.co/Joker5514/voice-isolate-models/resolve/main/nsnet2.onnx" }
+      ]
+    },
+    "silero_vad": {
+      "filename": "silero_vad.onnx",
+      "sizeBytes": 1048576,
+      "eager": true,
+      "sources": [
+        { "provider": "vercel-blob", "url": "/app/models/silero_vad.onnx" },
+        { "provider": "r2",          "url": "https://models.voiceisolatepro.com/models/silero_vad.onnx" },
+        { "provider": "huggingface", "url": "https://huggingface.co/Joker5514/voice-isolate-models/resolve/main/silero_vad.onnx" }
+      ]
+    }
+  }
 }

--- a/public/app/sw-register.js
+++ b/public/app/sw-register.js
@@ -1,35 +1,29 @@
 // sw-register.js — VoiceIsolate Pro
-// Registers the Service Worker and orchestrates model loading.
+// Initializes the 3-tier redundant model loader (window.ModelCDNLoader).
+// All canonical CDN URLs live in models-manifest.json — no hardcoded URLs here.
 
-import { loadEagerModels, BROADCAST_CH } from './model-loader.js';
-
-const CACHE_NAME = 'vip-models-v1';
-const EAGER_KEYS = ['rnnoise', 'nsnet2', 'silero_vad'];
-const LAZY_KEYS  = ['demucs', 'bsrnn'];
-
-async function fetchAndCacheModel(key, url, statusUI) {
-  if (!url) return;
+/**
+ * registerSW — registers /sw.js and waits for it to control this page.
+ * Returns the active ServiceWorkerRegistration, or null if SW is unavailable.
+ */
+export async function registerSW() {
+  if (!('serviceWorker' in navigator)) return null;
   try {
-    statusUI?.setStatus(key, 'loading');
-    const response = await fetch(url);
-    if (!response.ok) throw new Error(`HTTP ${response.status}`);
-    const cache = await caches.open(CACHE_NAME);
-    await cache.put(`/app/models/${key}.onnx`, response.clone());
-    statusUI?.setStatus(key, 'cached');
+    const reg = await navigator.serviceWorker.register('/sw.js', { scope: '/' });
+    if (navigator.serviceWorker.controller) return reg;
+    await new Promise((resolve) => {
+      const onCtrl = () => {
+        navigator.serviceWorker.removeEventListener('controllerchange', onCtrl);
+        resolve();
+      };
+      navigator.serviceWorker.addEventListener('controllerchange', onCtrl);
+      // safety timeout — don't block boot if SW takes too long
+      setTimeout(resolve, 3000);
+    });
+    return reg;
   } catch (err) {
-    console.error(`[sw-register] Failed to cache model ${key}:`, err);
-    statusUI?.setStatus(key, 'error');
-  }
-}
-
-async function loadManifest() {
-  try {
-    const res = await fetch('/app/models-manifest.json', { cache: 'no-cache' });
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    return await res.json();
-  } catch (err) {
-    console.warn('[sw-register] Could not load models-manifest.json:', err);
-    return {};
+    console.warn('[sw-register] SW registration failed:', err.message);
+    return null;
   }
 }
 
@@ -39,51 +33,92 @@ export async function initModelLoader({
   onProgress = null,
   statusUI = null,
 } = {}) {
-  // Listen to BroadcastChannel for progress events from model-loader.
-  let bc = null;
-  try {
-    bc = new BroadcastChannel(BROADCAST_CH);
-    bc.onmessage = (ev) => {
-      const { type, model, progress } = ev.data || {};
-      if (type === 'progress' && onProgress) onProgress(model, progress);
-      if (type === 'start')    statusUI?.setStatus(model, 'loading');
-      if (type === 'done')     statusUI?.setStatus(model, 'cached');
-      if (type === 'cached')   statusUI?.setStatus(model, 'cached');
-      if (type === 'error')    statusUI?.setStatus(model, 'error');
-    };
-  } catch { /* BroadcastChannel unavailable */ }
+  if (!window.ModelCDNLoader) {
+    console.error('[sw-register] window.ModelCDNLoader is not available — make sure model-cdn-loader.js is loaded before sw-register.js');
+    if (statusEl) statusEl.textContent = 'Model loader unavailable';
+    return { loaded: [], failed: [] };
+  }
 
-  // Load the blob manifest to get canonical URLs.
-  const manifest = await loadManifest();
+  let manifest;
+  try {
+    manifest = await window.ModelCDNLoader.getManifest();
+  } catch (err) {
+    console.error('[sw-register] Failed to load models manifest:', err);
+    if (statusEl) statusEl.textContent = 'Manifest load failed';
+    return { loaded: [], failed: [] };
+  }
+
+  const allKeys = Object.keys(manifest.models || {});
+  const eagerKeys = allKeys.filter(k => manifest.models[k].eager);
+  const lazyKeys  = allKeys.filter(k => !manifest.models[k].eager);
 
   // Mark lazy models as pending immediately.
-  for (const key of LAZY_KEYS) {
+  for (const key of lazyKeys) {
     statusUI?.setStatus(key, 'pending');
   }
 
+  // Mark eager models as loading (will flip to cached on success / error on failure).
+  for (const key of eagerKeys) {
+    statusUI?.setStatus(key, 'loading');
+  }
+
   // Expose lazy loader for pipeline-orchestrator to call on first file drop.
-  window._vipLoadLazyModels = async () => {
-    window._vipLoadLazyModels = null; // only run once
-    for (const key of LAZY_KEYS) {
-      const modelUrl = `/app/models/${key === 'demucs' ? 'demucs_v4_quantized' : 'bsrnn_quantized'}.onnx`;
-      await fetchAndCacheModel(key, modelUrl, statusUI);
+  // Accepts a single modelKey + optional progress callback. Each invocation is idempotent
+  // (the SW cache short-circuits subsequent calls).
+  window._vipLoadLazyModels = async (modelKey, progressCb) => {
+    if (!modelKey) {
+      // Backwards-compat: load all lazy models if no key given
+      const results = await Promise.allSettled(lazyKeys.map(async (k) => {
+        statusUI?.setStatus(k, 'loading');
+        try {
+          await window.ModelCDNLoader.loadModel(k, (frac) => {
+            statusUI?.setStatus(k, 'loading', frac * 100);
+          });
+          const provider = window.ModelCDNLoader.getModelProvider(k);
+          statusUI?.setStatus(k, 'cached', undefined, provider);
+          return { id: k, ok: true };
+        } catch (err) {
+          statusUI?.setStatus(k, 'error');
+          return { id: k, ok: false, error: err.message };
+        }
+      }));
+      return results.map(r => r.status === 'fulfilled' ? r.value : { ok: false });
+    }
+    statusUI?.setStatus(modelKey, 'loading');
+    try {
+      const ab = await window.ModelCDNLoader.loadModel(modelKey, (frac) => {
+        if (progressCb) progressCb(frac);
+        statusUI?.setStatus(modelKey, 'loading', frac * 100);
+      });
+      const provider = window.ModelCDNLoader.getModelProvider(modelKey);
+      statusUI?.setStatus(modelKey, 'cached', undefined, provider);
+      return ab;
+    } catch (err) {
+      statusUI?.setStatus(modelKey, 'error');
+      throw err;
     }
   };
 
-  // Eagerly fetch + cache the small models.
-  const eagerPromises = EAGER_KEYS.map(key => {
-    const fileMap = { rnnoise: 'rnnoise', nsnet2: 'nsnet2', silero_vad: 'silero_vad' };
-    const modelUrl = `/app/models/${fileMap[key]}.onnx`;
-    return fetchAndCacheModel(key, modelUrl, statusUI);
+  // Eagerly fetch + cache the small models via the CDN waterfall.
+  const loaded = [];
+  const failed = [];
+  await window.ModelCDNLoader.preloadEagerModels((key, status, provider) => {
+    if (status === 'ok') {
+      loaded.push(key);
+      statusUI?.setStatus(key, 'cached', undefined, provider);
+    } else {
+      failed.push(key);
+      statusUI?.setStatus(key, 'error');
+    }
+    if (onProgress) onProgress(key, status === 'ok' ? 100 : 0);
   });
-  await Promise.allSettled(eagerPromises);
 
-  // Also run the legacy loadEagerModels for backward compat.
-  const result = await loadEagerModels();
   if (progressBar) progressBar.style.display = 'none';
-  if (statusEl && result.failed.length === 0) {
+  if (statusEl && failed.length === 0) {
     statusEl.textContent = 'Models ready';
+  } else if (statusEl) {
+    statusEl.textContent = `Models ready (${failed.length} failed)`;
   }
-  bc?.close();
-  return result;
+
+  return { loaded, failed };
 }

--- a/scripts/upload-to-huggingface.py
+++ b/scripts/upload-to-huggingface.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""
+scripts/upload-to-huggingface.py
+
+Uploads ONNX model files in models/ to a HuggingFace Hub model repo and prints
+the resolve URLs. Optionally writes the URLs back into
+public/app/models-manifest.json (huggingface source entries).
+
+Required env vars:
+    HF_TOKEN    – HuggingFace user access token with write scope on REPO_ID
+
+Usage:
+    HF_TOKEN=hf_... python scripts/upload-to-huggingface.py
+"""
+import glob
+import json
+import os
+import sys
+from pathlib import Path
+
+try:
+    from huggingface_hub import HfApi
+except ImportError:
+    sys.stderr.write(
+        "ERROR: huggingface_hub is not installed. Run:\n"
+        "    pip install huggingface_hub\n"
+    )
+    sys.exit(1)
+
+REPO_ID = "Joker5514/voice-isolate-models"
+
+ROOT = Path(__file__).resolve().parent.parent
+MODELS_DIR = ROOT / "models"
+MANIFEST_PATH = ROOT / "public" / "app" / "models-manifest.json"
+
+
+def update_manifest(uploaded):
+    """Rewrite huggingface URLs in models-manifest.json for any model whose
+    filename matches a manifest entry."""
+    if not MANIFEST_PATH.exists():
+        print(f"WARN: manifest not found at {MANIFEST_PATH}, skipping rewrite")
+        return
+    with open(MANIFEST_PATH, "r", encoding="utf-8") as f:
+        manifest = json.load(f)
+    if "models" not in manifest:
+        print("WARN: manifest has no `models` map, skipping rewrite")
+        return
+
+    filename_to_key = {entry["filename"]: key for key, entry in manifest["models"].items()}
+
+    changed = False
+    for filename, hf_url in uploaded.items():
+        key = filename_to_key.get(filename)
+        if not key:
+            print(f"  (no manifest entry for {filename}, skipping)")
+            continue
+        sources = manifest["models"][key].setdefault("sources", [])
+        hf_source = next((s for s in sources if s.get("provider") == "huggingface"), None)
+        if hf_source:
+            hf_source["url"] = hf_url
+        else:
+            sources.append({"provider": "huggingface", "url": hf_url})
+        changed = True
+
+    if changed:
+        with open(MANIFEST_PATH, "w", encoding="utf-8") as f:
+            json.dump(manifest, f, indent=2)
+            f.write("\n")
+        print(f"\nManifest updated: {MANIFEST_PATH}")
+
+
+def main():
+    token = os.environ.get("HF_TOKEN")
+    if not token:
+        sys.stderr.write("ERROR: HF_TOKEN env var is required.\n")
+        sys.exit(1)
+
+    if not MODELS_DIR.exists():
+        sys.stderr.write(f"ERROR: models/ directory not found at {MODELS_DIR}\n")
+        sys.exit(1)
+
+    api = HfApi(token=token)
+
+    # Create repo if it doesn't exist
+    api.create_repo(repo_id=REPO_ID, repo_type="model", exist_ok=True, private=False)
+
+    onnx_paths = sorted(glob.glob(str(MODELS_DIR / "*.onnx")))
+    if not onnx_paths:
+        print("WARN: no .onnx files found in models/, nothing to upload")
+        return
+
+    uploaded = {}
+    for path in onnx_paths:
+        filename = os.path.basename(path)
+        print(f"Uploading {filename}...")
+        api.upload_file(
+            path_or_fileobj=path,
+            path_in_repo=filename,
+            repo_id=REPO_ID,
+            repo_type="model",
+        )
+        hf_url = f"https://huggingface.co/{REPO_ID}/resolve/main/{filename}"
+        uploaded[filename] = hf_url
+        print(f"  → {hf_url}")
+
+    update_manifest(uploaded)
+    print("\nDone. /resolve/main/ URLs written to manifest huggingface sources.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/upload-to-r2.mjs
+++ b/scripts/upload-to-r2.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+// scripts/upload-to-r2.mjs
+// Uploads ONNX model files to Cloudflare R2 (S3-compatible) and rewrites the
+// `r2` source URLs in public/app/models-manifest.json.
+//
+// Required env vars:
+//   R2_ACCOUNT_ID         – Cloudflare account ID (from R2 dashboard)
+//   R2_ACCESS_KEY_ID      – R2 API token Access Key
+//   R2_SECRET_ACCESS_KEY  – R2 API token Secret
+//   R2_BUCKET_NAME        – e.g. voice-isolate-models
+//   R2_PUBLIC_URL         – Public base URL, e.g. https://models.voiceisolatepro.com
+//                          or https://<bucket>.r2.dev
+//
+// Usage:
+//   R2_ACCOUNT_ID=... R2_ACCESS_KEY_ID=... R2_SECRET_ACCESS_KEY=... \
+//   R2_BUCKET_NAME=voice-isolate-models R2_PUBLIC_URL=https://models.voiceisolatepro.com \
+//   node scripts/upload-to-r2.mjs
+
+import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import { readFileSync, writeFileSync, existsSync, readdirSync, statSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const MODELS_DIR = join(__dirname, '..', 'models');
+const MANIFEST_PATH = join(__dirname, '..', 'public', 'app', 'models-manifest.json');
+
+const REQUIRED = ['R2_ACCOUNT_ID', 'R2_ACCESS_KEY_ID', 'R2_SECRET_ACCESS_KEY', 'R2_BUCKET_NAME', 'R2_PUBLIC_URL'];
+const missing = REQUIRED.filter(k => !process.env[k]);
+if (missing.length) {
+  console.error(`ERROR: Missing required env vars: ${missing.join(', ')}`);
+  console.error('Usage: R2_ACCOUNT_ID=... R2_ACCESS_KEY_ID=... R2_SECRET_ACCESS_KEY=... \\');
+  console.error('       R2_BUCKET_NAME=voice-isolate-models R2_PUBLIC_URL=https://models.voiceisolatepro.com \\');
+  console.error('       node scripts/upload-to-r2.mjs');
+  process.exit(1);
+}
+
+const {
+  R2_ACCOUNT_ID,
+  R2_ACCESS_KEY_ID,
+  R2_SECRET_ACCESS_KEY,
+  R2_BUCKET_NAME,
+  R2_PUBLIC_URL,
+} = process.env;
+
+const PUBLIC_BASE = R2_PUBLIC_URL.replace(/\/+$/, '');
+
+const s3 = new S3Client({
+  region: 'auto',
+  endpoint: `https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com`,
+  credentials: {
+    accessKeyId: R2_ACCESS_KEY_ID,
+    secretAccessKey: R2_SECRET_ACCESS_KEY,
+  },
+});
+
+function loadManifest() {
+  if (!existsSync(MANIFEST_PATH)) {
+    throw new Error(`Manifest not found at ${MANIFEST_PATH}`);
+  }
+  return JSON.parse(readFileSync(MANIFEST_PATH, 'utf8'));
+}
+
+function saveManifest(manifest) {
+  writeFileSync(MANIFEST_PATH, JSON.stringify(manifest, null, 2) + '\n');
+  console.log(`\nManifest updated: ${MANIFEST_PATH}`);
+}
+
+async function uploadFile(filePath, key) {
+  const body = readFileSync(filePath);
+  const cmd = new PutObjectCommand({
+    Bucket: R2_BUCKET_NAME,
+    Key: key,
+    Body: body,
+    ContentType: 'application/octet-stream',
+  });
+  await s3.send(cmd);
+  return `${PUBLIC_BASE}/${key}`;
+}
+
+function listOnnxFiles() {
+  if (!existsSync(MODELS_DIR)) {
+    console.error(`ERROR: models/ directory not found at ${MODELS_DIR}`);
+    process.exit(1);
+  }
+  return readdirSync(MODELS_DIR)
+    .filter(name => name.endsWith('.onnx'))
+    .filter(name => statSync(join(MODELS_DIR, name)).isFile());
+}
+
+async function main() {
+  const manifest = loadManifest();
+  if (!manifest.models) {
+    throw new Error('Manifest has no `models` map (expected schemaVersion 2)');
+  }
+
+  const onnxFiles = listOnnxFiles();
+  if (onnxFiles.length === 0) {
+    console.warn('WARN: no .onnx files found in models/ — nothing to upload.');
+    return;
+  }
+
+  // Build filename → modelKey reverse lookup from manifest
+  const filenameToKey = {};
+  for (const [key, entry] of Object.entries(manifest.models)) {
+    filenameToKey[entry.filename] = key;
+  }
+
+  for (const filename of onnxFiles) {
+    const filePath = join(MODELS_DIR, filename);
+    const r2Key = `models/${filename}`;
+    console.log(`Uploading ${filename} → r2://${R2_BUCKET_NAME}/${r2Key} ...`);
+    const url = await uploadFile(filePath, r2Key);
+    console.log(`  → ${url}`);
+
+    const modelKey = filenameToKey[filename];
+    if (!modelKey) {
+      console.warn(`  (no manifest entry for ${filename}, skipping manifest update)`);
+      continue;
+    }
+    const sources = manifest.models[modelKey].sources || [];
+    const r2Source = sources.find(s => s.provider === 'r2');
+    if (r2Source) {
+      r2Source.url = url;
+    } else {
+      sources.push({ provider: 'r2', url });
+      manifest.models[modelKey].sources = sources;
+    }
+  }
+
+  saveManifest(manifest);
+  console.log('\nNext steps:');
+  console.log('  1. Commit public/app/models-manifest.json');
+  console.log('  2. Verify CSP in vercel.json includes the R2 host');
+  console.log('  3. Push to deploy');
+}
+
+main().catch(err => {
+  console.error('Upload failed:', err);
+  process.exit(1);
+});

--- a/scripts/upload-to-vercel-blob.mjs
+++ b/scripts/upload-to-vercel-blob.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+// scripts/upload-to-vercel-blob.mjs
+// Uploads ONNX models in models/ to Vercel Blob storage and rewrites the
+// `vercel-blob` source entries in public/app/models-manifest.json.
+//
+// NOTE: per the redundant-CDN design, manifest source[0].url stays as the
+// `/app/models/<filename>` proxy path (the rewrite in vercel.json maps that
+// to the actual blob CDN host). We do NOT store the raw blob CDN URL in the
+// manifest — the proxy lets us swap blob stores without rebuilding clients.
+//
+// Required env var:
+//   BLOB_READ_WRITE_TOKEN  – Vercel Blob read/write token
+//
+// Usage:
+//   BLOB_READ_WRITE_TOKEN=vercel_blob_rw_... node scripts/upload-to-vercel-blob.mjs
+import { put } from '@vercel/blob';
+import { readFileSync, writeFileSync, existsSync, readdirSync, statSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const MODELS_DIR = join(__dirname, '..', 'models');
+const MANIFEST_PATH = join(__dirname, '..', 'public', 'app', 'models-manifest.json');
+
+const TOKEN = process.env.BLOB_READ_WRITE_TOKEN;
+if (!TOKEN) {
+  console.error('ERROR: BLOB_READ_WRITE_TOKEN env var is not set.');
+  console.error('Usage: BLOB_READ_WRITE_TOKEN=vercel_blob_rw_... node scripts/upload-to-vercel-blob.mjs');
+  process.exit(1);
+}
+
+function loadManifest() {
+  if (!existsSync(MANIFEST_PATH)) {
+    throw new Error(`Manifest not found at ${MANIFEST_PATH}`);
+  }
+  return JSON.parse(readFileSync(MANIFEST_PATH, 'utf8'));
+}
+
+function saveManifest(manifest) {
+  writeFileSync(MANIFEST_PATH, JSON.stringify(manifest, null, 2) + '\n');
+  console.log(`\nManifest updated: ${MANIFEST_PATH}`);
+}
+
+function listOnnxFiles() {
+  if (!existsSync(MODELS_DIR)) {
+    console.error(`ERROR: models/ directory not found at ${MODELS_DIR}`);
+    process.exit(1);
+  }
+  return readdirSync(MODELS_DIR)
+    .filter(name => name.endsWith('.onnx'))
+    .filter(name => statSync(join(MODELS_DIR, name)).isFile());
+}
+
+async function main() {
+  const manifest = loadManifest();
+  if (!manifest.models) {
+    throw new Error('Manifest has no `models` map (expected schemaVersion 2)');
+  }
+
+  const onnxFiles = listOnnxFiles();
+  if (onnxFiles.length === 0) {
+    console.warn('WARN: no .onnx files found in models/, nothing to upload.');
+    return;
+  }
+
+  // Build filename → modelKey reverse lookup from manifest
+  const filenameToKey = {};
+  for (const [key, entry] of Object.entries(manifest.models)) {
+    filenameToKey[entry.filename] = key;
+  }
+
+  for (const filename of onnxFiles) {
+    const filePath = join(MODELS_DIR, filename);
+    console.log(`Uploading ${filename} → vercel blob ...`);
+    const buffer = readFileSync(filePath);
+    const { url: blobUrl } = await put(`models/${filename}`, buffer, {
+      access: 'public',
+      contentType: 'application/octet-stream',
+      addRandomSuffix: false,
+      token: TOKEN,
+    });
+    console.log(`  raw blob URL: ${blobUrl}`);
+
+    const modelKey = filenameToKey[filename];
+    if (!modelKey) {
+      console.warn(`  (no manifest entry for ${filename}, skipping manifest update)`);
+      continue;
+    }
+    // Per design: manifest stays as the proxy path so vercel.json rewrite handles it.
+    const proxyUrl = `/app/models/${filename}`;
+    const sources = manifest.models[modelKey].sources || [];
+    const blobSource = sources.find(s => s.provider === 'vercel-blob');
+    if (blobSource) {
+      blobSource.url = proxyUrl;
+    } else {
+      sources.unshift({ provider: 'vercel-blob', url: proxyUrl });
+      manifest.models[modelKey].sources = sources;
+    }
+  }
+
+  saveManifest(manifest);
+  console.log('\nNext steps:');
+  console.log('  1. Update vercel.json rewrite destination with your blob store hostname');
+  console.log('     (the /app/models/:model proxy maps to https://<store>.public.blob.vercel-storage.com/models/:model)');
+  console.log('  2. Commit public/app/models-manifest.json');
+  console.log('  3. Push to deploy');
+}
+
+main().catch(err => {
+  console.error('Upload failed:', err);
+  process.exit(1);
+});

--- a/vercel.json
+++ b/vercel.json
@@ -31,7 +31,7 @@
         { "key": "Strict-Transport-Security", "value": "max-age=31536000; includeSubDomains; preload" },
         { "key": "Permissions-Policy", "value": "microphone=(self), camera=(), geolocation=(), payment=(), usb=()" },
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
-        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' /_vercel/; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob:; media-src 'self' blob: mediastream:; connect-src 'self' blob: https://va.vercel-scripts.com https://blob.vercel-storage.com https://*.public.blob.vercel-storage.com; worker-src 'self' blob:; frame-ancestors 'none'" }
+        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' /_vercel/; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob:; media-src 'self' blob: mediastream:; connect-src 'self' blob: https://va.vercel-scripts.com https://blob.vercel-storage.com https://*.public.blob.vercel-storage.com https://*.r2.cloudflarestorage.com https://*.r2.dev https://models.voiceisolatepro.com https://huggingface.co https://*.xethub.hf.co https://cas-bridge.xethub.hf.co; worker-src 'self' blob:; frame-ancestors 'none'" }
       ]
     },
     {


### PR DESCRIPTION
Adds a waterfall model loader (Vercel Blob → Cloudflare R2 → HuggingFace
Hub) so model delivery survives any single CDN outage. All canonical
URLs live in models-manifest.json (schemaVersion 2); no hardcoded CDN
URLs remain in client code.

- public/app/model-cdn-loader.js: window.ModelCDNLoader with provider
  health tracking, SW-cache short-circuit, and per-model provider
  recording for diagnostics.
- public/app/sw-register.js: rewritten to drive ModelCDNLoader; adds
  registerSW export the import in index.html had been depending on.
- public/app/model-status-ui.js: provider badges per model pill plus a
  CDN Health panel rendered from getProviderHealthReport().
- public/app/models-manifest.json: schemaVersion 2 with sizeBytes,
  eager flags, and 3 sources per model.
- scripts/upload-to-{vercel-blob,r2,huggingface}.{mjs,py}: each
  rewrites its provider's URLs back into the manifest after upload.
- vercel.json CSP connect-src extended for R2 + HF + xethub.
- engines.node bumped to 24.x.
- README: new "Model CDN Setup" section documenting upload order and
  required env vars.

https://claude.ai/code/session_01HvSsS1fqRXipjdD7h1Nspp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented 3-tier redundant CDN model loading system with automatic failover across multiple providers.
  * Added provider health diagnostics available in Engineer Mode for monitoring model fetch reliability.
  * Models are now cached in Service Worker Cache for faster subsequent loads.

* **Documentation**
  * Added Model CDN Setup guide documenting model fetching and caching infrastructure.

* **Chores**
  * Updated Node.js engine requirement to 24.x.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->