### PR TITLE
fix(transport): clearer A/B label, smooth seek slider, loading indicator, speed +/-

### DIFF
--- a/public/app/app.js
+++ b/public/app/app.js
@@ -612,6 +612,9 @@ class VoiceIsolatePro {
       tpDur: g('tpDur'),
       tpSeek: g('tpSeek'),
       tpSpeed: g('tpSpeed'),
+      tpSpeedUp: g('tpSpeedUp'),
+      tpSpeedDown: g('tpSpeedDown'),
+      fileLoadIndicator: g('fileLoadIndicator'),
       hDur: g('hDur'),
       hFile: g('hFile'),
       hSR: g('hSR'),
@@ -714,9 +717,37 @@ class VoiceIsolatePro {
       this.dom.tpAB.addEventListener('click', () => this.toggleAB());
     }
     if (this.dom.tpSeek) {
-      this.dom.tpSeek.addEventListener('input', () => {
-        this.seekTo(parseFloat(this.dom.tpSeek.value) / 1000);
+      const seek = this.dom.tpSeek;
+      const beginSeek = () => { this._isSeeking = true; };
+      const endSeek = () => {
+        this._isSeeking = false;
+        this.seekTo(parseFloat(seek.value) / 1000);
+      };
+      seek.addEventListener('pointerdown', beginSeek);
+      seek.addEventListener('mousedown', beginSeek);
+      seek.addEventListener('touchstart', beginSeek, { passive: true });
+      seek.addEventListener('keydown', beginSeek);
+      seek.addEventListener('pointerup', endSeek);
+      seek.addEventListener('mouseup', endSeek);
+      seek.addEventListener('touchend', endSeek);
+      seek.addEventListener('keyup', endSeek);
+      seek.addEventListener('change', endSeek);
+      seek.addEventListener('input', () => {
+        this._isSeeking = true;
+        const frac = parseFloat(seek.value) / 1000;
+        if (this.inputBuffer && this.dom.tpCur) {
+          this.dom.tpCur.textContent = this.fmtDur(frac * this.inputBuffer.duration);
+        }
       });
+    }
+    if (this.dom.tpSpeed) {
+      this.dom.tpSpeed.addEventListener('change', () => this._applyPlaybackRate());
+    }
+    if (this.dom.tpSpeedUp) {
+      this.dom.tpSpeedUp.addEventListener('click', () => this._stepSpeed(1));
+    }
+    if (this.dom.tpSpeedDown) {
+      this.dom.tpSpeedDown.addEventListener('click', () => this._stepSpeed(-1));
     }
     if (this.dom.processBtn) {
       this.dom.processBtn.addEventListener('click', () => this.runPipeline());
@@ -1088,11 +1119,14 @@ class VoiceIsolatePro {
     if (this.dom.tpSeek) this.dom.tpSeek.value = 0;
     this._setScrubPos(0);
     this.renderStaticVisuals(0);
+    if (this.dom.tpABLabel && this.dom.tpABLabel.classList && this.dom.tpABLabel.classList.remove) {
+      this.dom.tpABLabel.classList.remove('is-playing');
+    }
   }
 
   pause() {
     if (!this.isPlaying) return;
-    const speed = parseFloat(this.dom.tpSpeed && this.dom.tpSpeed.value) || 1;
+    const speed = this._activeSpeed || parseFloat(this.dom.tpSpeed && this.dom.tpSpeed.value) || 1;
     this.playOffset += (this.ctx.currentTime - this.playStartTime) * speed;
     this.teardownChain();
     this.stopSpectro();
@@ -1102,6 +1136,9 @@ class VoiceIsolatePro {
       this.dom.videoPlayer.pause();
     }
     if (this.inputBuffer) this.renderStaticVisuals(this.playOffset / Math.max(this.inputBuffer.duration || 1, 1));
+    if (this.dom.tpABLabel && this.dom.tpABLabel.classList && this.dom.tpABLabel.classList.remove) {
+      this.dom.tpABLabel.classList.remove('is-playing');
+    }
   }
 
   seekDelta(dt) {
@@ -1137,13 +1174,14 @@ class VoiceIsolatePro {
   toggleAB() {
     if (!this.outputBuffer) return;
     if (this.isPlaying) {
-      const speed = parseFloat(this.dom.tpSpeed && this.dom.tpSpeed.value) || 1;
+      const speed = this._activeSpeed || parseFloat(this.dom.tpSpeed && this.dom.tpSpeed.value) || 1;
       this.playOffset += (this.ctx.currentTime - this.playStartTime) * speed;
     }
     this.abMode = this.abMode === 'original' ? 'processed' : 'original';
     const isProcessed = this.abMode === 'processed';
     if (this.dom.tpAB) this.dom.tpAB.classList.toggle('active', isProcessed);
     if (this.dom.tpABLabel) this.dom.tpABLabel.textContent = isProcessed ? 'Processed' : 'Original';
+    if (typeof this._setABLabel === 'function') this._setABLabel();
     this.renderStaticVisuals(this.playOffset / Math.max(this.inputBuffer?.duration || 1, 1));
     if (this.isPlaying) { this.play(); }
   }
@@ -1156,7 +1194,9 @@ class VoiceIsolatePro {
     this.buildLiveChain(buf);
     this.isPlaying = true;
     this.playStartTime = this.ctx.currentTime;
+    this._activeSpeed = parseFloat(this.dom.tpSpeed && this.dom.tpSpeed.value) || 1;
     if (this.dom.tpABLabel) this.dom.tpABLabel.textContent = this.abMode === 'processed' ? 'Processed' : 'Original';
+    if (typeof this._setABLabel === 'function') this._setABLabel();
 
     if (this.isVideo && this.dom.videoPlayer) {
       this.dom.videoPlayer.currentTime = this.playOffset;
@@ -1277,10 +1317,11 @@ class VoiceIsolatePro {
   }
 
   tickTime() {
-    const speed = parseFloat(this.dom.tpSpeed && this.dom.tpSpeed.value) || 1;
+    if (!this.isPlaying || !this.ctx || !this.inputBuffer) return;
+    const speed = this._activeSpeed || parseFloat(this.dom.tpSpeed && this.dom.tpSpeed.value) || 1;
     const elapsed = (this.ctx.currentTime - this.playStartTime) * speed;
     const cur = this.playOffset + elapsed;
-    if (this.dom.tpCur) this.dom.tpCur.textContent = this.fmtDur(cur);
+    if (this.dom.tpCur && !this._isSeeking) this.dom.tpCur.textContent = this.fmtDur(cur);
     const dur = this.inputBuffer.duration;
     if (dur > 0 && this.dom.tpSeek) this._setScrubPos(cur / dur);
     this.renderStaticVisuals(cur / Math.max(dur || 1, 1));
@@ -1292,7 +1333,78 @@ class VoiceIsolatePro {
   }
 
   _setScrubPos(frac) {
+    if (this._isSeeking) return;
     if (this.dom.tpSeek) this.dom.tpSeek.value = frac * 1000;
+  }
+
+  _setABLabel() {
+    const isProcessed = this.abMode === 'processed';
+    const version = isProcessed ? 'B' : 'A';
+    const name = isProcessed ? 'Processed' : 'Original';
+    const lbl = this.dom.tpABLabel;
+    if (lbl) {
+      try { if (lbl.setAttribute) lbl.setAttribute('data-version', version); } catch (_) {}
+      try { if (lbl.classList && lbl.classList.toggle) lbl.classList.toggle('is-playing', !!this.isPlaying); } catch (_) {}
+      const tagEl = (lbl.querySelector && lbl.querySelector('.tp-ab-tag')) || null;
+      const nameEl = (lbl.querySelector && lbl.querySelector('.tp-ab-name')) || null;
+      if (tagEl && nameEl) {
+        tagEl.textContent = version;
+        nameEl.textContent = name;
+      } else {
+        lbl.textContent = name;
+      }
+    }
+    const ab = this.dom.tpAB;
+    if (ab) {
+      try { if (ab.setAttribute) ab.setAttribute('aria-label', 'Toggle A/B (currently playing ' + version + ' · ' + name + ')'); } catch (_) {}
+      try { ab.title = 'Toggle A/B (currently ' + version + ' · ' + name + ')'; } catch (_) {}
+    }
+  }
+
+  _stepSpeed(direction) {
+    const sel = this.dom.tpSpeed;
+    if (!sel) return;
+    const opts = Array.from(sel.options || []).map(o => parseFloat(o.value)).filter(v => !isNaN(v)).sort((a, b) => a - b);
+    if (!opts.length) return;
+    const cur = parseFloat(sel.value) || 1;
+    let idx = opts.findIndex(v => Math.abs(v - cur) < 1e-6);
+    if (idx < 0) idx = opts.findIndex(v => v >= cur);
+    if (idx < 0) idx = opts.length - 1;
+    const next = Math.max(0, Math.min(opts.length - 1, idx + direction));
+    sel.value = String(opts[next]);
+    this._applyPlaybackRate();
+  }
+
+  _applyPlaybackRate() {
+    const rate = parseFloat(this.dom.tpSpeed && this.dom.tpSpeed.value) || 1;
+    if (this.isPlaying) {
+      const prevSpeed = this._activeSpeed || 1;
+      if (this.ctx) {
+        this.playOffset += (this.ctx.currentTime - this.playStartTime) * prevSpeed;
+        this.playStartTime = this.ctx.currentTime;
+      }
+      if (this.currentSource && this.currentSource.playbackRate) {
+        try { this.currentSource.playbackRate.value = rate; } catch (_) {}
+      }
+      if (this.isVideo && this.dom.videoPlayer) {
+        try { this.dom.videoPlayer.playbackRate = rate; } catch (_) {}
+      }
+    }
+    this._activeSpeed = rate;
+  }
+
+  _showFileLoading(text) {
+    const el = this.dom.fileLoadIndicator;
+    if (!el) return;
+    const t = el.querySelector('.file-load-text');
+    if (t && text) t.textContent = text;
+    el.hidden = false;
+  }
+
+  _hideFileLoading() {
+    const el = this.dom.fileLoadIndicator;
+    if (!el) return;
+    el.hidden = true;
   }
 
   drawEmptyVisuals(message) {
@@ -1589,6 +1701,8 @@ class VoiceIsolatePro {
     if (this.dom.pipeDetail) this.dom.pipeDetail.textContent = detail || STAGES[normalizedStage] || 'Ready';
     if (typeof this.updateProcessingOverlay === 'function') {
       this.updateProcessingOverlay(STAGES[normalizedStage] || detail || 'Ready', percent, normalizedStage);
+    } else if (typeof window !== 'undefined' && window.VIPOverlay && typeof window.VIPOverlay.update === 'function') {
+      try { window.VIPOverlay.update(STAGES[normalizedStage] || detail || 'Ready', percent, normalizedStage); } catch (_) {}
     }
   }
 
@@ -1615,6 +1729,11 @@ class VoiceIsolatePro {
       return;
     }
 
+    if (typeof this._showFileLoading === 'function') {
+      this._showFileLoading(isVideo ? 'Extracting audio from video…' : 'Decoding audio…');
+    }
+    if (this.dom.fileInfo) this.dom.fileInfo.textContent = (name ? name + ' — ' : '') + 'loading…';
+
     try {
       if (isVideo) {
         const result = await this.decodeViaVideoElement(file);
@@ -1638,6 +1757,8 @@ class VoiceIsolatePro {
       this.setStatus('ERROR');
       structuredLog('error', 'handleFile decode failed', { e });
       if (this.dom.fileInfo) this.dom.fileInfo.textContent = 'Cannot decode this audio format';
+    } finally {
+      if (typeof this._hideFileLoading === 'function') this._hideFileLoading();
     }
   }
 
@@ -1749,6 +1870,10 @@ class VoiceIsolatePro {
     if (this.dom.mobileReprocessBtn) this.dom.mobileReprocessBtn.style.display = 'none';
     if (this.dom.mobileStopBtn) this.dom.mobileStopBtn.style.display = 'inline-flex';
 
+    if (typeof window !== 'undefined' && window.VIPOverlay && typeof window.VIPOverlay.show === 'function') {
+      try { window.VIPOverlay.show('Preparing pipeline…', 0); } catch (_) {}
+    }
+
     try {
       this.setStatus('PROCESSING');
       structuredLog('info', 'Pipeline start', { stages: 32 });
@@ -1844,6 +1969,9 @@ class VoiceIsolatePro {
       if (this.dom.mobileProcessBtn) this.dom.mobileProcessBtn.style.display='inline-flex';
       if (this.dom.mobileReprocessBtn) this.dom.mobileReprocessBtn.style.display='inline-flex';
       if (this.dom.mobileStopBtn) this.dom.mobileStopBtn.style.display='none';
+      if (typeof window !== 'undefined' && window.VIPOverlay && typeof window.VIPOverlay.hide === 'function') {
+        try { window.VIPOverlay.hide(); } catch (_) {}
+      }
     }
   }
 

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -163,6 +163,10 @@
         <div class="upload-row">
           <button id="micBtn" class="btn btn-mic" aria-label="Toggle Microphone"><span id="micLabel">Record</span></button>
           <span id="fileInfo" class="file-info">No file loaded</span>
+          <span id="fileLoadIndicator" class="file-load-indicator" role="status" aria-live="polite" hidden>
+            <span class="vip-eq-spinner" aria-hidden="true"><i></i><i></i><i></i><i></i><i></i></span>
+            <span class="file-load-text">Loading…</span>
+          </span>
           <button id="clearFile" class="btn btn-outline" type="button">Clear</button>
         </div>
       </div>
@@ -244,10 +248,24 @@
           <span class="tp-time" id="tpCur">0:00</span>
           <span class="tp-time">/</span>
           <span class="tp-time" id="tpDur">0:00</span>
-          <input type="range" id="tpSeek" class="tp-seek" min="0" max="1000" value="0" />
-          <div class="tp-speed"><label for="tpSpeed">Speed</label><select id="tpSpeed"><option value="0.5">0.5x</option><option value="1" selected>1x</option><option value="1.5">1.5x</option><option value="2">2x</option></select></div>
-          <button id="tpAB" class="btn btn-ab" type="button" aria-label="Toggle A/B Comparison" aria-describedby="tpABLabel" title="Toggle A/B Comparison" disabled>A/B</button>
-          <span id="tpABLabel" class="tp-ab-label">Original</span>
+          <input type="range" id="tpSeek" class="tp-seek" min="0" max="1000" value="0" aria-label="Playback position" />
+          <div class="tp-speed">
+            <label for="tpSpeed">Speed</label>
+            <button id="tpSpeedDown" class="btn btn-tp btn-speed" type="button" aria-label="Slow Down Playback" title="Slow Down (−)"><span aria-hidden="true">−</span></button>
+            <select id="tpSpeed" aria-label="Playback speed">
+              <option value="0.25">0.25x</option>
+              <option value="0.5">0.5x</option>
+              <option value="0.75">0.75x</option>
+              <option value="1" selected>1x</option>
+              <option value="1.25">1.25x</option>
+              <option value="1.5">1.5x</option>
+              <option value="1.75">1.75x</option>
+              <option value="2">2x</option>
+            </select>
+            <button id="tpSpeedUp" class="btn btn-tp btn-speed" type="button" aria-label="Speed Up Playback" title="Speed Up (+)"><span aria-hidden="true">+</span></button>
+          </div>
+          <button id="tpAB" class="btn btn-ab" type="button" aria-label="Toggle A/B Comparison" aria-describedby="tpABLabel" title="Toggle A/B (currently playing Original)" disabled>A/B</button>
+          <span id="tpABLabel" class="tp-ab-label" data-version="A" aria-live="polite"><span class="tp-ab-tag">A</span> <span class="tp-ab-name">Original</span></span>
         </div>
       </div>
 

--- a/public/app/style.css
+++ b/public/app/style.css
@@ -235,7 +235,19 @@ input[type="range"].realtime::-webkit-slider-thumb{background:var(--cyan);box-sh
 .tp-speed label{font-size:0.6rem;color:var(--dim)}
 .tp-speed select{background:var(--s3);color:var(--text2);border:1px solid var(--border);border-radius:4px;font-family:var(--fm);font-size:0.65rem;padding:2px 4px}
 .tp-ab{display:flex;align-items:center;gap:4px}
-.tp-ab-label{font-family:var(--fm);font-size:0.62rem;color:var(--yellow)}
+.tp-ab-label{display:inline-flex;align-items:center;gap:5px;font-family:var(--fm);font-size:0.62rem;color:var(--yellow);transition:color .2s ease,filter .2s ease}
+.tp-ab-label .tp-ab-tag{display:inline-flex;align-items:center;justify-content:center;min-width:18px;height:18px;padding:0 5px;border-radius:9px;font-weight:800;font-size:0.66rem;letter-spacing:.5px;background:rgba(234,179,8,.16);border:1px solid rgba(234,179,8,.4);color:var(--yellow);box-shadow:0 0 8px rgba(234,179,8,.2) inset}
+.tp-ab-label[data-version="B"]{color:var(--cyan)}
+.tp-ab-label[data-version="B"] .tp-ab-tag{background:rgba(34,211,238,.16);border-color:rgba(34,211,238,.45);color:var(--cyan);box-shadow:0 0 8px rgba(34,211,238,.22) inset}
+.tp-ab-label.is-playing .tp-ab-tag{animation:tp-ab-pulse 1.4s ease-in-out infinite}
+@keyframes tp-ab-pulse{0%,100%{box-shadow:0 0 8px rgba(234,179,8,.2) inset,0 0 0 0 rgba(234,179,8,.55)}50%{box-shadow:0 0 12px rgba(234,179,8,.4) inset,0 0 0 4px rgba(234,179,8,0)}}
+.tp-ab-label[data-version="B"].is-playing .tp-ab-tag{animation-name:tp-ab-pulse-b}
+@keyframes tp-ab-pulse-b{0%,100%{box-shadow:0 0 8px rgba(34,211,238,.22) inset,0 0 0 0 rgba(34,211,238,.55)}50%{box-shadow:0 0 14px rgba(34,211,238,.45) inset,0 0 0 4px rgba(34,211,238,0)}}
+.btn-speed{padding:2px 7px;font-weight:700;font-size:0.78rem;line-height:1}
+.tp-speed select{min-width:62px}
+.file-load-indicator{display:inline-flex;align-items:center;gap:6px;font-family:var(--fm);font-size:0.66rem;color:var(--cyan)}
+.file-load-indicator[hidden]{display:none}
+.file-load-text{color:var(--text2)}
 
 /* ═══════════════════════════════════════════
    DIAGNOSTIC DASHBOARD (6-Panel)


### PR DESCRIPTION
## Summary

Polishes the transport controls based on user feedback:

- **A/B label clarity** — The label next to the A/B button now shows the version letter (`A` or `B`) in a colour-coded chip with the channel name (`Original` / `Processed`), plus a pulse animation while playing so the active channel is unmistakable. The button's `aria-label` and tooltip update to match.
- **Playback slider** — The seek slider no longer fights the user during interaction. `tickTime` skips writes while `pointer/mouse/touch/keyboard` interaction is active (`_isSeeking` flag) and the tick loop now bails out cleanly when playback is paused. Dragging the slider also live-updates the current-time display.
- **Processing loading indicator** — `handleFile` shows an inline spinner + status text while decoding audio (or extracting from video). `runPipeline` now calls `VIPOverlay.show/hide/update` directly in addition to the existing patch, so the full-screen processing overlay is guaranteed to appear even if the patch fails to wire up.
- **Speed up / slow down** — Added `−` / `+` buttons around the speed dropdown to step through rates, plus extra 0.25x / 0.75x / 1.25x / 1.75x options. Rate changes mid-playback retarget `playStartTime` so the seek position stays accurate when the user toggles speed.

## Test plan

- [x] `pnpm test` — all 60 suites / 1887 tests pass
- [x] `pnpm validate` — structural integrity checks pass
- [x] `pnpm lint` — no new errors (warnings unchanged)
- [ ] Manual: drag seek slider during playback — playhead follows the drag without snapping back
- [ ] Manual: click A/B with output buffer present — label flips between `A · Original` and `B · Processed`
- [ ] Manual: drop a file — inline "Decoding audio…" spinner appears until decode resolves
- [ ] Manual: click Process — full-screen processing overlay is visible during the pipeline
- [ ] Manual: click ± speed buttons during playback — playback rate changes smoothly with no jump

https://claude.ai/code/session_01449YBMu1cTQHrNCo3K65W9

---
_Generated by [Claude Code](https://claude.ai/code/session_01449YBMu1cTQHrNCo3K65W9)_