### PR TITLE
fix(deploy): restore vercel.json header config & revert COEP to require-corp

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -8,7 +8,7 @@
       "source": "/(.*)",
       "headers": [
         { "key": "Cross-Origin-Opener-Policy", "value": "same-origin" },
-        { "key": "Cross-Origin-Embedder-Policy", "value": "credentialless" },
+        { "key": "Cross-Origin-Embedder-Policy", "value": "require-corp" },
         { "key": "X-Content-Type-Options", "value": "nosniff" },
         { "key": "X-Frame-Options", "value": "DENY" },
         { "key": "X-XSS-Protection", "value": "1; mode=block" },
@@ -18,10 +18,70 @@
     {
       "source": "/((?!api/).*)",
       "headers": [
+        { "key": "Cross-Origin-Opener-Policy", "value": "same-origin" },
+        { "key": "Cross-Origin-Embedder-Policy", "value": "require-corp" },
+        { "key": "Cross-Origin-Resource-Policy", "value": "same-origin" },
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "X-Frame-Options", "value": "DENY" },
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
+        { "key": "Strict-Transport-Security", "value": "max-age=31536000; includeSubDomains; preload" },
+        { "key": "Permissions-Policy", "value": "microphone=(self), camera=(), geolocation=(), payment=(), usb=()" },
         {
           "key": "Content-Security-Policy",
           "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' /_vercel/insights/ https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob:; media-src 'self' blob: mediastream:; connect-src 'self' blob: https://3jq9akm8vl1tub82.public.blob.vercel-storage.com https://blob.vercel-storage.com https://*.public.blob.vercel-storage.com https://identitytoolkit.googleapis.com https://firestore.googleapis.com https://securetoken.googleapis.com https://api.revenuecat.com; worker-src 'self' blob: 'wasm-unsafe-eval'; frame-ancestors 'none'"
         }
+      ]
+    },
+    {
+      "source": "/(.*\\.js)",
+      "headers": [
+        { "key": "Content-Type", "value": "application/javascript" }
+      ]
+    },
+    {
+      "source": "/(.*\\.wasm)",
+      "headers": [
+        { "key": "Content-Type", "value": "application/wasm" }
+      ]
+    },
+    {
+      "source": "/(.*\\.onnx)",
+      "headers": [
+        { "key": "Content-Type", "value": "application/octet-stream" }
+      ]
+    },
+    {
+      "source": "/sw.js",
+      "headers": [
+        { "key": "Content-Type", "value": "application/javascript" },
+        { "key": "Cache-Control", "value": "no-cache, no-store, must-revalidate" },
+        { "key": "Service-Worker-Allowed", "value": "/" }
+      ]
+    },
+    {
+      "source": "/app/dsp-processor.js",
+      "headers": [
+        { "key": "Cross-Origin-Opener-Policy", "value": "same-origin" },
+        { "key": "Cross-Origin-Embedder-Policy", "value": "require-corp" },
+        { "key": "Content-Type", "value": "application/javascript" },
+        { "key": "Cache-Control", "value": "no-cache, no-store, must-revalidate" }
+      ]
+    },
+    {
+      "source": "/app/models/(.*\\.onnx)",
+      "headers": [
+        { "key": "Content-Type", "value": "application/octet-stream" },
+        { "key": "Cross-Origin-Resource-Policy", "value": "cross-origin" },
+        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" },
+        { "key": "Access-Control-Allow-Origin", "value": "*" }
+      ]
+    },
+    {
+      "source": "/lib/(.*\\.wasm)",
+      "headers": [
+        { "key": "Content-Type", "value": "application/wasm" },
+        { "key": "Cross-Origin-Resource-Policy", "value": "same-origin" },
+        { "key": "Cache-Control", "value": "public, max-age=31536000" }
       ]
     }
   ]


### PR DESCRIPTION
## Code audit — first fix: production-breaking `vercel.json` regression

A full audit of the repo surfaced one **production-breaking, CI-red** regression as the highest-priority item. This PR fixes it. (Broader audit findings are listed at the bottom for follow-up.)

### What was wrong
Two recent commits degraded `vercel.json`:
- **`8e8dee8` "Refactor vercel.json to simplify headers and rewrites"** deleted ~100 lines of working config — content-type headers, model CORP headers, cache headers, service-worker headers, and security headers.
- **`e64a067`** then switched `Cross-Origin-Embedder-Policy` from `require-corp` to `credentialless`.

