### PR TITLE
fix(tests): mock fetch in ml-worker test sandbox to prevent external network calls

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,18 +29,9 @@ importers:
 
   .:
     dependencies:
-      '@capacitor/android':
-        specifier: ^8.3.1
-        version: 8.3.1(@capacitor/core@8.3.1)
-      '@capacitor/cli':
-        specifier: ^8.3.1
-        version: 8.3.1
       '@capacitor/core':
         specifier: ^8.3.1
         version: 8.3.1
-      '@capacitor/ios':
-        specifier: ^8.3.1
-        version: 8.3.1(@capacitor/core@8.3.1)
       '@grpc/grpc-js':
         specifier: ^1.14.3
         version: 1.14.3
@@ -56,9 +47,6 @@ importers:
       express-rate-limit:
         specifier: ^8.3.2
         version: 8.3.2(express@5.2.1)
-      jsdom:
-        specifier: ^26.1.0
-        version: 26.1.0
       onnxruntime-web:
         specifier: 1.25.1
         version: 1.25.1
@@ -66,6 +54,15 @@ importers:
         specifier: 0.184.0
         version: 0.184.0
     devDependencies:
+      '@capacitor/android':
+        specifier: ^8.3.1
+        version: 8.3.1(@capacitor/core@8.3.1)
+      '@capacitor/cli':
+        specifier: ^8.3.1
+        version: 8.3.1
+      '@capacitor/ios':
+        specifier: ^8.3.1
+        version: 8.3.1(@capacitor/core@8.3.1)
       '@eslint/js':
         specifier: ^9.0.0
         version: 9.39.4
@@ -81,6 +78,9 @@ importers:
       jest-environment-jsdom:
         specifier: ^30.3.0
         version: 30.3.0
+      jsdom:
+        specifier: ^26.1.0
+        version: 26.1.0
       playwright:
         specifier: ^1.58.2
         version: 1.58.2

--- a/tests/ml-worker.test.js
+++ b/tests/ml-worker.test.js
@@ -39,6 +39,11 @@ describe('ml-worker.js', () => {
       Float32Array: Float32Array,
       Promise: Promise,
       console: console,
+      // Shadow the Node.js 22.x global fetch so the SHA-256 integrity check
+      // in createSessionWithFallback fails fast (non-mismatch error) instead of
+      // attempting real network requests to external Vercel Blob URLs, which
+      // would exceed the 5 s Jest timeout.
+      fetch: jest.fn(() => Promise.reject(new Error('network unavailable in test env'))),
     };
 
     // Evaluate the worker code in the mock global context


### PR DESCRIPTION
Node.js 22.x ships with a global fetch, causing the SHA-256 integrity check
inside createSessionWithFallback to attempt real HTTPS connections to Vercel
Blob URLs for rnnoise/demucs/bsrnn models during unit tests.  Those network
requests exceeded the 5s Jest timeout, failing 3 tests.  Adding a local
fetch mock to the workerGlobal sandbox makes the integrity check fail fast
with a non-mismatch error, falling through to the mocked InferenceSession
as the tests expect.

https://claude.ai/code/session_01DbWoXfRPEcmzT9mbZM9G96

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test stability by preventing unnecessary network requests during test execution, reducing potential timeout issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Joker5514/VoiceIsolate-Pro/pull/530?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->