### PR TITLE
🎨 Palette: Add focus-visible state to custom toggle switches

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -12,3 +12,7 @@
 ## 2026-05-18 - [Custom Modal Keyboard Accessibility & ARIA States]
 **Learning:** Custom UI modals must implement complete keyboard and accessibility flows, including `role="dialog"`, `aria-modal="true"`, `aria-labelledby`, dynamic `aria-hidden` synchronization, auto-focusing the primary input on open, returning focus to the trigger on close, and keydown listeners for Escape (to close) and Enter (to submit).
 **Action:** When creating or modifying custom modals, ensure the entire lifecycle of the modal is accessible by syncing the `aria-hidden` state, managing focus effectively on open and close, and supporting keyboard interactions.
+
+## 2026-05-18 - [Toggle Switch Keyboard Accessibility]
+**Learning:** Hidden inputs in custom toggle switches using `opacity: 0` lose default browser focus outlines. This renders them invisible to keyboard-only users who navigate via Tab.
+**Action:** When hiding inputs to style them, always add explicit `:focus-visible` rules (e.g., `input:focus-visible + .slider`) to draw a custom focus ring, ensuring the element is visible during keyboard navigation.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,13 +67,13 @@ importers:
         version: 0.184.0
     devDependencies:
       '@eslint/js':
-        specifier: ^9.39.4
+        specifier: ^9.0.0
         version: 9.39.4
       eslint:
-        specifier: ^9.39.4
+        specifier: ^9.0.0
         version: 9.39.4
       globals:
-        specifier: ^16.5.0
+        specifier: ^16.0.0
         version: 16.5.0
       jest:
         specifier: ^30.3.0

--- a/public/app/voice-isolator.html
+++ b/public/app/voice-isolator.html
@@ -406,6 +406,7 @@
         }
         input:checked + .slider { background-color: var(--accent); }
         input:checked + .slider:before { transform: translateX(14px); }
+        input:focus-visible + .slider { outline: 2px solid var(--accent); outline-offset: 2px; }
 
         .big-btn {
             background: var(--accent);


### PR DESCRIPTION
💡 **What:** Added an `input:focus-visible + .slider` CSS rule to the custom toggle switches in `public/app/voice-isolator.html`.
🎯 **Why:** To ensure that keyboard-only users who navigate the UI using the Tab key can visibly see which toggle switch is currently focused.
📸 **Before/After:** Custom CSS was added that creates an outline when focused.
♿ **Accessibility:** Re-established the focus ring that was hidden when the underlying native checkbox input was made fully transparent via `opacity: 0`.

---
*PR created automatically by Jules for task [9516175365807303799](https://jules.google.com/task/9516175365807303799) started by @Joker5514*