### PR TITLE
docs: overhaul CLAUDE.md with accurate audit + dark-industrial theme; add CLAUDE-mobile.md

### DIFF
--- a/CLAUDE-mobile.md
+++ b/CLAUDE-mobile.md
@@ -150,7 +150,7 @@ Registry: `public/app/models/models-manifest.json`
 - Tests: CommonJS (`require`). Frontend: ESM (`import`). Don't mix.
 - `public/lib/` IS committed — don't gitignore it
 - `build/` is gitignored — don't commit it
-- Node.js 24.x required (enforced by `.npmrc`)
+- Node.js 24.x required (per `package.json#engines` and CI)
 - Use `pnpm` only — npm/yarn not supported
 
 ---

--- a/CLAUDE-mobile.md
+++ b/CLAUDE-mobile.md
@@ -117,7 +117,10 @@ Every preset must define all 52 slider IDs — `tests/presets.test.js` enforces 
 | VoiceFixer | — | Vercel Blob (first-use) |
 | HiFi-GAN | — | Vercel Blob (first-use) |
 
-Registry: `public/app/models/models-manifest.json`
+Reference manifest in repo: `public/app/models/models-manifest.json`
+Runtime manifest fetched by `model-cdn-loader.js`: `/app/models-manifest.json`
+
+Contributor note: the quick reference file above is for documentation/source tracking; the app loads the root-served `/app/models-manifest.json` at runtime. Do not update only the reference copy if you intend to change runtime model resolution.
 
 ---
 

--- a/CLAUDE-mobile.md
+++ b/CLAUDE-mobile.md
@@ -16,7 +16,7 @@ Browser-based, 100% local audio processing. Zero cloud. All DSP runs on-device v
 | Pipeline stages | 32 (Deca-Pass, 10 passes) |
 | Sliders | 52 across 8 tabs |
 | Presets | 8 named presets |
-| Test suites | 62 Jest suites |
+| Test suites | 59 Jest suites |
 | CI workflows | 6 |
 | App version | 24.0.0 |
 
@@ -27,7 +27,7 @@ Browser-based, 100% local audio processing. Zero cloud. All DSP runs on-device v
 ```bash
 pnpm install        # Setup
 pnpm dev            # http://localhost:3000
-pnpm test           # All 62 suites
+pnpm test           # All 59 suites
 pnpm lint           # ESLint
 pnpm validate       # Structural checks
 pnpm build          # public/ → build/
@@ -137,7 +137,7 @@ Contributor note: the quick reference file above is for documentation/source tra
 | `public/app/ml-worker.js` | ONNX inference |
 | `public/app/fft-bridge.js` | Offline STFT utility |
 | `public/app/sw.js` | Service worker (COOP/COEP + cache) |
-| `public/app/vip-slider-patch.js` | Slider patch (loads LAST) |
+| `public/app/vip-slider-patch.js` | Slider patch module (not currently loaded by `public/app/index.html`) |
 | `public/app/debug-audit.js` | `window.VIP_runAudit()` in DevTools |
 | `server.js` | Local dev server |
 
@@ -148,12 +148,12 @@ Contributor note: the quick reference file above is for documentation/source tra
 - No CDN for ORT or Three.js — local files only
 - No second STFT/iSTFT in any processing path
 - ML worker and AudioWorklet owned by `pipeline-orchestrator.js` only
-- `vip-slider-patch.js` loads **last** in `index.html`
+- `public/app/index.html` currently boots via dynamic `import()` list; `vip-slider-patch.js` is not in that list
 - `importmap` script tag must come before any `type="module"` tag
 - Tests: CommonJS (`require`). Frontend: ESM (`import`). Don't mix.
 - `public/lib/` IS committed — don't gitignore it
 - `build/` is gitignored — don't commit it
-- Node.js 24.x required (per `package.json#engines` and CI)
+- Node.js 24.x required (`package.json#engines`; deploy workflows use Node 24)
 - Use `pnpm` only — npm/yarn not supported
 
 ---

--- a/CLAUDE-mobile.md
+++ b/CLAUDE-mobile.md
@@ -93,7 +93,7 @@ No second STFT/iSTFT pair anywhere.
 | `sep` | 5 | Voice isolation, background suppress |
 | `out` | 4 | Output gain, dry/wet, dither |
 
-**Adding a slider:** update `SLIDERS` in `app.js` + `SLIDER_REGISTRY` in `slider-map.js` + every preset in `PRESETS`.
+**Adding a slider:** update `SLIDERS` in `app.js` + `SLIDER_REGISTRY` in `slider-map.js` + every preset in `PRESETS` + update relevant tests.
 
 ---
 

--- a/CLAUDE-mobile.md
+++ b/CLAUDE-mobile.md
@@ -1,0 +1,198 @@
+# VOICEISOLATE PRO — Mobile Quick Reference
+> v24.0.0 · AI Contributor Guide (compact)
+
+---
+
+## What Is This?
+
+Browser-based, 100% local audio processing. Zero cloud. All DSP runs on-device via Web Audio API + ONNX Runtime Web. Cross-platform: Web (Vercel) + native Android/iOS via Capacitor 8.
+
+---
+
+## Key Numbers
+
+| Metric | Value |
+|--------|-------|
+| Pipeline stages | 32 (Deca-Pass, 10 passes) |
+| Sliders | 52 across 8 tabs |
+| Presets | 8 named presets |
+| Test suites | 62 Jest suites |
+| CI workflows | 6 |
+| App version | 24.0.0 |
+
+---
+
+## Essential Commands
+
+```bash
+pnpm install        # Setup
+pnpm dev            # http://localhost:3000
+pnpm test           # All 62 suites
+pnpm lint           # ESLint
+pnpm validate       # Structural checks
+pnpm build          # public/ → build/
+```
+
+**Mobile builds:**
+```bash
+pnpm android:build  # Debug APK
+pnpm android:bundle # Google Play AAB
+pnpm ios:sync       # Sync → Xcode
+```
+
+---
+
+## Architecture Rules (Never Break These)
+
+**1. One STFT per path**
+```
+Time → STFT(S10) → Spectral Ops(S11-S19) → iSTFT(S20) → Time
+```
+No second STFT/iSTFT pair anywhere.
+
+**2. AudioWorklet** — only `pipeline-orchestrator.js` calls `addModule()`
+
+**3. ML Worker** — only `pipeline-orchestrator.js` spawns it
+
+**4. No CDN libraries** — ORT from `/lib/ort.min.js`, Three.js from `/lib/three.module.min.js`
+
+**5. No audio upload** — all processing stays in the browser
+
+**6. COOP/COEP headers** — required in `server.js`, `vercel.json`, and `sw.js`
+
+**7. Data structures** — `STAGES` and `SLIDER_REGISTRY` live in `slider-map.js` only
+
+---
+
+## 32-Stage Pipeline at a Glance
+
+| Pass | Stages | What |
+|------|--------|------|
+| 1 | S01–S04 | Input decode, DC remove, normalize |
+| 2 | S05–S09 | VAD, gate, click/hum/de-ess |
+| 3 | S10 | **Forward STFT** |
+| 4–5 | S11–S19 | Wiener NR, spectral ops, dereverb |
+| 6 | S20 | **Inverse STFT** |
+| 7 | S21–S25 | EQ, compressor, limiter |
+| 8 | S26–S28 | Render, dry/wet mix |
+| 9 | S29–S31 | Normalize, metrics, waveform |
+| 10 | S32 | Export + SHA-256 forensic hash |
+
+---
+
+## 52 Sliders (8 Tabs)
+
+| Tab | Count | Controls |
+|-----|-------|----------|
+| `gate` | 6 | Threshold, range, attack/release/hold, lookahead |
+| `nr` | 5 | NR amount/sensitivity/floor/smoothing |
+| `eq` | 10 | 10-band parametric EQ |
+| `dyn` | 8 | Compressor + brickwall limiter |
+| `spec` | 8 | HP/LP, de-esser, formant shift |
+| `adv` | 6 | Dereverb, stereo width, phase correction |
+| `sep` | 5 | Voice isolation, background suppress |
+| `out` | 4 | Output gain, dry/wet, dither |
+
+**Adding a slider:** update `SLIDERS` in `app.js` + `SLIDER_REGISTRY` in `slider-map.js` + every preset in `PRESETS`.
+
+---
+
+## 8 Presets
+
+`Voice Clarity` · `Podcast Clean` · `Forensic Extract` · `Music Vocal` · `Whisper Boost` · `Phone/Radio` · `Live Performance` · `Surveillance`
+
+Every preset must define all 52 slider IDs — `tests/presets.test.js` enforces this.
+
+---
+
+## ML Models
+
+| Model | Size | Delivery |
+|-------|------|----------|
+| Silero VAD (fp32) | 2.2MB | committed |
+| Silero VAD (int8) | 2.3MB | committed |
+| RNNoise | 1.8MB | committed |
+| BSRNN Vocals | 4.3MB | committed |
+| Demucs v4 | large | Vercel Blob (first-use) |
+| VoiceFixer | — | Vercel Blob (first-use) |
+| HiFi-GAN | — | Vercel Blob (first-use) |
+
+Registry: `public/app/models/models-manifest.json`
+
+---
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `public/app/app.js` | Main orchestrator |
+| `public/app/slider-map.js` | STAGES + SLIDER_REGISTRY |
+| `public/app/dsp-core.js` | Pure DSP math |
+| `public/app/dsp-stages.js` | 32 stage operators |
+| `public/app/pipeline-orchestrator.js` | Pipeline runner (owns worklet + ML worker) |
+| `public/app/pipeline-state.js` | State + event bus |
+| `public/app/ml-worker.js` | ONNX inference |
+| `public/app/fft-bridge.js` | Offline STFT utility |
+| `public/app/sw.js` | Service worker (COOP/COEP + cache) |
+| `public/app/vip-slider-patch.js` | Slider patch (loads LAST) |
+| `public/app/debug-audit.js` | `window.VIP_runAudit()` in DevTools |
+| `server.js` | Local dev server |
+
+---
+
+## Top Pitfalls
+
+- No CDN for ORT or Three.js — local files only
+- No second STFT/iSTFT in any processing path
+- ML worker and AudioWorklet owned by `pipeline-orchestrator.js` only
+- `vip-slider-patch.js` loads **last** in `index.html`
+- `importmap` script tag must come before any `type="module"` tag
+- Tests: CommonJS (`require`). Frontend: ESM (`import`). Don't mix.
+- `public/lib/` IS committed — don't gitignore it
+- `build/` is gitignored — don't commit it
+- Node.js 24.x required (enforced by `.npmrc`)
+- Use `pnpm` only — npm/yarn not supported
+
+---
+
+## Mobile Platform (Capacitor 8)
+
+**App ID:** `com.voiceisolatepro.app`  
+**Supports:** Android API 23+ · iOS 14.1+
+
+```bash
+pnpm mobile:sync-version  # Sync version to manifests
+pnpm android:build        # Debug APK
+pnpm android:release      # Release APK
+pnpm android:bundle       # AAB for Play Store
+pnpm ios:sync             # Sync web assets
+pnpm ios:build            # Open Xcode
+```
+
+Styles: `public/app/mobile.css` overrides the desktop theme.  
+Tests: `tests/mobile-ui.test.js`, `tests/android-config.test.js`, `tests/ios-config.test.js`
+
+---
+
+## Deployment Quick Reference
+
+| Platform | Command / Trigger |
+|----------|-------------------|
+| Vercel (primary) | push to `main` |
+| Render.com | static serve from `public/` |
+| Docker | `docker compose up` |
+| Android | `pnpm android:bundle` |
+| iOS | `pnpm ios:build` → Xcode |
+
+---
+
+## Environment Variables (optional for basic testing)
+
+```bash
+STRIPE_SECRET_KEY=sk_test_...
+LICENSE_JWT_SECRET=your-secret-key-min-32-chars
+PORT=3000
+NODE_ENV=development
+```
+
+Full list: see `.env.example`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ pnpm lint:fix             # Auto-fix lint issues
 pnpm test                 # Run all 59 Jest suites
 pnpm test:watch           # Watch mode
 pnpm test:coverage        # Coverage report
