### PR TITLE
fix: route playback through worklet and wire all visualizer tabs

### DIFF
--- a/public/app/app.js
+++ b/public/app/app.js
@@ -1042,6 +1042,7 @@ class VoiceIsolatePro {
     if (this.dom.hFile) this.dom.hFile.textContent = (name || '').slice(0, 20);
 
     this.renderStaticVisuals(buf);
+    try { window.dispatchEvent(new CustomEvent('vip:fileLoaded', { detail: { name } })); } catch (_) {}
     this.showNotification('File loaded: ' + name, 'info');
   }
 
@@ -1110,6 +1111,7 @@ class VoiceIsolatePro {
       if (this.outputBuffer) this.renderStaticVisuals(this.outputBuffer);
       this.updatePipelineProgress(32, 'Complete', 100);
       this.setStatus('DONE');
+      try { window.dispatchEvent(new CustomEvent('vip:processingDone')); } catch (_) {}
       this.showNotification('Processing complete!', 'info');
     } catch (err) {
       structuredLog('error', '[VIP] Pipeline error', { err: err.message });

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -24,6 +24,8 @@
   <script src="./ring-buffer.js"></script>
   <script src="./visuals.js"></script>
   <script src="./premium-visuals.js"></script>
+  <!-- // LOAD ORDER VERIFIED: visuals-bootstrap.js follows visuals.js + premium-visuals.js so VIP_INFERNO_LUT and premium init helpers are already defined when the driver wires its tab listener. -->
+  <script src="./visuals-bootstrap.js"></script>
   <link rel="stylesheet" href="model-status-ui.css" />
   <link id="vip-overlay-css" rel="stylesheet" href="processing-overlay.css" />
   <link rel="stylesheet" href="mobile.css" />

--- a/public/app/vip-fixes.js
+++ b/public/app/vip-fixes.js
@@ -44,6 +44,9 @@
     let _seeking     = false;
     let _source      = null;
     let _gainNode    = null;
+    let _analyser    = null;  // FFT analyser tapped after worklet — drives visualizers
+    let _workletWired = false; // sticky flag: once we route through worklet, stay routed
+    let _chainBuilt  = false;  // downstream chain (gain → [worklet] → analyser → dest) wired once
 
     /* ── Helpers ── */
     function _fmt(sec) {
@@ -103,6 +106,7 @@
       const stop  = $('tpStop');
       if (pause) pause.disabled = true;
       if (stop)  stop.disabled  = true;
+      try { window.dispatchEvent(new CustomEvent('vip:playStopped')); } catch (_) {}
     }
 
     /* ── Core play ── */
@@ -130,8 +134,52 @@
       _source.playbackRate.value = parseFloat(spSel?.value || '1');
 
       if (!_gainNode) { _gainNode = ctx.createGain(); _gainNode.gain.value = 1; }
+
+      /* ── Analyser node — single shared FFT tap that drives every visualizer ── */
+      if (!_analyser) {
+        try {
+          _analyser = ctx.createAnalyser();
+          _analyser.fftSize = 2048;
+          _analyser.smoothingTimeConstant = 0.82;
+          window._vipPlayAnalyser = _analyser;
+        } catch (e) { warn('Analyser create failed', e); _analyser = null; }
+      }
+
+      /* ── Routing chain ──
+         Wired ONCE and reused across replays — each new source connects to
+         the persistent _gainNode and the downstream chain takes care of the
+         rest. Reconnecting downstream nodes per-play would tear down the
+         worklet's connections to the orchestrator's other consumers.
+
+         Chain layout (built on first play, kept until teardown):
+           Source → Gain → [Worklet] → Analyser → ctx.destination
+       */
       _source.connect(_gainNode);
-      _gainNode.connect(ctx.destination);
+      if (!_chainBuilt) {
+        const orchWorklet = window._vipOrch?.workletNode;
+        try {
+          if (orchWorklet) {
+            _gainNode.connect(orchWorklet);
+            if (_analyser) {
+              orchWorklet.connect(_analyser);
+              _analyser.connect(ctx.destination);
+            } else {
+              orchWorklet.connect(ctx.destination);
+            }
+            _workletWired = true;
+          } else if (_analyser) {
+            _gainNode.connect(_analyser);
+            _analyser.connect(ctx.destination);
+          } else {
+            _gainNode.connect(ctx.destination);
+          }
+          _chainBuilt = true;
+        } catch (e) {
+          warn('Chain build failed, falling back to direct gain → destination', e);
+          try { _gainNode.connect(ctx.destination); } catch (_) {}
+          _chainBuilt = true;
+        }
+      }
 
       const safeOffset = Math.min(Math.max(_pauseOffset, 0), Math.max(_duration - 0.01, 0));
       _pauseOffset = safeOffset;
@@ -158,7 +206,15 @@
 
       cancelAnimationFrame(_rafId);
       _updateUI();
-      log('play() started at offset', safeOffset);
+
+      /* Announce playback so visualizers can hook in */
+      try {
+        window.dispatchEvent(new CustomEvent('vip:playStarted', {
+          detail: { analyser: _analyser, workletRouted: _workletWired }
+        }));
+      } catch (_) {}
+
+      log('play() started at offset', safeOffset, _workletWired ? '(worklet-routed)' : '(direct)');
     }
 
     function _pause() {
@@ -261,11 +317,17 @@
       if (e.code === 'Space') { e.preventDefault(); if (_isPlaying) _pause(); else _play(); }
     });
 
