### PR TITLE
🎨 Palette: [Add tab keyboard navigation and fix global shortcuts]

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -16,3 +16,7 @@
 ## 2026-05-18 - [Custom Modal Keyboard Accessibility & ARIA States Update]
 **Learning:** When implementing 'Enter' to submit within custom UI modals, scope the keydown listener to the specific input field (e.g., verifying `e.target.id`) rather than the entire modal document/container to prevent intercepting and hijacking Enter key presses on other interactive elements like buttons.
 **Action:** When implementing modal keyboard accessibility, ensure `Enter` key events do not globally override native button click events by strictly limiting the event scope to text inputs.
+
+## 2026-06-04 - [Global Keyboard Shortcuts Intercepting UI Components]
+**Learning:** When adding specific keyboard navigation (like Arrow keys for Tabs) to UI components, ensure that global keyboard shortcut handlers (e.g., `_handleGlobalKeydown` in `app.js` or `vip-fixes.js`) are updated to explicitly return/ignore events originating from those components (e.g., `[role="tablist"]`, `BUTTON`) to prevent unintended global actions.
+**Action:** Always check and update global shortcut listeners when adding new interactive keyboard elements to prevent event hijacking or double actions.

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -825,9 +825,10 @@ class VoiceIsolatePro {
     });
 
     // Tab switching
-    qsa('.tab-btn[data-tab]').forEach(btn => {
+    const tabBtns = Array.from(qsa('.tab-btn[data-tab]'));
+    tabBtns.forEach((btn, index) => {
       btn.addEventListener('click', () => {
-        qsa('.tab-btn').forEach(b => {
+        tabBtns.forEach(b => {
           b.classList.remove('active');
           b.setAttribute('aria-selected', 'false');
           b.setAttribute('tabindex', '-1');
@@ -838,6 +839,21 @@ class VoiceIsolatePro {
         btn.setAttribute('tabindex', '0');
         const panel = document.getElementById('tab-' + btn.dataset.tab);
         if (panel) panel.classList.add('active');
+      });
+
+      btn.addEventListener('keydown', (e) => {
+        let nextIndex = index;
+        if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+          nextIndex = (index + 1) % tabBtns.length;
+          e.preventDefault();
+        } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+          nextIndex = (index - 1 + tabBtns.length) % tabBtns.length;
+          e.preventDefault();
+        }
+        if (nextIndex !== index) {
+          tabBtns[nextIndex].focus();
+          tabBtns[nextIndex].click();
+        }
       });
     });
 
@@ -929,7 +945,8 @@ class VoiceIsolatePro {
   _handleGlobalKeydown(e) {
     const tag = e.target && e.target.tagName;
     const contentEditable = e.target && e.target.isContentEditable;
-    const inInput = tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || contentEditable;
+    const isTab = e.target && typeof e.target.getAttribute === 'function' && e.target.getAttribute('role') === 'tab';
+    const inInput = tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || tag === 'BUTTON' || contentEditable || isTab;
     if (inInput) return;
 
     if ((e.key === ' ' || e.key === 'k' || e.key === 'K') && (this.inputBuffer || this.origBuffer)) {

--- a/public/app/vip-fixes.js
+++ b/public/app/vip-fixes.js
@@ -313,7 +313,8 @@
     /* Space = play/pause keyboard shortcut */
     document.addEventListener('keydown', (e) => {
       const tag = (e.target?.tagName || '').toUpperCase();
-      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+      const isTab = e.target && typeof e.target.getAttribute === 'function' && e.target.getAttribute('role') === 'tab';
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || tag === 'BUTTON' || isTab) return;
       if (e.code === 'Space') { e.preventDefault(); if (_isPlaying) _pause(); else _play(); }
     });
 
@@ -405,7 +406,8 @@
     /* X key shortcut */
     document.addEventListener('keydown', (e) => {
       const tag = (e.target?.tagName || '').toUpperCase();
-      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+      const isTab = e.target && typeof e.target.getAttribute === 'function' && e.target.getAttribute('role') === 'tab';
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || tag === 'BUTTON' || isTab) return;
       if (e.code === 'KeyX') _toggleAB();
     });
 


### PR DESCRIPTION
💡 What: Added Arrow key navigation for UI tab elements and prevented global keyboard shortcuts (like Space/X) from inadvertently firing when user is interacting with buttons and tab roles.
🎯 Why: Tabs couldn't be navigated natively via keyboard arrows. Additionally, pressing Space on a button would both "click" the button and toggle playback, resulting in unexpected duplicate/hijacked actions.
📸 Before/After: N/A - Behavioral
♿ Accessibility: Improves accessibility significantly for keyboard-reliant users.

---
*PR created automatically by Jules for task [14768300013229655663](https://jules.google.com/task/14768300013229655663) started by @Joker5514*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add arrow key navigation to palette tabs and fix global shortcuts on focused buttons
> - Adds ArrowRight/ArrowLeft/ArrowDown/ArrowUp keyboard navigation to tab buttons in [app.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/578/files#diff-8a8b7ea624d7fccc12a516d122dcb07bd67c6a8f796c80e33b898ee6a7557650), moving focus and activating the adjacent tab with wrap-around and proper ARIA updates.
> - Fixes global Space, X, and other shortcut handlers in [app.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/578/files#diff-8a8b7ea624d7fccc12a516d122dcb07bd67c6a8f796c80e33b898ee6a7557650) and [vip-fixes.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/578/files#diff-e1b2a993f0bf64b447304c6c2d82a496fd3b394e13cc5cda2d6568a7f7a92e9d) to return early when the focused element is a `BUTTON` or has `role="tab"`, preventing unintended playback and A/B toggle actions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 44c77bf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->