### PR TITLE
fix(video): unblock video decode stuck at S01/0% on mobile

### DIFF
--- a/public/app/app.js
+++ b/public/app/app.js
@@ -1774,10 +1774,25 @@ class VoiceIsolatePro {
 
     try {
       if (isVideo) {
-        const result = await this.decodeViaVideoElement(file);
-        if (result) {
-          this.inputBuffer = result;
+        // Fast path: decodeAudioData handles MP4/WebM containers directly in modern browsers.
+        // This avoids real-time MediaRecorder playback (which hangs when AudioContext is
+        // suspended or when muted=true silences the Web Audio pipeline on mobile).
+        let decoded = null;
+        try {
+          const rawBuffer = await file.arrayBuffer();
+          decoded = await this.ctx.decodeAudioData(rawBuffer.slice(0));
+        } catch (_) {
+          // Container not decodable directly — fall through to MediaRecorder extraction.
+        }
+        if (decoded && decoded.length > 0) {
+          this.inputBuffer = decoded;
           this.onAudioLoaded(name);
+        } else {
+          const result = await this.decodeViaVideoElement(file);
+          if (result) {
+            this.inputBuffer = result;
+            this.onAudioLoaded(name);
+          }
         }
       } else {
         const rawBuffer = await file.arrayBuffer();
@@ -1805,7 +1820,8 @@ class VoiceIsolatePro {
     if (this.dom.videoPlayer) this.dom.videoPlayer.src = url;
     const videoEl = document.createElement('video');
     videoEl.preload = 'auto';
-    videoEl.muted = true;
+    // Do NOT set muted=true — it silences the Web Audio pipeline on mobile,
+    // causing MediaRecorder to capture empty chunks.
     videoEl.src = url;
     return new Promise((resolve, reject) => {
       const cleanup = () => {
@@ -1818,6 +1834,8 @@ class VoiceIsolatePro {
 
       videoEl.onloadedmetadata = async () => {
         try {
+          // Resume the AudioContext — it may be suspended on mobile after page load.
+          if (this.ctx.state === 'suspended') await this.ctx.resume().catch(() => {});
           const source = this.ctx.createMediaElementSource(videoEl);
           const dest = this.ctx.createMediaStreamDestination();
           source.connect(dest);

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -1780,7 +1780,7 @@ class VoiceIsolatePro {
         let decoded = null;
         try {
           const rawBuffer = await file.arrayBuffer();
-          decoded = await this.ctx.decodeAudioData(rawBuffer.slice(0));
+          decoded = await this.ctx.decodeAudioData(rawBuffer);
         } catch (_) {
           // Container not decodable directly — fall through to MediaRecorder extraction.
         }

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -1774,6 +1774,14 @@ class VoiceIsolatePro {
 
     try {
       if (isVideo) {
+        if (this.dom.videoPlayer && typeof URL !== 'undefined' && typeof URL.createObjectURL === 'function') {
+          const nextVideoUrl = URL.createObjectURL(file);
+          if (this._videoPreviewUrl && this._videoPreviewUrl !== nextVideoUrl && typeof URL.revokeObjectURL === 'function') {
+            try { URL.revokeObjectURL(this._videoPreviewUrl); } catch (_) {}
+          }
+          this._videoPreviewUrl = nextVideoUrl;
+          this.dom.videoPlayer.src = nextVideoUrl;
+        }
         // Fast path: decodeAudioData handles MP4/WebM containers directly in modern browsers.
         // This avoids real-time MediaRecorder playback (which hangs when AudioContext is
         // suspended or when muted=true silences the Web Audio pipeline on mobile).
@@ -1817,7 +1825,6 @@ class VoiceIsolatePro {
 
   async decodeViaVideoElement(file) {
     const url = URL.createObjectURL(file);
-    if (this.dom.videoPlayer) this.dom.videoPlayer.src = url;
     const videoEl = document.createElement('video');
     videoEl.preload = 'auto';
     // Do NOT set muted=true — it silences the Web Audio pipeline on mobile,

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -547,6 +547,7 @@ class VoiceIsolatePro {
     this.visualEngine = null;
     this._vizRaf = 0;
     this._spectroFrame = 0;
+    this._videoPreviewUrl = null;
 
     Object.values(SLIDERS).flat().forEach(s => { this.params[s.id] = s.val; });
     if (typeof window !== 'undefined') {
@@ -1827,6 +1828,7 @@ class VoiceIsolatePro {
     const url = URL.createObjectURL(file);
     const videoEl = document.createElement('video');
     videoEl.preload = 'auto';
+    videoEl.playsInline = true;
     // Do NOT set muted=true — it silences the Web Audio pipeline on mobile,
     // causing MediaRecorder to capture empty chunks.
     videoEl.src = url;
@@ -1871,7 +1873,26 @@ class VoiceIsolatePro {
           videoEl.onended = () => {
             try { if (recorder.state !== 'inactive') recorder.stop(); } catch (_) {}
           };
-          await videoEl.play().catch(() => {});
+          let started = false;
+          try {
+            videoEl.muted = false;
+            await videoEl.play();
+            started = true;
+          } catch (_) {
+            try {
+              videoEl.muted = true;
+              await videoEl.play();
+              videoEl.muted = false;
+              started = true;
+            } catch (playErr) {
+              fail(playErr);
+              return;
+            }
+          }
+          if (!started) {
+            fail(new Error('Video playback blocked by autoplay policy'));
+            return;
+          }
           const durationMs = Math.max(1000, Math.ceil((videoEl.duration || 0) * 1000) + 250);
           setTimeout(() => {
             try {

--- a/tests/handle_file_decode.test.js
+++ b/tests/handle_file_decode.test.js
@@ -57,7 +57,7 @@ describe('VoiceIsolatePro handleFile() Audio Decoding', () => {
     jest.clearAllTimers();
   });
 
-  it('tries decodeAudioData first, then falls back to decodeViaVideoElement for video files', async () => {
+  it('tries decodeAudioData first and falls back to decodeViaVideoElement for video files', async () => {
     const handleFile = VoiceIsolatePro.prototype.handleFile;
 
     const mockVip = {
@@ -96,9 +96,10 @@ describe('VoiceIsolatePro handleFile() Audio Decoding', () => {
 
     clearTimeout(timeoutId);
 
-    expect(mockVip.ctx.decodeAudioData).toHaveBeenCalled();
+    expect(mockVip.ctx.decodeAudioData).toHaveBeenCalledTimes(1);
     expect(mockVip.decodeViaVideoElement).toHaveBeenCalledWith(mockFile);
     expect(mockVip.inputBuffer).toEqual([1, 2, 3]);
+    expect(mockVip.dom.videoPlayer.src).toBe('blob:test');
   });
 
   it('throws an error when decodeAudioData fails and file is not a video', async () => {

--- a/tests/handle_file_decode.test.js
+++ b/tests/handle_file_decode.test.js
@@ -57,7 +57,7 @@ describe('VoiceIsolatePro handleFile() Audio Decoding', () => {
     jest.clearAllTimers();
   });
 
-  it('uses decodeViaVideoElement directly for video files', async () => {
+  it('tries decodeAudioData first, then falls back to decodeViaVideoElement for video files', async () => {
     const handleFile = VoiceIsolatePro.prototype.handleFile;
 
     const mockVip = {
@@ -96,7 +96,7 @@ describe('VoiceIsolatePro handleFile() Audio Decoding', () => {
 
     clearTimeout(timeoutId);
 
-    expect(mockVip.ctx.decodeAudioData).not.toHaveBeenCalled();
+    expect(mockVip.ctx.decodeAudioData).toHaveBeenCalled();
     expect(mockVip.decodeViaVideoElement).toHaveBeenCalledWith(mockFile);
     expect(mockVip.inputBuffer).toEqual([1, 2, 3]);
   });

--- a/tests/handle_file_validation.test.js
+++ b/tests/handle_file_validation.test.js
@@ -233,8 +233,9 @@ describe('handleFile() — file type validation', () => {
     expect(mockVip.dom.fileInfo.textContent).not.toContain('Unsupported');
   });
 
-  test('accepts video/mp4 files via video decode path', async () => {
+  test('accepts video/mp4 files by trying decodeAudioData first then video fallback', async () => {
     const mockVip = makeMockVip();
+    mockVip.ctx.decodeAudioData.mockRejectedValue(new Error('Decode failed'));
     const videoPlayer = { src: '', _onloadedmetadata: null, _onerror: null };
     Object.defineProperty(videoPlayer, 'onloadedmetadata', {
       get() { return this._onloadedmetadata; },
@@ -252,8 +253,8 @@ describe('handleFile() — file type validation', () => {
 
     await handleFile.call(mockVip, mockFile);
 
+    expect(mockVip.ctx.decodeAudioData).toHaveBeenCalled();
     expect(mockVip.decodeViaVideoElement).toHaveBeenCalledWith(mockFile);
-    expect(mockVip.ctx.decodeAudioData).not.toHaveBeenCalled();
     expect(mockVip.dom.fileInfo.textContent).not.toContain('Unsupported');
   });
 

--- a/tests/handle_file_validation.test.js
+++ b/tests/handle_file_validation.test.js
@@ -253,8 +253,9 @@ describe('handleFile() — file type validation', () => {
 
     await handleFile.call(mockVip, mockFile);
 
-    expect(mockVip.ctx.decodeAudioData).toHaveBeenCalled();
+    expect(mockVip.ctx.decodeAudioData).toHaveBeenCalledTimes(1);
     expect(mockVip.decodeViaVideoElement).toHaveBeenCalledWith(mockFile);
+    expect(mockVip.dom.videoPlayer.src).toBe('blob:test');
     expect(mockVip.dom.fileInfo.textContent).not.toContain('Unsupported');
   });
 


### PR DESCRIPTION
Three root causes:
1. `videoEl.muted = true` silences the Web Audio pipeline on mobile Chrome/Safari,
   causing MediaRecorder to capture empty chunks and the promise to never resolve.
2. AudioContext may be suspended on mobile; createMediaElementSource then produces
   no data — add ctx.resume() before capturing.
3. No fast path: decodeAudioData() handles MP4/WebM containers directly in modern
   browsers without real-time playback. Try it first; fall back to MediaRecorder
   only if the container is not directly decodable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Faster video audio extraction with optimized decoding pathway
  * Improved audio capture stability on mobile devices
  * Enhanced audio context state handling for better reliability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Joker5514/VoiceIsolate-Pro/pull/531?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->