-    /* Expose internal state for A/B patch */
+    /* Expose internal state for A/B patch + visualizer playhead */
     app._fixPlayState = {
       get isPlaying() { return _isPlaying; },
       resetOffset()   { _pauseOffset = 0; },
       restart()       { if (_isPlaying) { _stopSource(); _play(); } },
+      elapsed() {
+        const ctx = _getCtx();
+        if (!ctx) return _pauseOffset;
+        return _isPlaying ? (_pauseOffset + (ctx.currentTime - _startTime)) : _pauseOffset;
+      },
+      get analyser() { return _analyser; },
     };
 
     /* Enable play button when buffer lands */

--- a/public/app/visuals-bootstrap.js
+++ b/public/app/visuals-bootstrap.js
@@ -1,0 +1,400 @@
+/**
+ * visuals-bootstrap.js
+ * ─────────────────────────────────────────────────────────────────────────────
+ * Wires the visualization tabs to the playback analyser created in vip-fixes.js.
+ *
+ * What this owns (purely additive — no module imports, no STFT/iSTFT):
+ *   1. Static waveform render to #waveCanvas on `vip:fileLoaded`.
+ *   2. A single RAF loop driving:
+ *        • #spectro2DCanvas — scrolling 2D spectrogram (Inferno LUT from visuals.js)
+ *        • #freqCanvas      — frequency bar rail
+ *        • LUFS readouts (#lufsI / #lufsS) — rolling 400ms short-term, 3s integrated
+ *        • Header peak/RMS (#hPeak / #hRMS)
+ *   3. Lazy init of premium visualizers (aura / topo / swarm / liquid)
+ *      from premium-visuals.js the first time the user activates their tab.
+ *   4. Wave A/B comparison render whenever a processed buffer becomes available.
+ *
+ * Inputs:
+ *   • window._vipPlayAnalyser  → set by vip-fixes.js when play() starts
+ *   • Events:  vip:fileLoaded, vip:playStarted, vip:playStopped, vip:processingDone
+ *
+ * Hard constraints honored:
+ *   • Zero external fetches / zero network.
+ *   • Loaded as a classic <script src> so it works without ESM evaluation order
+ *     gymnastics. Exposes globals on window for testability.
+ *   • One RAF loop total (premium tab visualizers run their own internal loops,
+ *     but only one is active at a time and we stop the previous on tab switch).
+ * ─────────────────────────────────────────────────────────────────────────────
+ */
+(function (global) {
+  'use strict';
+
+  if (global.__VIP_VISUALS_BOOT__) return;
+  global.__VIP_VISUALS_BOOT__ = true;
+
+  const $ = (id) => document.getElementById(id);
+
+  /* ── State ────────────────────────────────────────────────────────────── */
+  let _rafId = 0;
+  let _running = false;
+  let _activeTab = 'spectrogram';
+  let _activePremium = null;   // { stop() } handle for aura/topo/swarm/liquid
+  let _activePremiumTab = null;
+  // Rolling spectrogram scroll position
+  let _specX = 0;
+  // LUFS rolling state
+  let _lufsShortBuf = []; // last ~400 ms of mean-square per RAF tick
+  let _lufsIntBuf   = []; // last ~3 s
+
+  /* ── Static waveform render ───────────────────────────────────────────── */
+  function _drawWaveformOnto(canvas, audioBuf, color) {
+    if (!canvas || !audioBuf || !audioBuf.getChannelData) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    const rect = canvas.getBoundingClientRect();
+    if (rect.width > 0)  canvas.width  = Math.floor(rect.width);
+    if (rect.height > 0) canvas.height = Math.floor(rect.height);
+    const w = canvas.width || 800;
+    const h = canvas.height || 120;
+    ctx.fillStyle = '#030306';
+    ctx.fillRect(0, 0, w, h);
+
+    const data = audioBuf.getChannelData(0);
+    const step = Math.max(1, Math.floor(data.length / w));
+    const mid  = h / 2;
+
+    ctx.strokeStyle = color || '#22d3ee';
+    ctx.fillStyle   = (color || '#22d3ee') + '33';
+    ctx.lineWidth   = 1;
+    ctx.beginPath();
+    ctx.moveTo(0, mid);
+    for (let x = 0; x < w; x++) {
+      let min = 1.0, max = -1.0;
+      const base = x * step;
+      const end = Math.min(base + step, data.length);
+      for (let i = base; i < end; i++) {
+        const v = data[i];
+        if (v < min) min = v;
+        if (v > max) max = v;
+      }
+      const yMin = mid - max * mid * 0.92;
+      const yMax = mid - min * mid * 0.92;
+      ctx.moveTo(x + 0.5, yMin);
+      ctx.lineTo(x + 0.5, yMax);
+    }
+    ctx.stroke();
+
+    // Zero line
+    ctx.strokeStyle = 'rgba(255,255,255,0.06)';
+    ctx.beginPath();
+    ctx.moveTo(0, mid);
+    ctx.lineTo(w, mid);
+    ctx.stroke();
+  }
+
+  function drawStaticVisuals() {
+    const app = global._vipApp;
+    if (!app) return;
+    const inBuf  = app.inputBuffer || app.origBuffer;
+    const outBuf = app.outputBuffer || app.procBuffer;
+    _drawWaveformOnto($('waveCanvas'), inBuf, '#22d3ee');
+    _drawWaveformOnto($('waveOrigCanvas'), inBuf,  '#22d3ee');
+    _drawWaveformOnto($('waveProcCanvas'), outBuf, '#69ff47');
+  }
+
+  /* ── 2D scrolling spectrogram using Inferno LUT (or fallback ramp) ────── */
+  function _drawSpectro2DColumn(canvas, freqBytes) {
+    if (!canvas) return;
+    // willReadFrequently=true avoids the Canvas2D readback warning since we
+    // call getImageData every RAF tick to scroll the spectrogram left by 1 px.
+    const ctx = canvas.getContext('2d', { willReadFrequently: true });
+    if (!ctx) return;
+    const w = canvas.width  || canvas.clientWidth || 800;
+    const h = canvas.height || canvas.clientHeight || 240;
+    if (canvas.width !== w || canvas.height !== h) {
+      canvas.width = w;
+      canvas.height = h;
+    }
+    // Shift image left by 1 px
+    try {
+      const img = ctx.getImageData(1, 0, w - 1, h);
+      ctx.putImageData(img, 0, 0);
+    } catch (_) { /* tainted canvas — recover by clearing */ ctx.clearRect(0, 0, w, h); }
+    // Draw new column at right edge
+    const colX = w - 1;
+    const N = freqBytes.length;
+    const lut = global.VIP_INFERNO_LUT;
+    for (let y = 0; y < h; y++) {
+      // Top of canvas = high freq, bottom = low. Use log scale.
+      const t = 1 - (y / h);
+      const idx = Math.min(N - 1, Math.floor(Math.pow(t, 2.0) * (N - 1)));
+      const v = freqBytes[idx] / 255;
+      if (lut) {
+        const li = Math.min(255, Math.floor(v * 255)) * 3;
+        ctx.fillStyle = 'rgb(' + lut[li] + ',' + lut[li + 1] + ',' + lut[li + 2] + ')';
+      } else {
+        // Built-in fallback gradient (cyan → magenta → yellow)
+        const r = Math.min(255, Math.floor(v * 320));
+        const g = Math.min(255, Math.floor((1 - Math.abs(v - 0.55)) * 220));
+        const b = Math.min(255, Math.floor((1 - v) * 220));
+        ctx.fillStyle = 'rgb(' + r + ',' + g + ',' + b + ')';
+      }
+      ctx.fillRect(colX, y, 1, 1);
+    }
+    _specX = (_specX + 1) % w;
+  }
+
+  /* ── Frequency bars ───────────────────────────────────────────────────── */
+  function _drawFreqBars(canvas, freqBytes) {
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    const rect = canvas.getBoundingClientRect();
+    const w = (rect.width > 0 ? Math.floor(rect.width) : canvas.width)  || 800;
+    const h = (rect.height > 0 ? Math.floor(rect.height) : canvas.height) || 80;
+    if (canvas.width !== w || canvas.height !== h) {
+      canvas.width = w;
+      canvas.height = h;
+    }
+    // Trail for motion blur
+    ctx.fillStyle = 'rgba(3,3,6,0.45)';
+    ctx.fillRect(0, 0, w, h);
+
+    const N = freqBytes.length;
+    const bars = 64;
+    const step = Math.max(1, Math.floor(N / bars));
+    const barW = w / bars;
+    for (let b = 0; b < bars; b++) {
+      let sum = 0;
+      const base = b * step;
+      const end = Math.min(base + step, N);
+      for (let i = base; i < end; i++) sum += freqBytes[i];
+      const avg = sum / (end - base);
+      const v = avg / 255;
+      const barH = v * h * 0.92;
+      // Color: cyan → red as frequency rises
+      const hue = 180 - (b / bars) * 160;
+      ctx.fillStyle = 'hsla(' + hue.toFixed(0) + ',95%,55%,0.9)';
+      ctx.fillRect(b * barW + 1, h - barH, Math.max(1, barW - 2), barH);
+    }
+  }
+
+  /* ── LUFS rolling estimate + header peak/RMS ──────────────────────────── */
+  function _updateLufs(timeBytes, freqBytes) {
+    // K-weighted LUFS is expensive — approximate with un-weighted RMS scaled to
+    // BS.1770 style ~−0.691 LU offset so the readouts feel familiar to ENGs.
+    let sumSq = 0;
+    let peak  = 0;
+    for (let i = 0; i < timeBytes.length; i++) {
+      const s = (timeBytes[i] - 128) / 128;
+      const a = Math.abs(s);
+      if (a > peak) peak = a;
+      sumSq += s * s;
+    }
+    const ms = sumSq / timeBytes.length;
+    _lufsShortBuf.push(ms);
+    _lufsIntBuf.push(ms);
+    if (_lufsShortBuf.length > 24) _lufsShortBuf.shift(); // ~400 ms @ 60 fps
+    if (_lufsIntBuf.length > 180) _lufsIntBuf.shift();    // ~3 s
+
+    const meanShort = _lufsShortBuf.reduce((a, b) => a + b, 0) / Math.max(1, _lufsShortBuf.length);
+    const meanInt   = _lufsIntBuf.reduce((a, b) => a + b, 0) / Math.max(1, _lufsIntBuf.length);
+
+    const lufsShort = meanShort > 1e-12 ? 10 * Math.log10(meanShort) - 0.691 : -70;
+    const lufsInt   = meanInt   > 1e-12 ? 10 * Math.log10(meanInt)   - 0.691 : -70;
+
+    const sEl = $('lufsS'); if (sEl) sEl.textContent = lufsShort.toFixed(1);
+    const iEl = $('lufsI'); if (iEl) iEl.textContent = lufsInt.toFixed(1);
+
+    // Header peak / rms
+    const peakDb = peak > 1e-6 ? 20 * Math.log10(peak) : -60;
+    const rmsDb  = meanShort > 1e-12 ? 10 * Math.log10(meanShort) : -60;
+    const fmt = (v) => (v >= 0 ? '+' : '') + v.toFixed(1) + ' dB';
+    const hPeak = $('hPeak'); if (hPeak) hPeak.textContent = fmt(peakDb);
+    const hRMS  = $('hRMS');  if (hRMS)  hRMS.textContent  = fmt(rmsDb);
+
+    // VU meters defined in static HTML — drive the first two as IN / OUT
+    const meters = document.querySelectorAll('#panel-vu-meters .vu-meter');
+    const toLevel = (db) => Math.max(0, ((db + 60) / 60) * 100).toFixed(1) + '%';
+    if (meters.length >= 1) meters[0].style.setProperty('--vu-level', toLevel(rmsDb));
+    if (meters.length >= 2) meters[1].style.setProperty('--vu-level', toLevel(peakDb));
+  }
+
+  /* ── Main RAF loop ────────────────────────────────────────────────────── */
+  function _loop() {
+    if (!_running) return;
+    _rafId = requestAnimationFrame(_loop);
+    const an = global._vipPlayAnalyser;
+    if (!an) return;
+
+    const bins = an.frequencyBinCount;
+    const freqBytes = new Uint8Array(bins);
+    const timeBytes = new Uint8Array(bins);
+    try {
+      an.getByteFrequencyData(freqBytes);
+      an.getByteTimeDomainData(timeBytes);
+    } catch (_) { return; }
+
+    // Always update LUFS / header — cheap and informative across tabs
+    _updateLufs(timeBytes, freqBytes);
+
+    // Tab-targeted draws — only redraw the active tab to keep RAF light
+    if (_activeTab === 'spectrogram') {
+      const spec2d = $('spectro2DCanvas');
+      if (spec2d) {
+        if (spec2d.style.display === 'none') spec2d.style.display = '';
+        _drawSpectro2DColumn(spec2d, freqBytes);
+      }
+      const freq = $('freqCanvas');
+      if (freq) _drawFreqBars(freq, freqBytes);
+    } else if (_activeTab === 'waveform') {
+      // Live playhead overlay on the static waveform
+      const wave = $('waveCanvas');
+      const app  = global._vipApp;
+      if (wave && app) {
+        const buf = app.inputBuffer || app.origBuffer;
+        if (buf) {
+          const ctx = wave.getContext('2d');
+          // Redraw static then overlay playhead (cheap — buffer is decoded once)
+          _drawWaveformOnto(wave, buf, '#22d3ee');
+          const playOffset = (app._fixPlayState && typeof app._fixPlayState.elapsed === 'function')
+            ? app._fixPlayState.elapsed()
+            : 0;
+          const dur = buf.duration || 1;
+          const px = (playOffset / dur) * wave.width;
+          ctx.strokeStyle = '#ff2a2a';
+          ctx.lineWidth = 1.5;
+          ctx.beginPath();
+          ctx.moveTo(px, 0);
+          ctx.lineTo(px, wave.height);
+          ctx.stroke();
+        }
+      }
+    }
+  }
+
+  function start() {
+    if (_running) return;
+    _running = true;
+    _rafId = requestAnimationFrame(_loop);
+  }
+  function stop() {
+    _running = false;
+    if (_rafId) { cancelAnimationFrame(_rafId); _rafId = 0; }
+  }
+
+  /* ── Premium visualizer lazy init on tab activation ───────────────────── */
+  function _stopPremium() {
+    if (_activePremium && typeof _activePremium.stop === 'function') {
+      try { _activePremium.stop(); } catch (_) {}
+    }
+    _activePremium = null;
+    _activePremiumTab = null;
+  }
+  function _initPremium(tabName) {
+    if (_activePremiumTab === tabName && _activePremium) return; // already running
+    _stopPremium();
+    const an = global._vipPlayAnalyser;
+    if (!an) return; // analyser will appear when play() starts; we'll re-init then
+    if (tabName === 'aura') {
+      const c = $('auraCanvas');
+      if (c && typeof global.VIP_initPulsingAura === 'function') {
+        const r = c.getBoundingClientRect();
+        if (r.width > 0)  c.width  = Math.floor(r.width);
+        if (r.height > 0) c.height = Math.floor(r.height);
+        _activePremium = global.VIP_initPulsingAura(an, c);
+      }
+    } else if (tabName === 'topo') {
+      const cont = $('topoContainer');
+      if (cont && typeof global.VIP_initTopographic3D === 'function') {
+        _activePremium = global.VIP_initTopographic3D(an, cont);
+      }
+    } else if (tabName === 'swarm') {
+      const cont = $('swarmContainer');
+      if (cont && typeof global.VIP_initParticleSwarm === 'function') {
+        _activePremium = global.VIP_initParticleSwarm(an, cont);
+      }
+    } else if (tabName === 'liquid') {
+      const c = $('liquidCanvas');
+      if (c && typeof global.VIP_initLiquidWaves === 'function') {
+        const r = c.getBoundingClientRect();
+        if (r.width > 0)  c.width  = Math.floor(r.width);
+        if (r.height > 0) c.height = Math.floor(r.height);
+        _activePremium = global.VIP_initLiquidWaves(an, c);
+      }
+    } else if (tabName === 'clusters' || tabName === 'lufs' || tabName === 'abcompare') {
+      // No premium visualizer to spin up — main RAF loop already drives meters/lufs
+    }
+    _activePremiumTab = tabName;
+  }
+
+  function _onTabActivated(tab) {
+    _activeTab = tab;
+    if (tab === 'aura' || tab === 'topo' || tab === 'swarm' || tab === 'liquid') {
+      _initPremium(tab);
+    } else if (tab === 'abcompare') {
+      // Refresh the A/B waveform pair lazily — output buffer may have arrived
+      drawStaticVisuals();
+      _stopPremium();
+    } else {
+      _stopPremium();
+    }
+  }
+
+  /* ── Listen for tab clicks via a delegated listener ───────────────────── */
+  function _wireTabListener() {
+    document.addEventListener('click', (e) => {
+      const t = e.target && e.target.closest && e.target.closest('.tab-btn[data-tab]');
+      if (!t) return;
+      const tab = t.dataset.tab;
+      if (!tab) return;
+      _onTabActivated(tab);
+    });
+  }
+
+  /* ── Event wiring ─────────────────────────────────────────────────────── */
+  function _bindEvents() {
+    window.addEventListener('vip:fileLoaded',     drawStaticVisuals);
+    window.addEventListener('vip:processingDone', drawStaticVisuals);
+    window.addEventListener('vip:playStarted', () => {
+      start();
+      if (_activePremiumTab) _initPremium(_activePremiumTab); // re-bind analyser
+    });
+    window.addEventListener('vip:playStopped', stop);
+
+    // Synthesize vip:fileLoaded when buffers arrive — vip-fixes already dispatches it
+    // but in case the legacy code path is used, poll briefly for first buffer.
+    let polls = 0;
+    const poll = setInterval(() => {
+      polls++;
+      const app = global._vipApp;
+      if (app && (app.inputBuffer || app.origBuffer)) {
+        clearInterval(poll);
+        try { window.dispatchEvent(new CustomEvent('vip:fileLoaded')); } catch (_) {}
+      } else if (polls > 600) { // ~60s
+        clearInterval(poll);
+      }
+    }, 100);
+  }
+
+  function _init() {
+    _wireTabListener();
+    _bindEvents();
+    // Initial render in case a file is already loaded (re-mount / hot reload)
+    setTimeout(drawStaticVisuals, 400);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', _init, { once: true });
+  } else {
+    _init();
+  }
+
+  /* ── Export for tests / diagnostics ───────────────────────────────────── */
+  global.VIP_VISUALS = {
+    drawStatic: drawStaticVisuals,
+    start, stop,
+    onTabActivated: _onTabActivated,
+    initPremium: _initPremium,
+  };
+})(typeof window !== 'undefined' ? window : this);

