### PR TITLE
fix: link missing mobile.css in Engineer Mode index.html

### DIFF
--- a/public/app/index.html
+++ b/public/app/index.html
@@ -16,9 +16,9 @@
   <link rel="stylesheet" href="slider-theme.css" />
   <link rel="stylesheet" href="style-diag-log.css" />
   <link rel="stylesheet" href="model-status-ui.css" />
-  <link rel="stylesheet" href="mobile.css" />
   <!-- FIXED: was /app/processing-overlay.css (absolute, breaks on static hosts) -->
   <link id="vip-overlay-css" rel="stylesheet" href="processing-overlay.css" />
+  <link rel="stylesheet" href="mobile.css" />
 
   <!-- Module-error guard: surfaces broken imports as a red banner instead of blank page -->
   <style>

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -16,6 +16,7 @@
   <link rel="stylesheet" href="slider-theme.css" />
   <link rel="stylesheet" href="style-diag-log.css" />
   <link rel="stylesheet" href="model-status-ui.css" />
+  <link rel="stylesheet" href="mobile.css" />
   <!-- FIXED: was /app/processing-overlay.css (absolute, breaks on static hosts) -->
   <link id="vip-overlay-css" rel="stylesheet" href="processing-overlay.css" />
 


### PR DESCRIPTION
mobile.css existed with full responsive styles (960px/768px breakpoints,
safe-area insets, touch targets, mobile action bar) but was never loaded.

https://claude.ai/code/session_01BQsfrZDcmBExoqddBny1Cp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Added a mobile stylesheet to improve layout and presentation on mobile devices; the app now loads mobile-specific styles to better optimize appearance on smaller screens.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Joker5514/VoiceIsolate-Pro/pull/499)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->