### PR TITLE
🎨 Palette: Custom preset modal keyboard accessibility and focus management

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -12,3 +12,7 @@
 ## 2026-05-18 - [Custom Modal Keyboard Accessibility & ARIA States]
 **Learning:** Custom UI modals must implement complete keyboard and accessibility flows, including `role="dialog"`, `aria-modal="true"`, `aria-labelledby`, dynamic `aria-hidden` synchronization, auto-focusing the primary input on open, returning focus to the trigger on close, and keydown listeners for Escape (to close) and Enter (to submit).
 **Action:** When creating or modifying custom modals, ensure the entire lifecycle of the modal is accessible by syncing the `aria-hidden` state, managing focus effectively on open and close, and supporting keyboard interactions.
+
+## 2026-05-18 - [Custom Modal Keyboard Accessibility & ARIA States Update]
+**Learning:** When implementing 'Enter' to submit within custom UI modals, scope the keydown listener to the specific input field (e.g., verifying `e.target.id`) rather than the entire modal document/container to prevent intercepting and hijacking Enter key presses on other interactive elements like buttons.
+**Action:** When implementing modal keyboard accessibility, ensure `Enter` key events do not globally override native button click events by strictly limiting the event scope to text inputs.

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -862,13 +862,64 @@ class VoiceIsolatePro {
     });
 
     // Custom preset modal
+    const _handlePresetModalKeydown = (e) => {
+      const modal = $('customPresetModal');
+      if (!modal || modal.style.display === 'none') return;
+
+      if (e.key === 'Escape') {
+        const closeBtn = $('closePresetModal');
+        if (closeBtn) closeBtn.click();
+      } else if (e.key === 'Enter') {
+        // Only trigger Enter if we are in the input, to avoid conflicting with button interactions
+        if (e.target && e.target.id === 'customPresetName') {
+          const saveBtn = $('saveCustomPresetBtn');
+          if (saveBtn) saveBtn.click();
+        }
+      }
+    };
+
     bind('openPresetModalBtn', $('openPresetModalBtn'), 'click', () => {
       const modal = $('customPresetModal');
-      if (modal) { modal.style.display = 'flex'; modal.setAttribute('aria-hidden', 'false'); }
+      if (modal) {
+        modal.style.display = 'flex';
+        modal.setAttribute('aria-hidden', 'false');
+
+        // Auto-focus input on open
+        const input = $('customPresetName');
+        if (input) {
+          // Delay focus slightly to ensure modal is visible
+          setTimeout(() => input.focus(), 10);
+        }
+
+        document.addEventListener('keydown', _handlePresetModalKeydown);
+      }
     });
+
     bind('closePresetModal', $('closePresetModal'), 'click', () => {
       const modal = $('customPresetModal');
-      if (modal) { modal.style.display = 'none'; modal.setAttribute('aria-hidden', 'true'); }
+      if (modal) {
+        modal.style.display = 'none';
+        modal.setAttribute('aria-hidden', 'true');
+
+        document.removeEventListener('keydown', _handlePresetModalKeydown);
+
+        // Return focus to trigger
+        const trigger = $('openPresetModalBtn');
+        if (trigger) trigger.focus();
+      }
+    });
+
+    // Also remove the keydown listener when save is clicked (assuming save handles its own close/hide logic if any, but since we are handling keydown, we should also intercept save button directly to remove listener)
+    bind('saveCustomPresetBtn', $('saveCustomPresetBtn'), 'click', () => {
+      document.removeEventListener('keydown', _handlePresetModalKeydown);
+      // Wait a tick then return focus to the trigger if modal is closed (in case save logic closes it)
+      setTimeout(() => {
+        const modal = $('customPresetModal');
+        if (modal && modal.style.display === 'none') {
+          const trigger = $('openPresetModalBtn');
+          if (trigger) trigger.focus();
+        }
+      }, 50);
     });
 
     // Forensic toggle


### PR DESCRIPTION
💡 What: Added keyboard accessibility to the Custom Preset Modal, including auto-focus on open, Escape/Enter key support, and focus return on close.
🎯 Why: Keyboard users previously lost focus when the modal opened and had to manually tab through the DOM to find it. They also lacked standard keyboard interactions for saving or closing the modal.
📸 Before/After: Visuals verified via Playwright integration tests. Input is now immediately focused.
♿ Accessibility:
- Inputs auto-focus when modal displays.
- Focus returns to the trigger button when modal closes.
- Escape key correctly closes modal.
- Enter key inside the input submits the form.

---
*PR created automatically by Jules for task [2136837418787567341](https://jules.google.com/task/2136837418787567341) started by @Joker5514*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add keyboard accessibility and focus management to the custom preset modal
> - Opening the modal now auto-focuses the `customPresetName` input and attaches a scoped `_handlePresetModalKeydown` listener in [app.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/574/files#diff-8a8b7ea624d7fccc12a516d122dcb07bd67c6a8f796c80e33b898ee6a7557650).
> - The listener closes the modal on Escape and triggers save on Enter only when the event target is the name input, preventing Enter from activating other modal elements.
> - Closing or saving removes the listener and returns focus to the trigger button (`openPresetModalBtn`).
> - `aria-hidden` is toggled on open/close to keep screen reader state in sync.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 738dec2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->