### PR TITLE
fix: wire DSPCore so runPipeline actually performs STFT/iSTFT

### DIFF
--- a/public/app/app.js
+++ b/public/app/app.js
@@ -1,6 +1,10 @@
 import { SLIDER_REGISTRY, STAGES } from './slider-map.js';
 import { ModelStatusUI } from './model-status-ui.js';
-const DSP = globalThis.DSP || {};
+// DSP math (forwardSTFT / inverseSTFT) lives on globalThis.DSPCore, exposed by
+// the classic <script src="./dsp-core.js"> tag in index.html — loaded before
+// this module so the binding is live at evaluation time. `DSP` retained as a
+// shorter alias; legacy globalThis.DSP kept as a fallback.
+const DSP = globalThis.DSPCore || globalThis.DSP || {};
 
 // ── Structured logging ───────────────────────────────────────────────────────
 function structuredLog(level, msg, data = {}) {

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -4,7 +4,37 @@ import { ModelStatusUI } from './model-status-ui.js';
 // the classic <script src="./dsp-core.js"> tag in index.html — loaded before
 // this module so the binding is live at evaluation time. `DSP` retained as a
 // shorter alias; legacy globalThis.DSP kept as a fallback.
-const DSP = globalThis.DSPCore || globalThis.DSP || {};
+function resolveDSPOrFail() {
+  const dsp = globalThis.DSPCore || globalThis.DSP;
+  const hasForward = !!dsp && typeof dsp.forwardSTFT === 'function';
+  const hasInverse = !!dsp && typeof dsp.inverseSTFT === 'function';
+
+  if (hasForward && hasInverse) return dsp;
+
+  const error = new Error(
+    'DSPCore is required but was not initialized correctly. Missing DSP.forwardSTFT and/or DSP.inverseSTFT.'
+  );
+  const details = {
+    hasDSPCore: !!globalThis.DSPCore,
+    hasLegacyDSP: !!globalThis.DSP,
+    hasForwardSTFT: hasForward,
+    hasInverseSTFT: hasInverse,
+  };
+
+  console.error('[VIP] Failed to initialize DSP dependency', details);
+  if (typeof window !== 'undefined' && typeof window.dispatchEvent === 'function') {
+    window.dispatchEvent(new CustomEvent('vip:dsp-error', {
+      detail: {
+        message: error.message,
+        ...details,
+      },
+    }));
+  }
+
+  throw error;
+}
+
+const DSP = resolveDSPOrFail();
 
 // ── Structured logging ───────────────────────────────────────────────────────
 function structuredLog(level, msg, data = {}) {

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -12,6 +12,10 @@
   <script type="module">
     import('three').then((m) => { globalThis.THREE = m; }).catch(() => {});
   </script>
+  <!-- DSP math (STFT/iSTFT, filters, Wiener NR) on window.DSPCore. Loaded as a
+       classic blocking script so the binding is live before any module imports
+       evaluate — app.js captures DSP = globalThis.DSPCore at module init. -->
+  <script src="./dsp-core.js"></script>
   <link rel="stylesheet" href="style.css" />
   <link rel="stylesheet" href="slider-theme.css" />
   <link rel="stylesheet" href="style-diag-log.css" />

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -12,13 +12,13 @@
   <script type="module">
     import('three').then((m) => { globalThis.THREE = m; }).catch(() => {});
   </script>
+  <link rel="stylesheet" href="style.css" />
+  <link rel="stylesheet" href="slider-theme.css" />
+  <link rel="stylesheet" href="style-diag-log.css" />
   <!-- DSP math (STFT/iSTFT, filters, Wiener NR) on window.DSPCore. Loaded as a
        classic blocking script so the binding is live before any module imports
        evaluate — app.js captures DSP = globalThis.DSPCore at module init. -->
   <script src="./dsp-core.js"></script>
-  <link rel="stylesheet" href="style.css" />
-  <link rel="stylesheet" href="slider-theme.css" />
-  <link rel="stylesheet" href="style-diag-log.css" />
   <link rel="stylesheet" href="model-status-ui.css" />
   <!-- FIXED: was /app/processing-overlay.css (absolute, breaks on static hosts) -->
   <link id="vip-overlay-css" rel="stylesheet" href="processing-overlay.css" />


### PR DESCRIPTION
app.js captured `const DSP = globalThis.DSP || {}` at module init, but
nothing populated globalThis.DSP — the dsp-bootstrap.js helper added in
a3c8839 was never loaded by index.html. As a result runPipeline's
forward/inverse STFT calls (app.js:1978, 2002) silently skipped (the
guards return null when the methods are missing) and the output buffer
was just a copy of the input — processing appeared to run but produced
no real DSP.

Load dsp-core.js as a classic blocking script in index.html (already
exposes window.DSPCore with matching forwardSTFT/inverseSTFT signatures)
and point the DSP alias at globalThis.DSPCore. dsp-bootstrap.js is left
unused — wiring it in would violate CLAUDE.md rules 2 and 3 since it
calls audioWorklet.addModule() and new Worker(), which only
pipeline-orchestrator.js may do.

https://claude.ai/code/session_01KWEFq494hKrizQkzFbhJLU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved DSP core module initialization with enhanced fallback handling to ensure more reliable startup behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Joker5514/VoiceIsolate-Pro/pull/540?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->