### PR TITLE
Consolidate CDN to Vercel Blob; remove Cloudflare R2 & HuggingFace

### DIFF
--- a/public/app/index.html
+++ b/public/app/index.html
@@ -412,23 +412,32 @@
     cannot silence the rest or produce a blank page.
   -->
   <script type="module">
-    const _mods = [
+    // app.js must resolve before vip-boot.js so VoiceIsolatePro is defined.
+    // Load parallel-safe modules first, then app.js, then boot/enhancements.
+    const _parallel = [
       './visuals.js',
       './processing-overlay.js',
       './pipeline-orchestrator.js',
       './session-persist.js',
-      './vip-boot.js',
-      './app.js',
-      './vip-enhancements.js',
     ];
-    for (const src of _mods) {
+    await Promise.allSettled(_parallel.map(src =>
       import(src).catch(err => {
         console.error('[VIP] Failed to load module:', src, err);
-        if (typeof window._vipReportError === 'function') {
-          window._vipReportError(src, err);
-        }
-      });
-    }
+        if (typeof window._vipReportError === 'function') window._vipReportError(src, err);
+      })
+    ));
+    await import('./app.js').catch(err => {
+      console.error('[VIP] Failed to load module: ./app.js', err);
+      if (typeof window._vipReportError === 'function') window._vipReportError('./app.js', err);
+    });
+    await import('./vip-boot.js').catch(err => {
+      console.error('[VIP] Failed to load module: ./vip-boot.js', err);
+      if (typeof window._vipReportError === 'function') window._vipReportError('./vip-boot.js', err);
+    });
+    import('./vip-enhancements.js').catch(err => {
+      console.error('[VIP] Failed to load module: ./vip-enhancements.js', err);
+      if (typeof window._vipReportError === 'function') window._vipReportError('./vip-enhancements.js', err);
+    });
   </script>
 
   <script>

--- a/public/app/model-cdn-loader.js
+++ b/public/app/model-cdn-loader.js
@@ -13,10 +13,14 @@
 //
 // The CDN waterfall order is:
 //   1. SW Cache (Cache API) — zero network, instant
-//   2. Same-origin /app/models/ (committed files + Vercel Blob rewrite for demucs)
-//   3. Vercel Blob public URLs (for demucs only, via vercel.json $BLOB_DEMUCS_URL)
+//   2. Same-origin /app/models/ URLs (committed files served directly, plus demucs
+//      fetched via the same-origin /app/models/demucs_v4_quantized.onnx route when
+//      that path is rewritten server-side to Vercel Blob)
+//   3. Direct Vercel Blob public URLs when explicitly present in the manifest as a
+//      fallback source
 //
-// Cloudflare R2 removed. All models now served via Vercel Blob or same-origin.
+// Cloudflare R2 removed. Models are now fetched via same-origin routes and, when
+// configured as fallback sources, direct Vercel Blob public URLs.
 // See docs/MODEL_DELIVERY.md for full architecture details.
 // ============================================================
 

--- a/public/app/model-cdn-loader.js
+++ b/public/app/model-cdn-loader.js
@@ -13,21 +13,22 @@
 //
 // The CDN waterfall order is:
 //   1. SW Cache (Cache API) — zero network, instant
-//   2. Vercel Blob proxied via /app/models/ rewrite (same-origin)
-//   3. Cloudflare R2 (CORS whitelisted in vercel.json connect-src)
+//   2. Same-origin /app/models/ (committed files + Vercel Blob rewrite for demucs)
+//   3. Vercel Blob public URLs (for demucs only, via vercel.json $BLOB_DEMUCS_URL)
 //