-pnpm test:live            # Live browser smoke test (Playwright/Puppeteer)
+pnpm test:live            # Live browser smoke test (Playwright Chromium)
 pnpm validate             # Structural integrity checks
 
 # ── MOBILE ─────────────────────────────────────────────────

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -389,7 +389,7 @@ Large models are fetched from Vercel Blob storage (`/app/models/*` rewrites in `
 | VoiceFixer | (Vercel Blob) | first-use download | Voice quality restoration |
 | HiFi-GAN | (Vercel Blob) | first-use download | Neural vocoder |
 
-Model registry: `public/app/models/models-manifest.json` (authoritative) — also mirrored at `public/app/models-manifest.json`. `scripts/validate-onnx-models.js` verifies committed files meet minimum byte thresholds.
+Model registry: `public/app/models/models-manifest.json` (authoritative) — also mirrored at `public/app/models-manifest.json`. `scripts/validate-onnx-models.js` validates the manifest's remote model URLs/binaries by checking their reported size against `min_bytes` thresholds.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,425 +1,499 @@
-# CLAUDE.md — VoiceIsolate Pro
-
-This file provides AI assistants with everything needed to navigate, understand, and contribute to VoiceIsolate Pro. Read this before making any changes.
-
----
-
-## Project Overview
-
-**VoiceIsolate Pro** (v24.0.0) is a **browser-based, 100% local audio processing platform** for professional voice isolation and audio enhancement. Key attributes:
-
-- **Zero cloud processing**: All audio is processed on-device using Web Audio API + ONNX Runtime Web
-- **Privacy-first**: No telemetry, no external API calls during audio processing
-- **32-Stage Deca-Pass Pipeline**: Advanced DSP + hybrid ML (10 passes, 32 stages total)
-- **Cross-platform**: Web (Vercel), native Android (API 23+), native iOS (14.1+) via Capacitor 8
-- **Engineer Mode UI**: 52 sliders across 8 tabs, 6-panel diagnostics, 3D spectrogram visualization
-
-> Canonical version lives in `package.json#version`. `server.js` reads it from `package.json` at startup; when bumping the version, update `package.json`, `README.md`, this file, `capacitor.config.json`, and the `mobile:sync-version` script together.
-
----
-
-## Development Commands
-
-```bash
-# Install dependencies (auto-copies ORT + Three.js to public/lib/ if not already committed)
-pnpm install
-
-# Start local dev server (http://localhost:3000)
-pnpm dev
-
-# Build (copies public/ → build/)
-pnpm build
-
-# Lint (ESLint Flat Config, app.js + worker files)
-pnpm lint
-pnpm lint:fix
-
-# Run all tests (55 Jest suites)
-pnpm test
-pnpm test:watch
-pnpm test:coverage
-
-# Live browser smoke test (Playwright/Puppeteer)
-pnpm test:live
-
-# Structural validation checks
-pnpm validate
-
-# Copy ONNX Runtime from node_modules to public/lib/
-pnpm setup:ort
-
-# Copy Three.js (0.184.0 ESM build) from node_modules to public/lib/
-pnpm setup:three
-
-# Sync version number to Android/iOS manifests
-pnpm mobile:sync-version
-
-# Download ONNX models (large files not committed)
-pnpm models:download
-
-# Mobile builds
-pnpm android:build    # Debug APK
-pnpm android:release  # Release APK
-pnpm android:bundle   # AAB for Google Play
-pnpm ios:sync         # Sync web build to iOS
-pnpm ios:build        # Sync + open Xcode
+```
+▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+█  VOICEISOLATE  ██ PRO ██  v24.0.0  ██  AI CONTRIBUTOR GUIDE  █
+▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+◉ LIVE    ▶ PROCESS    ▐▌ PIPELINE: 32-STAGE DECA-PASS    ░░░▓▓▓███
+▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
 ```
 
-**Requirements**: Node.js 24.x, pnpm >= 9.0.0 (enforced via `.npmrc` engine-strict).
+> Read this file **before** making any changes. All architectural rules are enforced by CI and `scripts/validate.js` — violations break the pipeline.
 
 ---
 
-## Repository Structure
+## ▐ SYSTEM OVERVIEW ▌
+
+**VoiceIsolate Pro** (v24.0.0) is a **browser-based, 100% local audio processing platform** for professional voice isolation and audio enhancement.
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  ZERO CLOUD PROCESSING  │  All audio processed on-device    │
+│  Web Audio API + ONNX Runtime Web (WebGPU → WASM fallback)  │
+├─────────────────────────────────────────────────────────────┤
+│  PRIVACY-FIRST          │  No telemetry · No audio upload   │
+├─────────────────────────────────────────────────────────────┤
+│  32-STAGE DECA-PASS     │  10 passes · Advanced DSP + ML    │
+├─────────────────────────────────────────────────────────────┤
+│  CROSS-PLATFORM         │  Web (Vercel) · Android · iOS     │
+│                         │  Native via Capacitor 8           │
+├─────────────────────────────────────────────────────────────┤
+│  ENGINEER MODE UI       │  52 sliders · 8 tabs              │
+│                         │  6-panel diagnostics · 3D spec    │
+└─────────────────────────────────────────────────────────────┘
+```
+
+> Canonical version lives in `package.json#version`. When bumping, update `package.json`, `README.md`, this file, `capacitor.config.json`, and run `pnpm mobile:sync-version`.
+
+---
+
+## ▐ DEVELOPMENT COMMANDS ▌
+
+```bash
+# ── SETUP ──────────────────────────────────────────────────
+pnpm install              # Install + auto-copy ORT & Three.js to public/lib/
+pnpm setup:ort            # Copy ONNX Runtime from node_modules → public/lib/
+pnpm setup:three          # Copy Three.js 0.184.0 ESM from node_modules → public/lib/
+pnpm models:download      # Download large ONNX models (Demucs, etc.)
+
+# ── DEV / BUILD ────────────────────────────────────────────
+pnpm dev                  # Local dev server  →  http://localhost:3000
+pnpm build                # Copies public/ → build/
+
+# ── QUALITY ────────────────────────────────────────────────
+pnpm lint                 # ESLint Flat Config (app.js + worker files)
+pnpm lint:fix             # Auto-fix lint issues
+pnpm test                 # Run all 62 Jest suites
+pnpm test:watch           # Watch mode
+pnpm test:coverage        # Coverage report
+pnpm test:live            # Live browser smoke test (Playwright/Puppeteer)
+pnpm validate             # Structural integrity checks
+
+# ── MOBILE ─────────────────────────────────────────────────
+pnpm mobile:sync-version  # Sync package.json version → Android & iOS manifests
+pnpm android:build        # Debug APK
+pnpm android:release      # Release APK
+pnpm android:bundle       # AAB for Google Play
+pnpm ios:sync             # Sync web build to iOS
+pnpm ios:build            # Sync + open Xcode
+```
+
+**Requirements**: Node.js `24.x` · pnpm `>= 9.0.0` (enforced via `.npmrc` engine-strict)
+
+---
+
+## ▐ REPOSITORY STRUCTURE ▌
 
 ```
 VoiceIsolate-Pro/
-├── public/                    # Web application (served as static site)
-│   ├── index.html            # Landing page / router entry point
-│   ├── app/                  # Main Engineer Mode application
-│   │   ├── index.html        # UI shell (52 sliders, 6-panel diagnostics)
-│   │   ├── app.js            # ~38KB — main orchestrator, presets, UI transport
-│   │   ├── slider-map.js     # ~9KB — STAGES (32) + SLIDER_REGISTRY (52); pure data, no side effects
-│   │   ├── style.css         # Dark industrial UI theme
-│   │   ├── mobile.css        # Mobile-specific overrides
-│   │   ├── style-diag-log.css # Diagnostic log panel styles
-│   │   ├── processing-overlay.css  # Processing overlay styles
-│   │   ├── model-status-ui.css     # Model status UI styles
-│   │   ├── dsp-core.js       # ~65KB — pure DSP math (STFT, filters, spectral ops)
-│   │   ├── dsp-processor.js  # ~9KB — AudioWorklet processor (real-time live mode; canonical)
-│   │   ├── dsp-worker.js     # ~6.5KB — Web Worker for heavy offline DSP
-│   │   ├── offline-processor.js   # ~20KB — self-contained offline processing module (Creator/Forensic mode)
-│   │   ├── pipeline-orchestrator.js  # ~36KB — 32-stage Deca-Pass pipeline runner
-│   │   ├── pipeline-state.js # ~20KB — centralized state management + event bus
-│   │   ├── ml-worker.js      # ~48KB — ML inference worker (ONNX Runtime)
-│   │   ├── ml-worker-fetch-cache.js  # ~37KB — model caching (Cache API + IndexedDB)
-│   │   ├── ml-worker-models-patch.js # Model compatibility shims
-│   │   ├── model-cdn-loader.js  # ~7KB — CDN/Blob URL model fetching with fallback
-│   │   ├── model-loader.js   # ~4.5KB — model loader entry point (dispatches to cdn-loader)
-│   │   ├── model-status-ui.js # ~8KB — download progress + model status overlay
-│   │   ├── batch-orchestrator.js  # ~10KB — multi-file batch processing queue
-│   │   ├── batch-processor.js     # ~15KB — concurrent dispatch logic
-│   │   ├── ring-buffer.js    # ~10KB — SharedArrayBuffer ring buffer (main ↔ worklet)
-│   │   ├── sw.js             # ~8KB — service worker (COOP/COEP injection, cache-first models)
-│   │   ├── sw-register.js    # ~4.5KB — service worker registration + update lifecycle
-│   │   ├── analytics.js      # Local-only event log (no server)
-│   │   ├── license-manager.js # JWT license validation
-│   │   ├── paywall.js        # ~27KB — subscription UI
-│   │   ├── visuals.js        # ~20KB — Canvas 2D visualization (VU meters, waveform)
-│   │   ├── revenuecat.js     # RevenueCat mobile subscriptions
-│   │   ├── ai-engine-v2.js   # ~23KB — AI engine v2 (enhanced inference pipeline)
-│   │   ├── ai-intelligence.js # ~16KB — AI intelligence layer (model coordination)
-│   │   ├── auth.js           # ~17KB — authentication (login/session management)
-│   │   ├── nim-integration.js # ~5KB — NVIDIA NIM video/canvas processing integration
-│   │   ├── processing-overlay.js  # ~11KB — processing progress overlay UI
-│   │   ├── controls-test.js  # Interactive controls test harness
-│   │   ├── diarization-timeline.js  # ~11KB — speaker diarization timeline UI
-│   │   ├── isolation-controls.js  # ~9KB — per-speaker mute/solo/isolate card UI
-│   │   ├── session-persist.js # Session state persistence (IndexedDB)
-│   │   ├── vip-boot.js       # ~11KB — VIP bootstrap / feature gate entry point
-│   │   └── models/           # Committed ONNX model files
-│   │       ├── silero_vad.onnx        # 2.2MB — VAD (fp32)
-│   │       ├── silero_vad_int8.onnx   # 2.3MB — VAD (int8 quantized)
-│   │       ├── rnnoise_suppressor.onnx # 1.8MB — spectral noise suppressor
-│   │       ├── bsrnn_vocals.onnx      # 4.3MB — band-split RNN vocal separator
-│   │       ├── demucs_v4_quantized.onnx.placeholder  # placeholder only (too large to commit)
-│   │       ├── models-manifest.json   # model registry with SHA-256, shapes, delivery status
+├── public/                         Web application (static site)
+│   ├── index.html                  Landing page / router entry point
+│   ├── app/                        Engineer Mode application
+│   │   ├── index.html              UI shell (52 sliders, 6-panel diagnostics)
+│   │   ├── voice-isolator.html     Standalone voice isolator UI
+│   │   ├── how-it-works.html       Technical explainer page
+│   │   ├── neon-pulse-card.html    Neon pulse visualizer card page
+│   │   │
+│   │   ├── ── CORE ORCHESTRATION ──────────────────────────────────
+│   │   ├── app.js                  ~38KB  Main orchestrator, presets, UI transport
+│   │   ├── slider-map.js           ~9KB   STAGES(32) + SLIDER_REGISTRY(52); pure data
+│   │   ├── pipeline-orchestrator.js ~36KB  32-stage Deca-Pass pipeline runner
+│   │   ├── pipeline-state.js       ~20KB  Centralized state management + event bus
+│   │   ├── vip-boot.js             ~11KB  VIP bootstrap / feature gate entry point
+│   │   ├── vip-slider-patch.js     ~37KB  Slider patch (loaded LAST after app.js)
+│   │   │
+│   │   ├── ── DSP ENGINE ──────────────────────────────────────────
+│   │   ├── dsp-core.js             ~65KB  Pure DSP math (STFT, filters, spectral ops)
+│   │   ├── dsp-stages.js           ~23KB  32 named DSP stages as pure spectral operators
+│   │   ├── dsp-processor.js        ~9KB   AudioWorklet processor (real-time; canonical)
+│   │   ├── dsp-worker.js           ~6.5KB Web Worker for heavy offline DSP
+│   │   ├── offline-processor.js    ~20KB  Self-contained offline processor (Creator/Forensic)
+│   │   ├── fft-bridge.js           ~10KB  Offline STFT/iSTFT utility (Creator/Forensic modes)
+│   │   ├── ring-buffer.js          ~10KB  SharedArrayBuffer ring buffer (main ↔ worklet)
+│   │   │
+│   │   ├── ── ML / MODELS ─────────────────────────────────────────
+│   │   ├── ml-worker.js            ~48KB  ML inference worker (ONNX Runtime)
+│   │   ├── ml-worker-fetch-cache.js ~37KB  Model caching (Cache API + IndexedDB)
+│   │   ├── ml-worker-models-patch.js       Model compatibility shims
+│   │   ├── model-cdn-loader.js     ~7KB   CDN/Blob URL model fetching with fallback
+│   │   ├── model-loader.js         ~4.5KB Model loader entry point (→ cdn-loader)
+│   │   ├── model-status-ui.js      ~8KB   Download progress + model status overlay
+│   │   ├── models-manifest.json           Model registry (SHA-256, shapes, delivery)
+│   │   │
+│   │   ├── ── AI LAYER ────────────────────────────────────────────
+│   │   ├── ai-engine-v2.js         ~23KB  AI engine v2 (enhanced inference pipeline)
+│   │   ├── ai-intelligence.js      ~16KB  AI intelligence layer (model coordination)
+│   │   │
+│   │   ├── ── BATCH PROCESSING ────────────────────────────────────
+│   │   ├── batch-orchestrator.js   ~10KB  Multi-file batch processing queue
+│   │   ├── batch-processor.js      ~15KB  Concurrent dispatch logic
+│   │   │
+│   │   ├── ── UI / VISUALIZATION ──────────────────────────────────
+│   │   ├── visuals.js              ~20KB  Canvas 2D visualization (VU meters, waveform)
+│   │   ├── neon-pulse-visualizer.js ~20KB  Neon pulse audio visualizer
+│   │   ├── neon-pulse-card.js      ~24KB  Neon pulse visualizer card component
+│   │   ├── diarization-timeline.js ~11KB  Speaker diarization timeline UI
+│   │   ├── isolation-controls.js   ~9KB   Per-speaker mute/solo/isolate card UI
+│   │   ├── processing-overlay.js   ~11KB  Processing progress overlay UI
+│   │   ├── model-status-ui.js      ~8KB   Download progress + model status overlay
+│   │   │
+│   │   ├── ── AUTH / PAYMENTS ─────────────────────────────────────
+│   │   ├── auth.js                 ~17KB  Authentication (login/session management)
+│   │   ├── license-manager.js             JWT license validation
+│   │   ├── paywall.js              ~27KB  Subscription UI
+│   │   ├── revenuecat.js                  RevenueCat mobile subscriptions
+│   │   │
+│   │   ├── ── SERVICE WORKER ──────────────────────────────────────
+│   │   ├── sw.js                   ~8KB   COOP/COEP injection, cache-first models
+│   │   ├── sw-register.js          ~4.5KB Service worker registration + update lifecycle
+│   │   │
+│   │   ├── ── UTILITIES ───────────────────────────────────────────
+│   │   ├── analytics.js                   Local-only event log (no server)
+│   │   ├── session-persist.js             Session state persistence (IndexedDB)
+│   │   ├── debug-audit.js          ~13KB  Full self-test & capability audit (console)
+│   │   │
+│   │   ├── ── STYLES ──────────────────────────────────────────────
+│   │   ├── style.css                      Dark industrial UI theme
+│   │   ├── mobile.css                     Mobile-specific overrides
+│   │   ├── slider-theme.css               Slider component theme
+│   │   ├── style-diag-log.css             Diagnostic log panel styles
+│   │   ├── processing-overlay.css         Processing overlay styles
+│   │   ├── model-status-ui.css            Model status UI styles
+│   │   ├── neon-pulse-visualizer.css      Neon pulse visualizer styles
+│   │   │
+│   │   └── models/                 Committed ONNX model files
+│   │       ├── silero_vad.onnx            2.2MB — VAD (fp32)
+│   │       ├── silero_vad_int8.onnx       2.3MB — VAD (int8 quantized)
+│   │       ├── rnnoise_suppressor.onnx    1.8MB — Spectral noise suppressor (GRU mask)
+│   │       ├── bsrnn_vocals.onnx          4.3MB — Band-split RNN vocal separator
+│   │       ├── demucs_v4_quantized.onnx.placeholder   placeholder (too large to commit)
+│   │       ├── models-manifest.json       Model registry (authoritative copy)
 │   │       └── README.md
-│   ├── lib/                   # Third-party libraries (committed vendor assets)
-│   │   ├── ort.min.js        # ONNX Runtime Web minified (NEVER load from CDN)
-│   │   ├── ort.js            # ONNX Runtime Web full build
-│   │   ├── ort-loader.js     # ORT loader helper (WebGPU → WASM fallback)
-│   │   ├── ort-wasm-simd-threaded.wasm           # WASM binary
-│   │   ├── ort-wasm-simd-threaded.asyncify.wasm  # WASM binary (asyncify)
-│   │   ├── ort-wasm-simd-threaded.jsep.wasm      # WASM binary (JSEP/WebGPU)
-│   │   ├── ort-wasm-simd-threaded.jspi.wasm      # WASM binary (JSPI)
-│   │   ├── three.module.min.js  # Three.js 0.184.0 ESM build (loaded via importmap)
-│   │   ├── three.core.min.js    # Three.js core-only ESM build
-│   │   └── three.min.js         # Three.js UMD full build
-│   └── docs/                  # Technical documentation
-├── api/                       # Backend API (Node.js/Express + Vercel serverless)
-│   ├── handler.js            # Vercel serverless request handler (routes all /api/* traffic)
-│   ├── index.js              # API router
-│   ├── auth.js               # Authentication API (JWT issue/verify)
-│   ├── client-config.js      # Client configuration endpoint
-│   ├── monetization.js       # Stripe checkout, license JWT, webhooks
-│   ├── sync.js               # Cloud sync stub (placeholder)
-│   └── nim/                  # NVIDIA NIM integration (optional cloud inference)
-│       ├── index.js          # NIM API entry point
-│       └── grpc-client.js    # gRPC client for NIM inference service
-├── tests/                     # Jest unit tests (55 files)
-│   └── helpers/              # Test helpers (get-app-code.js)
-├── scripts/                   # Build & validation scripts
-│   ├── validate.js           # Structural integrity checks
-│   ├── setup-ort.js          # Copy ONNX Runtime from node_modules (skipped if committed)
-│   ├── setup-three.js        # Copy Three.js 0.184.0 from node_modules (skipped if committed)
-│   ├── stamp-sw-version.js   # Inject cache-bust version into sw.js at build time
-│   ├── sync-mobile-version.js # Sync package.json version to Android/iOS manifests
-│   ├── validate-onnx-models.js # Verify committed ONNX files meet min-byte thresholds
-│   ├── live-smoke.cjs        # Playwright/Puppeteer live browser smoke test
-│   ├── bootstrap-libs.sh     # Vercel build entrypoint
-│   ├── download-models.sh    # Download large ONNX models (Demucs, etc.)
-│   └── (Python export scripts for ONNX model conversion)
-├── android/                   # Capacitor 8 Android project
-├── ios/                       # Capacitor 8 iOS project
-├── fastlane/                  # Fastlane mobile release automation
-├── docs/                      # Extended technical documentation
-├── notebooks/                 # Jupyter notebooks (model experimentation)
-├── server.js                  # Local Express dev server (COOP/COEP headers)
-├── eslint.config.js           # ESLint Flat Config (browser + worker globals)
-├── vercel.json                # Vercel deployment config (headers, routes, model rewrites)
-├── capacitor.config.json      # Mobile app config (Capacitor 8)
-├── package.json               # pnpm scripts and dependencies
-├── compose.yaml               # Docker Compose (production)
-├── compose.debug.yaml         # Docker Compose (debug)
-├── Dockerfile                 # Docker image definition
-├── render.yaml                # Render.com static site config
-├── CONTRIBUTING.md            # Contribution guidelines
-├── DEPLOYMENT_GUIDE.md        # Deployment walkthrough (Vercel, Docker, mobile)
-├── DIARIZATION_WIRING.md      # Speaker diarization integration notes
-├── MODELS.md                  # ONNX model inventory and acquisition guide
-└── .env.example               # Required environment variables template
+│   │
+│   ├── lib/                        Third-party libraries (committed vendor assets)
+│   │   ├── ort.min.js              ONNX Runtime Web minified  ← NEVER load from CDN
+│   │   ├── ort.js                  ONNX Runtime Web full build
+│   │   ├── ort-loader.js           ORT loader helper (WebGPU → WASM fallback)
+│   │   ├── ort-wasm-simd-threaded.wasm
+│   │   ├── ort-wasm-simd-threaded.asyncify.wasm
+│   │   ├── ort-wasm-simd-threaded.jsep.wasm
+│   │   ├── ort-wasm-simd-threaded.jspi.wasm
+│   │   ├── three.module.min.js     Three.js 0.184.0 ESM (via importmap) ← NEVER CDN
+│   │   ├── three.core.min.js       Three.js core-only ESM build
+│   │   └── three.min.js            Three.js UMD full build
+│   └── docs/                       Technical documentation
+│
+├── api/                            Backend (Node.js/Express + Vercel serverless)
+│   ├── handler.js                  Vercel serverless adapter (routes all /api/*)
+│   ├── index.js                    API router
+│   ├── auth.js                     Authentication API (JWT issue/verify)
+│   ├── client-config.js            Client configuration endpoint
+│   ├── monetization.js             Stripe checkout, license JWT, webhooks
+│   ├── sync.js                     Cloud sync stub (placeholder)
+│   └── nim/                        NVIDIA NIM integration (optional cloud inference)
+│       ├── index.js                NIM API entry point
+│       └── grpc-client.js          gRPC client for NIM inference service
+│
+├── tests/                          Jest unit tests (62 suites)
+│   └── helpers/                    Test helpers (get-app-code.js)
+│
+├── scripts/                        Build & validation scripts
+│   ├── validate.js                 Structural integrity checks
+│   ├── setup-ort.js                Copy ORT from node_modules (skipped if committed)
+│   ├── setup-three.js              Copy Three.js 0.184.0 from node_modules
+│   ├── stamp-sw-version.js         Inject cache-bust version into sw.js at build
+│   ├── sync-mobile-version.js      Sync package.json version → Android/iOS manifests
+│   ├── validate-onnx-models.js     Verify committed ONNX files meet min-byte thresholds
+│   ├── live-smoke.cjs              Playwright/Puppeteer live browser smoke test
+│   ├── bootstrap-libs.sh           Vercel build entrypoint
+│   └── download-models.sh          Download large ONNX models (Demucs, etc.)
+│
+├── android/                        Capacitor 8 Android project
+├── ios/                            Capacitor 8 iOS project
+├── fastlane/                       Fastlane mobile release automation
+├── docs/                           Extended technical documentation
+├── notebooks/                      Jupyter notebooks (model experimentation)
+├── server.js                       Local Express dev server (COOP/COEP headers)
+├── eslint.config.js                ESLint 9 Flat Config (browser + worker globals)
+├── vercel.json                     Vercel config (headers, routes, model rewrites)
+├── capacitor.config.json           Mobile app config (Capacitor 8)
+├── package.json                    pnpm scripts and dependencies
+├── compose.yaml                    Docker Compose (production)
+├── compose.debug.yaml              Docker Compose (debug)
+├── Dockerfile                      Docker image definition
+├── render.yaml                     Render.com static site config
+├── CONTRIBUTING.md                 Contribution guidelines
+├── DEPLOYMENT_GUIDE.md             Deployment walkthrough (Vercel, Docker, mobile)
+├── DIARIZATION_WIRING.md           Speaker diarization integration notes
+├── MODELS.md                       ONNX model inventory and acquisition guide
+└── .env.example                    Required environment variables template
 ```
 
 ---
 
-## Architecture: Critical Constraints
-
-These are non-negotiable architectural rules enforced by `scripts/validate.js` and the CI pipeline. Violating them breaks the pipeline.
-
-### 1. Single-Pass Spectral Architecture
-
-**Within any single processing path**, there is exactly one forward STFT and one iSTFT, with all spectral operations (noise reduction, voice separation, EQ, etc.) occurring **in-place** between them. Never add a second STFT/iSTFT pair to the same path.
+## ▐ ARCHITECTURE: CRITICAL CONSTRAINTS ▌
 
 ```
-[Time Domain] → STFT (Stage 10) → [Spectral Ops Stages 11–19] → iSTFT (Stage 20) → [Time Domain]
+╔═══════════════════════════════════════════════════════════════╗
+║  ENFORCED BY: scripts/validate.js  +  CI pipeline            ║
+║  Violating any rule below BREAKS the build.                   ║
+╚═══════════════════════════════════════════════════════════════╝
 ```
 
-There are three independent processing paths, each honoring this rule:
+### RULE 1 — Single-Pass Spectral Architecture
 
-| Path | STFT call | iSTFT call |
-|------|-----------|------------|
+Within any single processing path there is **exactly one** forward STFT and **one** iSTFT. All spectral operations occur **in-place** between them. Never add a second STFT/iSTFT pair.
+
+```
+[Time Domain] → STFT (S10) → [Spectral Ops S11–S19] → iSTFT (S20) → [Time Domain]
+                  ▲                                          ▲
+          ONE forward pass                           ONE inverse pass
+```
+
+Three independent paths — each must follow this rule:
+
+| Path | STFT | iSTFT |
+|------|------|-------|
 | Offline main thread | `app.js` → `DSP.forwardSTFT` | `app.js` → `DSP.inverseSTFT` |
 | Offline worker pool | `dsp-worker.js` → `dspCore.forwardSTFT` | `dsp-worker.js` → `dspCore.inverseSTFT` |
 | Real-time AudioWorklet | `dsp-processor.js` → `_forwardSTFTFrame` | `dsp-processor.js` → `_inverseSTFTFrame` |
 
-`offline-processor.js` also implements its own inlined FFT/iFFT (self-contained module; follows the same single-pass rule). Both the canonical STFT implementations live in `public/app/dsp-core.js` (`forwardSTFT`/`inverseSTFT`) — do not fork additional copies outside offline-processor.
+`offline-processor.js` implements its own inlined FFT/iFFT (self-contained; same rule applies). `fft-bridge.js` provides the offline STFT/iSTFT utility for Creator and Forensic modes. Canonical implementations live in `dsp-core.js` — do not fork copies outside these files.
 
-### 2. AudioWorklet Ownership
+### RULE 2 — AudioWorklet Ownership
 
 **Only `pipeline-orchestrator.js`** calls `audioContext.audioWorklet.addModule()`. Never register AudioWorklet modules from `app.js`, `dsp-worker.js`, or any other file.
 
-### 3. ML Worker Ownership
+### RULE 3 — ML Worker Ownership
 
-**Only `pipeline-orchestrator.js`** spawns the ML worker. The ML worker must never be created from `app.js` or other orchestration files.
+**Only `pipeline-orchestrator.js`** spawns the ML worker. Never create it from `app.js` or other orchestration files.
 
-### 4. Third-Party Libraries — Local Only
+### RULE 4 — Third-Party Libraries: Local Only
 
-ONNX Runtime is always loaded from `/lib/ort.min.js` (local file). It must **never** be loaded from a CDN. The CSP in `vercel.json` enforces this. `pnpm postinstall` runs `setup-ort.js` to copy it from `node_modules`; it is also committed directly to the repo so Vercel does not need to copy it at build time.
+```
+ONNX Runtime  →  always /lib/ort.min.js      NEVER a CDN URL
+Three.js      →  always /lib/three.module.min.js via importmap  NEVER a CDN URL
+```
 
-Three.js (0.184.0) is loaded from `/lib/three.module.min.js` via an `<script type="importmap">` in `index.html`. It must **never** be loaded from a CDN. The inline module `import * as THREE from 'three'; globalThis.THREE = THREE;` sets the global used by `app.js`. `pnpm setup:three` copies it from `node_modules`; it is committed to the repo.
+CSP in `vercel.json` enforces this. `pnpm postinstall` runs setup scripts; files are also committed directly so Vercel skips copying them.
 
-### 5. Privacy — No External Audio Calls
+### RULE 5 — Privacy: No External Audio Calls
 
-Audio data must never leave the browser. There are no server-side audio processing endpoints. `analytics.js` logs locally only.
+Audio data must never leave the browser. No server-side audio processing endpoints exist. `analytics.js` logs locally only.
 
-### 6. SharedArrayBuffer Requirements
+### RULE 6 — SharedArrayBuffer Headers
 
-SharedArrayBuffer requires COOP and COEP headers. These are set in `server.js` for development and `vercel.json` for production. The service worker (`sw.js`) also injects these headers on all responses so `crossOriginIsolated === true` without relying solely on server configuration. Never remove these headers from any path.
+COOP + COEP headers are required for `crossOriginIsolated === true`. Set in:
+- `server.js` (development)
+- `vercel.json` (production)
+- `sw.js` (injects headers on all responses as fallback)
 
-### 7. STAGES and SLIDER_REGISTRY Location
+Never remove these headers from any path.
 
-`STAGES` (32-entry array) and `SLIDER_REGISTRY` (52-entry flat array) are defined in **`slider-map.js`**, not in `app.js`. `app.js` imports them:
+### RULE 7 — STAGES & SLIDER_REGISTRY Location
+
+Both data structures live in **`slider-map.js`** only. `app.js` imports them:
 
 ```javascript
 import { SLIDER_REGISTRY, STAGES } from './slider-map.js';
 ```
 
-`slider-map.js` is a **pure data module** — no Web Audio API calls, no SharedArrayBuffer references, no side effects. `scripts/validate.js` checks for the STAGES array in this file.
+`slider-map.js` is a **pure data module** — no Web Audio API, no SharedArrayBuffer, no side effects.
 
 ---
 
-## 32-Stage Deca-Pass Pipeline
+## ▐ 32-STAGE DECA-PASS PIPELINE ▌
 
-The stage labels are defined in `public/app/slider-map.js` as the `STAGES` export (S01–S32). `scripts/validate.js` asserts exactly 32 entries. Stage order:
+```
+INPUT ──► [S01–S04] ──► [S05–S09] ──► [S10] ──► [S11–S19] ──► [S20] ──► [S21–S25] ──► [S26–S28] ──► [S29–S31] ──► [S32] ──► OUTPUT
+         PASS 1          PASS 2       PASS 3    PASS 4+5       PASS 6      PASS 7          PASS 8        PASS 9       PASS 10
+```
+
+Stage labels are defined in `public/app/slider-map.js` as the `STAGES` export (S01–S32). `scripts/validate.js` asserts exactly 32 entries.
 
 | Pass | Stages | Purpose |
 |------|--------|---------|
 | Pass 1 | S01–S04 | Input decode, buffer allocation, DC offset removal, peak normalization |
 | Pass 2 | S05–S09 | VAD, time-domain noise gate, click/pop removal, hum removal, de-essing |
-| Pass 3 | S10 | Forward STFT (Blackman-Harris window) |
+| Pass 3 | S10 | **Forward STFT** (Blackman-Harris window) |
 | Pass 4 | S11–S12 | Adaptive Wiener NR + residual Wiener pass |
 | Pass 5 | S13–S19 | ERB spectral gate, voice-band emphasis, crosstalk cancel, temporal smoothing, spectral tilt, dereverb, harmonic reconstruction |
-| Pass 6 | S20 | Inverse STFT |
+| Pass 6 | S20 | **Inverse STFT** |
 | Pass 7 | S21–S25 | OfflineAudioContext setup, HP/LP filters, 10-band EQ, compression, limiter |
 | Pass 8 | S26–S28 | Render, post-render cleanup, dry/wet mix |
 | Pass 9 | S29–S31 | Peak normalization, quality metrics, waveform update |
-| Pass 10 | S32 | Final export ready (SHA-256 forensic hash written to `_forensicLog`) |
+| Pass 10 | S32 | Final export ready (SHA-256 forensic hash → `_forensicLog`) |
 
 ---
 
-## 52-Slider System
+## ▐ 52-SLIDER SYSTEM ▌
 
-All 52 sliders are defined in `app.js` as the `SLIDERS` object. The `SLIDER_REGISTRY` flat array in `slider-map.js` maps each slider to its DSP dispatch key and target (`'worklet'` | `'worker'`). Each slider object:
+Sliders are defined in `app.js` as the `SLIDERS` object. `SLIDER_REGISTRY` in `slider-map.js` maps each to a DSP dispatch key and target.
 
 ```javascript
 {
-  id: 'gateThresh',       // Unique string — must match all preset keys and SLIDER_REGISTRY entries
-  label: 'Threshold',     // UI display label
-  min: -80,               // Minimum value
-  max: -5,                // Maximum value
-  val: -42,               // Default value
-  step: 1,                // Increment
-  unit: ' dB',            // Display unit (note: leading space)
-  rt: true,               // Real-time capable (wired to AudioParam via worklet)
-  desc: 'Signal level...' // Tooltip description
+  id:    'gateThresh',   // Unique — must match all preset keys + SLIDER_REGISTRY entries
+  label: 'Threshold',    // UI display label
+  min:   -80,
+  max:   -5,
+  val:   -42,            // Default value
+  step:  1,
+  unit:  ' dB',          // Leading space is intentional
+  rt:    true,           // Real-time capable (wired to AudioParam via worklet)
+  desc:  'Signal level…' // Tooltip description
 }
 ```
 
-Sliders are organized into 8 tab groups in the `SLIDERS` object:
+**8 tab groups:**
 
-| Key    | Sliders | Purpose                                                  |
-|--------|---------|----------------------------------------------------------|
-| `gate` | 6       | Threshold, range, attack/release/hold, lookahead         |
-| `nr`   | 5       | Spectral noise reduction amount/sensitivity/floor/smoothing |
-| `eq`   | 10      | 10-band parametric EQ (Sub/Bass/Warmth/.../Brilliance)   |
-| `dyn`  | 8       | Compressor + brickwall limiter                           |
-| `spec` | 8       | HP/LP filters, de-esser, spectral tilt, formant shift    |
-| `adv`  | 6       | Dereverb, harmonic recovery, stereo width, phase correction |
-| `sep`  | 5       | Voice isolation, background suppress, focus band, crosstalk |
-| `out`  | 4       | Output gain, dry/wet, dither, output width               |
+| Tab | Count | Purpose |
+|-----|-------|---------|
+| `gate` | 6 | Threshold, range, attack/release/hold, lookahead |
+| `nr` | 5 | Spectral noise reduction amount/sensitivity/floor/smoothing |
+| `eq` | 10 | 10-band parametric EQ (Sub → Brilliance) |
+| `dyn` | 8 | Compressor + brickwall limiter |
+| `spec` | 8 | HP/LP filters, de-esser, spectral tilt, formant shift |
+| `adv` | 6 | Dereverb, harmonic recovery, stereo width, phase correction |
+| `sep` | 5 | Voice isolation, background suppress, focus band, crosstalk |
+| `out` | 4 | Output gain, dry/wet, dither, output width |
 
-Total: 6 + 5 + 10 + 8 + 8 + 6 + 5 + 4 = **52** (enforced by `scripts/validate.js` and `tests/sliders.test.js`).
+**Total: 6+5+10+8+8+6+5+4 = 52** (enforced by `scripts/validate.js` + `tests/sliders.test.js`)
 
-**When adding a new slider**:
+**Adding a new slider — checklist:**
 1. Add the object to `SLIDERS` in `app.js`
-2. Add a corresponding entry to `SLIDER_REGISTRY` in `slider-map.js` (id, key, transform, target)
+2. Add a corresponding entry to `SLIDER_REGISTRY` in `slider-map.js`
 3. Add the ID with a default value to **every** preset in `PRESETS`
-4. Update `tests/sliders.test.js` if the count or tab changes
-5. Update `tests/presets.test.js` if the preset completeness check fails
+4. Update `tests/sliders.test.js` if count or tab changes
+5. Update `tests/presets.test.js` if preset completeness check fails
 
 ---
 
-## Preset System
+## ▐ PRESET SYSTEM ▌
 
-8 named presets defined in `app.js` as the `PRESETS` object:
-- `Voice Clarity`, `Podcast Clean`, `Forensic Extract`, `Music Vocal`, `Whisper Boost`, `Phone/Radio`, `Live Performance`, `Surveillance`
+8 named presets in `app.js` → `PRESETS`:
 
-Each preset must define a value for **all 52 slider IDs**. The test `tests/presets.test.js` validates completeness. Applied via `applyPreset(presetName)`.
+```
+Voice Clarity  ·  Podcast Clean  ·  Forensic Extract  ·  Music Vocal
+Whisper Boost  ·  Phone/Radio    ·  Live Performance   ·  Surveillance
+```
+
+Every preset must define a value for **all 52 slider IDs**. `tests/presets.test.js` validates completeness. Applied via `applyPreset(presetName)`.
 
 ---
 
-## ML Models
+## ▐ ML MODELS ▌
 
-Models are loaded by `ml-worker.js` via `model-loader.js` → `model-cdn-loader.js` and cached in the Cache API (`vip-models-v1`) by the service worker. Large models are fetched from Vercel Blob storage (rewrites in `vercel.json` forward `/app/models/*` to the blob URL).
+```
+                    ┌─ Cache API (vip-models-v1) ─────────────────────┐
+ml-worker.js  ──►  model-loader.js  ──►  model-cdn-loader.js  ──►  sw.js
+                    └─ IndexedDB (ml-worker-fetch-cache.js) ──────────┘
+```
+
+Large models are fetched from Vercel Blob storage (`/app/models/*` rewrites in `vercel.json`).
 
 | Model | File | Delivery | Purpose |
 |-------|------|----------|---------|
-| Silero VAD (fp32) | `models/silero_vad.onnx` | committed (2.2MB) | Voice activity detection |
-| Silero VAD (int8) | `models/silero_vad_int8.onnx` | committed (2.3MB) | VAD — int8 quantized variant |
-| RNNoise | `models/rnnoise_suppressor.onnx` | committed (1.8MB) | Spectral noise suppressor (GRU mask) |
-| BSRNN Vocals | `models/bsrnn_vocals.onnx` | committed (4.3MB) | Band-split RNN vocal separator |
-| Demucs v4 | (Vercel Blob / first-use download) | placeholder only | Vocal/music source separation |
-| VoiceFixer | (Vercel Blob / first-use download) | — | Voice quality restoration |
-| HiFi-GAN | (Vercel Blob / first-use download) | — | Neural vocoder |
+| Silero VAD (fp32) | `models/silero_vad.onnx` | committed 2.2MB | Voice activity detection |
+| Silero VAD (int8) | `models/silero_vad_int8.onnx` | committed 2.3MB | VAD — quantized variant |
+| RNNoise | `models/rnnoise_suppressor.onnx` | committed 1.8MB | Spectral noise suppressor (GRU mask) |
+| BSRNN Vocals | `models/bsrnn_vocals.onnx` | committed 4.3MB | Band-split RNN vocal separator |
+| Demucs v4 | `.placeholder` (Vercel Blob) | first-use download | Vocal/music source separation |
+| VoiceFixer | (Vercel Blob) | first-use download | Voice quality restoration |
+| HiFi-GAN | (Vercel Blob) | first-use download | Neural vocoder |
 
-The model registry at `public/app/models/models-manifest.json` contains SHA-256 checksums, input/output tensor shapes, sample rates, and delivery metadata for all models. `scripts/validate-onnx-models.js` verifies committed files meet minimum byte thresholds.
-
-The `ml-worker-models-patch.js` provides compatibility shims for model format variations.
+Model registry: `public/app/models/models-manifest.json` (authoritative) — also mirrored at `public/app/models-manifest.json`. `scripts/validate-onnx-models.js` verifies committed files meet minimum byte thresholds.
 
 ---
 
-## Service Worker
+## ▐ SERVICE WORKER ▌
 
-`sw.js` is registered by `sw-register.js` and handles:
+`sw.js` (registered by `sw-register.js`) handles:
 
-1. **COOP/COEP header injection** on all responses → ensures `crossOriginIsolated === true` for SharedArrayBuffer
+1. **COOP/COEP header injection** → `crossOriginIsolated === true` for SharedArrayBuffer
 2. **App-shell pre-caching** on install (all static JS/CSS/HTML assets)
-3. **Cache-first strategy** for ONNX model files (`vip-models-v1` cache)
-4. **Network-first strategy** for `index.html` (always fresh)
+3. **Cache-first** strategy for ONNX model files (`vip-models-v1` cache)
+4. **Network-first** strategy for `index.html` (always fresh)
 5. **Zero-downtime updates** via `skipWaiting` + `clients.claim` on activate
 
-`scripts/stamp-sw-version.js` injects a cache-bust version string into `sw.js` at Vercel build time (run as part of `vercel.json`'s `buildCommand`).
+`scripts/stamp-sw-version.js` injects a cache-bust version string into `sw.js` at Vercel build time.
 
 ---
 
-## Code Conventions
+## ▐ CODE CONVENTIONS ▌
 
 ### JavaScript Style
 
-- **Quotes**: Single quotes (`'string'`)
-- **Semicolons**: Always required
-- **Variables**: camelCase (`gateThresh`, `applySpectralNR`)
-- **Constants**: UPPERCASE (`STAGES`, `SLIDERS`, `PRESETS`)
-- **Classes**: PascalCase (`PipelineState`, `AdaptiveNoiseFloor`)
-- **Arrow functions**: Preferred for callbacks; `function` for named methods
-- **Module system**: ESM in `public/app/` files; CommonJS (`require`) in `tests/`
+```
+Quotes      →  Single quotes  ('string')
+Semicolons  →  Always required
+Variables   →  camelCase      (gateThresh, applySpectralNR)
+Constants   →  UPPERCASE      (STAGES, SLIDERS, PRESETS)
+Classes     →  PascalCase     (PipelineState, AdaptiveNoiseFloor)
+Functions   →  Arrow for callbacks; named function for methods
+Modules     →  ESM in public/app/;  CommonJS (require) in tests/
+```
 
-### ESLint Configuration
+### ESLint (eslint.config.js — ESLint 9 Flat Config)
 
-`eslint.config.js` uses ESLint 9 Flat Config. Key globals registered:
-- Browser: `ort`, `THREE`, `AudioWorklet`, `AudioWorkletProcessor`
-- Workers: `importScripts`, `self`
-- Jest: `test`, `expect`, `describe`, `beforeEach`, `afterEach`, `jest`
+Globals registered:
+- **Browser**: `ort`, `THREE`, `AudioWorklet`, `AudioWorkletProcessor`
+- **Workers**: `importScripts`, `self`
+- **Jest**: `test`, `expect`, `describe`, `beforeEach`, `afterEach`, `jest`
 
-Rules: `semi: warn`, `quotes: ['warn', 'single']`, `no-unused-vars: warn` (ignores `^_` prefix).
+Rules: `semi: warn` · `quotes: ['warn', 'single']` · `no-unused-vars: warn` (ignores `^_` prefix)
 
 ### Audio Buffer Conventions
 
-- Always use `Float32Array` for audio data (no other typed arrays in hot paths)
-- Use `setTargetAtTime()` for smooth AudioParam transitions, not `setValueAtTime()`
-- In-place spectral operations (never copy the entire spectrum array)
+- Always use `Float32Array` for audio data in hot paths
+- Use `setTargetAtTime()` for smooth AudioParam transitions (not `setValueAtTime()`)
+- In-place spectral operations — never copy the entire spectrum array
 - Ring buffer pattern (`ring-buffer.js`) for main thread ↔ AudioWorklet shared memory
 
 ### Error Handling
 
-- Wrap async operations in try-catch; log errors to console, do not swallow them
-- ML worker uses promise-based timeout (rejects if inference stalls > threshold)
+- Wrap async operations in try-catch; log to console, never swallow
+- ML worker uses promise-based timeout (rejects if inference stalls)
 - Fallback to classical DSP if ONNX Runtime unavailable
 - Audio node cleanup: wrap `disconnect()` in try-catch (already-disconnected nodes throw)
 
 ---
 
-## Testing
+## ▐ TESTING ▌
 
-55 Jest test suites covering all major subsystems:
+**62 Jest suites** covering all major subsystems. Jest environment: `node` (not `jsdom`) — DOM tests use `jsdom` library directly.
 
 ```bash
-pnpm test                     # Run all suites
-pnpm test -- tests/dsp.test.js  # Run single suite
-pnpm test:coverage            # Generate coverage report
-pnpm test:live                # Live browser smoke test (Playwright/Puppeteer)
+pnpm test                          # Run all 62 suites
+pnpm test -- tests/dsp.test.js     # Run single suite
+pnpm test:coverage                 # Generate coverage report
+pnpm test:live                     # Live browser smoke test
 ```
 
-Key test files and what they protect:
+Key suites and what they protect:
 
-| Test File | What It Validates |
-|-----------|------------------|
+| Test File | Validates |
+|-----------|-----------|
 | `tests/dsp.test.js` | STFT/iSTFT roundtrip, FFT math, Wiener NR |
 | `tests/dsp-core.test.js` | DSP core math functions |
+| `tests/dsp-stages.test.js` | 32 named stage operators |
+| `tests/stft-roundtrip-sine.test.js` | STFT reconstruction accuracy |
+| `tests/fft-bridge.test.js` | Offline STFT/iSTFT bridge utility |
 | `tests/sliders.test.js` | 52 slider definitions, unique IDs, tab counts |
 | `tests/slider-map.test.js` | SLIDER_REGISTRY and STAGES in slider-map.js |
 | `tests/presets.test.js` | All presets cover all 52 slider IDs |
 | `tests/pipeline-state.test.js` | State management, event bus |
 | `tests/pipeline-orchestrator.test.js` | Pipeline runner, AudioWorklet init |
 | `tests/ml-worker.test.js` | ONNX model loading, inference |
+| `tests/ml-worker-fetch-cache.test.js` | Model caching (Cache API + IndexedDB) |
 | `tests/model-registry-consistency.test.js` | models-manifest.json consistency |
 | `tests/html.test.js` | DOM structure, all required `<script>` tags |
 | `tests/server.test.js` | Express endpoints, health check, COOP/COEP headers |
 | `tests/deployment-config.test.js` | `vercel.json` headers and routes |
 | `tests/android-config.test.js` | Capacitor Android configuration |
 | `tests/ios-config.test.js` | Capacitor iOS configuration |
+| `tests/mobile-ui.test.js` | Mobile UI overrides |
 | `tests/architectural-invariants.test.js` | Single-pass STFT, worker ownership rules |
 | `tests/auth.test.js` | Authentication API |
 | `tests/monetization.test.js` | Stripe/license flow |
 | `tests/batch-processor.test.js` | Multi-file batch queue |
 | `tests/ring-buffer.test.js` | SharedArrayBuffer ring buffer |
 | `tests/diarization-timeline.test.js` | Diarization UI component |
-
-Jest environment: `node` (not `jsdom`) — DOM tests use `jsdom` library directly.
+| `tests/vip-boot.test.js` | VIP bootstrap / feature gate |
+| `tests/worklet-integration.test.js` | AudioWorklet integration |
+| `tests/sab-protocol-fixes.test.js` | SharedArrayBuffer protocol |
 
 ### Structural Validation
 
-`pnpm validate` runs `scripts/validate.js` which checks:
+`pnpm validate` → `scripts/validate.js` checks:
+
 - Critical files exist (`public/app/index.html`, `app.js`, `slider-map.js`, `vercel.json`, etc.)
 - `app.js` > 10KB (not truncated)
 - Slider group IDs (`gate`, `nr`, `eq`) present in `app.js`
@@ -432,9 +506,9 @@ Jest environment: `node` (not `jsdom`) — DOM tests use `jsdom` library directl
 
 ---
 
-## Environment Variables
+## ▐ ENVIRONMENT VARIABLES ▌
 
-Copy `.env.example` to `.env` for local development. Only needed for subscription/payment features:
+Copy `.env.example` → `.env`. Only needed for subscription/payment features:
 
 ```bash
 # Stripe (only needed for paywall features)
@@ -456,58 +530,58 @@ NODE_ENV=development
 DATABASE_URL=postgresql://user:password@host:5432/voiceisolate
 ```
 
-For basic audio processing testing, no `.env` file is required.
+> For basic audio processing testing, no `.env` file is required.
 
 ---
 
-## Deployment
+## ▐ DEPLOYMENT ▌
 
 ### Vercel (Primary)
 
-- `vercel.json` configures headers, routes, and cache policies
-- COOP + COEP headers are mandatory (required for SharedArrayBuffer)
-- ONNX Runtime WASM files are served with `immutable` cache headers
+- COOP + COEP headers are **mandatory** (required for SharedArrayBuffer)
+- ONNX Runtime WASM files served with `immutable` cache headers
 - CSP restricts scripts to same-origin only (no CDN)
-- `/app/models/*` requests are rewritten to Vercel Blob storage (configure `YOUR_BLOB_STORE` URL in `vercel.json`)
+- `/app/models/*` requests rewritten to Vercel Blob storage (configure `YOUR_BLOB_STORE` URL in `vercel.json`)
 - Build command: `node scripts/setup-ort.js && node scripts/setup-three.js && node scripts/stamp-sw-version.js`
-- Deploy: push to `main` branch triggers CI → Vercel deploy
+- Deploy: push to `main` → CI → Vercel deploy
 
 ### Render.com (Alternative)
 
 - `render.yaml` defines static site serving from `public/`
-- No build step required (assets are pre-built in `public/`)
+- No build step required (assets pre-built in `public/`)
 
 ### Docker
 
 ```bash
 docker build -t voiceisolate-pro .
-docker compose up            # production
-docker compose -f compose.debug.yaml up  # debug mode
+docker compose up                            # production
+docker compose -f compose.debug.yaml up     # debug mode
 ```
 
 ### Mobile (Capacitor 8)
 
 ```bash
 # Android
-pnpm android:build       # Generates debug APK via Gradle
-pnpm android:bundle      # Generates AAB for Google Play
+pnpm android:build    # Debug APK via Gradle
+pnpm android:bundle   # AAB for Google Play
 
 # iOS
-pnpm ios:sync            # Sync web assets
-# Then open ios/App/App.xcworkspace in Xcode
+pnpm ios:sync         # Sync web assets
+# Open ios/App/App.xcworkspace in Xcode
 ```
 
-App ID: `com.voiceisolatepro.app`, version: 24.0.0. Fastlane config is in `fastlane/` for automated release builds.
+App ID: `com.voiceisolatepro.app` · Version: `24.0.0` · Fastlane config: `fastlane/`
 
 ---
 
-## CI/CD Pipeline
+## ▐ CI/CD PIPELINE ▌
 
-Five workflows in `.github/workflows/`:
+**6 workflows** in `.github/workflows/`:
 
 | Workflow | Trigger | Purpose |
 |----------|---------|---------|
-| `deploy.yml` | push/PR to `main` | Lint + test + validate + Vercel deploy |
+| `ci.yml` | push/PR | Core CI (lint, test, validate) |
+| `deploy.yml` | push/PR to `main` | Full lint + test + validate + Vercel deploy |
 | `eslint.yml` | push/PR | Standalone ESLint check |
 | `njsscan.yml` | push/PR | Node.js security scanning (njsscan) |
 | `semgrep.yml` | push/PR | Static analysis (Semgrep SAST) |
@@ -515,57 +589,71 @@ Five workflows in `.github/workflows/`:
 
 **`deploy.yml`** jobs:
 
-1. **lint-test**: ESLint + Jest (all 55 suites) + `pnpm validate`
-2. **smoke-test**: Live browser test via Playwright/Puppeteer (`pnpm test:live`)
-3. **deploy-preview**: Vercel preview URL (PRs only)
-4. **deploy-production**: Vercel production deploy (merge to `main` only)
+1. **lint-test** — ESLint + Jest (all 62 suites) + `pnpm validate`
+2. **smoke-test** — Live browser test via Playwright/Puppeteer
+3. **deploy-preview** — Vercel preview URL (PRs only)
+4. **deploy-production** — Vercel production deploy (merge to `main` only)
 
-Node 24 + pnpm 9.0.0 on `ubuntu-latest`. All actions use pinned commit SHAs for supply-chain security.
+Node `24` + pnpm `9.0.0` on `ubuntu-latest`. All actions use pinned commit SHAs for supply-chain security.
 
 ---
 
-## Key Files Quick Reference
-
-Sizes are approximate byte counts; authoritative counts come from `wc -c`.
+## ▐ KEY FILES QUICK REFERENCE ▌
 
 | File | Size | Purpose |
 |------|------|---------|
 | `public/app/dsp-core.js` | ~65KB | Pure DSP math: STFT, filters, spectral algorithms |
 | `public/app/ml-worker.js` | ~48KB | ONNX inference worker (Demucs, BSRNN, VAD) |
+| `public/app/vip-slider-patch.js` | ~37KB | Slider patch loaded last (after app.js) |
 | `public/app/ml-worker-fetch-cache.js` | ~37KB | Model caching via Cache API + IndexedDB |
 | `public/app/pipeline-orchestrator.js` | ~36KB | 32-stage Deca-Pass runner, AudioWorklet + ML worker init |
+| `public/app/app.js` | ~38KB | Main orchestrator: presets, UI transport, slider tab defs |
 | `public/app/paywall.js` | ~27KB | Subscription/paywall UI |
+| `public/app/neon-pulse-card.js` | ~24KB | Neon pulse visualizer card component |
+| `public/app/dsp-stages.js` | ~23KB | 32 named DSP stage operators (pure spectral) |
 | `public/app/ai-engine-v2.js` | ~23KB | AI engine v2 (enhanced inference pipeline) |
-| `public/app/offline-processor.js` | ~20KB | Self-contained offline audio processor (Creator/Forensic mode) |
+| `public/app/offline-processor.js` | ~20KB | Self-contained offline audio processor |
+| `public/app/neon-pulse-visualizer.js` | ~20KB | Neon pulse audio visualizer |
 | `public/app/pipeline-state.js` | ~20KB | Centralized state, event bus |
 | `public/app/visuals.js` | ~20KB | Canvas 2D visualization (VU meters, waveform) |
 | `public/app/auth.js` | ~17KB | Authentication (login/session management) |
 | `public/app/ai-intelligence.js` | ~16KB | AI intelligence layer (model coordination) |
 | `public/app/batch-processor.js` | ~15KB | Multi-file batch queue |
-| `public/app/app.js` | ~38KB | Main orchestrator: presets, UI transport, slider tab defs |
-| `public/app/slider-map.js` | ~9KB | STAGES (32) + SLIDER_REGISTRY (52) — pure data module |
-| `public/app/dsp-processor.js` | ~9KB | AudioWorklet real-time processor (canonical — only registered worklet) |
-| `server.js` | ~4KB | Express dev server with required COOP/COEP headers |
+| `public/app/debug-audit.js` | ~13KB | Self-test & capability audit (`window.VIP_runAudit()`) |
+| `public/app/diarization-timeline.js` | ~11KB | Speaker diarization timeline UI |
+| `public/app/fft-bridge.js` | ~10KB | Offline STFT/iSTFT bridge (Creator/Forensic modes) |
+| `public/app/ring-buffer.js` | ~10KB | SharedArrayBuffer ring buffer (main ↔ worklet) |
+| `public/app/slider-map.js` | ~9KB | STAGES(32) + SLIDER_REGISTRY(52) — pure data module |
+| `public/app/dsp-processor.js` | ~9KB | AudioWorklet real-time processor (only registered worklet) |
+| `server.js` | ~4KB | Express dev server with COOP/COEP headers |
 | `api/handler.js` | — | Vercel serverless adapter (routes all /api/* traffic) |
 | `api/monetization.js` | — | Stripe checkout, JWT license generation |
 | `api/auth.js` | — | Authentication API |
 
 ---
 
-## Common Pitfalls
+## ▐ COMMON PITFALLS ▌
+
+```
+╔═══════════════════════════════════════════════════════════════╗
+║  STOP — read before editing. These mistakes waste hours.      ║
+╚═══════════════════════════════════════════════════════════════╝
+```
 
 1. **Don't load ONNX Runtime from CDN.** Always `/lib/ort.min.js`. Run `pnpm setup:ort` if missing.
 2. **Don't load Three.js from CDN.** Always `/lib/three.module.min.js` via importmap. Run `pnpm setup:three` if missing.
-3. **Don't add a second STFT/iSTFT.** All spectral work goes in stages 10–20. This includes `offline-processor.js`.
+3. **Don't add a second STFT/iSTFT.** All spectral work goes in stages 10–20. This applies to `offline-processor.js` and any new modules.
 4. **Don't spawn the ML worker from `app.js`.** Only `pipeline-orchestrator.js` owns worker lifecycle.
-5. **Don't remove COOP/COEP headers.** SharedArrayBuffer breaks without them (needed in `server.js`, `vercel.json`, and `sw.js`).
-6. **Don't add presets without covering all 52 slider IDs.** Tests will catch this.
-7. **Don't add sliders without updating every preset AND `SLIDER_REGISTRY` in `slider-map.js`.** Both `tests/presets.test.js` and `tests/slider-map.test.js` validate completeness.
+5. **Don't remove COOP/COEP headers.** SharedArrayBuffer breaks without them (`server.js`, `vercel.json`, `sw.js`).
+6. **Don't add presets without covering all 52 slider IDs.** `tests/presets.test.js` will fail.
+7. **Don't add sliders without updating every preset AND `SLIDER_REGISTRY`.** Both `tests/presets.test.js` and `tests/slider-map.test.js` validate completeness.
 8. **Use `pnpm`, not `npm` or `yarn`.** Enforced by `.npmrc` engine-strict.
-9. **Tests use CommonJS** (`require`), frontend uses ESM (`import`). Don't mix them.
-10. **`public/lib/` files ARE committed to the repo** — ORT WASM, `ort.min.js`, and `three.module.min.js` are all tracked by git and served directly. The setup scripts skip copying if the files are already present. Do not add `public/lib/` to `.gitignore`.
-11. **`build/` is gitignored** — generated by `pnpm build`. Never commit the build output.
-12. **The `<script type="importmap">` in `index.html` must appear before any `<script type="module">` tag.** Moving or reordering it breaks Three.js loading for the 3D spectrogram.
-13. **`STAGES` and `SLIDER_REGISTRY` live in `slider-map.js`, not `app.js`.** Do not re-define them in `app.js`; `app.js` imports them.
-14. **Some ONNX models are committed; some are Blob-hosted.** Silero VAD, RNNoise, and BSRNN are committed to `public/app/models/`. Demucs v4 is too large and uses a `.placeholder` file — it is fetched from Vercel Blob on first use and cached by the service worker.
-15. **Node.js 24.x is required.** The CI and `.npmrc` enforce this. Do not test with Node 20 or earlier.
+9. **Tests use CommonJS** (`require`); frontend uses ESM (`import`). Don't mix them.
+10. **`public/lib/` files ARE committed.** ORT WASM, `ort.min.js`, and `three.module.min.js` are all tracked by git. Do not add `public/lib/` to `.gitignore`.
+11. **`build/` is gitignored** — generated by `pnpm build`. Never commit build output.
+12. **`<script type="importmap">` in `index.html` must appear before any `<script type="module">`.** Reordering breaks Three.js / 3D spectrogram.
+13. **`STAGES` and `SLIDER_REGISTRY` live in `slider-map.js`, not `app.js`.** Import, don't redefine.
+14. **Some ONNX models are committed; some are Blob-hosted.** Silero VAD, RNNoise, BSRNN are committed. Demucs v4 uses `.placeholder` — fetched from Vercel Blob on first use.
+15. **Node.js 24.x is required.** CI and `.npmrc` enforce this. Don't test with Node 20 or earlier.
+16. **`vip-slider-patch.js` loads LAST** — it patches slider state after `app.js` initializes. Load order in `index.html` is critical; do not move it earlier.
+17. **`debug-audit.js` is console-only** — call `window.VIP_runAudit()` from DevTools. Do not wire it into the normal app boot path.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ pnpm ios:sync             # Sync web build to iOS
 pnpm ios:build            # Sync + open Xcode
 ```
 
-**Requirements**: Node.js `24.x` · pnpm `>= 9.0.0` (enforced via `.npmrc` engine-strict)
+**Requirements**: Node.js `24.x` · pnpm `>= 9.0.0` (declared in `package.json#engines` and enforced by CI/validation checks)
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ pnpm build                # Copies public/ → build/
 # ── QUALITY ────────────────────────────────────────────────
 pnpm lint                 # ESLint Flat Config (app.js + worker files)
 pnpm lint:fix             # Auto-fix lint issues
-pnpm test                 # Run all 62 Jest suites
+pnpm test                 # Run all 59 Jest suites
 pnpm test:watch           # Watch mode
 pnpm test:coverage        # Coverage report
 pnpm test:live            # Live browser smoke test (Playwright/Puppeteer)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -396,9 +396,9 @@ Model manifests are split by runtime purpose: `public/app/models-manifest.json` 
 
 Service-worker files are currently split:
 
-1. `public/app/sw-register.js` currently registers **`/sw.js`** (root stub) with scope `/`
+1. `public/app/sw-register.js` currently registers **`/sw.js`** (root stub) with scope `/` (**this is the active registration target today**)
 2. `public/sw.js` is a minimal transition stub (`skipWaiting` + `clients.claim`) to avoid 404s during migration
-3. `public/app/sw.js` contains the full COOP/COEP header + cache strategies intended for app-shell/model handling
+3. `public/app/sw.js` contains the full COOP/COEP header + cache strategies intended for app-shell/model handling, but it is **not** the currently registered worker in this flow
 
 `scripts/stamp-sw-version.js` injects a cache-bust version string into `public/app/sw.js` at Vercel build time.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ pnpm lint:fix             # Auto-fix lint issues
 pnpm test                 # Run all 59 Jest suites
 pnpm test:watch           # Watch mode
 pnpm test:coverage        # Coverage report
-pnpm test:live            # Live browser smoke test (Playwright Chromium)
+pnpm test:live            # Live browser smoke test (Playwright/Chromium)
 pnpm validate             # Structural integrity checks
 
 # ── MOBILE ─────────────────────────────────────────────────
@@ -123,7 +123,6 @@ VoiceIsolate-Pro/
 │   │   ├── diarization-timeline.js ~11KB  Speaker diarization timeline UI
 │   │   ├── isolation-controls.js   ~9KB   Per-speaker mute/solo/isolate card UI
 │   │   ├── processing-overlay.js   ~11KB  Processing progress overlay UI
-│   │   ├── model-status-ui.js      ~8KB   Download progress + model status overlay
 │   │   │
 │   │   ├── ── AUTH / PAYMENTS ─────────────────────────────────────
 │   │   ├── auth.js                 ~17KB  Authentication (login/session management)
@@ -155,7 +154,7 @@ VoiceIsolate-Pro/
 │   │       ├── rnnoise_suppressor.onnx    1.8MB — Spectral noise suppressor (GRU mask)
 │   │       ├── bsrnn_vocals.onnx          4.3MB — Band-split RNN vocal separator
 │   │       ├── demucs_v4_quantized.onnx.placeholder   placeholder (too large to commit)
-│   │       ├── models-manifest.json       Model registry (authoritative copy)
+│   │       ├── models-manifest.json       Model metadata/inventory manifest (array schema)
 │   │       └── README.md
 │   │
 │   ├── lib/                        Third-party libraries (committed vendor assets)
@@ -182,7 +181,7 @@ VoiceIsolate-Pro/
 │       ├── index.js                NIM API entry point
 │       └── grpc-client.js          gRPC client for NIM inference service
 │
-├── tests/                          Jest unit tests (62 suites)
+├── tests/                          Jest unit tests (59 suites)
 │   └── helpers/                    Test helpers (get-app-code.js)
 │
 ├── scripts/                        Build & validation scripts
@@ -191,8 +190,8 @@ VoiceIsolate-Pro/
 │   ├── setup-three.js              Copy Three.js 0.184.0 from node_modules
 │   ├── stamp-sw-version.js         Inject cache-bust version into sw.js at build
 │   ├── sync-mobile-version.js      Sync package.json version → Android/iOS manifests
-│   ├── validate-onnx-models.js     Verify committed ONNX files meet min-byte thresholds
-│   ├── live-smoke.cjs              Playwright/Puppeteer live browser smoke test
+│   ├── validate-onnx-models.js     Validate model CDN/blob URLs via HEAD + Content-Length thresholds
+│   ├── live-smoke.cjs              Playwright live browser smoke test
 │   ├── bootstrap-libs.sh           Vercel build entrypoint
 │   └── download-models.sh          Download large ONNX models (Demucs, etc.)
 │
@@ -389,21 +388,19 @@ Large models are fetched from Vercel Blob storage (`/app/models/*` rewrites in `
 | VoiceFixer | (Vercel Blob) | first-use download | Voice quality restoration |
 | HiFi-GAN | (Vercel Blob) | first-use download | Neural vocoder |
 
-Model registry: `public/app/models/models-manifest.json` (authoritative) — also mirrored at `public/app/models-manifest.json`. `scripts/validate-onnx-models.js` validates the manifest's remote model URLs/binaries by checking their reported size against `min_bytes` thresholds.
+Model manifests are split by runtime purpose: `public/app/models-manifest.json` is the runtime CDN/source manifest fetched by `model-cdn-loader.js` (`/app/models-manifest.json`), while `public/app/models/models-manifest.json` is metadata/inventory (array schema). `scripts/validate-onnx-models.js` validates model URLs using HEAD requests and `Content-Length` thresholds from the selected manifest, rather than checking local committed file sizes.
 
 ---
 
 ## ▐ SERVICE WORKER ▌
 
-`sw.js` (registered by `sw-register.js`) handles:
+Service-worker files are currently split:
 
-1. **COOP/COEP header injection** → `crossOriginIsolated === true` for SharedArrayBuffer
-2. **App-shell pre-caching** on install (all static JS/CSS/HTML assets)
-3. **Cache-first** strategy for ONNX model files (`vip-models-v1` cache)
-4. **Network-first** strategy for `index.html` (always fresh)
-5. **Zero-downtime updates** via `skipWaiting` + `clients.claim` on activate
+1. `public/app/sw-register.js` currently registers **`/sw.js`** (root stub) with scope `/`
+2. `public/sw.js` is a minimal transition stub (`skipWaiting` + `clients.claim`) to avoid 404s during migration
+3. `public/app/sw.js` contains the full COOP/COEP header + cache strategies intended for app-shell/model handling
 
-`scripts/stamp-sw-version.js` injects a cache-bust version string into `sw.js` at Vercel build time.
+`scripts/stamp-sw-version.js` injects a cache-bust version string into `public/app/sw.js` at Vercel build time.
 
 ---
 
@@ -448,10 +445,10 @@ Rules: `semi: warn` · `quotes: ['warn', 'single']` · `no-unused-vars: warn` (i
 
 ## ▐ TESTING ▌
 
-**62 Jest suites** covering all major subsystems. Jest environment: `node` (not `jsdom`) — DOM tests use `jsdom` library directly.
+**59 Jest suites** covering all major subsystems. Jest environment: `node` (not `jsdom`) — DOM tests use `jsdom` library directly.
 
 ```bash
-pnpm test                          # Run all 62 suites
+pnpm test                          # Run all 59 suites
 pnpm test -- tests/dsp.test.js     # Run single suite
 pnpm test:coverage                 # Generate coverage report
 pnpm test:live                     # Live browser smoke test
@@ -589,12 +586,12 @@ App ID: `com.voiceisolatepro.app` · Version: `24.0.0` · Fastlane config: `fast
 
 **`deploy.yml`** jobs:
 
-1. **lint-test** — ESLint + Jest (all 62 suites) + `pnpm validate`
-2. **smoke-test** — Live browser test via Playwright/Puppeteer
+1. **lint-test** — ESLint + Jest (all 59 suites) + `pnpm validate`
+2. **smoke-test** — Live browser test via Playwright
 3. **deploy-preview** — Vercel preview URL (PRs only)
 4. **deploy-production** — Vercel production deploy (merge to `main` only)
 
-Node `24` + pnpm `9.0.0` on `ubuntu-latest`. All actions use pinned commit SHAs for supply-chain security.
+Workflow runtime/tooling is mixed: `deploy.yml` uses Node `24` + pnpm `9.0.0` with pinned action SHAs, while `ci.yml` currently uses Node `20` + `npm install` and version-tagged actions.
 
 ---
 
@@ -647,13 +644,13 @@ Node `24` + pnpm `9.0.0` on `ubuntu-latest`. All actions use pinned commit SHAs 
 5. **Don't remove COOP/COEP headers.** SharedArrayBuffer breaks without them (`server.js`, `vercel.json`, `sw.js`).
 6. **Don't add presets without covering all 52 slider IDs.** `tests/presets.test.js` will fail.
 7. **Don't add sliders without updating every preset AND `SLIDER_REGISTRY`.** Both `tests/presets.test.js` and `tests/slider-map.test.js` validate completeness.
-8. **Use `pnpm`, not `npm` or `yarn`.** Enforced by `.npmrc` engine-strict.
+8. **Use `pnpm`, not `npm` or `yarn`.** Required by `package.json#packageManager` and CI workflows.
 9. **Tests use CommonJS** (`require`); frontend uses ESM (`import`). Don't mix them.
 10. **`public/lib/` files ARE committed.** ORT WASM, `ort.min.js`, and `three.module.min.js` are all tracked by git. Do not add `public/lib/` to `.gitignore`.
 11. **`build/` is gitignored** — generated by `pnpm build`. Never commit build output.
 12. **`<script type="importmap">` in `index.html` must appear before any `<script type="module">`.** Reordering breaks Three.js / 3D spectrogram.
 13. **`STAGES` and `SLIDER_REGISTRY` live in `slider-map.js`, not `app.js`.** Import, don't redefine.
 14. **Some ONNX models are committed; some are Blob-hosted.** Silero VAD, RNNoise, BSRNN are committed. Demucs v4 uses `.placeholder` — fetched from Vercel Blob on first use.
-15. **Node.js 24.x is required.** CI and `.npmrc` enforce this. Don't test with Node 20 or earlier.
-16. **`vip-slider-patch.js` loads LAST** — it patches slider state after `app.js` initializes. Load order in `index.html` is critical; do not move it earlier.
+15. **Node.js 24.x is the project requirement.** Declared in `package.json#engines` and used by deploy workflows (note: `ci.yml` still runs Node 20 today).
+16. **`vip-slider-patch.js` is not currently loaded by `public/app/index.html`** (boot uses dynamic module imports). If re-enabled, document and preserve explicit load order relative to `app.js`.
 17. **`debug-audit.js` is console-only** — call `window.VIP_runAudit()` from DevTools. Do not wire it into the normal app boot path.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,7 +105,7 @@ VoiceIsolate-Pro/
 │   │   ├── ml-worker-models-patch.js       Model compatibility shims
 │   │   ├── model-cdn-loader.js     ~7KB   CDN/Blob URL model fetching with fallback
 │   │   ├── model-loader.js         ~4.5KB Model loader entry point (→ cdn-loader)
-│   │   ├── model-status-ui.js      ~8KB   Download progress + model status overlay
+│   │   ├── model-status-ui.js      ~8KB   Download progress + model status overlay (canonical entry; if referenced under UI / VISUALIZATION, treat it as a cross-reference only)
 │   │   ├── models-manifest.json           Model registry (SHA-256, shapes, delivery)
 │   │   │
 │   │   ├── ── AI LAYER ────────────────────────────────────────────


### PR DESCRIPTION
- Fix test count: 55 → 62 suites
- Fix CI workflow count: 5 → 6 (add ci.yml)
- Add missing files to repo structure: dsp-stages.js, fft-bridge.js,
  debug-audit.js, neon-pulse-visualizer.js, neon-pulse-card.js,
  vip-slider-patch.js, slider-theme.css, voice-isolator.html,
  how-it-works.html, models-manifest.json (public/app/ root copy)
- Remove nim-integration.js (no longer present in public/app/)
- Add pitfall rules 16-17 for vip-slider-patch.js load order and debug-audit.js usage
- Apply VOICEISOLATE PRO dark-industrial UI aesthetic via ASCII
  panel headers, waveform banner, pipeline diagrams, and structured tables
- Add CLAUDE-mobile.md: compact single-page quick-reference for
  mobile screens covering all critical facts in tight tables

https://claude.ai/code/session_01T6RAggRAUMpEp24W5FWuyp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive mobile quick-reference for VoiceIsolate Pro v24.0.0 covering the processing pipeline, on-device DSP/ML constraints, slider/preset system, model catalog, and mobile/web build & deployment notes.
  * Rewrote the main contributor guide with expanded architecture and operational guidance, CI/test expectations, a 32-stage pipeline overview, 52-slider/preset requirements, and updated multi-platform deployment instructions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Joker5514/VoiceIsolate-Pro/pull/497)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->