### PR TITLE
🎨 Palette: Add aria-label to mic button

### DIFF
--- a/public/app/index.html
+++ b/public/app/index.html
@@ -138,5 +138,5 @@
           <button id="fileBtn" class="btn btn-outline" type="button" style="position:relative;z-index:10;cursor:pointer;">Browse Files</button>
         </div>
         <div class="upload-row">
-          <button id="micBtn" class="btn btn-mic">
+          <button id="micBtn" class="btn btn-mic" aria-label="Toggle Microphone">
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z"/><path d="M19 10v2a7 7 0 0 1-14


### PR DESCRIPTION
🎯 **What:** Added an `aria-label` attribute to the microphone button (`#micBtn`) in `index.html`.
💡 **Why:** The button is an icon-only button without any accessible name. Adding `aria-label="Toggle Microphone"` ensures screen readers correctly announce the button's purpose to users.
📸 **Before/After:** No visual changes.
♿ **Accessibility:** Fixes a critical WCAG violation regarding missing accessible names for icon-only buttons.

---
*PR created automatically by Jules for task [7690422741771693584](https://jules.google.com/task/7690422741771693584) started by @Joker5514*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Enhanced microphone toggle button with improved screen reader support for better accessibility.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Joker5514/VoiceIsolate-Pro/pull/483)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->