### PR TITLE
🎨 Palette: Add proper ARIA roles to visualization tabs and labels to icon buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-05-10 - [Tabs & Icon Buttons Accessibility]
+**Learning:** Custom tab structures (like the Visualizations tabs in `index.html`) require explicit `role="tab"`, `aria-controls`, `role="tabpanel"`, and `aria-labelledby` attributes. Active tabs should use `tabindex="0"` while inactive tabs use `tabindex="-1"` for proper keyboard navigation. Icon-only buttons (like `#fullscreenSpectroBtn`) must always have an `aria-label` and `title` to be screen reader and mouse hover friendly.
+**Action:** Always check for explicit ARIA roles and labels on custom UI structures and icon-only buttons to ensure they remain accessible to all users.

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -162,7 +162,7 @@
           <button id="btn-clusters" class="tab-btn" type="button" role="tab" aria-controls="tab-clusters" data-tab="clusters" aria-selected="false" tabindex="-1">Speaker Clusters</button>
         </div>
 
-        <div id="tab-spectrogram" role="tabpanel" aria-labelledby="btn-spectrogram" class="panel active">
+        <div id="tab-spectrogram" role="tabpanel" aria-labelledby="btn-spectrogram" class="panel active" tabindex="0">
           <div id="spectro3d-container" class="spectro3d-container"><canvas id="spectroCanvas" class="viz-canvas"></canvas></div>
           <canvas id="spectro2DCanvas" class="viz-canvas spectro2d" style="display:none"></canvas>
           <canvas id="freqCanvas" class="viz-canvas freq-cv"></canvas>

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -152,7 +152,7 @@
       </div>
 
       <div class="card viz-card">
-        <div class="viz-hdr"><span>Visualizations</span><button id="fullscreenSpectroBtn" class="btn btn-xs" type="button" aria-label="Toggle Fullscreen" title="Toggle Fullscreen">⛶</button></div>
+        <div class="viz-hdr"><span>Visualizations</span><button id="fullscreenSpectroBtn" class="btn btn-xs" type="button" aria-label="Toggle Fullscreen" title="Toggle Fullscreen"><span aria-hidden="true">⛶</span></button></div>
         <div id="tabBar" class="tabs" role="tablist" aria-label="Visualization tabs">
           <button id="btn-spectrogram" class="tab-btn active" type="button" role="tab" aria-controls="tab-spectrogram" data-tab="spectrogram" aria-selected="true" tabindex="0">Spectrogram</button>
           <button id="btn-waveform" class="tab-btn" type="button" role="tab" aria-controls="tab-waveform" data-tab="waveform" aria-selected="false" tabindex="-1">Waveform</button>

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -152,26 +152,26 @@
       </div>
 
       <div class="card viz-card">
-        <div class="viz-hdr"><span>Visualizations</span><button id="fullscreenSpectroBtn" class="btn btn-xs" type="button">⛶</button></div>
+        <div class="viz-hdr"><span>Visualizations</span><button id="fullscreenSpectroBtn" class="btn btn-xs" type="button" aria-label="Toggle Fullscreen" title="Toggle Fullscreen">⛶</button></div>
         <div id="tabBar" class="tabs" role="tablist" aria-label="Visualization tabs">
-          <button class="tab-btn active" type="button" data-tab="spectrogram" aria-selected="true">Spectrogram</button>
-          <button class="tab-btn" type="button" data-tab="waveform" aria-selected="false">Waveform</button>
-          <button class="tab-btn" type="button" data-tab="abcompare" aria-selected="false">A/B Compare</button>
-          <button class="tab-btn" type="button" data-tab="lufs" aria-selected="false">LUFS Meter</button>
-          <button class="tab-btn" type="button" data-tab="saliency" aria-selected="false">Saliency Map</button>
-          <button class="tab-btn" type="button" data-tab="clusters" aria-selected="false">Speaker Clusters</button>
+          <button id="btn-spectrogram" class="tab-btn active" type="button" role="tab" aria-controls="tab-spectrogram" data-tab="spectrogram" aria-selected="true" tabindex="0">Spectrogram</button>
+          <button id="btn-waveform" class="tab-btn" type="button" role="tab" aria-controls="tab-waveform" data-tab="waveform" aria-selected="false" tabindex="-1">Waveform</button>
+          <button id="btn-abcompare" class="tab-btn" type="button" role="tab" aria-controls="tab-abcompare" data-tab="abcompare" aria-selected="false" tabindex="-1">A/B Compare</button>
+          <button id="btn-lufs" class="tab-btn" type="button" role="tab" aria-controls="tab-lufs" data-tab="lufs" aria-selected="false" tabindex="-1">LUFS Meter</button>
+          <button id="btn-saliency" class="tab-btn" type="button" role="tab" aria-controls="tab-saliency" data-tab="saliency" aria-selected="false" tabindex="-1">Saliency Map</button>
+          <button id="btn-clusters" class="tab-btn" type="button" role="tab" aria-controls="tab-clusters" data-tab="clusters" aria-selected="false" tabindex="-1">Speaker Clusters</button>
         </div>
 
