### PR TITLE
🎨 Palette: Add accessibility and keyboard support to Custom Preset modal

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -8,3 +8,7 @@
 ## 2026-05-13 - [Accordion Accessibility & Visual Feedback]
 **Learning:** Custom UI accordions (like the slider groups) require semantic ARIA attributes (`aria-expanded`, `aria-controls`) to communicate their state to screen readers, and benefit from visual cues (like an animated chevron arrow) to clarify interactive behavior. Changing DOM classes is not sufficient for accessibility without syncing the corresponding ARIA state.
 **Action:** When building or maintaining collapsible panels, always use explicit IDs to link toggles and content with `aria-controls`, synchronize the `aria-expanded` attribute dynamically via JS, and ensure expansion state is visually conveyed (e.g., via CSS transitions on an icon).
+
+## 2026-05-16 - [Custom Modal Accessibility & Keyboard Flow]
+**Learning:** Custom modals require explicit ARIA attributes (`role="dialog"`, `aria-modal="true"`, `aria-labelledby`) and dynamic synchronization of `aria-hidden` with their visual state. Furthermore, managing focus when a modal opens (e.g., auto-focusing the first input) and providing keyboard shortcuts (like `Enter` to save and `Escape` to close) are essential for a complete and accessible keyboard flow.
+**Action:** Always ensure custom modals implement proper dialog roles, sync `aria-hidden` when toggled, and manage focus and keyboard interactions (Enter/Escape) for full accessibility.

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -830,16 +830,45 @@ class VoiceIsolatePro {
     const openPresetModalBtn = document.getElementById('openPresetModalBtn');
     const customPresetModal = document.getElementById('customPresetModal');
     const closePresetModal = document.getElementById('closePresetModal');
-    if (openPresetModalBtn && customPresetModal) openPresetModalBtn.addEventListener('click', () => customPresetModal.classList.add('open'));
-    if (closePresetModal && customPresetModal) closePresetModal.addEventListener('click', () => customPresetModal.classList.remove('open'));
+    const customPresetName = document.getElementById('customPresetName');
+
+    const openPresetModal = () => {
+      if (!customPresetModal) return;
+      customPresetModal.classList.add('open');
+      customPresetModal.setAttribute('aria-hidden', 'false');
+      if (customPresetName) customPresetName.focus();
+    };
+
+    const closePresetModalFunc = () => {
+      if (!customPresetModal) return;
+      customPresetModal.classList.remove('open');
+      customPresetModal.setAttribute('aria-hidden', 'true');
+      if (openPresetModalBtn) openPresetModalBtn.focus();
+    };
+
+    const saveCustomPreset = () => {
+      const name = customPresetName && customPresetName.value.trim();
+      if (!name) {
+        if (customPresetName) customPresetName.focus();
+        return;
+      }
+      PRESETS[name] = { ...this.params };
+      closePresetModalFunc();
+      this.showNotification('Preset "' + name + '" saved', 'success');
+    };
+
+    if (openPresetModalBtn && customPresetModal) openPresetModalBtn.addEventListener('click', openPresetModal);
+    if (closePresetModal && customPresetModal) closePresetModal.addEventListener('click', closePresetModalFunc);
     if (saveCustomBtn) {
-      saveCustomBtn.addEventListener('click', () => {
-        const nameEl = document.getElementById('customPresetName');
-        const name = nameEl && nameEl.value.trim();
-        if (!name) return;
-        PRESETS[name] = { ...this.params };
-        if (customPresetModal) customPresetModal.classList.remove('open');
-        this.showNotification('Preset "' + name + '" saved', 'success');
+      saveCustomBtn.addEventListener('click', saveCustomPreset);
+    }
+    if (customPresetModal) {
+      customPresetModal.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape') {
+          closePresetModalFunc();
+        } else if (e.key === 'Enter') {
+          saveCustomPreset();
+        }
       });
     }
 

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -392,10 +392,10 @@
     </section>
   </main>
 
-  <div id="customPresetModal" class="modal" aria-hidden="true">
+  <div id="customPresetModal" class="modal" role="dialog" aria-modal="true" aria-labelledby="customPresetTitle" aria-hidden="true">
     <div class="modal-content">
-      <h3>Save Custom Preset</h3>
-      <input type="text" id="customPresetName" placeholder="Preset Name" />
+      <h3 id="customPresetTitle">Save Custom Preset</h3>
+      <input type="text" id="customPresetName" placeholder="Preset Name" aria-label="Preset Name" />
       <button id="saveCustomPresetBtn" class="btn btn-primary" type="button">Save</button>
       <button id="closePresetModal" class="btn btn-outline" type="button">Cancel</button>
     </div>


### PR DESCRIPTION
💡 **What:** Added comprehensive ARIA attributes (`role="dialog"`, `aria-modal="true"`, `aria-labelledby`, `aria-hidden`) to the "Save Custom Preset" modal and implemented focus management and keyboard shortcuts (Enter to save, Escape to cancel).
🎯 **Why:** To allow users (especially keyboard-only users) to quickly type their preset name and hit Enter, making the interaction smooth and intuitive, while preventing focus trapping.
📸 **Before/After:** Before, users had to manually click the input to type and click the Save button to confirm. Now, the input is focused automatically and the user can just type and hit Enter.
♿ **Accessibility:** Added full dialog semantics, synced `aria-hidden`, and keyboard-accessible save/cancel actions.

---
*PR created automatically by Jules for task [1090500541302610903](https://jules.google.com/task/1090500541302610903) started by @Joker5514*