### PR TITLE
fix: prevent engineer page boot splash from freezing on load

### DIFF
--- a/public/app/app.js
+++ b/public/app/app.js
@@ -1349,7 +1349,7 @@ class VoiceIsolatePro {
   _resolveDSP() {
     return (typeof globalThis !== 'undefined' && globalThis.DSPCore) ||
            (typeof window !== 'undefined' && window.DSPCore) ||
-           (typeof DSPCore !== 'undefined' ? DSPCore : null);
+           null;
   }
 
   // Single offline path: ONE forward STFT, in-place spectral ops S11–S19, ONE iSTFT

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -373,7 +373,7 @@ class VoiceIsolatePro {
     this.initModelStatusPanel();
 
     // Lazy AudioContext — requires user gesture
-    if (typeof document.addEventListener === 'function') {
+    if (typeof document !== 'undefined' && typeof document.addEventListener === 'function') {
       document.addEventListener('click', () => this.ensureCtx(), { once: true });
       document.addEventListener('keydown', () => this.ensureCtx(), { once: true });
     }

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -682,7 +682,7 @@ class VoiceIsolatePro {
 
     // Safe querySelectorAll — returns empty array when document is a partial mock
     const qsa = (sel) => {
-      if (typeof document.querySelectorAll === 'function') return document.querySelectorAll(sel);
+      if (typeof document !== 'undefined' && typeof document.querySelectorAll === 'function') return document.querySelectorAll(sel);
       return [];
     };
 

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -761,7 +761,7 @@ class VoiceIsolatePro {
 
     // A/B toggle
     bind('tpAB', d.tpAB, 'click', () => this.toggleAB());
-    if (typeof document.addEventListener === 'function') {
+    if (typeof document !== 'undefined' && typeof document.addEventListener === 'function') {
       document.addEventListener('keydown', e => this._handleGlobalKeydown(e));
     }
 

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -373,11 +373,15 @@ class VoiceIsolatePro {
     this.initModelStatusPanel();
 
     // Lazy AudioContext — requires user gesture
-    document.addEventListener('click', () => this.ensureCtx(), { once: true });
-    document.addEventListener('keydown', () => this.ensureCtx(), { once: true });
+    if (typeof document.addEventListener === 'function') {
+      document.addEventListener('click', () => this.ensureCtx(), { once: true });
+      document.addEventListener('keydown', () => this.ensureCtx(), { once: true });
+    }
 
     window.__vipAppReady = true;
-    window.dispatchEvent(new CustomEvent('app:ready'));
+    if (typeof CustomEvent !== 'undefined' && typeof window.dispatchEvent === 'function') {
+      window.dispatchEvent(new CustomEvent('app:ready'));
+    }
 
     if (window._vipOrch && typeof window._vipOrch.connectApp === 'function') {
       window._vipOrch.connectApp(this);
@@ -676,6 +680,12 @@ class VoiceIsolatePro {
       if (el) el.addEventListener(event, fn);
     };
 
+    // Safe querySelectorAll — returns empty array when document is a partial mock
+    const qsa = (sel) => {
+      if (typeof document.querySelectorAll === 'function') return document.querySelectorAll(sel);
+      return [];
+    };
+
     // File input
     bind('fileBtn', d.fileBtn, 'click', () => { if (d.fileInput) d.fileInput.click(); });
     if (d.uploadZone) {
@@ -751,7 +761,9 @@ class VoiceIsolatePro {
 
     // A/B toggle
     bind('tpAB', d.tpAB, 'click', () => this.toggleAB());
-    document.addEventListener('keydown', e => this._handleGlobalKeydown(e));
+    if (typeof document.addEventListener === 'function') {
+      document.addEventListener('keydown', e => this._handleGlobalKeydown(e));
+    }
 
     // Save buttons
     bind('saveOrigBtn', d.saveOrigBtn, 'click', () => {
@@ -764,13 +776,13 @@ class VoiceIsolatePro {
 
     // Preset selector
     bind('presetSel', d.presetSel, 'change', e => this.applyPreset(e.target.value));
-    document.querySelectorAll('.btn-preset').forEach(b => {
+    qsa('.btn-preset').forEach(b => {
       b.addEventListener('click', () => this.applyPreset(b.dataset.preset));
     });
 
     // Reset sliders
     bind('resetSlidersBtn', d.resetSlidersBtn, 'click', () => {
-      document.querySelectorAll('[id^="sl_"]').forEach(el => {
+      qsa('[id^="sl_"]').forEach(el => {
         const id = el.id.slice(3);
         const spec = SLIDER_BY_ID[id];
         if (spec) { el.value = spec.val; el.dispatchEvent(new Event('input', { bubbles: true })); }
@@ -780,21 +792,21 @@ class VoiceIsolatePro {
     // Slider search
     bind('sliderSearch', d.sliderSearch, 'input', () => {
       const q = d.sliderSearch.value.trim().toLowerCase();
-      document.querySelectorAll('.sr-row').forEach(row => {
+      qsa('.sr-row').forEach(row => {
         const label = (row.querySelector('.sr-label') || {}).textContent || '';
         row.style.display = (!q || label.toLowerCase().includes(q)) ? '' : 'none';
       });
     });
 
     // Tab switching
-    document.querySelectorAll('.tab-btn[data-tab]').forEach(btn => {
+    qsa('.tab-btn[data-tab]').forEach(btn => {
       btn.addEventListener('click', () => {
-        document.querySelectorAll('.tab-btn').forEach(b => {
+        qsa('.tab-btn').forEach(b => {
           b.classList.remove('active');
           b.setAttribute('aria-selected', 'false');
           b.setAttribute('tabindex', '-1');
         });
-        document.querySelectorAll('.panel').forEach(p => p.classList.remove('active'));
+        qsa('.panel').forEach(p => p.classList.remove('active'));
         btn.classList.add('active');
         btn.setAttribute('aria-selected', 'true');
         btn.setAttribute('tabindex', '0');
@@ -807,12 +819,12 @@ class VoiceIsolatePro {
     let uiScale = 1;
     bind('uiScaleDn', $('uiScaleDn'), 'click', () => {
       uiScale = Math.max(0.7, uiScale - 0.05);
-      document.body.style.zoom = uiScale;
+      if (document.body) document.body.style.zoom = uiScale;
       const v = $('uiScaleVal'); if (v) v.textContent = Math.round(uiScale * 100) + '%';
     });
     bind('uiScaleUp', $('uiScaleUp'), 'click', () => {
       uiScale = Math.min(1.4, uiScale + 0.05);
-      document.body.style.zoom = uiScale;
+      if (document.body) document.body.style.zoom = uiScale;
       const v = $('uiScaleVal'); if (v) v.textContent = Math.round(uiScale * 100) + '%';
     });
 
@@ -1842,6 +1854,9 @@ if (typeof module !== 'undefined') module.exports = VoiceIsolatePro;
 (function _vipBootstrap() {
   if (typeof VoiceIsolatePro === 'undefined') return;
   if (window._vipApp) return;
+  // Skip when running outside a real browser (test VMs, new Function sandboxes, CommonJS)
+  if (typeof document === 'undefined' || typeof document.readyState !== 'string') return;
+  if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') return;
 
   function _callAuthInit() {
     if (typeof Auth !== 'undefined' && Auth && typeof Auth.init === 'function') {
@@ -1856,8 +1871,8 @@ if (typeof module !== 'undefined') module.exports = VoiceIsolatePro;
     var app = null;
     try {
       app = new VoiceIsolatePro();
-      app._initCalled = true;
       app.init();
+      app._initCalled = true;
       window._vipApp = app;
       window.vip = app;
       console.info('[app] VoiceIsolatePro ready via app.js bootstrap');

--- a/public/app/vip-boot.js
+++ b/public/app/vip-boot.js
@@ -172,19 +172,19 @@
     if (window.vip instanceof VoiceIsolatePro) {
       window._vipApp = window.vip;
       if (typeof window._vipApp.init === 'function' && !window._vipApp._initCalled) {
-        window._vipApp._initCalled = true;
         try { window._vipApp.init(); } catch(e){ console.warn('[vip-boot] app.init() error:', e); }
       }
+      window._vipApp._initCalled = true;
       console.info('[vip-boot] Aliased window.vip \u2192 window._vipApp \u2713');
       _callAuthInit();
       return;
     }
     try {
       var app = new VoiceIsolatePro();
-      app._initCalled = true;
       if (typeof app.init === 'function') {
         try { app.init(); } catch(e){ console.warn('[vip-boot] app.init() error:', e); }
       }
+      app._initCalled = true;
       window.vip     = app;
       window._vipApp = app;
       console.info('[vip-boot] VoiceIsolatePro instantiated + init() called \u2713');

--- a/tests/vip-bootstrap.test.js
+++ b/tests/vip-bootstrap.test.js
@@ -566,8 +566,9 @@ describe('vip-boot.js — aliasOrCreate(): fresh instantiation', () => {
     expect(scope.window.vip).toBe(scope.window._vipApp);
   });
 
-  test('sets _initCalled = true before calling app.init()', () => {
-    // Verify _initCalled is set synchronously (init() reads it in the impl)
+  test('does not set _initCalled before calling app.init()', () => {
+    // init() itself is responsible for setting _initCalled; the bootstrap
+    // must not set it before the call (that would cause init() to skip itself).
     let initCalledAtCallTime = undefined;
     function TrackVIP() {
       this._initCalled = false;
@@ -577,7 +578,7 @@ describe('vip-boot.js — aliasOrCreate(): fresh instantiation', () => {
       window: { _vipApp: null, vip: null },
       VoiceIsolatePro: TrackVIP,
     });
-    expect(initCalledAtCallTime).toBe(true);
+    expect(initCalledAtCallTime).toBe(false);
   });
 
   test('calls app.init() on the new instance', () => {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Root cause**: `_vipBootstrap` IIFE in `app.js` and `aliasOrCreate()` in `vip-boot.js` both set `app._initCalled = true` *before* calling `app.init()`. Since `init()` guards with `if (this._initCalled) return` as its first line, it immediately returned without ever calling `_renderSliders()`, `bindEvents()`, or `initBootSplash()` — leaving the boot splash overlay permanently visible.
- **Fix**: Move `app._initCalled = true` to *after* `app.init()` completes in all bootstrap paths.
- **Test hardening**: Guard `document.readyState` in the IIFE so it exits cleanly in `new Function` test sandboxes; guard `document.addEventListener` calls in `bindEvents()` that lacked fallbacks; add `qsa()` helper for `querySelectorAll` calls; update `vip-bootstrap.test.js` to assert the corrected (not premature) `_initCalled` behavior.

## Test plan

- [ ] All 65 Jest suites pass (`pnpm test`)
- [ ] Engineer mode page loads without freezing on the boot splash
- [ ] Reloading the page still boots correctly (no double-init)
- [ ] `vip-boot.js` fallback paths (aliasOrCreate) also work correctly

https://claude.ai/code/session_01B9JoQ1Qq79YCYvMcQMTYpM
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B9JoQ1Qq79YCYvMcQMTYpM)_