-        <div id="tab-spectrogram" class="panel active">
+        <div id="tab-spectrogram" role="tabpanel" aria-labelledby="btn-spectrogram" class="panel active">
           <div id="spectro3d-container" class="spectro3d-container"><canvas id="spectroCanvas" class="viz-canvas"></canvas></div>
           <canvas id="spectro2DCanvas" class="viz-canvas spectro2d" style="display:none"></canvas>
           <canvas id="freqCanvas" class="viz-canvas freq-cv"></canvas>
         </div>
-        <div id="tab-waveform" class="panel"><canvas id="waveCanvas" class="viz-canvas wave-cv"></canvas></div>
-        <div id="tab-abcompare" class="panel"><div class="wave-row"><canvas id="waveOrigCanvas" class="viz-canvas wave-cv"></canvas><canvas id="waveProcCanvas" class="viz-canvas wave-cv"></canvas></div></div>
-        <div id="tab-lufs" class="panel"><div class="lufs-readouts"><div class="lufs-rd"><span class="lufs-val" id="lufsI">-23.0</span><span class="lufs-lbl">Integrated</span></div><div class="lufs-rd"><span class="lufs-val" id="lufsS">-20.0</span><span class="lufs-lbl">Short</span></div></div></div>
-        <div id="tab-saliency" class="panel"><canvas id="fsCanvas" class="viz-canvas diag-saliency-cv"></canvas></div>
-        <div id="tab-clusters" class="panel">
+        <div id="tab-waveform" role="tabpanel" aria-labelledby="btn-waveform" class="panel"><canvas id="waveCanvas" class="viz-canvas wave-cv"></canvas></div>
+        <div id="tab-abcompare" role="tabpanel" aria-labelledby="btn-abcompare" class="panel"><div class="wave-row"><canvas id="waveOrigCanvas" class="viz-canvas wave-cv"></canvas><canvas id="waveProcCanvas" class="viz-canvas wave-cv"></canvas></div></div>
+        <div id="tab-lufs" role="tabpanel" aria-labelledby="btn-lufs" class="panel"><div class="lufs-readouts"><div class="lufs-rd"><span class="lufs-val" id="lufsI">-23.0</span><span class="lufs-lbl">Integrated</span></div><div class="lufs-rd"><span class="lufs-val" id="lufsS">-20.0</span><span class="lufs-lbl">Short</span></div></div></div>
+        <div id="tab-saliency" role="tabpanel" aria-labelledby="btn-saliency" class="panel"><canvas id="fsCanvas" class="viz-canvas diag-saliency-cv"></canvas></div>
+        <div id="tab-clusters" role="tabpanel" aria-labelledby="btn-clusters" class="panel">
           <canvas id="diarCanvas" class="viz-canvas"></canvas>
           <div class="vu-meter-container">
             <div class="vu-meter" style="--vu-level:42%"><div class="vu-meter-fill"></div><div class="vu-meter-peak" style="--peak-top:58%"></div><span class="vu-meter-label">IN</span></div>


### PR DESCRIPTION
💡 **What:**
- Added explicit ARIA roles (`tab`, `tablist`, `tabpanel`) and correlation attributes (`aria-controls`, `aria-labelledby`) to the custom visualization tabs.
- Configured focus management attributes (`tabindex`) for the tabs.
- Added `aria-label` and `title` attributes to the full screen icon-only button to make it discoverable by screen readers and provide hover context.

🎯 **Why:**
Custom tab structures visually resemble tabs but do not inherently provide semantic meaning to screen readers or proper keyboard navigation paths out-of-the-box. Explicit ARIA roles communicate the structure, and focus management is required for accessibility compliance. Icon-only buttons without labels are completely opaque to screen reader users.

📸 **Before/After:**
*(Visual UI remains identical, but underlying DOM structure is now compliant)*

♿ **Accessibility:**
- Custom tabs are now explicitly announced as tabs by screen readers, along with their active/inactive states.
- The Fullscreen button is now clearly identified to users with visual impairments.

---
*PR created automatically by Jules for task [3265924239663210982](https://jules.google.com/task/3265924239663210982) started by @Joker5514*