### PR TITLE
🎨 Palette: Add accessibility labels and tooltips to transport controls

### DIFF
--- a/public/app/index.html
+++ b/public/app/index.html
@@ -187,7 +187,7 @@
           <span class="tp-time" id="tpDur">0:00</span>
           <input type="range" id="tpSeek" class="tp-seek" min="0" max="1000" value="0" />
           <div class="tp-speed"><label for="tpSpeed">Speed</label><select id="tpSpeed"><option value="0.5">0.5x</option><option value="1" selected>1x</option><option value="1.5">1.5x</option><option value="2">2x</option></select></div>
-          <button id="tpAB" class="btn btn-ab" type="button" aria-label="Toggle A/B Comparison" title="Toggle A/B Comparison" disabled>A/B</button>
+          <button id="tpAB" class="btn btn-ab" type="button" aria-label="Toggle A/B Comparison" aria-describedby="tpABLabel" title="Toggle A/B Comparison" disabled>A/B</button>
           <span id="tpABLabel" class="tp-ab-label">Original</span>
         </div>
       </div>

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -177,17 +177,17 @@
     <section class="col-right">
       <div class="card transport-card">
         <div class="transport-row">
-          <button id="tpPlay" class="btn btn-tp" type="button" disabled>&#9654;</button>
-          <button id="tpPause" class="btn btn-tp" type="button" disabled>&#9208;</button>
-          <button id="tpStop" class="btn btn-tp" type="button" disabled>&#9209;</button>
-          <button id="tpRew" class="btn btn-tp" type="button" disabled>&#9664;&#9664;</button>
-          <button id="tpFwd" class="btn btn-tp" type="button" disabled>&#9654;&#9654;</button>
+          <button id="tpPlay" class="btn btn-tp" type="button" aria-label="Play" title="Play" disabled>&#9654;</button>
+          <button id="tpPause" class="btn btn-tp" type="button" aria-label="Pause" title="Pause" disabled>&#9208;</button>
+          <button id="tpStop" class="btn btn-tp" type="button" aria-label="Stop" title="Stop" disabled>&#9209;</button>
+          <button id="tpRew" class="btn btn-tp" type="button" aria-label="Rewind" title="Rewind" disabled>&#9664;&#9664;</button>
+          <button id="tpFwd" class="btn btn-tp" type="button" aria-label="Fast Forward" title="Fast Forward" disabled>&#9654;&#9654;</button>
           <span class="tp-time" id="tpCur">0:00</span>
           <span class="tp-time">/</span>
           <span class="tp-time" id="tpDur">0:00</span>
           <input type="range" id="tpSeek" class="tp-seek" min="0" max="1000" value="0" />
           <div class="tp-speed"><label for="tpSpeed">Speed</label><select id="tpSpeed"><option value="0.5">0.5x</option><option value="1" selected>1x</option><option value="1.5">1.5x</option><option value="2">2x</option></select></div>
-          <button id="tpAB" class="btn btn-ab" type="button" disabled>A/B</button>
+          <button id="tpAB" class="btn btn-ab" type="button" aria-label="Toggle A/B Comparison" title="Toggle A/B Comparison" disabled>A/B</button>
           <span id="tpABLabel" class="tp-ab-label">Original</span>
         </div>
       </div>

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -177,11 +177,11 @@
     <section class="col-right">
       <div class="card transport-card">
         <div class="transport-row">
-          <button id="tpPlay" class="btn btn-tp" type="button" aria-label="Play" title="Play" disabled>&#9654;</button>
-          <button id="tpPause" class="btn btn-tp" type="button" aria-label="Pause" title="Pause" disabled>&#9208;</button>
-          <button id="tpStop" class="btn btn-tp" type="button" aria-label="Stop" title="Stop" disabled>&#9209;</button>
-          <button id="tpRew" class="btn btn-tp" type="button" aria-label="Rewind" title="Rewind" disabled>&#9664;&#9664;</button>
-          <button id="tpFwd" class="btn btn-tp" type="button" aria-label="Fast Forward" title="Fast Forward" disabled>&#9654;&#9654;</button>
+          <button id="tpPlay" class="btn btn-tp" type="button" aria-label="Play" title="Play" disabled><span aria-hidden="true">&#9654;</span></button>
+          <button id="tpPause" class="btn btn-tp" type="button" aria-label="Pause" title="Pause" disabled><span aria-hidden="true">&#9208;</span></button>
+          <button id="tpStop" class="btn btn-tp" type="button" aria-label="Stop" title="Stop" disabled><span aria-hidden="true">&#9209;</span></button>
+          <button id="tpRew" class="btn btn-tp" type="button" aria-label="Rewind" title="Rewind" disabled><span aria-hidden="true">&#9664;&#9664;</span></button>
+          <button id="tpFwd" class="btn btn-tp" type="button" aria-label="Fast Forward" title="Fast Forward" disabled><span aria-hidden="true">&#9654;&#9654;</span></button>
           <span class="tp-time" id="tpCur">0:00</span>
           <span class="tp-time">/</span>
           <span class="tp-time" id="tpDur">0:00</span>

--- a/public/app/sw.js
+++ b/public/app/sw.js
@@ -13,7 +13,7 @@
 // Privacy: 100% local processing — no fetch() calls to external APIs.
 // ─────────────────────────────────────────────────────────────────────────────
 
-const CACHE_VERSION  = 'vip-app-v1';
+const CACHE_VERSION  = 'vip-app-17b34e7';
 const MODEL_CACHE    = 'vip-models-v1';
 
 // Static app-shell assets to pre-cache on install.


### PR DESCRIPTION
💡 **What:** Added `aria-label` and `title` attributes to all the icon-only transport buttons (Play, Pause, Stop, Rewind, Fast Forward, and the A/B comparison toggle).

🎯 **Why:** The buttons relied purely on unicode characters (e.g., `&#9654;`) and abbreviations without accompanying descriptive text, making them completely inaccessible to screen reader users and confusing for sighted users unfamiliar with the UI since they lacked tooltips.

📸 **Before/After:** No major visual layout changes. Sighted users now see a native tooltip explaining the button action when hovering.

♿ **Accessibility:** This directly addresses an accessibility failure by giving screen readers programmatic access to the button intents via `aria-label`.

---
*PR created automatically by Jules for task [13357667590226142583](https://jules.google.com/task/13357667590226142583) started by @Joker5514*