### PR TITLE
feat: add network connectivity monitoring with Net status pill

### DIFF
--- a/public/app/index.html
+++ b/public/app/index.html
@@ -493,7 +493,7 @@
       <span class="engine-pill" id="engWorkletPill" data-state="pending" title="DSP AudioWorklet (real-time path)">Worklet</span>
       <span class="engine-pill" id="engMlPill"      data-state="pending" title="ML Worker (ONNX Runtime)">ML</span>
       <span class="engine-pill" id="engSabPill"     data-state="pending" title="SharedArrayBuffer ring buffer">SAB</span>
-      <span class="engine-pill" id="engNetPill"     data-state="loading" title="Network connectivity">Net</span>
+      <span class="engine-pill" id="engNetPill"     data-state="pending" title="Network connectivity">Net</span>
     </div>
     <div class="st-right">
       <div class="stat-box"><span class="st-lbl">Sample Rate</span><span class="st-val" id="stSR">--</span></div>

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -493,6 +493,7 @@
       <span class="engine-pill" id="engWorkletPill" data-state="pending" title="DSP AudioWorklet (real-time path)">Worklet</span>
       <span class="engine-pill" id="engMlPill"      data-state="pending" title="ML Worker (ONNX Runtime)">ML</span>
       <span class="engine-pill" id="engSabPill"     data-state="pending" title="SharedArrayBuffer ring buffer">SAB</span>
+      <span class="engine-pill" id="engNetPill"     data-state="loading" title="Network connectivity">Net</span>
     </div>
     <div class="st-right">
       <div class="stat-box"><span class="st-lbl">Sample Rate</span><span class="st-val" id="stSR">--</span></div>

--- a/public/app/vip-boot.js
+++ b/public/app/vip-boot.js
@@ -212,35 +212,61 @@
   }
 
   // -- Network connectivity monitor ----------------------------------------
+  function getInitialNetworkState() {
+    return (typeof navigator !== 'undefined' && typeof navigator.onLine === 'boolean')
+      ? navigator.onLine
+      : true;
+  }
+
+  function updateNetPill(online) {
+    setEnginePill('engNetPill', online ? 'ready' : 'error');
+  }
+
+  function resetProviderHealth() {
+    if (typeof window === 'undefined' || !window.ModelCDNLoader || !window.ModelCDNLoader.providerHealth) {
+      return false;
+    }
+    Object.keys(window.ModelCDNLoader.providerHealth).forEach(function (k) {
+      window.ModelCDNLoader.providerHealth[k] = true;
+    });
+    return true;
+  }
+
+  function applyNetworkState(online) {
+    updateNetPill(online);
+    if (online) {
+      console.info('[vip-boot] Network connected.');
+      // Reset any degraded CDN providers so the waterfall retries from the top
+      if (resetProviderHealth()) {
+        console.info('[vip-boot] CDN provider health reset after reconnect.');
+      }
+    } else {
+      console.warn('[vip-boot] Network disconnected.');
+    }
+  }
+
   function startNetworkMonitor() {
     if (typeof window === 'undefined' || typeof window.addEventListener !== 'function') return;
 
-    function updateNetPill(online) {
-      setEnginePill('engNetPill', online ? 'ready' : 'error');
-    }
-
     // Set initial state immediately
-    var isOnline = (typeof navigator !== 'undefined' && typeof navigator.onLine === 'boolean')
-      ? navigator.onLine
-      : true;
-    updateNetPill(isOnline);
+    applyNetworkState(getInitialNetworkState());
 
     window.addEventListener('online', function () {
-      updateNetPill(true);
-      console.info('[vip-boot] Network connected.');
-      // Reset any degraded CDN providers so the waterfall retries from the top
-      if (window.ModelCDNLoader && window.ModelCDNLoader.providerHealth) {
-        Object.keys(window.ModelCDNLoader.providerHealth).forEach(function (k) {
-          window.ModelCDNLoader.providerHealth[k] = true;
-        });
-        console.info('[vip-boot] CDN provider health reset after reconnect.');
-      }
+      applyNetworkState(true);
     });
 
     window.addEventListener('offline', function () {
-      updateNetPill(false);
-      console.warn('[vip-boot] Network disconnected.');
+      applyNetworkState(false);
     });
+  }
+
+  if (typeof window !== 'undefined') {
+    window._vipBootTestHooks = window._vipBootTestHooks || {};
+    window._vipBootTestHooks.getInitialNetworkState = getInitialNetworkState;
+    window._vipBootTestHooks.updateNetPill = updateNetPill;
+    window._vipBootTestHooks.resetProviderHealth = resetProviderHealth;
+    window._vipBootTestHooks.applyNetworkState = applyNetworkState;
+    window._vipBootTestHooks.startNetworkMonitor = startNetworkMonitor;
   }
 
   // -- Boot sequence -------------------------------------------------------

--- a/public/app/vip-boot.js
+++ b/public/app/vip-boot.js
@@ -211,11 +211,44 @@
     btn.addEventListener('mouseout',  function () { btn.style.color = '#666'; });
   }
 
+  // -- Network connectivity monitor ----------------------------------------
+  function startNetworkMonitor() {
+    if (typeof window === 'undefined' || typeof window.addEventListener !== 'function') return;
+
+    function updateNetPill(online) {
+      setEnginePill('engNetPill', online ? 'ready' : 'error');
+    }
+
+    // Set initial state immediately
+    var isOnline = (typeof navigator !== 'undefined' && typeof navigator.onLine === 'boolean')
+      ? navigator.onLine
+      : true;
+    updateNetPill(isOnline);
+
+    window.addEventListener('online', function () {
+      updateNetPill(true);
+      console.info('[vip-boot] Network connected.');
+      // Reset any degraded CDN providers so the waterfall retries from the top
+      if (window.ModelCDNLoader && window.ModelCDNLoader.providerHealth) {
+        Object.keys(window.ModelCDNLoader.providerHealth).forEach(function (k) {
+          window.ModelCDNLoader.providerHealth[k] = true;
+        });
+        console.info('[vip-boot] CDN provider health reset after reconnect.');
+      }
+    });
+
+    window.addEventListener('offline', function () {
+      updateNetPill(false);
+      console.warn('[vip-boot] Network disconnected.');
+    });
+  }
+
   // -- Boot sequence -------------------------------------------------------
   function boot() {
     wireDismissBtn();
     aliasOrCreate();
     startPillDriver();
+    startNetworkMonitor();
     // 2-second grace period for capability checks
     setTimeout(function () {
       try { runDiagnostics(); }


### PR DESCRIPTION
Adds a "Net" engine pill to the status bar and a network monitor in
vip-boot.js that uses navigator.onLine + window online/offline events.
The pill shows green (ready) when connected and red (error) when offline.
On reconnect, degraded CDN providers are reset so model downloads retry
from the top of the Vercel Blob → Cloudflare R2 → HuggingFace waterfall.

https://claude.ai/code/session_01HJipJRDVBNzUMEkDpXGg2M

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added network connectivity status indicator displayed in the fixed status bar, providing real-time visibility into network connection state.
  * Network connectivity monitor automatically detects online and offline transitions, resets network health tracking when reconnecting, and logs all connectivity state changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->