### PR TITLE
🎨 Palette: Semantic form control label for presets

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,6 +1,7 @@
 ## 2026-05-10 - [Tabs & Icon Buttons Accessibility]
 **Learning:** Custom tab structures (like the Visualizations tabs in `index.html`) require explicit `role="tab"`, `aria-controls`, `role="tabpanel"`, and `aria-labelledby` attributes. Active tabs should use `tabindex="0"` while inactive tabs use `tabindex="-1"` for proper keyboard navigation. Icon-only buttons (like `#fullscreenSpectroBtn`) must always have an `aria-label` and `title` to be screen reader and mouse hover friendly.
 **Action:** Always check for explicit ARIA roles and labels on custom UI structures and icon-only buttons to ensure they remain accessible to all users.
+
 ## 2026-05-12 - Custom Inputs and Keyboard Accessibility
 **Learning:** When creating custom toggle switches or sliders by hiding the native input with `opacity: 0`, the browser's default keyboard focus indicators also become invisible. This completely breaks keyboard navigation visibility.
 **Action:** Always provide explicit `:focus-visible` rules for the visual sibling elements (e.g., `input:focus-visible + .sw-track`) when hiding native inputs to ensure the element remains accessible to keyboard users.
@@ -16,3 +17,7 @@
 ## 2026-05-18 - [Custom Modal Keyboard Accessibility & ARIA States Update]
 **Learning:** When implementing 'Enter' to submit within custom UI modals, scope the keydown listener to the specific input field (e.g., verifying `e.target.id`) rather than the entire modal document/container to prevent intercepting and hijacking Enter key presses on other interactive elements like buttons.
 **Action:** When implementing modal keyboard accessibility, ensure `Enter` key events do not globally override native button click events by strictly limiting the event scope to text inputs.
+
+## 2026-05-24 - [Semantic form controls & Screen reader context]
+**Learning:** For form controls like `<select>`, using a generic `<span>` tag as a label does not provide the proper association for screen readers, unlike a semantic `<label for="...">` element. This results in the input being announced without its surrounding context.
+**Action:** Always use semantic `<label for="...">` elements rather than generic `<span>` tags for form controls to ensure proper screen reader context and increase the clickable target area.

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -189,7 +189,7 @@
 
       <div class="card">
         <div class="presets-row">
-          <span class="presets-label">Presets</span>
+          <label class="presets-label" for="presetSel">Presets</label>
           <select id="presetSel" class="btn btn-outline">
             <option>Voice Clarity</option>
             <option>Podcast Clean</option>


### PR DESCRIPTION
💡 **What**: Replaced the generic `<span>` wrapper for the preset selector with a semantic `<label for="presetSel">` and assigned it the existing styling class.
🎯 **Why**: Using generic spans provides no native association to `<select>` form elements, causing screen readers to miss surrounding context. Upgrading it to `<label for="..">` links the element cleanly and widens the user's clickable target area without changing visual presentation.
📸 **Before/After**: Visually identical. A semantic DOM change.
♿ **Accessibility**: Enhanced screen reader context and increased hit area for mouse users clicking "Presets".

---
*PR created automatically by Jules for task [535687705510921215](https://jules.google.com/task/535687705510921215) started by @Joker5514*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace `<span>` with semantic `<label>` for the Presets select control
> In [index.html](https://github.com/Joker5514/VoiceIsolate-Pro/pull/586/files#diff-4400aa5aa5292d143f7e2f1308aa82756255552567d5558874c994833e907ce4), the "Presets" label is changed from a non-semantic `<span>` to a `<label for="presetSel">`, associating it with the `<select id="presetSel">`. Clicking the label now focuses the select, and screen readers will announce the label in context with the control.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4f941c4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->