### PR TITLE
🎨 Palette: Add title attribute to stats toggle button

### DIFF
--- a/public/app/index.html
+++ b/public/app/index.html
@@ -124,7 +124,7 @@
     <div class="hdr-actions">
       <a class="btn btn-outline hdr-link" href="how-it-works.html">How It Works</a>
     </div>
-    <button id="statsToggle" class="hdr-stats-toggle" aria-label="Toggle stats" aria-expanded="false">&#9660;</button>
+    <button id="statsToggle" class="hdr-stats-toggle" aria-label="Toggle stats" title="Toggle stats" aria-expanded="false">&#9660;</button>
     <div class="hdr-stats" id="hdrStats">
       <div class="hdr-stat"><span class="hs-val" id="hSNR">-- dB</span><span class="hs-lbl">SNR Gain</span></div>
       <div class="hdr-stat"><span class="hs-val" id="hDur">--</span><span class="hs-lbl">Duration</span></div>


### PR DESCRIPTION
💡 What: Added the `title` attribute to the `statsToggle` icon button in `public/app/index.html`.
🎯 Why: The stats toggle button (`&#9660;`) was icon-only. It had an `aria-label` for screen readers but lacked a `title` attribute to show a tooltip on mouse hover, making it less intuitive for sighted mouse users.
📸 Before/After: Before, hovering the `▼` button showed no tooltip. Now, it displays "Toggle stats".
♿ Accessibility: Ensures that both screen reader users (via `aria-label`) and mouse users (via `title` tooltip) receive the same context for this icon-only button.

---
*PR created automatically by Jules for task [16062049490660066817](https://jules.google.com/task/16062049490660066817) started by @Joker5514*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add tooltip to stats toggle button in app header
> Adds a `title="Toggle stats"` attribute to the `#statsToggle` button in [index.html](https://github.com/Joker5514/VoiceIsolate-Pro/pull/572/files#diff-4400aa5aa5292d143f7e2f1308aa82756255552567d5558874c994833e907ce4), so browsers display a native tooltip on hover or focus.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0a47a83.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Minor internal markup updates with no visible impact to functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->