### PR TITLE
🎨 Palette: [UX improvement] Add keyboard navigation to tabs & fix shortcut hijacking

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -16,3 +16,6 @@
 ## 2026-05-18 - [Custom Modal Keyboard Accessibility & ARIA States Update]
 **Learning:** When implementing 'Enter' to submit within custom UI modals, scope the keydown listener to the specific input field (e.g., verifying `e.target.id`) rather than the entire modal document/container to prevent intercepting and hijacking Enter key presses on other interactive elements like buttons.
 **Action:** When implementing modal keyboard accessibility, ensure `Enter` key events do not globally override native button click events by strictly limiting the event scope to text inputs.
+## 2026-05-18 - [Global Shortcuts vs Custom Component Navigation]
+**Learning:** When adding specific keyboard navigation (like Arrow keys for Tabs) to UI components, ensure that global keyboard shortcut handlers (e.g., `_handleGlobalKeydown` in `app.js` or `vip-fixes.js`) are updated to explicitly return/ignore events originating from those components (e.g., `[role="tablist"]`, `BUTTON`) to prevent unintended global actions.
+**Action:** When implementing new keyboard shortcuts or interactive keyboard components, double-check that global keydown listeners have explicit scope checks and ignore interactions intended for component-level interaction.

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -825,9 +825,10 @@ class VoiceIsolatePro {
     });
 
     // Tab switching
-    qsa('.tab-btn[data-tab]').forEach(btn => {
+    const tabs = qsa('.tab-btn[data-tab]');
+    tabs.forEach((btn, index) => {
       btn.addEventListener('click', () => {
-        qsa('.tab-btn').forEach(b => {
+        tabs.forEach(b => {
           b.classList.remove('active');
           b.setAttribute('aria-selected', 'false');
           b.setAttribute('tabindex', '-1');
@@ -838,6 +839,28 @@ class VoiceIsolatePro {
         btn.setAttribute('tabindex', '0');
         const panel = document.getElementById('tab-' + btn.dataset.tab);
         if (panel) panel.classList.add('active');
+      });
+
+      btn.addEventListener('keydown', (e) => {
+        let newIndex = index;
+        if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+          newIndex = (index + 1) % tabs.length;
+          e.preventDefault();
+        } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+          newIndex = (index - 1 + tabs.length) % tabs.length;
+          e.preventDefault();
+        } else if (e.key === 'Home') {
+          newIndex = 0;
+          e.preventDefault();
+        } else if (e.key === 'End') {
+          newIndex = tabs.length - 1;
+          e.preventDefault();
+        }
+
+        if (newIndex !== index) {
+          tabs[newIndex].focus();
+          tabs[newIndex].click();
+        }
       });
     });
 
@@ -927,10 +950,17 @@ class VoiceIsolatePro {
 
   // ── Global keyboard shortcuts ────────────────────────────────────────────
   _handleGlobalKeydown(e) {
-    const tag = e.target && e.target.tagName;
-    const contentEditable = e.target && e.target.isContentEditable;
+    const target = e.target;
+    if (!target) return;
+
+    const tag = target.tagName;
+    const contentEditable = target.isContentEditable;
     const inInput = tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || contentEditable;
-    if (inInput) return;
+
+    // Do not intercept if interacting with a button or a tablist component
+    const inButtonOrTab = tag === 'BUTTON' || (typeof target.closest === 'function' && target.closest('[role="tablist"]'));
+
+    if (inInput || inButtonOrTab) return;
 
     if ((e.key === ' ' || e.key === 'k' || e.key === 'K') && (this.inputBuffer || this.origBuffer)) {
       if (e.ctrlKey || e.metaKey || e.altKey) return;

--- a/public/app/vip-fixes.js
+++ b/public/app/vip-fixes.js
@@ -312,8 +312,13 @@
 
     /* Space = play/pause keyboard shortcut */
     document.addEventListener('keydown', (e) => {
-      const tag = (e.target?.tagName || '').toUpperCase();
+      const target = e.target;
+      if (!target) return;
+      const tag = (target.tagName || '').toUpperCase();
       if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+      const inButtonOrTab = tag === 'BUTTON' || (typeof target.closest === 'function' && target.closest('[role="tablist"]'));
+      if (inButtonOrTab) return;
+
       if (e.code === 'Space') { e.preventDefault(); if (_isPlaying) _pause(); else _play(); }
     });
 
@@ -404,8 +409,13 @@
 
     /* X key shortcut */
     document.addEventListener('keydown', (e) => {
-      const tag = (e.target?.tagName || '').toUpperCase();
+      const target = e.target;
+      if (!target) return;
+      const tag = (target.tagName || '').toUpperCase();
       if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+      const inButtonOrTab = tag === 'BUTTON' || (typeof target.closest === 'function' && target.closest('[role="tablist"]'));
+      if (inButtonOrTab) return;
+
       if (e.code === 'KeyX') _toggleAB();
     });
 


### PR DESCRIPTION
🎯 **Why:** Custom UI tabs implemented as standard buttons without keyboard event routing are difficult for screen-reader and keyboard-only users to navigate naturally. Furthermore, global shortcuts were aggressively hijacking keystrokes originating from these interactive components, making focused UI operation frustrating.

💡 **What:** 
- Implemented standard W3C keyboard navigation (ArrowLeft, ArrowRight, Home, End) on the Visualizations tab bar.
- Refined the global keydown listeners in `app.js` and `vip-fixes.js` to securely bail out if the event originates from a button or a tablist, allowing native interactions to take precedence.
- Recorded the architectural boundary between global shortcuts and component navigation in `.Jules/palette.md`.

📸 **Before/After:** Not visually discernible, strictly an interaction improvement. Tested via Playwright to ensure `tabindex` and `aria-selected` attributes behave appropriately during keypress.

♿ **Accessibility:** Users can now naturally navigate the complex visualizations tab list using their arrow keys without accidentally pausing the audio engine via the Spacebar shortcut.

---
*PR created automatically by Jules for task [16490891289716640571](https://jules.google.com/task/16490891289716640571) started by @Joker5514*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add keyboard navigation to tabs and fix global shortcut hijacking in Palette
> - Adds Arrow, Home, and End key navigation to tab buttons in [app.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/587/files#diff-8a8b7ea624d7fccc12a516d122dcb07bd67c6a8f796c80e33b898ee6a7557650), moving focus and activating the corresponding panel on each keystroke.
> - Fixes global shortcuts (Space/K for playback, Escape, X for A/B toggle) firing when focus is on a `<button>` or inside a `role="tablist"` element, in both [app.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/587/files#diff-8a8b7ea624d7fccc12a516d122dcb07bd67c6a8f796c80e33b898ee6a7557650) and [vip-fixes.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/587/files#diff-e1b2a993f0bf64b447304c6c2d82a496fd3b394e13cc5cda2d6568a7f7a92e9d).
> - Behavioral Change: Space and X no longer trigger playback or A/B toggle when a button has focus, which changes behavior for any button not previously excluded by the input/contentEditable guard.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d0ce234.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->