### PR TITLE
fix: security + architecture audit — HF fallback removal, STFT safety, ORT EP, manifest hash

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,7 +34,7 @@ BLOB_READ_WRITE_TOKEN=vercel_blob_rw_...
 # ─── Blob rewrite URLs (used in vercel.json rewrites) ─────────────────────────
 # Set BLOB_DEMUCS_URL to the actual Vercel Blob public URL for the Demucs model.
 # This fixes the /app/models/demucs_v4_quantized.onnx rewrite in vercel.json.
-# Upload the model first: pnpm run upload:models  (or scripts/upload-models-to-blob.mjs)
+# Upload the model first: pnpm run models:upload:blob  (or scripts/upload-models-to-blob.mjs)
 # Then copy the returned public URL here.
 BLOB_DEMUCS_URL=https://blob.vercel-storage.com/voiceisolate-pro/models/demucs_v4_quantized.onnx
 

--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,13 @@ RC_API_KEY_IOS=rcb_ios_...
 # Required by: scripts/upload-to-vercel-blob.mjs, scripts/upload-models-to-blob.mjs
 BLOB_READ_WRITE_TOKEN=vercel_blob_rw_...
 
+# ─── Blob rewrite URLs (used in vercel.json rewrites) ─────────────────────────
+# Set BLOB_DEMUCS_URL to the actual Vercel Blob public URL for the Demucs model.
+# This fixes the /app/models/demucs_v4_quantized.onnx rewrite in vercel.json.
+# Upload the model first: pnpm run upload:models  (or scripts/upload-models-to-blob.mjs)
+# Then copy the returned public URL here.
+BLOB_DEMUCS_URL=https://blob.vercel-storage.com/voiceisolate-pro/models/demucs_v4_quantized.onnx
+
 # Vercel API token (used by Python upload scripts)
 # Create at: https://vercel.com/account/tokens
 # Required by: scripts/upload_models_to_vercel_blob.py, scripts/wire-blob-models.py

--- a/docs/adr/001-firebase-exception.md
+++ b/docs/adr/001-firebase-exception.md
@@ -48,7 +48,7 @@ Audio data (PCM samples, spectral frames, model inputs/outputs) is **never sent 
 
 **Negative:**
 - Introduces a runtime dependency on Google infrastructure for auth flows
-- Users without Google accounts cannot use social sign-in (mitigated: email/password auth also available)
+- Users without Google accounts cannot sign in, because Google Sign-In is the only authentication method currently supported
 - Firebase SDK is loaded from `gstatic.com` CDN — an exception to the local-library rule (acceptable because it is UI-layer only, not audio-processing layer)
 
 ---

--- a/docs/adr/001-firebase-exception.md
+++ b/docs/adr/001-firebase-exception.md
@@ -76,4 +76,4 @@ Audio data (PCM samples, spectral frames, model inputs/outputs) is **never sent 
 
 - Firebase credentials are injected at runtime via `window.FIREBASE_*` variables (set by the Vercel environment or the service worker) — never hardcoded in source
 - `firebase-config.js` exports `auth`, `db`, and helper functions — callers must guard against Firebase being unavailable in non-authenticated sessions
-- The `connect-src` CSP directive in `vercel.json` includes `https://identitytoolkit.googleapis.com` implicitly via `'self'` only if the domain is served from Vercel; ensure CSP is updated if Firebase endpoints change
+- The CSP in `vercel.json` must explicitly allow Firebase network endpoints in `connect-src` (for example `https://identitytoolkit.googleapis.com`, `https://securetoken.googleapis.com`, and `https://firestore.googleapis.com` as used by Auth and Firestore); `'self'` does **not** cover these third-party origins. If the Firebase SDK is loaded from the `gstatic.com` CDN, `script-src` must also allow `https://www.gstatic.com`.

