### PR TITLE
🎨 Palette: Form label accessibility & shortcut hints

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -16,3 +16,7 @@
 ## 2026-05-18 - [Custom Modal Keyboard Accessibility & ARIA States Update]
 **Learning:** When implementing 'Enter' to submit within custom UI modals, scope the keydown listener to the specific input field (e.g., verifying `e.target.id`) rather than the entire modal document/container to prevent intercepting and hijacking Enter key presses on other interactive elements like buttons.
 **Action:** When implementing modal keyboard accessibility, ensure `Enter` key events do not globally override native button click events by strictly limiting the event scope to text inputs.
+
+## 2026-05-19 - [Form Controls & Semantic Labels]
+**Learning:** Using generic `<span>` elements next to form controls (like `<select>`) misses out on critical accessibility benefits. Screen readers rely on semantic `<label for="...">` elements to announce the input's purpose, and `<label>` natively increases the hit target area, allowing users to click the text to focus the input.
+**Action:** Always link descriptive text to form controls using semantic `<label for="[id]">` tags rather than relying on visual proximity with `<span>` or `<div>`.

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -189,7 +189,7 @@
 
       <div class="card">
         <div class="presets-row">
-          <span class="presets-label">Presets</span>
+          <label for="presetSel" class="presets-label">Presets</label>
           <select id="presetSel" class="btn btn-outline">
             <option>Voice Clarity</option>
             <option>Podcast Clean</option>
@@ -261,8 +261,8 @@
     <section class="col-right">
       <div class="card transport-card">
         <div class="transport-row">
-          <button id="tpPlay" class="btn btn-tp" type="button" aria-label="Play" title="Play" disabled><span aria-hidden="true">&#9654;</span></button>
-          <button id="tpPause" class="btn btn-tp" type="button" aria-label="Pause" title="Pause" disabled><span aria-hidden="true">&#9208;</span></button>
+          <button id="tpPlay" class="btn btn-tp" type="button" aria-label="Play (Space)" title="Play (Space)" disabled><span aria-hidden="true">&#9654;</span></button>
+          <button id="tpPause" class="btn btn-tp" type="button" aria-label="Pause (Space)" title="Pause (Space)" disabled><span aria-hidden="true">&#9208;</span></button>
           <button id="tpStop" class="btn btn-tp" type="button" aria-label="Stop" title="Stop" disabled><span aria-hidden="true">&#9209;</span></button>
           <button id="tpRew" class="btn btn-tp" type="button" aria-label="Rewind" title="Rewind" disabled><span aria-hidden="true">&#9664;&#9664;</span></button>
           <button id="tpFwd" class="btn btn-tp" type="button" aria-label="Fast Forward" title="Fast Forward" disabled><span aria-hidden="true">&#9654;&#9654;</span></button>


### PR DESCRIPTION
💡 **What:**
Converted the `<span>` element acting as a label for the Presets dropdown into a proper `<label for="presetSel">` element. Additionally, appended ` (Space)` to the `title` and `aria-label` attributes of the Play and Pause transport buttons.

🎯 **Why:**
Using a generic `<span>` near an input control misses critical accessibility features. A semantic `<label>` explicitly links the text to the input, allowing screen readers to announce the input's purpose correctly, and increases the clickable target area so clicking the text focuses the input. Adding the keyboard shortcut hints makes the existing feature more discoverable to all users without relying solely on documentation.

📸 **Before/After:**
*(Visual changes verified via internal pre-commit Playwright scripts)*

♿ **Accessibility:**
- Increased screen reader context and clickable area for the Presets dropdown via semantic `<label>`.
- Improved discoverability of keyboard shortcuts via explicit visual and ARIA hints on transport buttons.

---
*PR created automatically by Jules for task [6631167309632535057](https://jules.google.com/task/6631167309632535057) started by @Joker5514*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add semantic label and keyboard shortcut hints to Palette form controls
> - Replaces the non-semantic `<span>` caption for the Presets field in [index.html](https://github.com/Joker5514/VoiceIsolate-Pro/pull/581/files#diff-4400aa5aa5292d143f7e2f1308aa82756255552567d5558874c994833e907ce4) with a `<label for="presetSel">`, making it clickable and properly associated for screen readers.
> - Updates `aria-label` and `title` attributes on the Play and Pause transport buttons to include `(Space)`, surfacing the keyboard shortcut in tooltips and assistive technology announcements.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0f1b735.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->