### PR TITLE
fix: harden runtime stability — DOM caching, worker watchdog, inference timeout, button re-enable

### DIFF
--- a/public/app/app.js
+++ b/public/app/app.js
@@ -756,9 +756,8 @@ class VoiceIsolatePro {
       if (this.mode === 'live') this.stopLive(); else this.startLive();
     });
 
-    // PATCHED BY vip-fixes.js — consider merging
     // Transport
-    bind('playBtn', this.dom.tpPlay, 'click', () => { this.togglePlayback(); });
+    bind('playBtn', this.dom.playBtn, 'click', () => { this.togglePlayback(); });
     bind('tpPlay', d.tpPlay, 'click', () => { this.togglePlayback(); });
     bind('tpPause', d.tpPause, 'click', () => this.pause());
     bind('tpStop', d.tpStop, 'click', () => this.stop());
@@ -1120,6 +1119,7 @@ class VoiceIsolatePro {
       this.updatePipelineProgress(0, 'Error', 0);
     } finally {
       this.isProcessing = false;
+      this._updateProcessButtonsState();
       if (this.dom.mobileProcessBtn) {
         this.dom.mobileProcessBtn.style.display='inline-flex';
       }

--- a/public/app/ml-worker.js
+++ b/public/app/ml-worker.js
@@ -555,11 +555,12 @@ self.onmessage = async (ev) => {
           [separated.buffer],
         );
       } catch (err) {
-        if (err.message.startsWith('Inference timed out')) {
+        const errMsg = (err && err.message) ? err.message : String(err);
+        if (errMsg.startsWith('Inference timed out')) {
           delete sessions['bsrnn_complex'];
           delete sessions['bsrnn_vocals_complex'];
         }
-        fail(`bsrnnComplex: ${err.message}`);
+        fail(`bsrnnComplex: ${errMsg}`);
       }
       break;
     }
@@ -846,12 +847,13 @@ self.onmessage = async (ev) => {
 
         self.postMessage({ type: 'mask', model: modelKey, mask: outMask }, [outMask.buffer]);
       } catch (inferErr) {
-        if (inferErr.message.startsWith('Inference timed out')) {
+        const inferErrMsg = (inferErr && inferErr.message) ? inferErr.message : String(inferErr);
+        if (inferErrMsg.startsWith('Inference timed out')) {
           delete sessions[modelKey];
           delete sessions[modelKey + '-v4'];
           delete sessions[modelKey + '_vocals'];
         }
-        self.postMessage({ type: 'error', message: `infer(${modelKey}): ${inferErr.message}` });
+        self.postMessage({ type: 'error', message: `infer(${modelKey}): ${inferErrMsg}` });
       }
       break;
     }

--- a/public/app/ml-worker.js
+++ b/public/app/ml-worker.js
@@ -355,12 +355,14 @@ async function runDiarization(pcm, sampleRate) {
 // ── Inference timeout helper — prevents a hung ONNX session from blocking the worker indefinitely ──
 const INFERENCE_TIMEOUT_MS = 30000;
 function _runWithTimeout(session, feeds) {
-  return Promise.race([
-    session.run(feeds),
-    new Promise((_, reject) =>
-      setTimeout(() => reject(new Error('Inference timed out after ' + INFERENCE_TIMEOUT_MS + 'ms')), INFERENCE_TIMEOUT_MS)
-    ),
-  ]);
+  let timer;
+  const timeoutPromise = new Promise((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error('Inference timed out after ' + INFERENCE_TIMEOUT_MS + 'ms')),
+      INFERENCE_TIMEOUT_MS
+    );
+  });
+  return Promise.race([session.run(feeds), timeoutPromise]).finally(() => clearTimeout(timer));
 }
 
 // ── 1. Message dispatcher ─────────────────────────────────────────────────────
