### PR TITLE
fix: remove direct audioWorklet.addModule() call from debug-test-harness.js

### DIFF
--- a/public/app/debug-test-harness.js
+++ b/public/app/debug-test-harness.js
@@ -196,17 +196,18 @@
       whileOK ? 'multi-hop frames handled' : 'REGRESSION: missed frames under load'
     );
 
-    // 2.9 AudioWorklet load into real AudioContext
-    try {
-      const ac = new AudioContext({ sampleRate: 48000 });
-      await withTimeout(
-        ac.audioWorklet.addModule('./dsp-processor.js'),
-        8000, 'addModule'
-      );
-      report('pass', 'dsp', 9, 'AudioWorklet addModule succeeded');
-      await ac.close();
-    } catch (e) {
-      report('fail', 'dsp', 9, 'AudioWorklet addModule failed', e.message);
+    // 2.9 AudioWorklet readiness — delegate ownership check to pipeline-orchestrator.js
+    // Direct addModule() calls are forbidden outside pipeline-orchestrator.js (CLAUDE.md §2).
+    // Instead, verify the orchestrator has already loaded the worklet.
+    {
+      const orch = typeof window !== 'undefined' ? window._vipOrch : null;
+      if (orch && orch.workletReady) {
+        report('pass', 'dsp', 9, 'AudioWorklet registered (pipeline-orchestrator workletReady=true)');
+      } else if (orch && !orch.workletReady) {
+        report('warn', 'dsp', 9, 'AudioWorklet not yet ready — pipeline-orchestrator init may be pending');
+      } else {
+        report('warn', 'dsp', 9, 'AudioWorklet status unknown — pipeline-orchestrator not found on window._vipOrch');
+      }
     }
   }
 


### PR DESCRIPTION
debug-test-harness.js test 2.9 was calling audioWorklet.addModule() directly,
violating CLAUDE.md §2 (AudioWorklet ownership belongs exclusively to
pipeline-orchestrator.js). Replaced with a check against window._vipOrch.workletReady
so the diagnostic still reports worklet status without bypassing the ownership rule.

https://claude.ai/code/session_014hazkKc3WyJiMvF1JCbFnu