### PR TITLE
🎨 Palette: Add Arrow key navigation to tabs and fix global shortcut interception

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -16,3 +16,7 @@
 ## 2026-05-18 - [Custom Modal Keyboard Accessibility & ARIA States Update]
 **Learning:** When implementing 'Enter' to submit within custom UI modals, scope the keydown listener to the specific input field (e.g., verifying `e.target.id`) rather than the entire modal document/container to prevent intercepting and hijacking Enter key presses on other interactive elements like buttons.
 **Action:** When implementing modal keyboard accessibility, ensure `Enter` key events do not globally override native button click events by strictly limiting the event scope to text inputs.
+
+## 2026-06-05 - [Arrow Key Navigation & Global Keyboard Shortcuts]
+**Learning:** When adding specific keyboard navigation (like Arrow keys for Tabs) to UI components, global keyboard shortcut handlers (e.g., Spacebar for play/pause or Arrow keys for seek) can unintentionally intercept those events if the handlers are attached to `document` or `window`.
+**Action:** Always ensure that global keyboard shortcut handlers explicitly check for and ignore events originating from interactive UI components (e.g., checking `e.target.tagName === 'BUTTON'` or `e.target.getAttribute('role') === 'tab'`) to prevent hijacking local component navigation.

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -825,9 +825,10 @@ class VoiceIsolatePro {
     });
 
     // Tab switching
-    qsa('.tab-btn[data-tab]').forEach(btn => {
+    const tabBtns = qsa('.tab-btn[data-tab]');
+    tabBtns.forEach((btn, index) => {
       btn.addEventListener('click', () => {
-        qsa('.tab-btn').forEach(b => {
+        tabBtns.forEach(b => {
           b.classList.remove('active');
           b.setAttribute('aria-selected', 'false');
           b.setAttribute('tabindex', '-1');
@@ -838,6 +839,21 @@ class VoiceIsolatePro {
         btn.setAttribute('tabindex', '0');
         const panel = document.getElementById('tab-' + btn.dataset.tab);
         if (panel) panel.classList.add('active');
+      });
+
+      // Keyboard navigation (Arrow keys)
+      btn.addEventListener('keydown', (e) => {
+        let newIndex;
+        if (e.key === 'ArrowRight') {
+          newIndex = (index + 1) % tabBtns.length;
+        } else if (e.key === 'ArrowLeft') {
+          newIndex = (index - 1 + tabBtns.length) % tabBtns.length;
+        } else {
+          return;
+        }
+        e.preventDefault();
+        tabBtns[newIndex].focus();
+        tabBtns[newIndex].click();
       });
     });
 
@@ -931,6 +947,9 @@ class VoiceIsolatePro {
     const contentEditable = e.target && e.target.isContentEditable;
     const inInput = tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || contentEditable;
     if (inInput) return;
+
+    // Prevent global shortcuts from overriding custom component interactions
+    if (tag === 'BUTTON' || (e.target && typeof e.target.getAttribute === 'function' && (e.target.getAttribute('role') === 'tab' || e.target.getAttribute('role') === 'tablist'))) return;
 
     if ((e.key === ' ' || e.key === 'k' || e.key === 'K') && (this.inputBuffer || this.origBuffer)) {
       if (e.ctrlKey || e.metaKey || e.altKey) return;

--- a/public/app/vip-fixes.js
+++ b/public/app/vip-fixes.js
@@ -314,6 +314,9 @@
     document.addEventListener('keydown', (e) => {
       const tag = (e.target?.tagName || '').toUpperCase();
       if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+      // Prevent global shortcuts from overriding custom component interactions
+      if (tag === 'BUTTON' || (e.target && typeof e.target.getAttribute === 'function' && (e.target.getAttribute('role') === 'tab' || e.target.getAttribute('role') === 'tablist'))) return;
+
       if (e.code === 'Space') { e.preventDefault(); if (_isPlaying) _pause(); else _play(); }
     });
 


### PR DESCRIPTION
💡 **What:**
Added Left/Right Arrow key navigation to the Visualizations tab bar. Protected interactive component keystrokes by ignoring `BUTTON` and `role="tab"` elements inside the application's global `keydown` shortcut handlers.

🎯 **Why:**
Arrow key navigation strictly adheres to the WAI-ARIA authoring practices for tabs, greatly improving keyboard accessibility for screen reader and keyboard-only users. Preventing global keystroke interception ensures that native component interactions (like Spacebar on buttons) trigger correctly without unintentionally starting/stopping audio playback.

📸 **Before/After:**
*(Visual changes are invisible, focuses on accessibility and DOM event handling)*

♿ **Accessibility:**
Provides full Arrow Key navigation support for tabs and eliminates global shortcut interception bugs.

---
*PR created automatically by Jules for task [10706023231100241450](https://jules.google.com/task/10706023231100241450) started by @Joker5514*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add ArrowLeft/ArrowRight tab navigation and fix global shortcut interception on buttons
> - Adds `keydown` handlers to tab buttons in `VoiceIsolatePro` so ArrowLeft/ArrowRight moves focus and activates adjacent tabs using modulo wrapping.
> - Fixes `_handleGlobalKeydown` in [app.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/580/files#diff-8a8b7ea624d7fccc12a516d122dcb07bd67c6a8f796c80e33b898ee6a7557650) and the Space shortcut in [vip-fixes.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/580/files#diff-e1b2a993f0bf64b447304c6c2d82a496fd3b394e13cc5cda2d6568a7f7a92e9d) to early-return when the event target is a `BUTTON` or has `role="tab"` or `role="tablist"`.
> - Behavioral Change: Space/K play-pause and Escape shortcuts no longer fire when focus is on any button or tab element.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0602e44.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->