Consequences:
| Problem | Impact |
|---|---|
| COEP `credentialless` in `vercel.json` vs `require-corp` in `sw.js`/`server.js` | Inconsistent cross-origin isolation; **`credentialless` is unsupported in Safari/WebKit**, silently breaking `SharedArrayBuffer` / `crossOriginIsolated` on **iOS + Safari** (this is a Capacitor iOS app) |
| `Cross-Origin-Resource-Policy: cross-origin` removed from `/app/models/*.onnx` | ONNX models can fail to load under `require-corp` |
| `Content-Type` headers for `.js`/`.wasm`/`.onnx` removed | Wrong MIME for ORT WASM / ONNX binaries |
| `Permissions-Policy` (microphone), HSTS, immutable cache headers removed | Mic-permission, security & perf regressions |
| — | **11 Jest tests red** (`deployment-config`, `architectural-invariants`, `engineer-mode-init-regression`) |

### The fix
Rewrote `vercel.json` to restore the complete, correct header set while **keeping the team's recent good changes**:
- ✅ COEP `require-corp` consistently (matches `sw.js`, `server.js`, tests, CLAUDE.md §6, Safari/iOS)
- ✅ Restored CORP `cross-origin` on models, content-types, cache, HSTS, Permissions-Policy
- ✅ **Kept** the hardened CSP from the recent security pass (`wasm-unsafe-eval` in `worker-src`)
- ✅ **Kept** static-site deploy settings (`framework: null`, validate-only build)
- ✅ **Kept** the obsolete Vercel Blob model rewrite removed — models are now same-origin-only (`model-cdn-loader.js` rejects non-`/app/models/` URLs)

### Verification
- `pnpm validate` → passes
- Full Jest suite → **1915 / 1915 pass** (was 1904 / 1915)

---

### Remaining audit findings (not in this PR — for discussion)
1. **`paywall.js` still calls `fetch('/api/checkout')`**, but deployment is now static-only (`framework: null`, no `/api` rewrite) → checkout will 404 in production. Needs a decision: Firebase function, restore serverless, or remove.
2. **Heavy doc drift**: `CLAUDE.md`/`AGENTS.md` describe a different tree than reality (`app.js` is 86KB not ~38KB; undocumented files `vip-fixes.js`, `debug-menu.js`, `firebase-config.js`, `dsp-bootstrap.js`, `premium-visuals.js`, `visuals-bootstrap.js`; AGENTS.md still calls deleted `voice-isolate-processor.js` the "primary engine").
3. **`vip-fixes.js`** monkey-patches app behavior at runtime (`TODO-vip-merge.md`) — should be merged into first-party source.
4. CI/env mismatch: project requires Node 24.x; `ci.yml` runs Node 20.
5. 23 ESLint warnings (unused vars) in `app.js`/`ml-worker.js`.

https://claude.ai/code/session_016jB1Gzxd8PtMwLWgiM7iKB

---
_Generated by [Claude Code](https://claude.ai/code/session_016jB1Gzxd8PtMwLWgiM7iKB)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore vercel.json headers and revert COEP to `require-corp`
> - Restores the full header configuration in [vercel.json](https://github.com/Joker5514/VoiceIsolate-Pro/pull/579/files#diff-a3265310f552fb66876e8bfe8809737e59e5ba946bdf39138b44d9baf4e21240), which was previously lost or incomplete.
> - Sets global security headers: COOP `same-origin`, COEP `require-corp` (reverted from `credentialless`), CORP `same-origin`, HSTS, `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, and a restrictive `Permissions-Policy`.
> - Adds path-specific headers for `.js`, `.wasm`, and `.onnx` assets with explicit `Content-Type` values; `/sw.js` gets `no-cache` and `Service-Worker-Allowed: /`; `/app/dsp-processor.js` gets COOP/COEP headers and `no-cache`.
> - `/app/models/*.onnx` responses are long-term cached with `Access-Control-Allow-Origin: *` and `Cross-Origin-Resource-Policy: cross-origin`; `/lib/*.wasm` responses use same-origin CORP with public caching.
> - Behavioral Change: `COEP` reverts to `require-corp`, which is stricter than `credentialless` and may block cross-origin resources that do not opt in via `Cross-Origin-Resource-Policy`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7a6e543.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->