--- a/tests/visuals-bootstrap.test.js
+++ b/tests/visuals-bootstrap.test.js
@@ -1,0 +1,133 @@
+const fs = require('fs');
+const path = require('path');
+
+const VISUALS_BOOT_PATH = path.join(__dirname, '..', 'public', 'app', 'visuals-bootstrap.js');
+const INDEX_HTML_PATH   = path.join(__dirname, '..', 'public', 'app', 'index.html');
+const VIP_FIXES_PATH    = path.join(__dirname, '..', 'public', 'app', 'vip-fixes.js');
+const APP_JS_PATH       = path.join(__dirname, '..', 'public', 'app', 'app.js');
+
+describe('visuals-bootstrap.js — visualization driver', () => {
+  let src;
+  beforeAll(() => { src = fs.readFileSync(VISUALS_BOOT_PATH, 'utf8'); });
+
+  test('file exists and is non-trivial', () => {
+    expect(src.length).toBeGreaterThan(3000);
+  });
+
+  test('exposes VIP_VISUALS API on window', () => {
+    expect(src).toContain('global.VIP_VISUALS');
+    expect(src).toContain('drawStatic');
+    expect(src).toContain('onTabActivated');
+    expect(src).toContain('initPremium');
+    expect(src).toContain('start');
+    expect(src).toContain('stop');
+  });
+
+  test('listens for vip:fileLoaded, vip:playStarted, vip:playStopped, vip:processingDone', () => {
+    expect(src).toContain("'vip:fileLoaded'");
+    expect(src).toContain("'vip:playStarted'");
+    expect(src).toContain("'vip:playStopped'");
+    expect(src).toContain("'vip:processingDone'");
+  });
+
+  test('wires premium visualizers for aura, topo, swarm, liquid', () => {
+    expect(src).toContain('VIP_initPulsingAura');
+    expect(src).toContain('VIP_initTopographic3D');
+    expect(src).toContain('VIP_initParticleSwarm');
+    expect(src).toContain('VIP_initLiquidWaves');
+  });
+
+  test('uses VIP_INFERNO_LUT from visuals.js for spectrogram colors', () => {
+    expect(src).toContain('VIP_INFERNO_LUT');
+  });
+
+  test('reads from window._vipPlayAnalyser', () => {
+    expect(src).toContain('_vipPlayAnalyser');
+  });
+
+  test('owns a single RAF loop guarded by a running flag', () => {
+    expect(src).toContain('requestAnimationFrame');
+    expect(src).toContain('_running');
+    // Single _loop function as the RAF callback
+    expect(src.match(/function _loop/g) || []).toHaveLength(1);
+  });
+
+  test('does NOT define any STFT/iSTFT or fetch — pure tap consumer', () => {
+    expect(src).not.toMatch(/forwardSTFT|inverseSTFT/);
+    expect(src).not.toMatch(/\bfetch\s*\(/);
+  });
+});
+
+describe('visuals-bootstrap loading and event wiring', () => {
+  test('index.html loads visuals-bootstrap.js after visuals.js + premium-visuals.js', () => {
+    const html = fs.readFileSync(INDEX_HTML_PATH, 'utf8');
+    const visualsIdx        = html.indexOf('./visuals.js');
+    const premiumIdx        = html.indexOf('./premium-visuals.js');
+    const bootstrapIdx      = html.indexOf('./visuals-bootstrap.js');
+    expect(visualsIdx).toBeGreaterThan(-1);
+    expect(premiumIdx).toBeGreaterThan(-1);
+    expect(bootstrapIdx).toBeGreaterThan(-1);
+    expect(bootstrapIdx).toBeGreaterThan(visualsIdx);
+    expect(bootstrapIdx).toBeGreaterThan(premiumIdx);
+  });
+
+  test('vip-fixes.js dispatches vip:playStarted with analyser detail', () => {
+    const src = fs.readFileSync(VIP_FIXES_PATH, 'utf8');
+    expect(src).toContain("'vip:playStarted'");
+    expect(src).toContain('analyser: _analyser');
+  });
+
+  test('vip-fixes.js dispatches vip:playStopped on teardown', () => {
+    const src = fs.readFileSync(VIP_FIXES_PATH, 'utf8');
+    expect(src).toContain("'vip:playStopped'");
+  });
+
+  test('vip-fixes.js routes playback through orchestrator workletNode when present', () => {
+    const src = fs.readFileSync(VIP_FIXES_PATH, 'utf8');
+    expect(src).toMatch(/_vipOrch\?\.workletNode|_vipOrch\.workletNode/);
+    expect(src).toContain('_gainNode.connect(orchWorklet)');
+  });
+
+  test('vip-fixes.js taps an analyser node and exposes it on window._vipPlayAnalyser', () => {
+    const src = fs.readFileSync(VIP_FIXES_PATH, 'utf8');
+    expect(src).toContain('createAnalyser');
+    expect(src).toContain('window._vipPlayAnalyser');
+  });
+
+  test('app.js dispatches vip:fileLoaded after onAudioLoaded', () => {
+    const src = fs.readFileSync(APP_JS_PATH, 'utf8');
+    expect(src).toContain("'vip:fileLoaded'");
+  });
+
+  test('app.js dispatches vip:processingDone after runPipeline success', () => {
+    const src = fs.readFileSync(APP_JS_PATH, 'utf8');
+    expect(src).toContain("'vip:processingDone'");
+  });
+});
+
+describe('visuals-bootstrap module evaluated in jsdom-like sandbox', () => {
+  test('exposes VIP_VISUALS object with expected methods after IIFE runs', () => {
+    const { JSDOM } = require('jsdom');
+    const dom = new JSDOM('<!doctype html><html><body></body></html>', {
+      runScripts: 'outside-only',
+      pretendToBeVisual: true,
+    });
+    const { window } = dom;
+    // Provide stubs the script references through the global namespace
+    window.VIP_INFERNO_LUT = new Uint8ClampedArray(256 * 3);
+    window.VIP_initPulsingAura   = () => ({ stop() {} });
+    window.VIP_initTopographic3D = () => ({ stop() {} });
+    window.VIP_initParticleSwarm = () => ({ stop() {} });
+    window.VIP_initLiquidWaves   = () => ({ stop() {} });
+
+    const src = fs.readFileSync(VISUALS_BOOT_PATH, 'utf8');
+    window.eval(src);
+
+    expect(window.VIP_VISUALS).toBeTruthy();
+    expect(typeof window.VIP_VISUALS.drawStatic).toBe('function');
+    expect(typeof window.VIP_VISUALS.onTabActivated).toBe('function');
+    expect(typeof window.VIP_VISUALS.initPremium).toBe('function');
+    expect(typeof window.VIP_VISUALS.start).toBe('function');
+    expect(typeof window.VIP_VISUALS.stop).toBe('function');
+  });
+});


### PR DESCRIPTION
## Summary

The transport playback path in `vip-fixes.js` previously bypassed both the orchestrator's `AudioWorkletNode` and any `AnalyserNode`, so:

- Live slider changes (gate / EQ / compressor / limiter) were **inaudible** during playback because the buffer source went `Source → Gain → ctx.destination` and never touched the worklet.
- Every downstream visualizer (`Spectrogram`, `Waveform`, `A/B`, `LUFS`, `Clusters`, `Aura`, `3D Topo`, `Swarm`, `Liquid`) had no analyser to read from, so the tabs rendered nothing during playback.
- The premium visualizers in `premium-visuals.js` (aura / topo / swarm / liquid) were defined but **never wired** — switching to those tabs did nothing.

This PR fixes the routing and wires every visualizer end-to-end.

### Routing chain change

Before:
```
Source → Gain → ctx.destination          (worklet + analyser orphaned)
```
After:
```
Source → Gain → [Worklet] → Analyser → ctx.destination
```
Built once and reused across replays — only the new `AudioBufferSourceNode` is reconnected per play, so we don't tear down the worklet's other connections.

## Changes

| File | What changed |
|------|--------------|
| `public/app/vip-fixes.js` | Insert `workletNode` + `AnalyserNode` in `_play()`. Build the chain once. Expose `window._vipPlayAnalyser`. Dispatch `vip:playStarted` / `vip:playStopped`. Add `_fixPlayState.elapsed()` + `.analyser` getter for the visualizer playhead. |
| `public/app/visuals-bootstrap.js` (new) | Single RAF loop that drives 2D scrolling spectrogram, frequency bars, LUFS readouts, header peak/RMS, VU meters, waveform playhead. Lazy-init for the four premium visualizers when their tab activates. Listens for `vip:fileLoaded` / `vip:processingDone` to refresh waveform and A/B canvases. |
| `public/app/index.html` | Load `visuals-bootstrap.js` after `visuals.js` + `premium-visuals.js` so `VIP_INFERNO_LUT` and the premium init helpers are defined. |
| `public/app/app.js` | Dispatch `vip:fileLoaded` after `onAudioLoaded()` and `vip:processingDone` after successful `runPipeline()`. |
| `tests/visuals-bootstrap.test.js` (new) | 16 tests covering the module's API surface, event wiring, load order, and a jsdom IIFE evaluation. |

## Test plan

- [x] `pnpm test` — **65 suites, 1914 tests** pass (was 64 / 1898)
- [x] `pnpm lint` — 0 errors, 23 warnings (pre-existing)
- [x] `pnpm validate` — all structural checks pass
- [x] `pnpm test:live` — Playwright smoke runs to completion (the existing peak/cov thresholds are pre-existing DSP-tuning issues unrelated to this PR; the pipeline now finishes with much lower frame-to-frame variance than before — cov dropped from ~1.3 to ~0.3)
- [x] Custom Playwright probe in headless Chromium confirms after first user gesture:
  - `window._vipPlayAnalyser` is created with `fftSize === 2048`
  - `window.VIP_VISUALS` exposes `drawStatic / start / stop / onTabActivated / initPremium`
  - `window.VIP_INFERNO_LUT` colormap is ready
  - `window._vipOrch.workletNode` is present
  - `AudioContext.state === 'running'`

## Constraints honored

- Zero new fetches, no CDN URLs — pure tap consumer.
- No new STFT/iSTFT pairs — visualizers read time/frequency bytes from the existing analyser.
- Single RAF loop in the driver; premium tabs run their own internal loop but only one premium is active at a time and the previous one is stopped on tab switch.
- `pipeline-orchestrator.js` retains exclusive ownership of `audioWorklet.addModule()` and the ML Worker — `vip-fixes.js` only **uses** the `workletNode` reference the orchestrator exposes.

https://claude.ai/code/session_01YQvK9smo7aERhgJT3CrX17

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQvK9smo7aERhgJT3CrX17)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added real-time visualization UI with spectrograms, frequency analysis, and audio metering during playback
  * Implemented playback lifecycle events enabling external integrations and custom observers
  * Added premium visualization modes (aura, topo, swarm, liquid) with waveform overlay capability
  * Enhanced file loading and processing completion feedback through custom events

* **Tests**
  * Added comprehensive test suite validating visualization system and event handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Joker5514/VoiceIsolate-Pro/pull/569?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->