### PR TITLE
feat: add neon frequency visualizer to dashboard

### DIFF
--- a/public/app/app.js
+++ b/public/app/app.js
@@ -93,6 +93,7 @@ let sabFloat32  = null;   // Float32 view into SharedArrayBuffer
 let sabInt32    = null;   // Int32  view (control word)
 let mlWorker    = null;   // Web Worker running ml-worker.js
 let mlReady     = false;  // true once worker sends { type: 'ready' }
+let neonAnalyser = null;  // AnalyserNode tapped from worklet output for neon visualizer
 
 // Pending SAB magnitude frames queued before ml-worker is ready
 const _pendingFrames = [];
@@ -186,6 +187,12 @@ async function initAudio() {
   };
 
   workletNode.connect(audioCtx.destination);
+
+  neonAnalyser = audioCtx.createAnalyser();
+  neonAnalyser.fftSize = 512;
+  neonAnalyser.smoothingTimeConstant = 0.85;
+  workletNode.connect(neonAnalyser);
+
   console.info('[AudioWorklet] dsp-processor loaded and connected.');
 }
 
@@ -364,6 +371,10 @@ export async function bootstrap() {
 
     updateStatus('Setting up AudioWorklet…');
     await initAudio();
+
+    if (typeof window !== 'undefined' && typeof window.VIP_initNeonVisualizer === 'function') {
+      window.VIP_initNeonVisualizer(neonAnalyser);
+    }
 
     updateStatus('Binding UI sliders…');
     initSliders();

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -768,8 +768,9 @@ class VoiceIsolatePro {
         }
       }
 
+    if (neonVizHandle) neonVizHandle.stop();
     if (typeof window !== 'undefined' && typeof window.VIP_initNeonVisualizer === 'function') {
-      window.VIP_initNeonVisualizer(neonAnalyser);
+      neonVizHandle = window.VIP_initNeonVisualizer(neonAnalyser);
     }
 
     updateStatus('Binding UI sliders…');

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -94,6 +94,7 @@ let sabInt32    = null;   // Int32  view (control word)
 let mlWorker    = null;   // Web Worker running ml-worker.js
 let mlReady     = false;  // true once worker sends { type: 'ready' }
 let neonAnalyser = null;  // AnalyserNode tapped from worklet output for neon visualizer
+let neonVizHandle = null; // Handle for the neon visualizer RAF loop
 
 // Pending SAB magnitude frames queued before ml-worker is ready
 const _pendingFrames = [];

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -200,12 +200,14 @@ async function initAudio() {
     }
   };
 
-  workletNode.connect(audioCtx.destination);
-
   neonAnalyser = audioCtx.createAnalyser();
   neonAnalyser.fftSize = 512;
   neonAnalyser.smoothingTimeConstant = 0.85;
+
+  // Keep the analyser on the active render path so frequency data is populated
+  // consistently across browsers without duplicating output.
   workletNode.connect(neonAnalyser);
+  neonAnalyser.connect(audioCtx.destination);
 
   console.info('[AudioWorklet] dsp-processor loaded and connected.');
 const PRESETS = {

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -273,6 +273,12 @@
         </div>
       </div>
 
+      <!-- Neon Visualizer -->
+      <div class="card viz-card" id="neonVisualizerCard">
+        <div class="viz-hdr"><span>Neon Frequency Visualizer</span><span class="viz-badge">Processed Output</span></div>
+        <canvas id="neonVisualizer" width="800" height="200" class="viz-canvas" aria-label="Real-time neon frequency visualizer"></canvas>
+      </div>
+
       <!-- Waveform -->
       <div class="card viz-card" id="waveCard">
         <div class="viz-hdr"><span>Waveform</span><span class="viz-badge">RMS + Peak</span></div>

--- a/public/app/visuals.js
+++ b/public/app/visuals.js
@@ -480,11 +480,71 @@
   };
 
   /* ------------------------------------------------------------------ */
-  /* 5. Global exports                                                   */
+  /* 5. Neon Frequency Visualizer                                        */
+  /* ------------------------------------------------------------------ */
+  // Accepts an AnalyserNode already wired into the Web Audio graph (tapped
+  // from the workletNode output in app.js). Renders a cyberpunk-style
+  // frequency bar chart on #neonVisualizer using its own RAF loop.
+  // Returns a { stop() } handle so callers can tear it down cleanly.
+  function initNeonVisualizer(analyser) {
+    var canvas = document.getElementById('neonVisualizer');
+    if (!canvas || !analyser) return { stop: function () {} };
+
+    var ctx2d = canvas.getContext('2d');
+    var bufferLength = analyser.frequencyBinCount;
+    var dataArray = new Uint8Array(bufferLength);
+    var rafId = 0;
+    var running = true;
+
+    function draw() {
+      if (!running) return;
+      rafId = requestAnimationFrame(draw);
+
+      analyser.getByteFrequencyData(dataArray);
+
+      // Trail / motion-blur effect
+      ctx2d.fillStyle = 'rgba(3, 3, 6, 0.25)';
+      ctx2d.fillRect(0, 0, canvas.width, canvas.height);
+
+      var barWidth = (canvas.width / bufferLength) * 2.5;
+      var x = 0;
+
+      for (var i = 0; i < bufferLength; i++) {
+        var barHeight = dataArray[i];
+        ctx2d.shadowBlur = 20;
+
+        // Electric blue (lows) → neon green (highs)
+        if (i < bufferLength / 2) {
+          ctx2d.shadowColor = '#00ffff';
+          ctx2d.fillStyle = '#00ffff';
+        } else {
+          ctx2d.shadowColor = '#39ff14';
+          ctx2d.fillStyle = '#39ff14';
+        }
+
+        var y = (canvas.height / 2) - (barHeight / 2);
+        ctx2d.fillRect(x, y, barWidth - 1, barHeight);
+        x += barWidth;
+      }
+    }
+
+    draw();
+
+    return {
+      stop: function () {
+        running = false;
+        if (rafId) { cancelAnimationFrame(rafId); rafId = 0; }
+      }
+    };
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* 6. Global exports                                                   */
   /* ------------------------------------------------------------------ */
   global.VIP_SPEAKER_COLORS = SPEAKER_COLORS;
   global.VIP_INFERNO_LUT    = INFERNO_LUT;
   global.VIP_buildInfernoLUT = buildInfernoLUT;
   global.VIP_inferno        = inferno;
   global.VisualizationEngine = VisualizationEngine;
+  global.VIP_initNeonVisualizer = initNeonVisualizer;
 })(typeof window !== 'undefined' ? window : this);

--- a/public/app/visuals.js
+++ b/public/app/visuals.js
@@ -491,6 +491,8 @@
     if (!canvas || !analyser) return { stop: function () {} };
 
     var ctx2d = canvas.getContext('2d');
+    if (!ctx2d) return { stop: function () {} };
+
     var bufferLength = analyser.frequencyBinCount;
     var dataArray = new Uint8Array(bufferLength);
     var rafId = 0;


### PR DESCRIPTION
Integrates a cyberpunk-style real-time frequency bar visualizer (electric
blue lows → neon green highs) below the transport controls, tapped directly
from the AudioWorklet processed output via a new AnalyserNode.

- public/app/index.html: new #neonVisualizerCard card below transport
- public/app/visuals.js: VIP_initNeonVisualizer() function + global export
- public/app/app.js: neonAnalyser wired from workletNode, called from bootstrap()

https://claude.ai/code/session_01UpmzT988JsGAhqcXBZaMgr