### PR TITLE
🎨 Palette: Improve custom preset modal accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -8,3 +8,7 @@
 ## 2026-05-13 - [Accordion Accessibility & Visual Feedback]
 **Learning:** Custom UI accordions (like the slider groups) require semantic ARIA attributes (`aria-expanded`, `aria-controls`) to communicate their state to screen readers, and benefit from visual cues (like an animated chevron arrow) to clarify interactive behavior. Changing DOM classes is not sufficient for accessibility without syncing the corresponding ARIA state.
 **Action:** When building or maintaining collapsible panels, always use explicit IDs to link toggles and content with `aria-controls`, synchronize the `aria-expanded` attribute dynamically via JS, and ensure expansion state is visually conveyed (e.g., via CSS transitions on an icon).
+
+## 2026-05-18 - [Custom Modal Keyboard Accessibility & ARIA States]
+**Learning:** Custom UI modals must implement complete keyboard and accessibility flows, including `role="dialog"`, `aria-modal="true"`, `aria-labelledby`, dynamic `aria-hidden` synchronization, auto-focusing the primary input on open, returning focus to the trigger on close, and keydown listeners for Escape (to close) and Enter (to submit).
+**Action:** When creating or modifying custom modals, ensure the entire lifecycle of the modal is accessible by syncing the `aria-hidden` state, managing focus effectively on open and close, and supporting keyboard interactions.

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -830,16 +830,53 @@ class VoiceIsolatePro {
     const openPresetModalBtn = document.getElementById('openPresetModalBtn');
     const customPresetModal = document.getElementById('customPresetModal');
     const closePresetModal = document.getElementById('closePresetModal');
-    if (openPresetModalBtn && customPresetModal) openPresetModalBtn.addEventListener('click', () => customPresetModal.classList.add('open'));
-    if (closePresetModal && customPresetModal) closePresetModal.addEventListener('click', () => customPresetModal.classList.remove('open'));
+    const customPresetNameInput = document.getElementById('customPresetName');
+
+    const openPresetModal = () => {
+      if (!customPresetModal) return;
+      customPresetModal.classList.add('open');
+      customPresetModal.setAttribute('aria-hidden', 'false');
+      if (customPresetNameInput) {
+        customPresetNameInput.value = '';
+        customPresetNameInput.focus();
+      }
+    };
+
+    const closePresetModalFunc = () => {
+      if (!customPresetModal) return;
+      customPresetModal.classList.remove('open');
+      customPresetModal.setAttribute('aria-hidden', 'true');
+      if (openPresetModalBtn) openPresetModalBtn.focus();
+    };
+
+    const savePreset = () => {
+      const nameEl = document.getElementById('customPresetName');
+      const name = nameEl && nameEl.value.trim();
+      if (!name) return;
+      PRESETS[name] = { ...this.params };
+      closePresetModalFunc();
+      this.showNotification('Preset "' + name + '" saved', 'success');
+    };
+
+    if (openPresetModalBtn && customPresetModal) {
+      openPresetModalBtn.addEventListener('click', openPresetModal);
+    }
+
+    if (closePresetModal && customPresetModal) {
+      closePresetModal.addEventListener('click', closePresetModalFunc);
+    }
+
     if (saveCustomBtn) {
-      saveCustomBtn.addEventListener('click', () => {
-        const nameEl = document.getElementById('customPresetName');
-        const name = nameEl && nameEl.value.trim();
-        if (!name) return;
-        PRESETS[name] = { ...this.params };
-        if (customPresetModal) customPresetModal.classList.remove('open');
-        this.showNotification('Preset "' + name + '" saved', 'success');
+      saveCustomBtn.addEventListener('click', savePreset);
+    }
+
+    if (customPresetModal) {
+      customPresetModal.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape') {
+          closePresetModalFunc();
+        } else if (e.key === 'Enter') {
+          savePreset();
+        }
       });
     }
 

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -392,10 +392,10 @@
     </section>
   </main>
 
-  <div id="customPresetModal" class="modal" aria-hidden="true">
+  <div id="customPresetModal" class="modal" role="dialog" aria-modal="true" aria-labelledby="customPresetTitle" aria-hidden="true">
     <div class="modal-content">
-      <h3>Save Custom Preset</h3>
-      <input type="text" id="customPresetName" placeholder="Preset Name" />
+      <h3 id="customPresetTitle">Save Custom Preset</h3>
+      <input type="text" id="customPresetName" placeholder="Preset Name" aria-label="Preset Name" />
       <button id="saveCustomPresetBtn" class="btn btn-primary" type="button">Save</button>
       <button id="closePresetModal" class="btn btn-outline" type="button">Cancel</button>
     </div>


### PR DESCRIPTION
💡 **What:** Added comprehensive ARIA attributes (`role="dialog"`, `aria-modal="true"`, `aria-labelledby`, `aria-hidden`) and full keyboard accessibility support to the Custom Preset Modal.
🎯 **Why:** Custom modal dialogs must effectively manage focus and semantic attributes to be accessible to screen reader users and keyboard-only navigators. Previous implementation was hidden to screen readers as a real modal and lacked proper keyboard focus management.
📸 **Before/After:** No visual change to mouse users, but keyboard users now see the focus ring immediately on the input when opened.
♿ **Accessibility:**
- Modal now properly identifies as a `dialog` and is linked to its title.
- Dynamic `aria-hidden` synchronization prevents screen readers from losing context.
- Modal input now auto-focuses on open.
- Modal trigger button regains focus upon closing.
- Modal handles `Escape` key to close and `Enter` key to submit safely.

---
*PR created automatically by Jules for task [17869636829499047480](https://jules.google.com/task/17869636829499047480) started by @Joker5514*