+// Cloudflare R2 removed. All models now served via Vercel Blob or same-origin.
 // See docs/MODEL_DELIVERY.md for full architecture details.
 // ============================================================
 
 (function() {
   'use strict';
 
-  // Provider priority order. vercel-blob first (proxied via /app/models/ rewrite —
-  // satisfies CSP connect-src 'self'). r2 second.
-  const PROVIDER_PRIORITY = ['vercel-blob', 'r2'];
+  // Provider priority order. same-origin first (committed files served directly).
+  // vercel-blob second (demucs routed via vercel.json rewrite to Vercel Blob).
+  const PROVIDER_PRIORITY = ['same-origin', 'vercel-blob'];
 
   // In-memory registry of which providers are known-healthy this session
-  const providerHealth = { 'vercel-blob': true, 'r2': true };
+  const providerHealth = { 'same-origin': true, 'vercel-blob': true };
 
   // Track which provider served each model in this session (for diagnostics)
   const modelProviderMap = {};

--- a/public/app/model-status-ui.js
+++ b/public/app/model-status-ui.js
@@ -11,16 +11,14 @@ const STATUS_CONFIG = {
 };
 
 const PROVIDER_BADGE = {
+  'same-origin': { label: '✓ Local',          cls: 'vip-provider--green'  },
   'vercel-blob': { label: '✓ Vercel Blob',    cls: 'vip-provider--green'  },
-  'r2':          { label: '✓ Cloudflare R2',  cls: 'vip-provider--blue'   },
-  'huggingface': { label: '✓ HuggingFace',    cls: 'vip-provider--yellow' },
   'cache':       { label: '✓ SW Cache',       cls: 'vip-provider--grey'   },
 };
 
 const HEALTH_LABELS = {
+  'same-origin': 'Local (same-origin)',
   'vercel-blob': 'Vercel Blob',
-  'r2':          'Cloudflare R2',
-  'huggingface': 'HuggingFace',
 };
 
 export class ModelStatusUI {
@@ -105,7 +103,7 @@ export class ModelStatusUI {
    * @param {string} key      – model key
    * @param {'cached'|'loading'|'pending'|'error'} status
    * @param {number} [pct]    – progress percentage for 'loading' state
-   * @param {string} [provider] – which CDN served the model (vercel-blob | r2 | huggingface)
+   * @param {string} [provider] – which CDN served the model (same-origin | vercel-blob | cache)
    */
   setStatus(key, status, pct, provider) {
     const pill = this._pills[key];

--- a/public/app/models-manifest.json
+++ b/public/app/models-manifest.json
@@ -1,5 +1,5 @@
 {
-  "_note": "HuggingFace removed from runtime sources per architecture constraint. Use scripts/upload-models-to-blob.mjs to seed Vercel Blob and R2 only.",
+  "_note": "Vercel Blob is the exclusive CDN provider. HuggingFace and Cloudflare R2 removed. Committed ONNX files (silero_vad, rnnoise, bsrnn) are served same-origin from /app/models/. Demucs is redirected to Vercel Blob via vercel.json rewrite ($BLOB_DEMUCS_URL).",
   "schemaVersion": 2,
   "models": {
     "demucs": {
@@ -7,8 +7,7 @@
       "sizeBytes": 88080384,
       "eager": false,
       "sources": [
-        { "provider": "vercel-blob", "url": "/app/models/demucs_v4_quantized.onnx" },
-        { "provider": "r2",          "url": "https://models.voiceisolatepro.com/models/demucs_v4_quantized.onnx" }
+        { "provider": "vercel-blob", "url": "/app/models/demucs_v4_quantized.onnx" }
       ]
     },
     "bsrnn": {
@@ -16,8 +15,7 @@
       "sizeBytes": 3870554,
       "eager": false,
       "sources": [
-        { "provider": "vercel-blob", "url": "/app/models/bsrnn_vocals.onnx" },
-        { "provider": "r2",          "url": "https://models.voiceisolatepro.com/models/bsrnn_vocals.onnx" }
+        { "provider": "same-origin", "url": "/app/models/bsrnn_vocals.onnx" }
       ]
     },
     "rnnoise": {
@@ -25,8 +23,7 @@
       "sizeBytes": 2027576,
       "eager": true,
       "sources": [
-        { "provider": "vercel-blob", "url": "/app/models/rnnoise_suppressor.onnx" },
-        { "provider": "r2",          "url": "https://models.voiceisolatepro.com/models/rnnoise_suppressor.onnx" }
+        { "provider": "same-origin", "url": "/app/models/rnnoise_suppressor.onnx" }
       ]
     },
     "silero_vad": {
@@ -34,8 +31,7 @@
       "sizeBytes": 2327524,
       "eager": true,
       "sources": [
-        { "provider": "vercel-blob", "url": "/app/models/silero_vad.onnx" },
-        { "provider": "r2",          "url": "https://models.voiceisolatepro.com/models/silero_vad.onnx" }
+        { "provider": "same-origin", "url": "/app/models/silero_vad.onnx" }
       ]
     }
   },
@@ -47,8 +43,7 @@
       "contentType": "application/javascript",
       "sources": [
         { "provider": "same-origin", "url": "/app/dsp-processor.js", "sha256": "9f0577b157461bff5e47cb1ba46ea538d902335fb1ead315c25a86e9d1812a48" },
-        { "provider": "vercel-blob", "url": "https://blob.vercel-storage.com/voiceisolate-pro/worklets/dsp-processor.js", "sha256": "9f0577b157461bff5e47cb1ba46ea538d902335fb1ead315c25a86e9d1812a48" },
-        { "provider": "r2",          "url": "https://models.voiceisolatepro.com/worklets/dsp-processor.js", "sha256": "9f0577b157461bff5e47cb1ba46ea538d902335fb1ead315c25a86e9d1812a48" }
+        { "provider": "vercel-blob", "url": "https://blob.vercel-storage.com/voiceisolate-pro/worklets/dsp-processor.js", "sha256": "9f0577b157461bff5e47cb1ba46ea538d902335fb1ead315c25a86e9d1812a48" }
       ]
     }
   }

--- a/public/app/models/models-manifest.json
+++ b/public/app/models/models-manifest.json
@@ -119,14 +119,12 @@
       "status": "committed",
       "sources": {
         "primary": "/app/dsp-processor.js",
-        "vercel_blob": "https://blob.vercel-storage.com/voiceisolate-pro/worklets/dsp-processor.js",
-        "r2": "https://models.voiceisolatepro.com/worklets/dsp-processor.js"
+        "vercel_blob": "https://blob.vercel-storage.com/voiceisolate-pro/worklets/dsp-processor.js"
       },
       "cdn_mirrors": [
-        { "provider": "vercel-blob", "url": "https://blob.vercel-storage.com/voiceisolate-pro/worklets/dsp-processor.js", "sha256": "9f0577b157461bff5e47cb1ba46ea538d902335fb1ead315c25a86e9d1812a48" },
-        { "provider": "r2",          "url": "https://models.voiceisolatepro.com/worklets/dsp-processor.js", "sha256": "9f0577b157461bff5e47cb1ba46ea538d902335fb1ead315c25a86e9d1812a48" }
+        { "provider": "vercel-blob", "url": "https://blob.vercel-storage.com/voiceisolate-pro/worklets/dsp-processor.js", "sha256": "9f0577b157461bff5e47cb1ba46ea538d902335fb1ead315c25a86e9d1812a48" }
       ],
-      "usage_notes": "Primary load path: same-origin /app/dsp-processor.js (COOP+COEP headers from vercel.json). Canonical mirror map for this manifest is `sources`; `cdn_mirrors` is retained as a backward-compatible alias of the same fallback URLs. Each mirror is SHA-256 pinned to guard against tampered CDN payloads before creating any Blob URL fallback. Fallback path: fetch from a mirror, wrap in a same-origin Blob URL, and pass that to AudioWorklet.addModule(). Blob URLs bypass COEP since they are same-origin. The R2 mirror keeps the real-time DSP path alive even when the static site is temporarily unavailable; audio data still never leaves the browser."
+      "usage_notes": "Primary load path: same-origin /app/dsp-processor.js (COOP+COEP headers from vercel.json). Canonical mirror map for this manifest is `sources`; `cdn_mirrors` is retained as a backward-compatible alias of the same fallback URLs. Each mirror is SHA-256 pinned to guard against tampered CDN payloads before creating any Blob URL fallback. Fallback path: fetch from a mirror, wrap in a same-origin Blob URL, and pass that to AudioWorklet.addModule(). Blob URLs bypass COEP since they are same-origin. Audio data never leaves the browser."
     }
   ],
   "delivery_notes": [
@@ -134,7 +132,7 @@
     "demucs_v4_quantized.onnx is not yet exportable; a .placeholder file holds the slot. ml-worker.js disables the Demucs stage cleanly when the file is absent or undersized.",
     "Same-origin fetch keeps COEP (require-corp) satisfied so SharedArrayBuffer stays alive.",
     "After first run all models are cached in Cache API (vip-models-v1) — zero network on repeat visits.",
-    "The dsp-processor.js AudioWorklet is also mirrored to Vercel Blob and Cloudflare R2. pipeline-orchestrator.js falls back to those mirrors via a same-origin Blob URL if the primary same-origin load fails. The worklet code itself contains no user audio — only DSP math — so mirroring it preserves the 100% local processing guarantee.",
+    "The dsp-processor.js AudioWorklet is also mirrored to Vercel Blob. pipeline-orchestrator.js falls back to that mirror via a same-origin Blob URL if the primary same-origin load fails. The worklet code itself contains no user audio — only DSP math — so mirroring it preserves the 100% local processing guarantee.",
     "100% local processing guarantee preserved — no audio data leaves the browser."
   ],
   "model_loader_behavior": {

--- a/public/app/pipeline-orchestrator.js
+++ b/public/app/pipeline-orchestrator.js
@@ -14,11 +14,11 @@ const WORKLET_SOURCE_SHA256 = '9f0577b157461bff5e47cb1ba46ea538d902335fb1ead315c
 
 // ─── AudioWorklet loader with CDN fallback ─────────────────────────────────
 // Primary path is same-origin /app/dsp-processor.js (COOP+COEP friendly).
-// If that fails (404, offline blob, etc.) we walk the manifest mirrors —
-// Vercel Blob → Cloudflare R2 — fetch the source text, wrap it in a
-// same-origin Blob URL, and pass that to addModule(). The Blob URL is
-// same-origin so it satisfies COEP require-corp without needing the remote
-// response to carry CORP headers.
+// If that fails (404, offline, etc.) we walk the manifest mirrors —
+// Vercel Blob only — fetch the source text, wrap it in a same-origin
+// Blob URL, and pass that to addModule(). The Blob URL is same-origin
+// so it satisfies COEP require-corp without needing the remote response
+// to carry CORP headers. Cloudflare R2 removed.
 const _WORKLET_FALLBACK_CACHE = { manifest: null, sourceText: null };
 async function _getWorkletManifest() {
   if (_WORKLET_FALLBACK_CACHE.manifest) return _WORKLET_FALLBACK_CACHE.manifest;
@@ -77,7 +77,6 @@ async function loadDspProcessorWorklet(ctx) {
     : [
         { provider: 'same-origin', url: '/app/dsp-processor.js', sha256: WORKLET_SOURCE_SHA256 },
         { provider: 'vercel-blob', url: 'https://blob.vercel-storage.com/voiceisolate-pro/worklets/dsp-processor.js', sha256: WORKLET_SOURCE_SHA256 },
-        { provider: 'r2',          url: 'https://models.voiceisolatepro.com/worklets/dsp-processor.js', sha256: WORKLET_SOURCE_SHA256 },
       ];
 
   let lastErr;

--- a/public/app/style.css
+++ b/public/app/style.css
@@ -1082,6 +1082,11 @@ body::after {
   text-shadow: 0 1px 0 rgba(255,255,255,.18);
   box-shadow: 0 4px 18px rgba(255,42,61,.4), inset 0 1px 0 rgba(255,255,255,.25);
 }
+.btn-primary:disabled {
+  background: linear-gradient(135deg, #6b1a22 0%, #8c3040 45%, #7a5020 100%);
+  opacity: 0.65;
+  color: #c8a0a8;
+}
 .btn-primary:hover:not(:disabled) {
   transform: translateY(-1px);
   box-shadow: 0 8px 30px rgba(255,42,61,.55), 0 0 24px rgba(255,182,72,.35), inset 0 1px 0 rgba(255,255,255,.3);

--- a/public/app/vip-boot.js
+++ b/public/app/vip-boot.js
@@ -126,7 +126,7 @@
       // CTX pill -- ready as soon as app instance owns an AudioContext
       if (!ctxResolved) {
         var app = window._vipApp;
-        if (app && app.audioCtx && typeof app.audioCtx.state === 'string') {
+        if (app && app.ctx && typeof app.ctx.state === 'string') {
           setEnginePill('engCtxPill', 'ready');
           ctxResolved = true;
         } else if (hasAudioContext()) {

--- a/vercel.json
+++ b/vercel.json
@@ -27,7 +27,7 @@
         { "key": "Strict-Transport-Security", "value": "max-age=31536000; includeSubDomains; preload" },
         { "key": "Permissions-Policy", "value": "microphone=(self), camera=(), geolocation=(), payment=(), usb=()" },
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
-        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' /_vercel/; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob:; media-src 'self' blob: mediastream:; connect-src 'self' blob: https://va.vercel-scripts.com https://blob.vercel-storage.com https://*.public.blob.vercel-storage.com https://*.r2.cloudflarestorage.com https://*.r2.dev https://models.voiceisolatepro.com https://identitytoolkit.googleapis.com https://firestore.googleapis.com; worker-src 'self' blob:; frame-ancestors 'none'" }
+        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' /_vercel/; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob:; media-src 'self' blob: mediastream:; connect-src 'self' blob: https://va.vercel-scripts.com https://blob.vercel-storage.com https://*.public.blob.vercel-storage.com https://identitytoolkit.googleapis.com https://firestore.googleapis.com; worker-src 'self' blob:; frame-ancestors 'none'" }
       ]
     },
     {


### PR DESCRIPTION
## Summary
Simplifies the model delivery architecture by removing Cloudflare R2 and HuggingFace as fallback CDN providers. All models now route through Vercel Blob (with same-origin committed files as primary source), reducing complexity and maintenance overhead while preserving the 100% local processing guarantee.

## Key Changes

### Model Delivery Architecture
- **Removed R2 and HuggingFace** from all model manifests and CDN fallback chains
- **Committed ONNX files** (silero_vad, rnnoise, bsrnn) now served same-origin from `/app/models/` with `same-origin` provider designation
- **Demucs** redirected to Vercel Blob via `vercel.json` rewrite (`$BLOB_DEMUCS_URL`)
- Updated `models-manifest.json` to reflect single-source delivery per model type

### Module Loading Order
- Refactored `index.html` script module loading to enforce strict dependency order:
  - Parallel-safe modules (visuals, processing-overlay, pipeline-orchestrator, session-persist) load concurrently via `Promise.allSettled()`
  - `app.js` awaited before `vip-boot.js` (ensures VoiceIsolatePro is defined)
  - `vip-boot.js` awaited before `vip-enhancements.js` (fire-and-forget)
- Improved error handling with consistent error reporting for each module

### CDN Loader Updates
- Updated `model-cdn-loader.js` provider priority: `['same-origin', 'vercel-blob']`
- Removed R2 from provider health tracking
- Updated comments to reflect Vercel Blob as exclusive CDN

### AudioWorklet Fallback
- `pipeline-orchestrator.js` now falls back to Vercel Blob only (removed R2 mirror)
- Maintains same-origin Blob URL wrapping for COEP compliance

### UI & Documentation
- Updated `model-status-ui.js` provider badges: removed R2 and HuggingFace, added `same-origin` badge
- Updated `vip-boot.js` to reference `app.ctx` instead of `app.audioCtx` for AudioContext state check
- Added CSS styling for disabled primary button state
- Updated CSP header in `vercel.json` to remove R2 and HuggingFace domains from `connect-src`
- Updated all manifest documentation notes to reflect Vercel Blob as exclusive CDN

## Implementation Details
- Same-origin delivery satisfies COEP (require-corp) without needing remote CORP headers
- Vercel Blob serves as single fallback source for demucs and worklet code
- All models remain SHA-256 pinned before Blob URL creation to prevent tampering
- 100% local processing guarantee preserved—no audio data leaves the browser

https://claude.ai/code/session_01CY3PSdHCdbq45fJsDcY9RM