--- a/docs/adr/001-firebase-exception.md
+++ b/docs/adr/001-firebase-exception.md
@@ -1,0 +1,79 @@
+# ADR-001: Firebase as Intentional Cloud Exception
+
+**Date:** 2026-05-20
+**Status:** Accepted
+**Deciders:** VoiceIsolate Pro core team
+
+---
+
+## Context
+
+VoiceIsolate Pro is designed as a **privacy-first, 100% local audio processing** platform. The core architecture constraint is that no audio data ever leaves the browser. All DSP, ML inference, and spectral processing runs on-device via Web Audio API, AudioWorklet, and ONNX Runtime Web.
+
+However, a commercial product requires:
+1. User identity (to gate tier features and prevent abuse)
+2. Optional cloud sync for user-created presets
+3. Session telemetry for billing and enforcement
+
+The question was whether to satisfy these needs with a cloud service or a purely local mechanism.
+
+---
+
+## Decision
+
+**Firebase (Auth + Firestore) is used as the sole cloud service** in VoiceIsolate Pro.
+
+It is used exclusively for:
+- **Authentication:** Google Sign-In via Firebase Auth (`firebase-config.js`)
+- **Preset sync:** Optional, user-initiated cloud save/load of presets (`savePreset`, `getUserPresets`)
+- **Session logging:** Billing/tier enforcement (`logSession`)
+
+Firebase is loaded only in `public/app/firebase-config.js` and is **never imported** from:
+- `dsp-processor.js` (AudioWorklet — no network allowed)
+- `ml-worker.js` (ML inference worker)
+- `dsp-worker.js` (DSP offline worker)
+- `dsp-core.js`, `dsp-stages.js`, `fft-bridge.js` (pure DSP math)
+- Any other audio pipeline file
+
+Audio data (PCM samples, spectral frames, model inputs/outputs) is **never sent to Firebase**.
+
+---
+
+## Consequences
+
+**Positive:**
+- Mature, well-maintained auth and realtime-database solution with Google Sign-In OAuth
+- Session logging enables accurate billing and tier enforcement
+- Cloud preset sync adds value for multi-device users
+
+**Negative:**
+- Introduces a runtime dependency on Google infrastructure for auth flows
+- Users without Google accounts cannot use social sign-in (mitigated: email/password auth also available)
+- Firebase SDK is loaded from `gstatic.com` CDN — an exception to the local-library rule (acceptable because it is UI-layer only, not audio-processing layer)
+
+---
+
+## Alternatives Considered
+
+### Option A: Supabase (PostgreSQL + Auth)
+- Self-hostable, open-source alternative
+- More complex to configure; Google Sign-In requires additional setup
+- Rejected: higher operational burden for a small team; Firebase's zero-config Google Auth is a strong advantage
+
+### Option B: Local-only (IndexedDB presets, no cloud auth)
+- Fully private; zero cloud dependency
+- No tier enforcement possible without a server
+- Rejected: business model requires gating Pro/Studio features; local-only cannot prevent abuse
+
+### Option C: Custom JWT server (existing `api/auth.js`)
+- VoiceIsolate Pro ships `api/auth.js` (Vercel serverless) for license JWT issuance
+- Could be extended to be the sole auth layer
+- Rejected as primary auth: Firebase reduces maintenance burden for auth flows (password reset, OAuth, session management) that are complex to implement securely from scratch
+
+---
+
+## Implementation Notes
+
+- Firebase credentials are injected at runtime via `window.FIREBASE_*` variables (set by the Vercel environment or the service worker) — never hardcoded in source
+- `firebase-config.js` exports `auth`, `db`, and helper functions — callers must guard against Firebase being unavailable in non-authenticated sessions
+- The `connect-src` CSP directive in `vercel.json` includes `https://identitytoolkit.googleapis.com` implicitly via `'self'` only if the domain is served from Vercel; ensure CSP is updated if Firebase endpoints change

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "test:watch": "node --experimental-vm-modules node_modules/jest/bin/jest.js --testEnvironment=node --watch",
     "lint:fix": "eslint public/app/app.js public/app/dsp-worker.js public/app/dsp-processor.js public/app/ml-worker.js public/app/vip-enhancements.js --fix",
     "validate": "node scripts/validate.js",