@@ -553,6 +555,10 @@ self.onmessage = async (ev) => {
           [separated.buffer],
         );
       } catch (err) {
+        if (err.message.startsWith('Inference timed out')) {
+          delete sessions['bsrnn_complex'];
+          delete sessions['bsrnn_vocals_complex'];
+        }
         fail(`bsrnnComplex: ${err.message}`);
       }
       break;
@@ -840,6 +846,11 @@ self.onmessage = async (ev) => {
 
         self.postMessage({ type: 'mask', model: modelKey, mask: outMask }, [outMask.buffer]);
       } catch (inferErr) {
+        if (inferErr.message.startsWith('Inference timed out')) {
+          delete sessions[modelKey];
+          delete sessions[modelKey + '-v4'];
+          delete sessions[modelKey + '_vocals'];
+        }
         self.postMessage({ type: 'error', message: `infer(${modelKey}): ${inferErr.message}` });
       }
       break;

--- a/public/app/ml-worker.js
+++ b/public/app/ml-worker.js
@@ -352,6 +352,17 @@ async function runDiarization(pcm, sampleRate) {
   return segments.filter(s => s.speakerId !== null && (s.end - s.start) >= 0.3);
 }
 
+// ── Inference timeout helper — prevents a hung ONNX session from blocking the worker indefinitely ──
+const INFERENCE_TIMEOUT_MS = 30000;
+function _runWithTimeout(session, feeds) {
+  return Promise.race([
+    session.run(feeds),
+    new Promise((_, reject) =>
+      setTimeout(() => reject(new Error('Inference timed out after ' + INFERENCE_TIMEOUT_MS + 'ms')), INFERENCE_TIMEOUT_MS)
+    ),
+  ]);
+}
+
 // ── 1. Message dispatcher ─────────────────────────────────────────────────────
 self.onmessage = async (ev) => {
   const { type, payload, models: msgModels } = ev.data || {};
@@ -529,7 +540,7 @@ self.onmessage = async (ev) => {
       }
       try {
         const tensor = new ort.Tensor('float32', flat, [1, 4, halfBins, timeFrames]);
-        const result = await session.run({ input: tensor });
+        const result = await _runWithTimeout(session, { input: tensor });
         const out = result.output?.data || result[Object.keys(result)[0]]?.data;
         if (!out || out.length !== expected) {
           fail(`bsrnnComplex: output size ${out?.length} != expected ${expected}`);
@@ -798,12 +809,12 @@ self.onmessage = async (ev) => {
         if (modelKey === 'demucs' || modelKey.startsWith('demucs')) {
           // Demucs operates on PCM; fall back to magnitude-based proxy mask
           const tensor = new ort.Tensor('float32', mag, [1, 1, numBins]);
-          const result = await session.run({ input: tensor });
+          const result = await _runWithTimeout(session, { input: tensor });
           maskData = result.vocal_mask?.data || result.output?.data || null;
         } else {
           // BSRNN and others accept [1, numBins] magnitude input
           const tensor = new ort.Tensor('float32', mag, [1, numBins]);
-          const result = await session.run({ input: tensor });
+          const result = await _runWithTimeout(session, { input: tensor });
           maskData = result.vocal_mask?.data || result.output?.data || null;
         }
 

--- a/public/app/pipeline-orchestrator.js
+++ b/public/app/pipeline-orchestrator.js
@@ -147,13 +147,17 @@ class PipelineOrchestrator {
     /** @type {AudioWorkletNode|null} */
     this.workletNode  = null;
     /** @type {Worker|null} */
-    this.mlWorker       = null;
+    this.mlWorker             = null;
     /** @type {boolean} */
-    this.mlReady        = false;
+    this.mlReady              = false;
     /** @type {number} */
-    this._mlLastMessage = 0;
+    this._mlLastMessage       = 0;
     /** @type {number|null} */
-    this._mlWatchdog    = null;
+    this._mlWatchdog          = null;
+    /** @type {number} */
+    this._pendingMsgCount     = 0;
+    /** @type {boolean} */
+    this._postMessageWrapped  = false;
     /** @type {boolean} */
     this.workletReady = false;
     /** @type {string} */
@@ -402,6 +406,10 @@ class PipelineOrchestrator {
       this.mlWorker.onmessage = (e) => {
         this._mlLastMessage = Date.now();
         const { type } = e.data;
+        // Decrement pending count for any response that isn't a passive log/status
+        if (type !== 'log' && type !== 'vad_status') {
+          this._pendingMsgCount = Math.max(0, this._pendingMsgCount - 1);
+        }
         if (type === 'ready') {
           this.mlReady    = true;
           this.mlProvider = e.data.provider || 'wasm';
@@ -430,13 +438,35 @@ class PipelineOrchestrator {
             }
           } catch (_) { /* best-effort */ }
           this._mlLastMessage = Date.now();
-          this._mlWatchdog = setInterval(() => {
-            if (!this.mlReady || !this.mlWorker) return;
-            if (Date.now() - this._mlLastMessage > 10000) {
-              console.warn('[Orchestrator] ML worker appears stalled — no messages for >10s');
-              this._mlLastMessage = Date.now();
-            }
-          }, 2000);
+          // Wrap postMessage once to count requests that expect a response.
+          // SAB-based live inference does not go through postMessage, so the
+          // watchdog must only fire when a tracked request has gone unanswered.
+          if (!this._postMessageWrapped) {
+            this._postMessageWrapped = true;
+            const _EXPECTS_RESPONSE = new Set([
+              'init', 'loadModel', 'process', 'bsrnnComplex',
+              'diarize', 'multi_separate', 'enrollVoiceprint',
+              'enrollFromDiarization', 'clearVoiceprint', 'infer',
+            ]);
+            const _origPost = this.mlWorker.postMessage.bind(this.mlWorker);
+            this.mlWorker.postMessage = (msg, transfer) => {
+              if (msg && _EXPECTS_RESPONSE.has(msg.type)) {
+                this._pendingMsgCount++;
+              }
+              _origPost(msg, transfer);
+            };
+          }
+          // Guard against duplicate intervals if 'ready' fires more than once
+          if (!this._mlWatchdog) {
+            this._mlWatchdog = setInterval(() => {
+              if (!this.mlReady || !this.mlWorker) return;
+              if (this._pendingMsgCount > 0 && Date.now() - this._mlLastMessage > 10000) {
+                console.warn('[Orchestrator] ML worker appears stalled — pending request timed out');
+                this._mlLastMessage = Date.now();
+                this._pendingMsgCount = 0;
+              }
+            }, 2000);
+          }
           resolve();
         } else if (type === 'log') {
           const lvl = e.data.level;

--- a/public/app/pipeline-orchestrator.js
+++ b/public/app/pipeline-orchestrator.js
@@ -119,6 +119,19 @@ async function loadDspProcessorWorklet(ctx) {
 // Expose for tests + diagnostics; keeps the helper available without polluting globals further.
 if (typeof self !== 'undefined') self.loadDspProcessorWorklet = loadDspProcessorWorklet;
 
+// Message types that mark a tracked request as complete.
+// Used by the ML worker watchdog to avoid false-positive stall warnings from
+// intermediate progress messages (e.g. model_loaded before ready, log lines, etc.)
+const _ML_TERMINAL_RESPONSES = new Set([
+  'ready',               // completes: init
+  'error',               // completes: any failed request
+  'mask',                // completes: infer
+  'bsrnnComplexResult',  // completes: bsrnnComplex
+  'diarization',         // completes: diarize
+  'voiceprintEnrolled',  // completes: enrollVoiceprint, enrollFromDiarization
+  'voiceprintCleared',   // completes: clearVoiceprint
+]);
+
 /**
  * PipelineOrchestrator
  * ─────────────────────
@@ -406,8 +419,9 @@ class PipelineOrchestrator {
       this.mlWorker.onmessage = (e) => {
         this._mlLastMessage = Date.now();
         const { type } = e.data;
-        // Decrement pending count for any response that isn't a passive log/status
-        if (type !== 'log' && type !== 'vad_status') {
+        // Only decrement on terminal responses — intermediate messages like
+        // model_loaded or progress updates must not prematurely clear the count
+        if (_ML_TERMINAL_RESPONSES.has(type)) {
           this._pendingMsgCount = Math.max(0, this._pendingMsgCount - 1);
         }
         if (type === 'ready') {
@@ -438,24 +452,6 @@ class PipelineOrchestrator {
             }
           } catch (_) { /* best-effort */ }
           this._mlLastMessage = Date.now();
-          // Wrap postMessage once to count requests that expect a response.
-          // SAB-based live inference does not go through postMessage, so the
-          // watchdog must only fire when a tracked request has gone unanswered.
-          if (!this._postMessageWrapped) {
-            this._postMessageWrapped = true;
-            const _EXPECTS_RESPONSE = new Set([
-              'init', 'loadModel', 'process', 'bsrnnComplex',
-              'diarize', 'multi_separate', 'enrollVoiceprint',
-              'enrollFromDiarization', 'clearVoiceprint', 'infer',
-            ]);
-            const _origPost = this.mlWorker.postMessage.bind(this.mlWorker);
-            this.mlWorker.postMessage = (msg, transfer) => {
-              if (msg && _EXPECTS_RESPONSE.has(msg.type)) {
-                this._pendingMsgCount++;
-              }
-              _origPost(msg, transfer);
-            };
-          }
           // Guard against duplicate intervals if 'ready' fires more than once
           if (!this._mlWatchdog) {
             this._mlWatchdog = setInterval(() => {
@@ -605,6 +601,26 @@ class PipelineOrchestrator {
           // Preload failure is fully non-fatal — DSP passthrough continues
           console.warn('[Orchestrator] Model preload warning:', err.message);
         });
+      }
+
+      // ── Wrap postMessage before sending the first tracked request ──────────
+      // Installed here (before 'init') so the init round-trip is covered.
+      // SAB-based live inference does not go through postMessage, so the
+      // watchdog only fires when a tracked message-based request goes unanswered.
+      if (!this._postMessageWrapped) {
+        this._postMessageWrapped = true;
+        const _EXPECTS_RESPONSE = new Set([
+          'init', 'loadModel', 'process', 'bsrnnComplex',
+          'diarize', 'multi_separate', 'enrollVoiceprint',
+          'enrollFromDiarization', 'clearVoiceprint', 'infer',
+        ]);
+        const _origPost = this.mlWorker.postMessage.bind(this.mlWorker);
+        this.mlWorker.postMessage = (msg, transfer) => {
+          if (msg && _EXPECTS_RESPONSE.has(msg.type)) {
+            this._pendingMsgCount++;
+          }
+          _origPost(msg, transfer);
+        };
       }
 
       // ── Init message ─────────────────────────────────────────────────────
@@ -1141,8 +1157,11 @@ class PipelineOrchestrator {
     if (this.mlWorker)   { this.mlWorker.terminate();  this.mlWorker   = null; }
     if (this.workletNode){ try { this.workletNode.disconnect(); } catch (_) {} this.workletNode = null; }
     if (this.ctx && this.ctx.state !== 'closed') { this.ctx.close(); this.ctx = null; }
-    this.mlReady = false;
-    this.initialized = false;
+    this.mlReady           = false;
+    this.initialized       = false;
+    this._mlLastMessage    = 0;
+    this._pendingMsgCount  = 0;
+    this._postMessageWrapped = false;
   }
 }
 

--- a/public/app/pipeline-orchestrator.js
+++ b/public/app/pipeline-orchestrator.js
@@ -147,9 +147,13 @@ class PipelineOrchestrator {
     /** @type {AudioWorkletNode|null} */
     this.workletNode  = null;
     /** @type {Worker|null} */
-    this.mlWorker     = null;
+    this.mlWorker       = null;
     /** @type {boolean} */
-    this.mlReady      = false;
+    this.mlReady        = false;
+    /** @type {number} */
+    this._mlLastMessage = 0;
+    /** @type {number|null} */
+    this._mlWatchdog    = null;
     /** @type {boolean} */
     this.workletReady = false;
     /** @type {string} */
@@ -396,6 +400,7 @@ class PipelineOrchestrator {
       // ── Standard message handler (must be set BEFORE _mlWorkerPatch so the
       //    patch wraps this handler and can forward messages to it) ──────────
       this.mlWorker.onmessage = (e) => {
+        this._mlLastMessage = Date.now();
         const { type } = e.data;
         if (type === 'ready') {
           this.mlReady    = true;
@@ -424,6 +429,14 @@ class PipelineOrchestrator {
               window._attachMLWorkerToIsolation(this.mlWorker);
             }
           } catch (_) { /* best-effort */ }
+          this._mlLastMessage = Date.now();
+          this._mlWatchdog = setInterval(() => {
+            if (!this.mlReady || !this.mlWorker) return;
+            if (Date.now() - this._mlLastMessage > 10000) {
+              console.warn('[Orchestrator] ML worker appears stalled — no messages for >10s');
+              this._mlLastMessage = Date.now();
+            }
+          }, 2000);
           resolve();
         } else if (type === 'log') {
           const lvl = e.data.level;
@@ -1094,6 +1107,7 @@ class PipelineOrchestrator {
 
   // ── Teardown ──────────────────────────────────────────────────────────────
   destroy() {
+    if (this._mlWatchdog) { clearInterval(this._mlWatchdog); this._mlWatchdog = null; }
     if (this.mlWorker)   { this.mlWorker.terminate();  this.mlWorker   = null; }
     if (this.workletNode){ try { this.workletNode.disconnect(); } catch (_) {} this.workletNode = null; }
     if (this.ctx && this.ctx.state !== 'closed') { this.ctx.close(); this.ctx = null; }

--- a/public/app/processing-overlay.js
+++ b/public/app/processing-overlay.js
@@ -619,9 +619,11 @@
     _refs:            null,
 
     _initRefs() {
-      if (this._refs) return;
+      if (this._refs && this._refs.el) return;
+      const el = document.getElementById('processingOverlay');
+      if (!el) return;
       this._refs = {
-        el:         document.getElementById('processingOverlay'),
+        el,
         stageChip:  document.getElementById('procStageChip'),
         stageName:  document.getElementById('procStageName'),
         stageIndex: document.getElementById('procStageIndex'),
@@ -634,18 +636,18 @@
       this._pills = Array.from(document.querySelectorAll('.proc-phase-pill'));
     },
 
-    _el()         { this._initRefs(); return this._refs.el; },
-    _stageChip()  { this._initRefs(); return this._refs.stageChip; },
-    _stageName()  { this._initRefs(); return this._refs.stageName; },
-    _stageIndex() { this._initRefs(); return this._refs.stageIndex; },
-    _pct()        { this._initRefs(); return this._refs.pct; },
-    _bar()        { this._initRefs(); return this._refs.bar; },
-    _msg()        { this._initRefs(); return this._refs.msg; },
-    _focus()      { this._initRefs(); return this._refs.focus; },
-    _mode()       { this._initRefs(); return this._refs.mode; },
+    _el()         { this._initRefs(); return this._refs && this._refs.el; },
+    _stageChip()  { this._initRefs(); return this._refs && this._refs.stageChip; },
+    _stageName()  { this._initRefs(); return this._refs && this._refs.stageName; },
+    _stageIndex() { this._initRefs(); return this._refs && this._refs.stageIndex; },
+    _pct()        { this._initRefs(); return this._refs && this._refs.pct; },
+    _bar()        { this._initRefs(); return this._refs && this._refs.bar; },
+    _msg()        { this._initRefs(); return this._refs && this._refs.msg; },
+    _focus()      { this._initRefs(); return this._refs && this._refs.focus; },
+    _mode()       { this._initRefs(); return this._refs && this._refs.mode; },
     _phasePills() {
       this._initRefs();
-      return this._pills;
+      return this._pills || [];
     },
 
     _initCanvases() {

--- a/public/app/processing-overlay.js
+++ b/public/app/processing-overlay.js
@@ -619,7 +619,7 @@
     _refs:            null,
 
     _initRefs() {
-      if (this._refs && this._refs.el) return;
+      if (this._refs && this._refs.el && this._refs.el.isConnected) return;
       const el = document.getElementById('processingOverlay');
       if (!el) return;
       this._refs = {

--- a/public/app/processing-overlay.js
+++ b/public/app/processing-overlay.js
@@ -616,20 +616,35 @@
     _spinner:         null,
     _spectro:         null,
     _pills:           null,
+    _refs:            null,
 
-    _el()          { return document.getElementById('processingOverlay'); },
-    _stageChip()   { return document.getElementById('procStageChip'); },
-    _stageName()   { return document.getElementById('procStageName'); },
-    _stageIndex()  { return document.getElementById('procStageIndex'); },
-    _pct()         { return document.getElementById('procPct'); },
-    _bar()         { return document.getElementById('procBarFill'); },
-    _msg()         { return document.getElementById('procMessage'); },
-    _focus()       { return document.getElementById('procFocusVal'); },
-    _mode()        { return document.getElementById('procModeVal'); },
-    _phasePills()  {
-      if (!this._pills) {
-        this._pills = Array.from(document.querySelectorAll('.proc-phase-pill'));
-      }
+    _initRefs() {
+      if (this._refs) return;
+      this._refs = {
+        el:         document.getElementById('processingOverlay'),
+        stageChip:  document.getElementById('procStageChip'),
+        stageName:  document.getElementById('procStageName'),
+        stageIndex: document.getElementById('procStageIndex'),
+        pct:        document.getElementById('procPct'),
+        bar:        document.getElementById('procBarFill'),
+        msg:        document.getElementById('procMessage'),
+        focus:      document.getElementById('procFocusVal'),
+        mode:       document.getElementById('procModeVal'),
+      };
+      this._pills = Array.from(document.querySelectorAll('.proc-phase-pill'));
+    },
+
+    _el()         { this._initRefs(); return this._refs.el; },
+    _stageChip()  { this._initRefs(); return this._refs.stageChip; },
+    _stageName()  { this._initRefs(); return this._refs.stageName; },
+    _stageIndex() { this._initRefs(); return this._refs.stageIndex; },
+    _pct()        { this._initRefs(); return this._refs.pct; },
+    _bar()        { this._initRefs(); return this._refs.bar; },
+    _msg()        { this._initRefs(); return this._refs.msg; },
+    _focus()      { this._initRefs(); return this._refs.focus; },
+    _mode()       { this._initRefs(); return this._refs.mode; },
+    _phasePills() {
+      this._initRefs();
       return this._pills;
     },
 

--- a/tests/play-button-wiring.test.js
+++ b/tests/play-button-wiring.test.js
@@ -8,7 +8,12 @@ describe('play button and controls diagnostics wiring', () => {
 
   test('bindEvents wires tpPlay to togglePlayback()', () => {
     const appJs = fs.readFileSync(appJsPath, 'utf8');
-    expect(appJs).toContain("bind('playBtn', this.dom.tpPlay, 'click', () => { this.togglePlayback(); });");
+    expect(appJs).toContain("bind('tpPlay', d.tpPlay, 'click', () => { this.togglePlayback(); });");
+  });
+
+  test('bindEvents wires playBtn alias to its own DOM element (not tpPlay)', () => {
+    const appJs = fs.readFileSync(appJsPath, 'utf8');
+    expect(appJs).toContain("bind('playBtn', this.dom.playBtn, 'click', () => { this.togglePlayback(); });");
   });
 
   test('onAudioLoaded enables play button alias if present', () => {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Implements the highest-value reliability fixes from the macroscope code review. All changes are surgical — no architectural changes, no new abstractions.

- **`app.js` — fix double-bind bug on `playBtn`**: `bindEvents()` was wiring `playBtn` to `this.dom.tpPlay` instead of `this.dom.playBtn`, causing `togglePlayback()` to fire twice per click on the play button. Fixed to point each alias at its own DOM element. Also added `_updateProcessButtonsState()` to `runPipeline`'s `finally` block so the process button is always re-enabled after an error (previously it only re-enabled on success).

- **`processing-overlay.js` — cache DOM element refs**: The `_el()`, `_stageChip()`, `_pct()`, etc. methods called `getElementById()` on every invocation. These are called on every `update()` tick (32 times per pipeline run). Replaced with a single `_initRefs()` that caches all references on first `show()` call.

- **`pipeline-orchestrator.js` — ML worker stall watchdog**: After the ML worker signals `ready`, a 2-second interval tracks `Date.now() - this._mlLastMessage`. If no messages arrive for >10 seconds, a console warning fires. Cleared in `destroy()` to prevent leaks. Every incoming worker message updates the timestamp.

- **`ml-worker.js` — inference timeout**: Added `_runWithTimeout(session, feeds)` helper that races `session.run()` against a 30-second `setTimeout` rejection. Applied to all hot-path `session.run()` calls (`bsrnnComplex` and `infer` cases). Prevents a hung ONNX session from blocking the worker indefinitely.

## Test plan

- [ ] `pnpm test` passes — 63 suites green, 2 pre-existing failures in `deployment-config` and `engineer-mode-init-regression` (vercel.json config issues unrelated to these changes)
- [ ] `play-button-wiring.test.js` updated: old assertion for the buggy binding replaced with two correct assertions (one for `tpPlay`, one for `playBtn` → own element)
- [ ] No regressions in `ml-worker.test.js`, `pipeline-orchestrator.test.js`, or `processing-overlay`-adjacent suites

https://claude.ai/code/session_012B19Qctorifz5QFFQyaP6p
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_012B19Qctorifz5QFFQyaP6p)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden runtime stability with inference timeouts, worker watchdog, DOM caching, and button re-enable
> - Adds a 30s inference timeout in [ml-worker.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/573/files#diff-3ee9cad7ecbd6f101735ef1c00f8cc6705e3419640a54d8a01f4ed76001402d0) via `_runWithTimeout`; timed-out sessions are deleted before posting an error to prevent stale state
> - Adds a watchdog interval in [pipeline-orchestrator.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/573/files#diff-49870fb9126abe0cb28eb53d3f4bfbc9f666105da1157c70df940ab1b50fd7d0) that logs a warning and resets the pending message count if an ML worker request stalls for >10s
> - Introduces lazy DOM caching in [processing-overlay.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/573/files#diff-e3cd5670d3aca7cedfa658493f37e2389b872fa904c6e42361488277fef2032a) via `_initRefs()` to avoid repeated element lookups
> - Fixes `playBtn` binding in [app.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/573/files#diff-8a8b7ea624d7fccc12a516d122dcb07bd67c6a8f796c80e33b898ee6a7557650) to target `this.dom.playBtn` and calls `_updateProcessButtonsState()` in the `runPipeline` finally block so buttons re-enable after processing
> - Behavioral Change: ONNX inference now hard-fails after 30s instead of hanging indefinitely
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c58e78c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->