### PR TITLE
🎨 Palette: Add semantic label for Presets dropdown

### DIFF
--- a/public/app/index.html
+++ b/public/app/index.html
@@ -189,7 +189,7 @@
 
       <div class="card">
         <div class="presets-row">
-          <span class="presets-label">Presets</span>
+          <label for="presetSel" class="presets-label">Presets</label>
           <select id="presetSel" class="btn btn-outline">
             <option>Voice Clarity</option>
             <option>Podcast Clean</option>


### PR DESCRIPTION
💡 **What:** Replaced the generic `<span class="presets-label">` with a semantic `<label for="presetSel" class="presets-label">` for the Presets dropdown.
🎯 **Why:** To improve accessibility for screen readers and increase the clickable target area for users. This allows users to click the text "Presets" to focus the select dropdown.
📸 **Before/After:** The visual appearance remains identical, but the element structure is now semantic.
♿ **Accessibility:** Provides explicit context for the `#presetSel` input and supports standard `<label>` click-to-focus behavior.

---
*PR created automatically by Jules for task [13009751481132909190](https://jules.google.com/task/13009751481132909190) started by @Joker5514*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add semantic `<label>` for the Presets dropdown in the palette
> Replaces the plain text heading next to the presets `<select>` with an HTML `<label>` element linked via the dropdown's `id`. Clicking the label now focuses the dropdown, and assistive technologies will correctly announce it as the control's label.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 88ef701.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->