### PR TITLE
test: wienerGain uses correct values instead of nEst as gain floor

### DIFF
--- a/tests/dsp.test.js
+++ b/tests/dsp.test.js
@@ -271,7 +271,7 @@ describe('Wiener NR — speech-frame gain (applySpectralNR fix)', () => {
     expect(gainSpeech).toBeGreaterThanOrEqual(gainNonSpeech);
   });
 
-  test('During speech, high nEst still yields gain ≤ 1 (regression: was amplifying)', () => {
+  test('wienerGain uses correct values instead of nEst as gain floor', () => {
     // Before fix: effectiveAlpha = Math.max(nEst * 0.3, beta) used nEst as gain floor.
     // With nEst=375, effectiveAlpha=112.5 — multiplied signal by 112.5.
     const beta = 0.05;


### PR DESCRIPTION
🎯 **What:** Update the test name in `tests/dsp.test.js` to accurately describe its purpose.
💡 **Why:** To accurately reflect that the `wienerGain` function uses the correct values rather than using the noise estimate directly as the gain floor. The function itself was correctly fixed previously.
✅ **Verification:** Verified that the relevant DSP tests pass successfully using `pnpm test`.
✨ **Result:** Test suite is better documented and describes the resolved issue accurately.

---
*PR created automatically by Jules for task [8872279185308114306](https://jules.google.com/task/8872279185308114306) started by @Joker5514*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test descriptions for improved clarity in Wiener gain assertions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Joker5514/VoiceIsolate-Pro/pull/546?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->