+    "worklets:hash": "node scripts/hash-worklets.js",
     "test:coverage": "node --experimental-vm-modules node_modules/jest/bin/jest.js --testEnvironment=node --coverage",
     "test:live": "node scripts/live-smoke.cjs",
     "build:mobile": "pnpm run build && npx cap sync",

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -1996,6 +1996,9 @@ class VoiceIsolatePro {
       updateStatus('Binding UI sliders…');
       initSliders();
 
+      // AUDIT-SAFE: single pipeline iSTFT (S20). inverseSTFT() only READS mag/phase
+      // (creates a new Float32Array for output; never mutates the input arrays).
+      // The shared spectral buffer is safe here — no deep copy needed.
       const processed = (DSP.inverseSTFT && spectrum?.mag && spectrum?.phase)
         ? DSP.inverseSTFT(spectrum.mag, spectrum.phase, fftSize, hopSize, signal.length)
         : null;

--- a/public/app/firebase-config.js
+++ b/public/app/firebase-config.js
@@ -2,6 +2,21 @@
 // Replace the placeholder values below with your actual Firebase project credentials
 // from the Firebase Console: https://console.firebase.google.com
 
+/**
+ * ARCHITECTURE EXCEPTION — INTENTIONAL CLOUD SERVICE
+ * =====================================================
+ * Firebase (Auth + Firestore) is the ONLY intentional cloud dependency
+ * in VoiceIsolate Pro. It is used exclusively for:
+ *   - User authentication (Google sign-in)
+ *   - Preset cloud sync (optional, user-initiated)
+ *   - Session logging for billing/tier enforcement
+ *
+ * ALL AUDIO PROCESSING is 100% local and never touches Firebase.
+ * Firebase is never called from AudioWorklet, ml-worker, or dsp-* files.
+ *
+ * This exception is documented in ADR-001 (docs/adr/001-firebase-exception.md).
+ */
+
 import { initializeApp } from 'https://www.gstatic.com/firebasejs/10.12.0/firebase-app.js';
 import { getAuth, onAuthStateChanged, signInWithPopup, GoogleAuthProvider, signOut } from 'https://www.gstatic.com/firebasejs/10.12.0/firebase-auth.js';
 import { getFirestore, doc, getDoc, setDoc, updateDoc, collection, addDoc, query, where, orderBy, getDocs } from 'https://www.gstatic.com/firebasejs/10.12.0/firebase-firestore.js';

--- a/public/app/ml-worker-fetch-cache.js
+++ b/public/app/ml-worker-fetch-cache.js
@@ -57,11 +57,11 @@ const VIP_IDB_STORE   = 'models';
 // vip-models-v1 Cache API entry that model-loader.js populated. Both caches
 // converge.
 const MODEL_REGISTRY = {
-  silero_vad:      { path: 'models/silero_vad.onnx',            sizeBytes:  2_327_524 , cdnUrls: ['https://huggingface.co/onnx-community/silero-vad/resolve/main/onnx/model.onnx'] },
+  silero_vad:      { path: 'models/silero_vad.onnx',            sizeBytes:  2_327_524 },
   silero_vad_int8: { path: 'models/silero_vad_int8.onnx',       sizeBytes:  2_376_297 },
-  rnnoise:         { path: 'models/rnnoise_suppressor.onnx',     sizeBytes:  2_027_576 , cdnUrls: ['https://huggingface.co/hubert-siuzdak/rnnoise-ort/resolve/main/rnnoise.onnx'] },
-  demucs_v4:       { path: 'models/demucs_v4_quantized.onnx',    sizeBytes: 87_031_808 , cdnUrls: ['https://huggingface.co/Joker5514/VoiceIsolate-Models/resolve/main/demucs_v4_quantized.onnx'] },
-  bsrnn_vocals:    { path: 'models/bsrnn_vocals.onnx',           sizeBytes:  3_870_554 , cdnUrls: ['https://huggingface.co/Joker5514/VoiceIsolate-Models/resolve/main/bsrnn_vocals.onnx'] },
+  rnnoise:         { path: 'models/rnnoise_suppressor.onnx',     sizeBytes:  2_027_576 },
+  demucs_v4:       { path: 'models/demucs_v4_quantized.onnx',    sizeBytes: 87_031_808 },
+  bsrnn_vocals:    { path: 'models/bsrnn_vocals.onnx',           sizeBytes:  3_870_554 },
 };
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/public/app/ml-worker.js
+++ b/public/app/ml-worker.js
@@ -172,7 +172,7 @@ function configureWasmRuntime() {
   ort.env.wasm.wasmPaths = '/lib/';
   ort.env.wasm.proxy = true;
   ort.env.wasm.numThreads = Math.min(navigator.hardwareConcurrency ?? 4, 4);
-  ort.env.wasm.simd = true;
+  ort.env.wasm.simd = detectWasmSimdSupport();
 }
 
 

--- a/public/app/ml-worker.js
+++ b/public/app/ml-worker.js
@@ -171,8 +171,8 @@ function configureWasmRuntime() {
   if (!ort || !ort.env || !ort.env.wasm) return;
   ort.env.wasm.wasmPaths = '/lib/';
   ort.env.wasm.proxy = true;
-  ort.env.wasm.numThreads = 2;
-  ort.env.wasm.simd = detectWasmSimdSupport();
+  ort.env.wasm.numThreads = navigator.hardwareConcurrency ?? 4;
+  ort.env.wasm.simd = true;
 }
 
 
@@ -954,6 +954,7 @@ async function createSessionWithFallback(modelUrl, expectedSha256, executionProv
   const canUseWebGpu = Array.isArray(executionProviders) && executionProviders.includes('webgpu');
   if (canUseWebGpu) {
     try {
+      // EP: WebGPU primary, WASM fallback — local inference only, no cloud.
       const session = await ort.InferenceSession.create(source, {
         executionProviders: ['webgpu', 'wasm'],
         graphOptimizationLevel: 'all',
@@ -965,6 +966,7 @@ async function createSessionWithFallback(modelUrl, expectedSha256, executionProv
   }
 
   {
+    // EP: WebGPU primary, WASM fallback — local inference only, no cloud.
     const session = await ort.InferenceSession.create(source, {
       executionProviders: ['wasm'],
       graphOptimizationLevel: 'all',

--- a/public/app/ml-worker.js
+++ b/public/app/ml-worker.js
@@ -171,7 +171,7 @@ function configureWasmRuntime() {
   if (!ort || !ort.env || !ort.env.wasm) return;
   ort.env.wasm.wasmPaths = '/lib/';
   ort.env.wasm.proxy = true;
-  ort.env.wasm.numThreads = navigator.hardwareConcurrency ?? 4;
+  ort.env.wasm.numThreads = Math.min(navigator.hardwareConcurrency ?? 4, 4);
   ort.env.wasm.simd = true;
 }
 

--- a/public/app/model-cdn-loader.js
+++ b/public/app/model-cdn-loader.js
@@ -15,7 +15,6 @@
 //   1. SW Cache (Cache API) — zero network, instant
 //   2. Vercel Blob proxied via /app/models/ rewrite (same-origin)
 //   3. Cloudflare R2 (CORS whitelisted in vercel.json connect-src)
-//   4. HuggingFace Hub (last resort)
 //
 // See docs/MODEL_DELIVERY.md for full architecture details.
 // ============================================================
@@ -24,12 +23,11 @@
   'use strict';
 
   // Provider priority order. vercel-blob first (proxied via /app/models/ rewrite —
-  // satisfies CSP connect-src 'self'). r2 second. huggingface last (Xet redirect
-  // layer can cause CORS issues on large files).
-  const PROVIDER_PRIORITY = ['vercel-blob', 'r2', 'huggingface'];
+  // satisfies CSP connect-src 'self'). r2 second.
+  const PROVIDER_PRIORITY = ['vercel-blob', 'r2'];
 
   // In-memory registry of which providers are known-healthy this session
-  const providerHealth = { 'vercel-blob': true, 'r2': true, 'huggingface': true };
+  const providerHealth = { 'vercel-blob': true, 'r2': true };
 
   // Track which provider served each model in this session (for diagnostics)
   const modelProviderMap = {};

--- a/public/app/models-manifest.json
+++ b/public/app/models-manifest.json
@@ -1,4 +1,5 @@
 {
+  "_note": "HuggingFace removed from runtime sources per architecture constraint. Use scripts/upload-models-to-blob.mjs to seed Vercel Blob and R2 only.",
   "schemaVersion": 2,
   "models": {
     "demucs": {
@@ -7,8 +8,7 @@
       "eager": false,
       "sources": [
         { "provider": "vercel-blob", "url": "/app/models/demucs_v4_quantized.onnx" },
-        { "provider": "r2",          "url": "https://models.voiceisolatepro.com/models/demucs_v4_quantized.onnx" },
-        { "provider": "huggingface", "url": "https://huggingface.co/Joker5514/voice-isolate-models/resolve/main/demucs_v4_quantized.onnx" }
+        { "provider": "r2",          "url": "https://models.voiceisolatepro.com/models/demucs_v4_quantized.onnx" }
       ]
     },
     "bsrnn": {
@@ -17,8 +17,7 @@
       "eager": false,
       "sources": [
         { "provider": "vercel-blob", "url": "/app/models/bsrnn_vocals.onnx" },
-        { "provider": "r2",          "url": "https://models.voiceisolatepro.com/models/bsrnn_vocals.onnx" },
-        { "provider": "huggingface", "url": "https://huggingface.co/Joker5514/voice-isolate-models/resolve/main/bsrnn_vocals.onnx" }
+        { "provider": "r2",          "url": "https://models.voiceisolatepro.com/models/bsrnn_vocals.onnx" }
       ]
     },
     "rnnoise": {
@@ -27,8 +26,7 @@
       "eager": true,
       "sources": [
         { "provider": "vercel-blob", "url": "/app/models/rnnoise_suppressor.onnx" },
-        { "provider": "r2",          "url": "https://models.voiceisolatepro.com/models/rnnoise_suppressor.onnx" },
-        { "provider": "huggingface", "url": "https://huggingface.co/Joker5514/voice-isolate-models/resolve/main/rnnoise_suppressor.onnx" }
+        { "provider": "r2",          "url": "https://models.voiceisolatepro.com/models/rnnoise_suppressor.onnx" }
       ]
     },
     "silero_vad": {
@@ -37,11 +35,11 @@
       "eager": true,
       "sources": [
         { "provider": "vercel-blob", "url": "/app/models/silero_vad.onnx" },
-        { "provider": "r2",          "url": "https://models.voiceisolatepro.com/models/silero_vad.onnx" },
-        { "provider": "huggingface", "url": "https://huggingface.co/Joker5514/voice-isolate-models/resolve/main/silero_vad.onnx" }
+        { "provider": "r2",          "url": "https://models.voiceisolatepro.com/models/silero_vad.onnx" }
       ]
     }
   },
+  "_sha256_note": "SHA256 last updated: 2026-05-20. Regenerate with: node scripts/hash-worklets.js",
   "worklets": {
     "dsp_processor": {
       "filename": "dsp-processor.js",
@@ -50,8 +48,7 @@
       "sources": [
         { "provider": "same-origin", "url": "/app/dsp-processor.js", "sha256": "9f0577b157461bff5e47cb1ba46ea538d902335fb1ead315c25a86e9d1812a48" },
         { "provider": "vercel-blob", "url": "https://blob.vercel-storage.com/voiceisolate-pro/worklets/dsp-processor.js", "sha256": "9f0577b157461bff5e47cb1ba46ea538d902335fb1ead315c25a86e9d1812a48" },
-        { "provider": "r2",          "url": "https://models.voiceisolatepro.com/worklets/dsp-processor.js", "sha256": "9f0577b157461bff5e47cb1ba46ea538d902335fb1ead315c25a86e9d1812a48" },
-        { "provider": "huggingface", "url": "https://huggingface.co/Joker5514/voice-isolate-models/resolve/main/worklets/dsp-processor.js", "sha256": "9f0577b157461bff5e47cb1ba46ea538d902335fb1ead315c25a86e9d1812a48" }
+        { "provider": "r2",          "url": "https://models.voiceisolatepro.com/worklets/dsp-processor.js", "sha256": "9f0577b157461bff5e47cb1ba46ea538d902335fb1ead315c25a86e9d1812a48" }
       ]
     }
   }

--- a/public/app/models/models-manifest.json
+++ b/public/app/models/models-manifest.json
@@ -120,15 +120,13 @@
       "sources": {
         "primary": "/app/dsp-processor.js",
         "vercel_blob": "https://blob.vercel-storage.com/voiceisolate-pro/worklets/dsp-processor.js",
-        "r2": "https://models.voiceisolatepro.com/worklets/dsp-processor.js",
-        "huggingface": "https://huggingface.co/Joker5514/voice-isolate-models/resolve/main/worklets/dsp-processor.js"
+        "r2": "https://models.voiceisolatepro.com/worklets/dsp-processor.js"
       },
       "cdn_mirrors": [
         { "provider": "vercel-blob", "url": "https://blob.vercel-storage.com/voiceisolate-pro/worklets/dsp-processor.js", "sha256": "9f0577b157461bff5e47cb1ba46ea538d902335fb1ead315c25a86e9d1812a48" },
-        { "provider": "r2",          "url": "https://models.voiceisolatepro.com/worklets/dsp-processor.js", "sha256": "9f0577b157461bff5e47cb1ba46ea538d902335fb1ead315c25a86e9d1812a48" },
-        { "provider": "huggingface", "url": "https://huggingface.co/Joker5514/voice-isolate-models/resolve/main/worklets/dsp-processor.js", "sha256": "9f0577b157461bff5e47cb1ba46ea538d902335fb1ead315c25a86e9d1812a48" }
+        { "provider": "r2",          "url": "https://models.voiceisolatepro.com/worklets/dsp-processor.js", "sha256": "9f0577b157461bff5e47cb1ba46ea538d902335fb1ead315c25a86e9d1812a48" }
       ],
-      "usage_notes": "Primary load path: same-origin /app/dsp-processor.js (COOP+COEP headers from vercel.json). Canonical mirror map for this manifest is `sources`; `cdn_mirrors` is retained as a backward-compatible alias of the same fallback URLs. Each mirror is SHA-256 pinned to guard against tampered CDN payloads before creating any Blob URL fallback. Fallback path: fetch from a mirror, wrap in a same-origin Blob URL, and pass that to AudioWorklet.addModule(). Blob URLs bypass COEP since they are same-origin. The HF Hub and R2 mirrors keep the real-time DSP path alive even when the static site is temporarily unavailable; audio data still never leaves the browser."
+      "usage_notes": "Primary load path: same-origin /app/dsp-processor.js (COOP+COEP headers from vercel.json). Canonical mirror map for this manifest is `sources`; `cdn_mirrors` is retained as a backward-compatible alias of the same fallback URLs. Each mirror is SHA-256 pinned to guard against tampered CDN payloads before creating any Blob URL fallback. Fallback path: fetch from a mirror, wrap in a same-origin Blob URL, and pass that to AudioWorklet.addModule(). Blob URLs bypass COEP since they are same-origin. The R2 mirror keeps the real-time DSP path alive even when the static site is temporarily unavailable; audio data still never leaves the browser."
     }
   ],
   "delivery_notes": [
@@ -136,7 +134,7 @@
     "demucs_v4_quantized.onnx is not yet exportable; a .placeholder file holds the slot. ml-worker.js disables the Demucs stage cleanly when the file is absent or undersized.",
     "Same-origin fetch keeps COEP (require-corp) satisfied so SharedArrayBuffer stays alive.",
     "After first run all models are cached in Cache API (vip-models-v1) — zero network on repeat visits.",
-    "The dsp-processor.js AudioWorklet is also mirrored to Vercel Blob, Cloudflare R2, and Hugging Face Hub. pipeline-orchestrator.js falls back to those mirrors via a same-origin Blob URL if the primary same-origin load fails. The worklet code itself contains no user audio — only DSP math — so mirroring it preserves the 100% local processing guarantee.",
+    "The dsp-processor.js AudioWorklet is also mirrored to Vercel Blob and Cloudflare R2. pipeline-orchestrator.js falls back to those mirrors via a same-origin Blob URL if the primary same-origin load fails. The worklet code itself contains no user audio — only DSP math — so mirroring it preserves the 100% local processing guarantee.",
     "100% local processing guarantee preserved — no audio data leaves the browser."
   ],
   "model_loader_behavior": {

--- a/public/app/pipeline-orchestrator.js
+++ b/public/app/pipeline-orchestrator.js
@@ -15,10 +15,10 @@ const WORKLET_SOURCE_SHA256 = '9f0577b157461bff5e47cb1ba46ea538d902335fb1ead315c
 // ─── AudioWorklet loader with CDN fallback ─────────────────────────────────
 // Primary path is same-origin /app/dsp-processor.js (COOP+COEP friendly).
 // If that fails (404, offline blob, etc.) we walk the manifest mirrors —
-// Vercel Blob → Cloudflare R2 → Hugging Face Hub — fetch the source text,
-// wrap it in a same-origin Blob URL, and pass that to addModule(). The Blob
-// URL is same-origin so it satisfies COEP require-corp without needing the
-// remote response to carry CORP headers.
+// Vercel Blob → Cloudflare R2 — fetch the source text, wrap it in a
+// same-origin Blob URL, and pass that to addModule(). The Blob URL is
+// same-origin so it satisfies COEP require-corp without needing the remote
+// response to carry CORP headers.
 const _WORKLET_FALLBACK_CACHE = { manifest: null, sourceText: null };
 async function _getWorkletManifest() {
   if (_WORKLET_FALLBACK_CACHE.manifest) return _WORKLET_FALLBACK_CACHE.manifest;
@@ -78,7 +78,6 @@ async function loadDspProcessorWorklet(ctx) {
         { provider: 'same-origin', url: '/app/dsp-processor.js', sha256: WORKLET_SOURCE_SHA256 },
         { provider: 'vercel-blob', url: 'https://blob.vercel-storage.com/voiceisolate-pro/worklets/dsp-processor.js', sha256: WORKLET_SOURCE_SHA256 },
         { provider: 'r2',          url: 'https://models.voiceisolatepro.com/worklets/dsp-processor.js', sha256: WORKLET_SOURCE_SHA256 },
-        { provider: 'huggingface', url: 'https://huggingface.co/Joker5514/voice-isolate-models/resolve/main/worklets/dsp-processor.js', sha256: WORKLET_SOURCE_SHA256 },
       ];
 
   let lastErr;

--- a/scripts/hash-worklets.js
+++ b/scripts/hash-worklets.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+'use strict';
+
+// Computes and prints the SHA-256 hash of each AudioWorklet file.
+// Run via: node scripts/hash-worklets.js
+// Or:      pnpm run worklets:hash
+//
+// Update the sha256 fields in public/app/models-manifest.json whenever
+// any worklet file changes (e.g. after patching dsp-processor.js).
+
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+
+const WORKLETS = [
+  'public/app/dsp-processor.js',
+];
+
+const root = path.resolve(__dirname, '..');
+
+for (const rel of WORKLETS) {
+  const abs = path.join(root, rel);
+  if (!fs.existsSync(abs)) {
+    console.error(`NOT FOUND: ${rel}`);
+    process.exitCode = 1;
+    continue;
+  }
+  const buf = fs.readFileSync(abs);
+  const hash = crypto.createHash('sha256').update(buf).digest('hex');
+  console.log(`${path.basename(rel)}: ${hash}`);
+}

--- a/tests/ml-worker.test.js
+++ b/tests/ml-worker.test.js
@@ -183,8 +183,8 @@ describe('ml-worker.js', () => {
 
     expect(workerGlobal.self.ort.env.wasm.wasmPaths).toBe('/lib/');
     expect(workerGlobal.self.ort.env.wasm.proxy).toBe(true);
-    expect(workerGlobal.self.ort.env.wasm.numThreads).toBe(2);
-    expect(typeof workerGlobal.self.ort.env.wasm.simd).toBe('boolean');
+    expect(workerGlobal.self.ort.env.wasm.numThreads).toBe(navigator.hardwareConcurrency ?? 4);
+    expect(workerGlobal.self.ort.env.wasm.simd).toBe(true);
   });
 
   it('uses PCM chunks for demucs input and never spectral mag_input', async () => {

--- a/tests/ml-worker.test.js
+++ b/tests/ml-worker.test.js
@@ -183,7 +183,7 @@ describe('ml-worker.js', () => {
 
     expect(workerGlobal.self.ort.env.wasm.wasmPaths).toBe('/lib/');
     expect(workerGlobal.self.ort.env.wasm.proxy).toBe(true);
-    expect(workerGlobal.self.ort.env.wasm.numThreads).toBe(navigator.hardwareConcurrency ?? 4);
+    expect(workerGlobal.self.ort.env.wasm.numThreads).toBe(workerGlobal.navigator.hardwareConcurrency ?? 4);
     expect(workerGlobal.self.ort.env.wasm.simd).toBe(true);
   });
 

--- a/vercel.json
+++ b/vercel.json
@@ -27,7 +27,7 @@
         { "key": "Strict-Transport-Security", "value": "max-age=31536000; includeSubDomains; preload" },
         { "key": "Permissions-Policy", "value": "microphone=(self), camera=(), geolocation=(), payment=(), usb=()" },
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
-        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' /_vercel/ https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob:; media-src 'self' blob: mediastream:; connect-src 'self' blob: https://va.vercel-scripts.com https://blob.vercel-storage.com https://*.public.blob.vercel-storage.com https://*.r2.cloudflarestorage.com https://*.r2.dev https://models.voiceisolatepro.com https://identitytoolkit.googleapis.com https://firestore.googleapis.com; worker-src 'self' blob:; frame-ancestors 'none'" }
+        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' /_vercel/ https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob:; media-src 'self' blob: mediastream:; connect-src 'self' blob: https://va.vercel-scripts.com https://blob.vercel-storage.com https://*.public.blob.vercel-storage.com https://*.r2.cloudflarestorage.com https://*.r2.dev https://models.voiceisolatepro.com https://huggingface.co https://cdn-lfs.huggingface.co https://identitytoolkit.googleapis.com https://firestore.googleapis.com; worker-src 'self' blob:; frame-ancestors 'none'" }
       ]
     },
     {

--- a/vercel.json
+++ b/vercel.json
@@ -10,7 +10,7 @@
   },
   "rewrites": [
     { "source": "/api/(.*)", "destination": "/api/handler" },
-    { "source": "/app/models/demucs_v4_quantized.onnx", "destination": "/app/models/demucs_v4_quantized.onnx" },
+    { "source": "/app/models/demucs_v4_quantized.onnx", "destination": "$BLOB_DEMUCS_URL" },
     { "source": "/app/((?!sw\\.js|dsp-processor\\.js|voice-isolate-processor\\.js|ml-worker\\.js|dsp-worker\\.js|ring-buffer\\.js|dsp-core\\.js|pipeline-orchestrator\\.js|pipeline-state\\.js|models\\/).*)", "destination": "/app/index.html" },
     { "source": "/app", "destination": "/app/index.html" },
     { "source": "/((?!api/|lib/|assets/|app/|sw\\.js|manifest\\.json|icon\\.jpg|favicon\\..*).*)","destination": "/index.html" }

--- a/vercel.json
+++ b/vercel.json
@@ -27,7 +27,7 @@
         { "key": "Strict-Transport-Security", "value": "max-age=31536000; includeSubDomains; preload" },
         { "key": "Permissions-Policy", "value": "microphone=(self), camera=(), geolocation=(), payment=(), usb=()" },
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
-        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' /_vercel/ https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob:; media-src 'self' blob: mediastream:; connect-src 'self' blob: https://va.vercel-scripts.com https://blob.vercel-storage.com https://*.public.blob.vercel-storage.com https://*.r2.cloudflarestorage.com https://*.r2.dev https://models.voiceisolatepro.com https://huggingface.co https://cdn-lfs.huggingface.co https://identitytoolkit.googleapis.com https://firestore.googleapis.com; worker-src 'self' blob:; frame-ancestors 'none'" }
+        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' /_vercel/ https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob:; media-src 'self' blob: mediastream:; connect-src 'self' blob: https://va.vercel-scripts.com https://blob.vercel-storage.com https://*.public.blob.vercel-storage.com https://*.r2.cloudflarestorage.com https://*.r2.dev https://models.voiceisolatepro.com https://identitytoolkit.googleapis.com https://firestore.googleapis.com; worker-src 'self' blob:; frame-ancestors 'none'" }
       ]
     },
     {

--- a/vercel.json
+++ b/vercel.json
@@ -27,7 +27,7 @@
         { "key": "Strict-Transport-Security", "value": "max-age=31536000; includeSubDomains; preload" },
         { "key": "Permissions-Policy", "value": "microphone=(self), camera=(), geolocation=(), payment=(), usb=()" },
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
-        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' /_vercel/; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob:; media-src 'self' blob: mediastream:; connect-src 'self' blob: https://va.vercel-scripts.com https://blob.vercel-storage.com https://*.public.blob.vercel-storage.com https://*.r2.cloudflarestorage.com https://*.r2.dev https://models.voiceisolatepro.com; worker-src 'self' blob:; frame-ancestors 'none'" }
+        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' /_vercel/ https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob:; media-src 'self' blob: mediastream:; connect-src 'self' blob: https://va.vercel-scripts.com https://blob.vercel-storage.com https://*.public.blob.vercel-storage.com https://*.r2.cloudflarestorage.com https://*.r2.dev https://models.voiceisolatepro.com https://identitytoolkit.googleapis.com https://firestore.googleapis.com; worker-src 'self' blob:; frame-ancestors 'none'" }
       ]
     },
     {

--- a/vercel.json
+++ b/vercel.json
@@ -27,7 +27,7 @@
         { "key": "Strict-Transport-Security", "value": "max-age=31536000; includeSubDomains; preload" },
         { "key": "Permissions-Policy", "value": "microphone=(self), camera=(), geolocation=(), payment=(), usb=()" },
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
-        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' /_vercel/; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob:; media-src 'self' blob: mediastream:; connect-src 'self' blob: https://va.vercel-scripts.com https://blob.vercel-storage.com https://*.public.blob.vercel-storage.com https://*.r2.cloudflarestorage.com https://*.r2.dev https://models.voiceisolatepro.com https://huggingface.co https://*.xethub.hf.co https://cas-bridge.xethub.hf.co; worker-src 'self' blob:; frame-ancestors 'none'" }
+        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' /_vercel/; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob:; media-src 'self' blob: mediastream:; connect-src 'self' blob: https://va.vercel-scripts.com https://blob.vercel-storage.com https://*.public.blob.vercel-storage.com https://*.r2.cloudflarestorage.com https://*.r2.dev https://models.voiceisolatepro.com; worker-src 'self' blob:; frame-ancestors 'none'" }
       ]
     },
     {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Six targeted fixes from the security and architecture audit. Each fix is an isolated commit.

- **fix(1)** — Audited the two `grep` hits for `inverseSTFT` in `app.js`. Both are the same expression split across two lines (guard check + ternary call). Confirmed `DSP.inverseSTFT()` is **read-only** on its `mag`/`phase` inputs (creates a new `Float32Array` for output; never mutates the spectral buffer). Added `AUDIT-SAFE` comment to eliminate ambiguity.
- **fix(2)** — Removed all `"provider": "huggingface"` entries from every model's sources in `models-manifest.json` (demucs, bsrnn, rnnoise, silero_vad) and from the worklets section. Removed `huggingface.co`, `*.xethub.hf.co`, `cas-bridge.xethub.hf.co` from `connect-src` in the CSP header in `vercel.json`. Fallback chain is now `vercel-blob → r2 → graceful error`.
- **fix(3)** — Fixed the Demucs rewrite in `vercel.json` that pointed to itself (infinite redirect). Now uses `$BLOB_DEMUCS_URL` env var. Documented in `.env.example`.
- **fix(4)** — Confirmed `dsp-processor.js` SHA-256 (`9f0577b...`) matches all manifest entries. Created `scripts/hash-worklets.js` (Node built-in crypto, no new deps). Added `worklets:hash` npm script. Added `_sha256_note` to manifest.
- **fix(5)** — Both `InferenceSession.create()` calls already had correct `executionProviders`. Added EP comment to each. Updated `configureWasmRuntime()`: `numThreads` now uses `navigator.hardwareConcurrency ?? 4`; `simd` set to `true` unconditionally. Updated the corresponding test assertion.
- **fix(6)** — Added architecture exception block comment to `firebase-config.js`. Created `docs/adr/001-firebase-exception.md` with full ADR covering context, decision, consequences, and alternatives (Supabase, local-only IndexedDB, custom JWT server).

## Test plan

- [x] `pnpm validate` — all structural checks pass
- [x] `pnpm lint` — 0 errors (pre-existing warnings only, none introduced by this PR)
- [x] `pnpm test:ci` — 1917/1919 tests pass; 2 pre-existing failures in `architectural-invariants.test.js` (caused by `dsp-bootstrap.js`, unrelated to this PR and present on `main` before these changes)
- [x] `node scripts/hash-worklets.js` — prints correct SHA-256 for `dsp-processor.js`
- [x] `models-manifest.json` — valid JSON, no HuggingFace sources remain
- [x] `vercel.json` — CSP `connect-src` no longer includes HuggingFace domains; Demucs rewrite no longer self-references

https://claude.ai/code/session_01NFjw9NJ97f183hhXSfBzET
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFjw9NJ97f183hhXSfBzET)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added environment configuration for external model URL support.

* **Performance Improvements**
  * ML worker now auto-adjusts threads to available CPU cores; improved GPU/WASM fallback behavior.

* **Infrastructure**
  * Switched runtime model hosting to R2 blob storage.

* **Security**
  * Tightened Content-Security-Policy to remove legacy external sources.

* **Documentation**
  * Added architecture decision record clarifying cloud usage and local-only audio processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Joker5514/VoiceIsolate-Pro/pull/539?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->