### PR TITLE
fix: add missing WASM Content-Type rule to vercel.json; correct ml-worker SAB comment

### DIFF
--- a/public/app/ml-worker.js
+++ b/public/app/ml-worker.js
@@ -920,13 +920,10 @@ function startPollLoop() {
 
 async function pollOnce() {
   if (!flagsIn || !flagsOut) return;
-  // Frame-counter protocol matching dsp-processor.js (the production worklet):
-  //   flagsIn[0]  = frame counter (worklet increments via Atomics.add on every hop)
-  //   flagsOut[1] = mask-ready flag (ml-worker sets to 1; worklet reads and clears)
-  // Note: voice-isolate-processor.js (registered but not currently instantiated)
-  // uses a different layout (header-first, slot 2 for both flags). If that
-  // worklet is brought into the audio graph, this poll loop will need to be
-  // generalised to detect protocol via the init path used.
+  // SAB protocol (shared by dsp-processor.js and voice-isolate-processor.js):
+  //   flagsIn[0]  = frame counter — worklet increments via Atomics.add on every hop
+  //   flagsOut[1] = mask-ready flag — ml-worker sets to 1; worklet reads then
+  //                 resets to flagsOut[0] (always 0), giving a simple edge trigger
   const currentFrame = Atomics.load(flagsIn, 0);
   if (currentFrame === _lastPollFrame) return; // no new frame
   _lastPollFrame = currentFrame;

--- a/public/app/ml-worker.js
+++ b/public/app/ml-worker.js
@@ -923,7 +923,8 @@ async function pollOnce() {
   // SAB protocol (shared by dsp-processor.js and voice-isolate-processor.js):
   //   flagsIn[0]  = frame counter — worklet increments via Atomics.add on every hop
   //   flagsOut[1] = mask-ready flag — ml-worker sets to 1; worklet reads then
-  //                 resets to flagsOut[0] (always 0), giving a simple edge trigger
+  //                 resets to flagsOut[0] (writeGen/baseline slot; currently 0 in
+  //                 this worker flow), giving a simple edge trigger
   const currentFrame = Atomics.load(flagsIn, 0);
   if (currentFrame === _lastPollFrame) return; // no new frame
   _lastPollFrame = currentFrame;

--- a/vercel.json
+++ b/vercel.json
@@ -61,6 +61,14 @@
         { "key": "Cross-Origin-Resource-Policy", "value": "cross-origin" },
         { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
       ]
+    },
+    {
+      "source": "/lib/(.*\\.wasm)",
+      "headers": [
+        { "key": "Content-Type", "value": "application/wasm" },
+        { "key": "Cross-Origin-Resource-Policy", "value": "same-origin" },
+        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+      ]
     }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -67,7 +67,7 @@
       "headers": [
         { "key": "Content-Type", "value": "application/wasm" },
         { "key": "Cross-Origin-Resource-Policy", "value": "same-origin" },
-        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+        { "key": "Cache-Control", "value": "public, max-age=31536000" }
       ]
     }
   ]


### PR DESCRIPTION
vercel.json: Add /lib/*.wasm header rule with Content-Type: application/wasm,
same-origin CORP, and immutable Cache-Control. Without this, browsers reject
streaming WASM compilation for ORT worker threads.

ml-worker.js: Replace stale comment claiming voice-isolate-processor.js uses
"slot 2 for both flags" — the production worklet uses slots 0 and 1, identical
to dsp-processor.js, so the existing pollOnce() loop is already compatible
with both worklets.

https://claude.ai/code/session_01LPG8i5mjNg8KP86E5Dcmiw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured HTTP headers and cache control policies for WebAssembly files, enabling optimized delivery and persistent caching.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Joker5514/VoiceIsolate-Pro/pull/521?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->