### PR TITLE
Add stem mute toggles and per-speaker isolation to the Stem-Split pipeline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,10 +82,13 @@ Layer 1  src/core/           Pure primitives. No DOM, no Web Audio, no I/O.
 | `src/core/audio-config.js` | 1 | Single source of truth for `SAMPLE_RATE = 48000` and DSP constants. |
 | `src/core/BufferPool.js` | 1 | Pre-allocated `Float32Array` pool (128 / 2048 / 4096) — zero-GC DSP. |
 | `src/core/ModelManifest.js` | 1 | Canonical model metadata: URLs, sizes, SHA-256 integrity hashes, I/O specs. |
+| `src/core/diarization.js` | 1 | Pure speaker diarization (frame features + k-means) run once per file on the clean stem. |
 | `src/workers/MLWorker.js` | 2 | Fetch → verify SHA-256 → cache in IndexedDB → run offline ONNX inference (overlap-add) → emit stems. |
+| `src/workers/DiarizationWorker.js` | 2 | Module worker (`{ type: 'module' }`) wrapping `diarization.js` — keeps segmentation off the main thread. |
 | `src/pipeline/FileIngestion.js` | 3 | Accept audio/video blobs, decode, resample to 48 kHz via `OfflineAudioContext`. |
-| `src/pipeline/PlaybackMixer.js` | 3 | The Live-Mix graph: stem sources → gains → EQ → destination. Exports `setNoiseReduction()` etc. |
+| `src/pipeline/PlaybackMixer.js` | 3 | The Live-Mix graph: stem sources → speaker lane → gains → mute lanes → EQ → destination. Exports `setNoiseReduction()`, `setVoiceMuted()`, `setSpeakerMuted()` etc. |
 | `src/presentation/SliderUI.js` | 4 | Slider event listeners, `requestAnimationFrame`-coalesced updates into `PlaybackMixer`. |
+| `src/presentation/SpeakerControls.js` | 4 | Per-speaker cards (volume / mute / solo) bound to `PlaybackMixer`'s speaker lane. |
 
 Rules:
 - **ESM everywhere** in `src/` (`import`/`export`). Tests use CommonJS (`require`).

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -235,6 +235,23 @@ export default [
       'quotes': ['warn', 'single', { avoidEscape: true }],
     },
   },
+  {
+    // Layer 2 — module workers (spawned with { type: 'module' }); they import
+    // src/core/ directly, so sourceType flips back to 'module'.
+    files: ['src/workers/DiarizationWorker.js'],
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module',
+      globals: { ...globals.worker },
+    },
+    rules: {
+      'no-unused-vars': ['warn', { argsIgnorePattern: '^_|^e$' }],
+      'no-undef': 'error',
+      'no-empty': ['error', { allowEmptyCatch: true }],
+      'semi': ['warn', 'always'],
+      'quotes': ['warn', 'single', { avoidEscape: true }],
+    },
+  },
 
   // ── Backend / tooling ─────────────────────────────────────────────────────────
   {

--- a/public/index.html
+++ b/public/index.html
@@ -58,6 +58,8 @@
         <button id="playBtn" class="btn" type="button" disabled>&#9654; Play</button>
         <button id="pauseBtn" class="btn" type="button" disabled>&#10074;&#10074; Pause</button>
         <button id="stopBtn" class="btn" type="button" disabled>&#9632; Stop</button>
+        <button id="muteVoiceBtn" class="btn btn-toggle" type="button" disabled aria-pressed="false">Mute Voice</button>
+        <button id="muteNoiseBtn" class="btn btn-toggle" type="button" disabled aria-pressed="false">Mute Background</button>
         <label for="presetSelect" class="inline-label">Preset</label>
         <select id="presetSelect" aria-label="Mix preset" disabled>
           <option value="voice-clarity" selected>Voice Clarity</option>
@@ -103,6 +105,20 @@
           <span class="slider-val" id="eqHighVal">0 dB</span>
         </div>
       </div>
+    </section>
+
+    <!-- ── STEP 3: Per-speaker isolation ───────────────────────────────── -->
+    <section class="panel" id="speakersPanel" aria-labelledby="speakersLabel" hidden>
+      <h2 id="speakersLabel" class="section-label">3 · Speakers</h2>
+      <p class="hint">
+        Speakers detected on the isolated voice stem — entirely on your device.
+        Mute, solo, or rebalance each voice; changes are instant gain
+        automation, the AI never re-runs.
+      </p>
+      <div class="status-row">
+        <span id="speakerStatus" role="status" aria-live="polite"></span>
+      </div>
+      <div id="speakerCardsGrid" class="speaker-grid" aria-label="Per-speaker controls"></div>
     </section>
 
     <section class="panel privacy-panel">

--- a/public/landing.css
+++ b/public/landing.css
@@ -147,6 +147,66 @@ input[type="range"] { width: 100%; accent-color: var(--accent); }
 
 .privacy-panel { border-left: 3px solid var(--good); }
 
+/* ── Mute toggles & per-speaker cards ───────────────────────────────────── */
+
+.btn-toggle.active {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+
+.speaker-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 12px;
+  margin-top: 6px;
+}
+
+.speaker-card {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.speaker-card-muted { opacity: 0.55; }
+
+.speaker-card-header { display: flex; align-items: center; gap: 8px; }
+
+.speaker-swatch { width: 10px; height: 10px; border-radius: 50%; flex: none; }
+.speaker-swatch-1 { background: #3b82f6; }
+.speaker-swatch-2 { background: #a855f7; }
+.speaker-swatch-3 { background: #10b981; }
+.speaker-swatch-4 { background: #f59e0b; }
+.speaker-swatch-5 { background: #ef4444; }
+.speaker-swatch-6 { background: #06b6d4; }
+.speaker-swatch-7 { background: #84cc16; }
+.speaker-swatch-8 { background: #f97316; }
+
+.speaker-label { font-weight: 600; font-size: 13px; }
+
+.speaker-talk-time {
+  margin-left: auto;
+  color: var(--dim);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+
+.speaker-vol-row {
+  display: grid;
+  grid-template-columns: 1fr 48px;
+  align-items: center;
+  gap: 10px;
+}
+
+.speaker-actions { display: flex; gap: 8px; }
+.speaker-actions .btn { padding: 5px 12px; font-size: 12px; }
+
+.speaker-empty { margin: 0; }
+
 @media (max-width: 560px) {
   .slider-row { grid-template-columns: 110px 1fr 52px; }
   .time-readout { margin-left: 0; }

--- a/public/landing.js
+++ b/public/landing.js
@@ -145,14 +145,19 @@ async function detectSpeakers(clean, sampleRate) {
   ui.speakersPanel.hidden = false;
   ui.speakerStatus.textContent = 'Detecting speakers…';
   speakerControls.clear();
+  // Staleness guard (same contract as onStems): if another file is processed
+  // while diarization is in flight, its result must not touch the new mixer.
+  const seq = requestSeq;
   try {
     const { segments, speakers } = await diarize(clean[0], sampleRate);
+    if (seq !== requestSeq) return;
     mixer.loadSpeakerSegments(segments);
     const count = speakerControls.render(speakers);
     ui.speakerStatus.textContent = count === 0
       ? 'No distinct speakers detected.'
       : `${count} speaker${count === 1 ? '' : 's'} detected · ${segments.length} segments`;
   } catch (err) {
+    if (seq !== requestSeq) return;
     // Graceful degradation: stems + global mutes keep working without it.
     console.error('[VIP][landing] diarization failed:', err);
     mixer.loadSpeakerSegments([]);

--- a/public/landing.js
+++ b/public/landing.js
@@ -14,6 +14,7 @@
 import { ingestFile } from '/src/pipeline/FileIngestion.js';
 import { PlaybackMixer } from '/src/pipeline/PlaybackMixer.js';
 import { SliderUI } from '/src/presentation/SliderUI.js';
+import { SpeakerControls } from '/src/presentation/SpeakerControls.js';
 import { LandingVisualizer } from '/src/presentation/LandingVisualizer.js';
 import { getModel } from '/src/core/ModelManifest.js';
 import { MODEL_MANIFEST } from '/src/core/ModelManifest.js';
@@ -27,6 +28,8 @@ const ui = {
   playBtn: $('playBtn'),
   pauseBtn: $('pauseBtn'),
   stopBtn: $('stopBtn'),
+  muteVoiceBtn: $('muteVoiceBtn'),
+  muteNoiseBtn: $('muteNoiseBtn'),
   statusDot: $('statusDot'),
   statusText: $('statusText'),
   progress: $('inferenceProgress'),
@@ -34,14 +37,22 @@ const ui = {
   presetSelect: $('presetSelect'),
   waveCanvas: $('waveCanvas'),
   specCanvas: $('specCanvas'),
+  speakersPanel: $('speakersPanel'),
+  speakerStatus: $('speakerStatus'),
+  speakerCardsGrid: $('speakerCardsGrid'),
 };
 
 let mixer = null;
 let sliderUI = null;
+let speakerControls = null;
 let visualizer = null;
 let worker = null;
+let diarWorker = null;
 let ingested = null;
 let requestSeq = 0;
+let diarSeq = 0;
+
+const DIARIZATION_TIMEOUT_MS = 60000;
 
 function setStatus(msg, cls = '') {
   ui.statusText.textContent = msg;
@@ -87,6 +98,66 @@ function getWorker() {
     ui.processBtn.disabled = false;
   });
   return worker;
+}
+
+// ─── Speaker diarization (module worker, one-shot per file) ──────────────────
+
+function getDiarWorker() {
+  if (diarWorker) return diarWorker;
+  diarWorker = new Worker('/src/workers/DiarizationWorker.js', { type: 'module' });
+  return diarWorker;
+}
+
+/**
+ * Diarize the clean stem off the main thread. Resolves with
+ * { segments, speakers }; rejects on worker error or stall (timeout).
+ */
+function diarize(cleanChannel, sampleRate) {
+  return new Promise((resolve, reject) => {
+    const w = getDiarWorker();
+    const requestId = ++diarSeq;
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error(`Diarization stalled (> ${DIARIZATION_TIMEOUT_MS / 1000}s)`));
+    }, DIARIZATION_TIMEOUT_MS);
+    const onMessage = (event) => {
+      const msg = event.data || {};
+      if (msg.requestId !== requestId) return;
+      cleanup();
+      if (msg.type === 'segments') resolve(msg);
+      else reject(new Error(msg.message || 'Diarization failed'));
+    };
+    const onError = (err) => { cleanup(); reject(new Error(err.message || 'Diarization worker error')); };
+    const cleanup = () => {
+      clearTimeout(timer);
+      w.removeEventListener('message', onMessage);
+      w.removeEventListener('error', onError);
+    };
+    w.addEventListener('message', onMessage);
+    w.addEventListener('error', onError);
+    // Transfer a copy — the mixer already holds its own AudioBuffer copy.
+    const samples = new Float32Array(cleanChannel);
+    w.postMessage({ type: 'diarize', requestId, samples, sampleRate }, [samples.buffer]);
+  });
+}
+
+async function detectSpeakers(clean, sampleRate) {
+  ui.speakersPanel.hidden = false;
+  ui.speakerStatus.textContent = 'Detecting speakers…';
+  speakerControls.clear();
+  try {
+    const { segments, speakers } = await diarize(clean[0], sampleRate);
+    mixer.loadSpeakerSegments(segments);
+    const count = speakerControls.render(speakers);
+    ui.speakerStatus.textContent = count === 0
+      ? 'No distinct speakers detected.'
+      : `${count} speaker${count === 1 ? '' : 's'} detected · ${segments.length} segments`;
+  } catch (err) {
+    // Graceful degradation: stems + global mutes keep working without it.
+    console.error('[VIP][landing] diarization failed:', err);
+    mixer.loadSpeakerSegments([]);
+    ui.speakerStatus.textContent = `Speaker detection unavailable: ${err.message}`;
+  }
 }
 
 // ─── Slider value readouts ───────────────────────────────────────────────────
@@ -177,20 +248,59 @@ function onStems({ requestId, clean, noise, sampleRate, passthrough }) {
     mixer = new PlaybackMixer();
     sliderUI = new SliderUI(mixer);
     sliderUI.bind();
+    speakerControls = new SpeakerControls(mixer, ui.speakerCardsGrid);
     visualizer = new LandingVisualizer(mixer, ui.waveCanvas, ui.specCanvas);
     // Read-only diagnostics handle for smoke tests and the debug console.
-    globalThis.__vipDiagnostics = { mixer, sliderUI, visualizer };
+    globalThis.__vipDiagnostics = { mixer, sliderUI, speakerControls, visualizer };
   }
   mixer.loadStems(clean, noise, sampleRate);
   visualizer.loadStems(clean, noise, mixer.duration());
+  syncMuteButtons();
 
-  for (const btn of [ui.playBtn, ui.pauseBtn, ui.stopBtn, ui.presetSelect]) btn.disabled = false;
+  for (const btn of [ui.playBtn, ui.pauseBtn, ui.stopBtn,
+    ui.muteVoiceBtn, ui.muteNoiseBtn, ui.presetSelect]) btn.disabled = false;
   setStatus(
     passthrough
       ? 'Model unavailable — passthrough stems loaded (original audio). Check that /app/models is being served.'
       : 'Stems ready — press Play and mix in real time.',
     passthrough ? 'warn' : 'active'
   );
+
+  // Per-speaker isolation runs on the clean stem; passthrough stems carry the
+  // raw mix, so speaker features would be meaningless noise — skip.
+  if (passthrough) {
+    ui.speakersPanel.hidden = false;
+    ui.speakerStatus.textContent = 'Speaker detection skipped — model unavailable (passthrough stems).';
+    speakerControls.clear();
+  } else {
+    detectSpeakers(clean, sampleRate);
+  }
+}
+
+// ─── Stem mute toggles ───────────────────────────────────────────────────────
+
+function syncMuteButtons() {
+  if (!mixer) return;
+  const paint = (btn, muted, label) => {
+    btn.textContent = muted ? `Unmute ${label}` : `Mute ${label}`;
+    btn.classList.toggle('active', muted);
+    btn.setAttribute('aria-pressed', String(muted));
+  };
+  paint(ui.muteVoiceBtn, mixer.isVoiceMuted(), 'Voice');
+  paint(ui.muteNoiseBtn, mixer.isNoiseMuted(), 'Background');
+}
+
+function wireMuteButtons() {
+  ui.muteVoiceBtn.addEventListener('click', () => {
+    if (!mixer) return;
+    mixer.setVoiceMuted(!mixer.isVoiceMuted());
+    syncMuteButtons();
+  });
+  ui.muteNoiseBtn.addEventListener('click', () => {
+    if (!mixer) return;
+    mixer.setNoiseMuted(!mixer.isNoiseMuted());
+    syncMuteButtons();
+  });
 }
 
 function wireTransport() {
@@ -213,4 +323,5 @@ ui.processBtn.addEventListener('click', onProcess);
 ui.presetSelect.addEventListener('change', () => applyPreset(ui.presetSelect.value));
 wireReadouts();
 wireTransport();
+wireMuteButtons();
 setStatus('Idle — choose a file to begin', '');

--- a/scripts/landing-smoke.cjs
+++ b/scripts/landing-smoke.cjs
@@ -94,7 +94,8 @@ async function main() {
     await page.goto(`${BASE}/`, { waitUntil: 'domcontentloaded' });
     check(await page.title() === 'VoiceIsolate Pro — Stem-Split & Live-Mix', 'title correct');
     for (const id of ['noiseReductionSlider', 'voiceLevelSlider', 'volumeSlider',
-      'eqLowSlider', 'eqHighSlider', 'presetSelect', 'waveCanvas', 'specCanvas']) {
+      'eqLowSlider', 'eqHighSlider', 'presetSelect', 'waveCanvas', 'specCanvas',
+      'muteVoiceBtn', 'muteNoiseBtn', 'speakersPanel', 'speakerCardsGrid']) {
       check(await page.locator(`#${id}`).count() === 1, `#${id} present`);
     }
 
@@ -207,6 +208,70 @@ async function main() {
       const p = await params();
       check(near(p.noise, expectNoise) && near(p.clean, expectClean),
         `preset '${name}' → noise ${p.noise.toFixed(2)} / voice ${p.clean.toFixed(2)}`);
+    }
+
+    // ── Stem mute toggles ───────────────────────────────────────────────────
+    console.log('\nStem mute toggles:');
+    const cleanBeforeMute = await page.evaluate(
+      () => globalThis.__vipDiagnostics.mixer.cleanGain.gain.value);
+    await page.click('#muteVoiceBtn');
+    await page.waitForTimeout(350);
+    let mute = await page.evaluate(() => {
+      const m = globalThis.__vipDiagnostics.mixer;
+      return { v: m.voiceMuteGain.gain.value, n: m.noiseMuteGain.gain.value,
+        vm: m.isVoiceMuted(), clean: m.cleanGain.gain.value };
+    });
+    check(mute.vm && near(mute.v, 0), `Mute Voice → voice lane ${mute.v.toFixed(3)} (expect 0)`);
+    check(near(mute.clean, cleanBeforeMute),
+      `Voice Level slider untouched by mute (${mute.clean.toFixed(2)} = pre-mute ${cleanBeforeMute.toFixed(2)})`);
+    check(near(mute.n, 1.0), 'noise lane unaffected');
+    check((await page.textContent('#muteVoiceBtn')).includes('Unmute'), 'button label flips to Unmute');
+
+    await page.click('#muteVoiceBtn');
+    await page.click('#muteNoiseBtn');
+    await page.waitForTimeout(350);
+    mute = await page.evaluate(() => {
+      const m = globalThis.__vipDiagnostics.mixer;
+      return { v: m.voiceMuteGain.gain.value, n: m.noiseMuteGain.gain.value, nm: m.isNoiseMuted() };
+    });
+    check(near(mute.v, 1.0), 'unmute restores voice lane to 1');
+    check(mute.nm && near(mute.n, 0), `Mute Background → noise lane ${mute.n.toFixed(3)} (expect 0)`);
+    await page.click('#muteNoiseBtn');
+    await page.waitForTimeout(200);
+
+    // ── Per-speaker isolation ───────────────────────────────────────────────
+    console.log('\nPer-speaker isolation:');
+    await page.waitForFunction(
+      () => /detected|unavailable|skipped/i.test(document.getElementById('speakerStatus').textContent),
+      null, { timeout: 90000 }
+    );
+    const speakerStatus = await page.textContent('#speakerStatus');
+    check(!(await page.evaluate(() => document.getElementById('speakersPanel').hidden)),
+      'speakers panel revealed after processing');
+    check(!/unavailable|skipped/i.test(speakerStatus), `diarization completed (“${speakerStatus}”)`);
+
+    const spk = await page.evaluate(() => {
+      const m = globalThis.__vipDiagnostics.mixer;
+      return { ids: m.speakerIds(), segments: m.getSpeakerSegments().length,
+        cards: document.querySelectorAll('.speaker-card').length };
+    });
+    check(spk.ids.length >= 1, `speakers detected (${spk.ids.join(', ') || 'none'})`);
+    check(spk.segments >= 1, `segments loaded into mixer (${spk.segments})`);
+    check(spk.cards === spk.ids.length, `one card per speaker (${spk.cards})`);
+
+    if (spk.ids.length >= 1) {
+      await page.click('.speaker-card .speaker-mute-btn');
+      const muted = await page.evaluate(() => {
+        const m = globalThis.__vipDiagnostics.mixer;
+        return m.getSpeakerState(m.speakerIds()[0]).muted;
+      });
+      check(muted, 'speaker mute button drives mixer state');
+      await page.click('.speaker-card .speaker-mute-btn'); // restore
+
+      await page.click('.speaker-card .speaker-solo-btn');
+      const solo = await page.evaluate(() => globalThis.__vipDiagnostics.mixer.getSoloSpeaker());
+      check(solo === spk.ids[0], `solo button sets exclusive solo (${solo})`);
+      await page.click('.speaker-card .speaker-solo-btn'); // clear
     }
 
     // ── Transport round-trip ────────────────────────────────────────────────

--- a/src/core/diarization.js
+++ b/src/core/diarization.js
@@ -1,0 +1,243 @@
+/**
+ * VoiceIsolate Pro — Speaker Diarization Primitives (Layer 1: Core)
+ *
+ * Lightweight, model-free speaker segmentation used by the Stem-Split &
+ * Live-Mix pipeline to power per-speaker mute/solo controls. Operates on a
+ * single mono channel (the CLEAN voice stem produced by MLWorker — running
+ * on the separated voice gives far better speaker features than the raw mix).
+ *
+ * Algorithm (ported from the retired Engineer-Mode prototype):
+ *   1. Slice the signal into 200 ms analysis windows (100 ms hop)
+ *   2. Per-window features: RMS energy, zero-crossing rate, spectral flatness
+ *   3. Min-max normalise features, cluster with k-means (k = 2–4 by duration)
+ *   4. Merge adjacent same-cluster windows into segments, drop silence and
+ *      segments shorter than MIN_SEGMENT_SEC
+ *
+ * Output contract (shared with PlaybackMixer.loadSpeakerSegments and the
+ * presentation layer): non-overlapping, time-ordered segments
+ *   { speakerId: 'S1', label: 'Speaker S1', start: s, end: s, confidence: 0..1 }
+ *
+ * Pure module: no DOM, no Web Audio, no I/O, no side effects — importable in
+ * Node (tests), workers, and the browser.
+ */
+'use strict';
+
+/** Analysis window length in seconds. */
+export const WINDOW_SEC = 0.2;
+/** Analysis hop in seconds. */
+export const HOP_SEC = 0.1;
+/** RMS below this is treated as silence (no speaker). */
+export const SILENCE_RMS = 0.003;
+/** Segments shorter than this are discarded as jitter. */
+export const MIN_SEGMENT_SEC = 0.3;
+
+/**
+ * Per-window feature vector: [rms, normalised zcr, spectral flatness].
+ * Cheap (no FFT) but discriminative enough to separate speaking voices.
+ * @param {Float32Array} frame
+ * @param {number} sampleRate
+ * @returns {number[]}
+ */
+export function frameFeatures(frame, sampleRate) {
+  const n = frame.length;
+  if (n === 0) return [0, 0, 0];
+
+  let sumSq = 0;
+  for (let i = 0; i < n; i++) sumSq += frame[i] * frame[i];
+  const rms = Math.sqrt(sumSq / n);
+
+  // Zero-crossing rate as a cheap spectral-centroid proxy.
+  let zc = 0;
+  for (let i = 1; i < n; i++) {
+    if ((frame[i] >= 0) !== (frame[i - 1] >= 0)) zc++;
+  }
+  const zcr = zc / (2 * n / sampleRate) / sampleRate; // normalised to ~[0,1]
+
+  // Spectral flatness via geometric/arithmetic mean ratio of |x|.
+  let sumAbs = 0;
+  let logSum = 0;
+  for (let i = 0; i < n; i++) {
+    const a = Math.abs(frame[i]) + 1e-9;
+    sumAbs += a;
+    logSum += Math.log(a);
+  }
+  const flatness = Math.exp(logSum / n) / (sumAbs / n);
+
+  return [rms, zcr, flatness];
+}
+
+/**
+ * Plain k-means over feature vectors. Deterministic init (centroids spread
+ * across the timeline) so results are reproducible for tests.
+ * @param {number[][]} features
+ * @param {number} k
+ * @param {number} [maxIter]
+ * @returns {Int32Array} cluster label per feature row
+ */
+export function kMeans(features, k, maxIter = 20) {
+  if (features.length === 0) return new Int32Array(0);
+  const dim = features[0].length;
+  const n = features.length;
+
+  const centroids = Array.from({ length: k }, (_, ci) => {
+    const fi = Math.floor((ci / k) * n);
+    return features[fi].slice();
+  });
+
+  const labels = new Int32Array(n);
+
+  for (let iter = 0; iter < maxIter; iter++) {
+    let changed = false;
+    for (let i = 0; i < n; i++) {
+      let best = 0;
+      let bestDist = Infinity;
+      for (let c = 0; c < k; c++) {
+        let d = 0;
+        for (let j = 0; j < dim; j++) {
+          const diff = features[i][j] - centroids[c][j];
+          d += diff * diff;
+        }
+        if (d < bestDist) { bestDist = d; best = c; }
+      }
+      if (labels[i] !== best) { labels[i] = best; changed = true; }
+    }
+    if (!changed) break;
+
+    const sums = Array.from({ length: k }, () => new Float64Array(dim));
+    const counts = new Int32Array(k);
+    for (let i = 0; i < n; i++) {
+      counts[labels[i]]++;
+      for (let j = 0; j < dim; j++) sums[labels[i]][j] += features[i][j];
+    }
+    for (let c = 0; c < k; c++) {
+      if (counts[c] > 0) {
+        for (let j = 0; j < dim; j++) centroids[c][j] = sums[c][j] / counts[c];
+      }
+    }
+  }
+
+  return labels;
+}
+
+/**
+ * Diarize one mono channel into speaker segments.
+ *
+ * @param {Float32Array} samples  mono PCM (use the clean voice stem)
+ * @param {number} sampleRate
+ * @param {object} [options]
+ * @param {number} [options.maxSpeakers]  cap on cluster count (2–8)
+ * @returns {Array<{speakerId: string, label: string, start: number, end: number, confidence: number}>}
+ */
+export function diarizeChannel(samples, sampleRate, options = {}) {
+  if (!(samples instanceof Float32Array) || samples.length === 0) return [];
+  if (!Number.isFinite(sampleRate) || sampleRate <= 0) {
+    throw new RangeError('[VIP][diarization] sampleRate must be a positive number.');
+  }
+
+  const winSamp = Math.round(WINDOW_SEC * sampleRate);
+  const hopSamp = Math.round(HOP_SEC * sampleRate);
+
+  const features = [];
+  const frameStarts = [];
+  for (let i = 0; i + winSamp <= samples.length; i += hopSamp) {
+    features.push(frameFeatures(samples.subarray(i, i + winSamp), sampleRate));
+    frameStarts.push(i);
+  }
+  if (features.length === 0) return [];
+
+  // Cluster VOICED frames only. Silent windows must not participate: their
+  // degenerate features (zero energy, flatness → 1) skew the min-max
+  // normalisation and absorb a whole cluster, collapsing real speakers.
+  const voicedIdx = [];
+  for (let fi = 0; fi < features.length; fi++) {
+    if (features[fi][0] >= SILENCE_RMS) voicedIdx.push(fi);
+  }
+  if (voicedIdx.length === 0) return [];
+
+  // Cluster count grows with duration; clamp to caller's cap and frame count.
+  const durSec = samples.length / sampleRate;
+  const maxSpeakers = Math.min(8, Math.max(2, options.maxSpeakers || 4));
+  const k = Math.min(maxSpeakers, voicedIdx.length, durSec < 10 ? 2 : durSec < 30 ? 3 : 4);
+
+  // Min-max normalise each dimension (over voiced frames) so no single
+  // feature dominates the distance metric.
+  const dim = features[0].length;
+  const fMin = new Float64Array(dim).fill(Infinity);
+  const fMax = new Float64Array(dim).fill(-Infinity);
+  for (const fi of voicedIdx) {
+    for (let d = 0; d < dim; d++) {
+      if (features[fi][d] < fMin[d]) fMin[d] = features[fi][d];
+      if (features[fi][d] > fMax[d]) fMax[d] = features[fi][d];
+    }
+  }
+  const norm = (fi) => features[fi].map(
+    (v, d) => (fMax[d] > fMin[d] ? (v - fMin[d]) / (fMax[d] - fMin[d]) : 0)
+  );
+
+  const voicedLabels = kMeans(voicedIdx.map(norm), k);
+  const labelByFrame = new Map(voicedIdx.map((fi, j) => [fi, voicedLabels[j]]));
+
+  // Merge adjacent same-speaker windows; silence breaks segments.
+  const segments = [];
+  let segCluster = null; // cluster index or null for silence
+  let segStart = 0;
+  const flush = (endSamp, confidence) => {
+    if (segCluster === null) return;
+    segments.push({
+      cluster: segCluster,
+      start: segStart / sampleRate,
+      end: endSamp / sampleRate,
+      confidence,
+    });
+  };
+
+  for (let fi = 0; fi < frameStarts.length; fi++) {
+    const cluster = labelByFrame.has(fi) ? labelByFrame.get(fi) : null;
+    if (cluster !== segCluster) {
+      flush(frameStarts[fi], Math.min(0.97, 0.68 + norm(fi)[0] * 0.29));
+      segStart = frameStarts[fi];
+      segCluster = cluster;
+    }
+  }
+  flush(samples.length, 0.72);
+
+  // Drop jitter, then relabel clusters compactly (S1, S2, …) in order of
+  // first appearance so absent clusters never produce phantom speakers.
+  const kept = segments.filter((s) => s.end - s.start >= MIN_SEGMENT_SEC);
+  const idByCluster = new Map();
+  return kept.map((s) => {
+    if (!idByCluster.has(s.cluster)) idByCluster.set(s.cluster, `S${idByCluster.size + 1}`);
+    const speakerId = idByCluster.get(s.cluster);
+    return {
+      speakerId,
+      label: `Speaker ${speakerId}`,
+      start: s.start,
+      end: s.end,
+      confidence: s.confidence,
+    };
+  });
+}
+
+/**
+ * Aggregate segments into a per-speaker summary for the presentation layer.
+ * @param {ReturnType<typeof diarizeChannel>} segments
+ * @returns {Array<{speakerId: string, label: string, talkTime: number, segmentCount: number}>}
+ */
+export function summarizeSpeakers(segments) {
+  const byId = new Map();
+  for (const seg of segments || []) {
+    if (!seg || typeof seg.speakerId !== 'string') continue;
+    const entry = byId.get(seg.speakerId) || {
+      speakerId: seg.speakerId,
+      label: seg.label || `Speaker ${seg.speakerId}`,
+      talkTime: 0,
+      segmentCount: 0,
+    };
+    entry.talkTime += Math.max(0, seg.end - seg.start);
+    entry.segmentCount++;
+    byId.set(seg.speakerId, entry);
+  }
+  return [...byId.values()];
+}
+
+export default diarizeChannel;

--- a/src/core/diarization.js
+++ b/src/core/diarization.js
@@ -35,10 +35,9 @@ export const MIN_SEGMENT_SEC = 0.3;
  * Per-window feature vector: [rms, normalised zcr, spectral flatness].
  * Cheap (no FFT) but discriminative enough to separate speaking voices.
  * @param {Float32Array} frame
- * @param {number} sampleRate
  * @returns {number[]}
  */
-export function frameFeatures(frame, sampleRate) {
+export function frameFeatures(frame) {
   const n = frame.length;
   if (n === 0) return [0, 0, 0];
 
@@ -51,7 +50,7 @@ export function frameFeatures(frame, sampleRate) {
   for (let i = 1; i < n; i++) {
     if ((frame[i] >= 0) !== (frame[i - 1] >= 0)) zc++;
   }
-  const zcr = zc / (2 * n / sampleRate) / sampleRate; // normalised to ~[0,1]
+  const zcr = zc / (2 * n); // fraction of sign flips per sample, ∈ [0, 0.5]
 
   // Spectral flatness via geometric/arithmetic mean ratio of |x|.
   let sumAbs = 0;
@@ -140,7 +139,7 @@ export function diarizeChannel(samples, sampleRate, options = {}) {
   const features = [];
   const frameStarts = [];
   for (let i = 0; i + winSamp <= samples.length; i += hopSamp) {
-    features.push(frameFeatures(samples.subarray(i, i + winSamp), sampleRate));
+    features.push(frameFeatures(samples.subarray(i, i + winSamp)));
     frameStarts.push(i);
   }
   if (features.length === 0) return [];
@@ -181,25 +180,37 @@ export function diarizeChannel(samples, sampleRate, options = {}) {
   const segments = [];
   let segCluster = null; // cluster index or null for silence
   let segStart = 0;
-  const flush = (endSamp, confidence) => {
+  let segEnergy = 0;     // Σ normalised RMS over the segment's own frames
+  let segFrames = 0;
+  const flush = (endSamp) => {
     if (segCluster === null) return;
+    // Confidence reflects the segment's own mean energy — never the frame
+    // that triggered the boundary, which is typically silence and would
+    // floor every confidence at the 0.68 baseline.
+    const meanEnergy = segFrames > 0 ? segEnergy / segFrames : 0;
     segments.push({
       cluster: segCluster,
       start: segStart / sampleRate,
       end: endSamp / sampleRate,
-      confidence,
+      confidence: Math.min(0.97, 0.68 + meanEnergy * 0.29),
     });
   };
 
   for (let fi = 0; fi < frameStarts.length; fi++) {
     const cluster = labelByFrame.has(fi) ? labelByFrame.get(fi) : null;
     if (cluster !== segCluster) {
-      flush(frameStarts[fi], Math.min(0.97, 0.68 + norm(fi)[0] * 0.29));
+      flush(frameStarts[fi]);
       segStart = frameStarts[fi];
       segCluster = cluster;
+      segEnergy = 0;
+      segFrames = 0;
+    }
+    if (cluster !== null) {
+      segEnergy += norm(fi)[0];
+      segFrames++;
     }
   }
-  flush(samples.length, 0.72);
+  flush(samples.length);
 
   // Drop jitter, then relabel clusters compactly (S1, S2, …) in order of
   // first appearance so absent clusters never produce phantom speakers.

--- a/src/core/diarization.js
+++ b/src/core/diarization.js
@@ -135,6 +135,13 @@ export function diarizeChannel(samples, sampleRate, options = {}) {
 
   const winSamp = Math.round(WINDOW_SEC * sampleRate);
   const hopSamp = Math.round(HOP_SEC * sampleRate);
+  // A rate this low rounds the hop to zero samples — the analysis loop could
+  // never advance. Reject it loudly rather than hang or guess.
+  if (hopSamp < 1 || winSamp < 1) {
+    throw new RangeError(
+      `[VIP][diarization] sampleRate ${sampleRate} is too low for the ${WINDOW_SEC}s analysis window.`
+    );
+  }
 
   const features = [];
   const frameStarts = [];

--- a/src/pipeline/PlaybackMixer.js
+++ b/src/pipeline/PlaybackMixer.js
@@ -3,9 +3,14 @@
  *
  * Routes the offline-processed stems through a real-time Web Audio graph:
  *
- *   Clean stem ─► AudioBufferSourceNode ─► CleanGain ─┐
- *                                                     ├─► lowShelf ─► highShelf ─► Master ─► destination
- *   Noise stem ─► AudioBufferSourceNode ─► NoiseGain ─┘
+ *   Clean stem ─► Source ─► SpeakerGain ─► CleanGain ─► VoiceMute ─┐
+ *                                                                  ├─► lowShelf ─► highShelf ─► Master ─► destination
+ *   Noise stem ─► Source ───────────────► NoiseGain ─► NoiseMute ─┘
+ *
+ * SpeakerGain is a per-speaker automation lane: diarization segments
+ * (src/core/diarization.js) schedule gain ramps so individual speakers can
+ * be muted/soloed/attenuated during playback. VoiceMute/NoiseMute are
+ * dedicated mute lanes so toggling mute never disturbs slider state.
  *
  * Every control method only touches AudioParams (setTargetAtTime for
  * click-free transitions). ML inference is NEVER triggered from here —
@@ -34,8 +39,11 @@ export class PlaybackMixer {
     verifyContextSampleRate(this.ctx);
 
     // ── Persistent graph (built once) ────────────────────────────────────
+    this.speakerGain = this.ctx.createGain();
     this.cleanGain = this.ctx.createGain();
+    this.voiceMuteGain = this.ctx.createGain();
     this.noiseGain = this.ctx.createGain();
+    this.noiseMuteGain = this.ctx.createGain();
     this.lowShelf = this.ctx.createBiquadFilter();
     this.highShelf = this.ctx.createBiquadFilter();
     this.masterGain = this.ctx.createGain();
@@ -47,8 +55,11 @@ export class PlaybackMixer {
     this.highShelf.frequency.value = 4000;
     this.analyser.fftSize = 2048;
 
-    this.cleanGain.connect(this.lowShelf);
-    this.noiseGain.connect(this.lowShelf);
+    this.speakerGain.connect(this.cleanGain);
+    this.cleanGain.connect(this.voiceMuteGain);
+    this.voiceMuteGain.connect(this.lowShelf);
+    this.noiseGain.connect(this.noiseMuteGain);
+    this.noiseMuteGain.connect(this.lowShelf);
     this.lowShelf.connect(this.highShelf);
     this.highShelf.connect(this.masterGain);
     this.masterGain.connect(this.analyser);
@@ -58,6 +69,9 @@ export class PlaybackMixer {
     // to the product intent: full voice, noise fully suppressed.
     this.cleanGain.gain.value = 1;
     this.noiseGain.gain.value = 0;
+    this.speakerGain.gain.value = 1;
+    this.voiceMuteGain.gain.value = 1;
+    this.noiseMuteGain.gain.value = 1;
 
     // ── Transport state ──────────────────────────────────────────────────
     /** @type {AudioBuffer|null} */ this.cleanBuffer = null;
@@ -67,6 +81,16 @@ export class PlaybackMixer {
     this._isPlaying = false;
     this._startedAt = 0;    // ctx.currentTime when playback began
     this._offset = 0;       // seconds into the stems
+
+    // ── Mute + per-speaker state ─────────────────────────────────────────
+    this._voiceMuted = false;
+    this._noiseMuted = false;
+    /** @type {Array<{speakerId: string, start: number, end: number}>} */
+    this._segments = [];
+    /** @type {Map<string, {volume: number, muted: boolean}>} */
+    this._speakers = new Map();
+    /** @type {string|null} */
+    this._soloId = null;
   }
 
   // ─── Stem loading ──────────────────────────────────────────────────────
@@ -85,6 +109,8 @@ export class PlaybackMixer {
     this.cleanBuffer = this._toAudioBuffer(cleanChannels, sampleRate);
     this.noiseBuffer = this._toAudioBuffer(noiseChannels, sampleRate);
     this._offset = 0;
+    // New stems invalidate any previous diarization.
+    this.loadSpeakerSegments([]);
   }
 
   _toAudioBuffer(channels, sampleRate) {
@@ -106,7 +132,7 @@ export class PlaybackMixer {
     this._teardownSources();
     this._cleanSource = this.ctx.createBufferSource();
     this._cleanSource.buffer = this.cleanBuffer;
-    this._cleanSource.connect(this.cleanGain);
+    this._cleanSource.connect(this.speakerGain);
 
     this._noiseSource = this.ctx.createBufferSource();
     this._noiseSource.buffer = this.noiseBuffer;
@@ -118,6 +144,7 @@ export class PlaybackMixer {
     this._noiseSource.start(when, this._offset);
     this._startedAt = when - this._offset;
     this._isPlaying = true;
+    this._scheduleSpeakerAutomation();
 
     this._cleanSource.onended = () => {
       if (this._isPlaying && this.currentTime() >= this.duration()) {
@@ -133,6 +160,7 @@ export class PlaybackMixer {
     this._offset = this.currentTime();
     this._teardownSources();
     this._isPlaying = false;
+    this._scheduleSpeakerAutomation(); // clear stale ramps from the old timeline
   }
 
   /** Stop and rewind. */
@@ -140,6 +168,7 @@ export class PlaybackMixer {
     this._teardownSources();
     this._isPlaying = false;
     this._offset = 0;
+    this._scheduleSpeakerAutomation();
   }
 
   /** Seek to an absolute position (seconds); keeps play state. */
@@ -226,6 +255,153 @@ export class PlaybackMixer {
     this._applyParam(this.highShelf.gain, clamp(db, -24, 24));
   }
 
+  /**
+   * Hard-mute the voice stem without disturbing the Voice Level slider.
+   * @param {boolean} muted
+   */
+  setVoiceMuted(muted) {
+    this._voiceMuted = Boolean(muted);
+    this._applyParam(this.voiceMuteGain.gain, this._voiceMuted ? 0 : 1);
+  }
+
+  /**
+   * Hard-mute the background/noise stem without disturbing the
+   * Noise Reduction slider.
+   * @param {boolean} muted
+   */
+  setNoiseMuted(muted) {
+    this._noiseMuted = Boolean(muted);
+    this._applyParam(this.noiseMuteGain.gain, this._noiseMuted ? 0 : 1);
+  }
+
+  isVoiceMuted() { return this._voiceMuted; }
+
+  isNoiseMuted() { return this._noiseMuted; }
+
+  // ─── Per-speaker controls (diarization-driven gain automation) ─────────
+
+  /**
+   * Load diarization segments for the current stems. Segments must be
+   * time-ordered and non-overlapping (the diarizeChannel contract).
+   * Speaker state (volume/mute/solo) resets with each new segment set.
+   * @param {Array<{speakerId: string, start: number, end: number}>} segments
+   */
+  loadSpeakerSegments(segments) {
+    this._segments = (segments || [])
+      .filter((s) => s && typeof s.speakerId === 'string' &&
+        Number.isFinite(s.start) && Number.isFinite(s.end) && s.end > s.start)
+      .slice()
+      .sort((a, b) => a.start - b.start);
+    this._speakers = new Map();
+    for (const seg of this._segments) {
+      if (!this._speakers.has(seg.speakerId)) {
+        this._speakers.set(seg.speakerId, { volume: 1, muted: false });
+      }
+    }
+    this._soloId = null;
+    this._scheduleSpeakerAutomation();
+  }
+
+  /** Speaker ids present in the loaded segments, in first-appearance order. */
+  speakerIds() { return [...this._speakers.keys()]; }
+
+  /** @returns {{volume: number, muted: boolean, solo: boolean}|null} */
+  getSpeakerState(speakerId) {
+    const s = this._speakers.get(speakerId);
+    return s ? { volume: s.volume, muted: s.muted, solo: this._soloId === speakerId } : null;
+  }
+
+  /** Segments currently driving the speaker lane (read-only copy). */
+  getSpeakerSegments() { return this._segments.slice(); }
+
+  /**
+   * Per-speaker volume, 0–100.
+   * @param {string} speakerId
+   * @param {number} percentage
+   */
+  setSpeakerVolume(speakerId, percentage) {
+    const s = this._speakers.get(speakerId);
+    if (!s) return;
+    s.volume = clamp(percentage, 0, 100) / 100;
+    this._scheduleSpeakerAutomation();
+  }
+
+  /**
+   * Mute/unmute one speaker. Volume is preserved across mute toggles.
+   * @param {string} speakerId
+   * @param {boolean} muted
+   */
+  setSpeakerMuted(speakerId, muted) {
+    const s = this._speakers.get(speakerId);
+    if (!s) return;
+    s.muted = Boolean(muted);
+    this._scheduleSpeakerAutomation();
+  }
+
+  /**
+   * Solo one speaker (all others silenced), or pass null to clear solo.
+   * @param {string|null} speakerId
+   */
+  setSpeakerSolo(speakerId) {
+    this._soloId = speakerId !== null && this._speakers.has(speakerId) ? speakerId : null;
+    this._scheduleSpeakerAutomation();
+  }
+
+  getSoloSpeaker() { return this._soloId; }
+
+  _effectiveSpeakerVolume(speakerId) {
+    const s = this._speakers.get(speakerId);
+    if (!s) return 1;
+    if (s.muted) return 0;
+    if (this._soloId && this._soloId !== speakerId) return 0;
+    return s.volume;
+  }
+
+  /**
+   * (Re)schedule the speaker lane's gain automation from the current
+   * playback position. Cheap enough to rebuild wholesale on every state
+   * change — it is AudioParam events only, never ML (CLAUDE.md §1).
+   */
+  _scheduleSpeakerAutomation() {
+    const g = this.speakerGain.gain;
+    const now = this.ctx.currentTime;
+    g.cancelScheduledValues(now);
+
+    if (!this._isPlaying) {
+      g.value = 1; // play() reschedules; idle lane stays transparent
+      return;
+    }
+    if (this._segments.length === 0) {
+      g.setTargetAtTime(1, now, PARAM_SMOOTHING);
+      return;
+    }
+
+    const offset = this.currentTime();
+    // ctx time at which stem position `pos` is audible (play() set _startedAt).
+    const timeAt = (pos) => this._startedAt + pos;
+
+    // Value at the current position, applied immediately…
+    let current = 1;
+    for (const seg of this._segments) {
+      if (offset >= seg.start && offset < seg.end) {
+        current = this._effectiveSpeakerVolume(seg.speakerId);
+        break;
+      }
+    }
+    g.setTargetAtTime(current, now, PARAM_SMOOTHING);
+
+    // …then boundary ramps for everything still ahead. Gaps between
+    // segments return to 1 (the clean stem is silent there anyway).
+    for (const seg of this._segments) {
+      if (seg.end <= offset) continue;
+      const vol = this._effectiveSpeakerVolume(seg.speakerId);
+      if (seg.start > offset) {
+        g.setTargetAtTime(vol, timeAt(seg.start), PARAM_SMOOTHING);
+      }
+      g.setTargetAtTime(1, timeAt(seg.end), PARAM_SMOOTHING);
+    }
+  }
+
   // ─── Introspection ─────────────────────────────────────────────────────
 
   isPlaying() { return this._isPlaying; }
@@ -244,7 +420,8 @@ export class PlaybackMixer {
   /** Release all audio resources. The instance is unusable afterwards. */
   async dispose() {
     this.stop();
-    for (const node of [this.cleanGain, this.noiseGain, this.lowShelf,
+    for (const node of [this.speakerGain, this.cleanGain, this.voiceMuteGain,
+      this.noiseGain, this.noiseMuteGain, this.lowShelf,
       this.highShelf, this.masterGain, this.analyser]) {
       try { node.disconnect(); } catch { /* already disconnected */ }
     }

--- a/src/pipeline/PlaybackMixer.js
+++ b/src/pipeline/PlaybackMixer.js
@@ -305,10 +305,14 @@ export class PlaybackMixer {
   /** Speaker ids present in the loaded segments, in first-appearance order. */
   speakerIds() { return [...this._speakers.keys()]; }
 
-  /** @returns {{volume: number, muted: boolean, solo: boolean}|null} */
+  /**
+   * Speaker state snapshot. `volume` is a 0–100 percentage, symmetric with
+   * setSpeakerVolume so state round-trips without rescaling.
+   * @returns {{volume: number, muted: boolean, solo: boolean}|null}
+   */
   getSpeakerState(speakerId) {
     const s = this._speakers.get(speakerId);
-    return s ? { volume: s.volume, muted: s.muted, solo: this._soloId === speakerId } : null;
+    return s ? { volume: s.volume * 100, muted: s.muted, solo: this._soloId === speakerId } : null;
   }
 
   /** Segments currently driving the speaker lane (read-only copy). */

--- a/src/pipeline/PlaybackMixer.js
+++ b/src/pipeline/PlaybackMixer.js
@@ -391,14 +391,22 @@ export class PlaybackMixer {
     g.setTargetAtTime(current, now, PARAM_SMOOTHING);
 
     // …then boundary ramps for everything still ahead. Gaps between
-    // segments return to 1 (the clean stem is silent there anyway).
-    for (const seg of this._segments) {
+    // segments return to 1 (the clean stem is silent there anyway). When the
+    // next segment starts exactly at this one's end (the common case — the
+    // diarizer splits on frame boundaries), skip the restore ramp: two events
+    // at the same instant would collide on the AudioParam, and the next
+    // segment's own ramp governs the boundary.
+    for (let i = 0; i < this._segments.length; i++) {
+      const seg = this._segments[i];
       if (seg.end <= offset) continue;
       const vol = this._effectiveSpeakerVolume(seg.speakerId);
       if (seg.start > offset) {
         g.setTargetAtTime(vol, timeAt(seg.start), PARAM_SMOOTHING);
       }
-      g.setTargetAtTime(1, timeAt(seg.end), PARAM_SMOOTHING);
+      const next = this._segments[i + 1];
+      if (!next || next.start > seg.end) {
+        g.setTargetAtTime(1, timeAt(seg.end), PARAM_SMOOTHING);
+      }
     }
   }
 

--- a/src/presentation/SpeakerControls.js
+++ b/src/presentation/SpeakerControls.js
@@ -58,7 +58,7 @@ export class SpeakerControls {
   }
 
   _buildCard(id, summary) {
-    const state = this.mixer.getSpeakerState(id) || { volume: 1, muted: false, solo: false };
+    const state = this.mixer.getSpeakerState(id) || { volume: 100, muted: false, solo: false };
     const card = this.doc.createElement('div');
     card.className = 'speaker-card';
     card.dataset.speakerId = id;
@@ -85,7 +85,7 @@ export class SpeakerControls {
     vol.min = '0';
     vol.max = '100';
     vol.step = '1';
-    vol.value = String(Math.round(state.volume * 100));
+    vol.value = String(Math.round(state.volume));
     vol.setAttribute('aria-label', `Volume for ${label.textContent}`);
     const volVal = this.doc.createElement('span');
     volVal.className = 'slider-val';

--- a/src/presentation/SpeakerControls.js
+++ b/src/presentation/SpeakerControls.js
@@ -1,0 +1,143 @@
+/**
+ * VoiceIsolate Pro — Per-Speaker Controls (Layer 4: Presentation)
+ *
+ * Renders one card per detected speaker (from diarization) with a volume
+ * slider plus Mute and Solo toggles, all wired to PlaybackMixer's
+ * per-speaker AudioParam automation.
+ *
+ * THE CONTRACT (CLAUDE.md §1.1): these controls talk to PlaybackMixer
+ * AudioParams ONLY. They never call into MLWorker, never re-trigger
+ * inference, never touch model state.
+ */
+'use strict';
+
+export class SpeakerControls {
+  /**
+   * @param {import('../pipeline/PlaybackMixer.js').PlaybackMixer} mixer
+   * @param {HTMLElement} container  grid the cards render into
+   * @param {object} [options]
+   * @param {Document} [options.document]  injectable for tests
+   */
+  constructor(mixer, container, options = {}) {
+    if (!mixer) throw new TypeError('[VIP][SpeakerControls] A PlaybackMixer instance is required.');
+    if (!container) throw new TypeError('[VIP][SpeakerControls] A container element is required.');
+    this.mixer = mixer;
+    this.container = container;
+    this.doc = options.document || globalThis.document;
+  }
+
+  /**
+   * Rebuild the cards from the mixer's loaded speaker segments.
+   * @param {Array<{speakerId: string, label?: string, talkTime?: number}>} [speakers]
+   *        optional summary (from summarizeSpeakers) for labels/talk time;
+   *        falls back to the mixer's speaker ids.
+   * @returns {number} number of cards rendered
+   */
+  render(speakers) {
+    this.container.textContent = '';
+    const summaryById = new Map((speakers || []).map((s) => [s.speakerId, s]));
+    const ids = this.mixer.speakerIds();
+
+    if (ids.length === 0) {
+      const empty = this.doc.createElement('p');
+      empty.className = 'hint speaker-empty';
+      empty.textContent = 'No distinct speakers detected in this file.';
+      this.container.appendChild(empty);
+      return 0;
+    }
+
+    for (const id of ids) {
+      this.container.appendChild(this._buildCard(id, summaryById.get(id)));
+    }
+    return ids.length;
+  }
+
+  /** Remove all cards (e.g. when a new file is processed). */
+  clear() {
+    this.container.textContent = '';
+  }
+
+  _buildCard(id, summary) {
+    const state = this.mixer.getSpeakerState(id) || { volume: 1, muted: false, solo: false };
+    const card = this.doc.createElement('div');
+    card.className = 'speaker-card';
+    card.dataset.speakerId = id;
+
+    const header = this.doc.createElement('div');
+    header.className = 'speaker-card-header';
+    const swatch = this.doc.createElement('span');
+    swatch.className = `speaker-swatch speaker-swatch-${(this.mixer.speakerIds().indexOf(id) % 8) + 1}`;
+    const label = this.doc.createElement('span');
+    label.className = 'speaker-label';
+    label.textContent = summary?.label || `Speaker ${id}`;
+    header.append(swatch, label);
+    if (summary && Number.isFinite(summary.talkTime)) {
+      const talk = this.doc.createElement('span');
+      talk.className = 'speaker-talk-time';
+      talk.textContent = `${summary.talkTime.toFixed(1)}s`;
+      header.appendChild(talk);
+    }
+
+    const volRow = this.doc.createElement('div');
+    volRow.className = 'speaker-vol-row';
+    const vol = this.doc.createElement('input');
+    vol.type = 'range';
+    vol.min = '0';
+    vol.max = '100';
+    vol.step = '1';
+    vol.value = String(Math.round(state.volume * 100));
+    vol.setAttribute('aria-label', `Volume for ${label.textContent}`);
+    const volVal = this.doc.createElement('span');
+    volVal.className = 'slider-val';
+    volVal.textContent = `${vol.value}%`;
+    vol.addEventListener('input', () => {
+      volVal.textContent = `${vol.value}%`;
+      this.mixer.setSpeakerVolume(id, Number(vol.value));
+    });
+    volRow.append(vol, volVal);
+
+    const actions = this.doc.createElement('div');
+    actions.className = 'speaker-actions';
+    const muteBtn = this.doc.createElement('button');
+    muteBtn.type = 'button';
+    muteBtn.className = 'btn btn-toggle speaker-mute-btn';
+    const soloBtn = this.doc.createElement('button');
+    soloBtn.type = 'button';
+    soloBtn.className = 'btn btn-toggle speaker-solo-btn';
+
+    const paint = () => {
+      const s = this.mixer.getSpeakerState(id) || state;
+      muteBtn.textContent = s.muted ? 'Muted' : 'Mute';
+      muteBtn.classList.toggle('active', s.muted);
+      muteBtn.setAttribute('aria-pressed', String(s.muted));
+      muteBtn.setAttribute('aria-label', `${s.muted ? 'Unmute' : 'Mute'} ${label.textContent}`);
+      soloBtn.textContent = s.solo ? 'Soloed' : 'Solo';
+      soloBtn.classList.toggle('active', s.solo);
+      soloBtn.setAttribute('aria-pressed', String(s.solo));
+      soloBtn.setAttribute('aria-label', `Solo ${label.textContent}`);
+      card.classList.toggle('speaker-card-muted', s.muted);
+    };
+
+    muteBtn.addEventListener('click', () => {
+      const s = this.mixer.getSpeakerState(id);
+      this.mixer.setSpeakerMuted(id, !(s && s.muted));
+      paint();
+    });
+    soloBtn.addEventListener('click', () => {
+      const s = this.mixer.getSpeakerState(id);
+      this.mixer.setSpeakerSolo(s && s.solo ? null : id);
+      // Solo is exclusive — repaint every card's solo button.
+      this.container.querySelectorAll('.speaker-card').forEach((el) => {
+        el.dispatchEvent(new Event('vip:repaint'));
+      });
+    });
+    card.addEventListener('vip:repaint', paint);
+
+    actions.append(muteBtn, soloBtn);
+    card.append(header, volRow, actions);
+    paint();
+    return card;
+  }
+}
+
+export default SpeakerControls;

--- a/src/workers/DiarizationWorker.js
+++ b/src/workers/DiarizationWorker.js
@@ -33,7 +33,11 @@ self.onmessage = (event) => {
         break;
       }
       default:
-        self.postMessage({ type: 'error', message: `Unknown message type '${msg.type}'` });
+        self.postMessage({
+          type: 'error',
+          requestId: msg.requestId,
+          message: `Unknown message type '${msg.type}'`,
+        });
     }
   } catch (err) {
     self.postMessage({

--- a/src/workers/DiarizationWorker.js
+++ b/src/workers/DiarizationWorker.js
@@ -1,0 +1,45 @@
+/**
+ * VoiceIsolate Pro — Diarization Worker (Layer 2: Workers)
+ *
+ * Module worker (spawned with { type: 'module' }) that runs the pure
+ * diarization core off the main thread so long files never jank the UI.
+ * No ONNX, no DOM, no microphone — feature extraction + k-means only,
+ * computed once per processed file on the CLEAN voice stem.
+ *
+ * Protocol (postMessage):
+ *   → { type: 'diarize', requestId, samples: Float32Array, sampleRate }
+ *   ← { type: 'segments', requestId, segments: Segment[], speakers: Summary[] }
+ *   ← { type: 'error', requestId?, message }
+ */
+'use strict';
+
+import { diarizeChannel, summarizeSpeakers } from '../core/diarization.js';
+
+self.onmessage = (event) => {
+  const msg = event.data || {};
+  try {
+    switch (msg.type) {
+      case 'diarize': {
+        const samples = msg.samples instanceof Float32Array
+          ? msg.samples
+          : new Float32Array(msg.samples || []);
+        const segments = diarizeChannel(samples, msg.sampleRate);
+        self.postMessage({
+          type: 'segments',
+          requestId: msg.requestId,
+          segments,
+          speakers: summarizeSpeakers(segments),
+        });
+        break;
+      }
+      default:
+        self.postMessage({ type: 'error', message: `Unknown message type '${msg.type}'` });
+    }
+  } catch (err) {
+    self.postMessage({
+      type: 'error',
+      requestId: msg.requestId,
+      message: err?.message || String(err),
+    });
+  }
+};

--- a/tests/diarization.test.js
+++ b/tests/diarization.test.js
@@ -42,19 +42,19 @@ function makeTwoSpeakerSignal() {
 
 describe('frameFeatures', () => {
   test('returns [rms, zcr, flatness]; silence is near-zero energy', () => {
-    const silent = diar.frameFeatures(new Float32Array(9600), SR);
+    const silent = diar.frameFeatures(new Float32Array(9600));
     expect(silent[0]).toBe(0);
 
     const tone = new Float32Array(9600);
     for (let i = 0; i < tone.length; i++) tone[i] = Math.sin((2 * Math.PI * 220 * i) / SR);
-    const f = diar.frameFeatures(tone, SR);
+    const f = diar.frameFeatures(tone);
     expect(f[0]).toBeCloseTo(Math.SQRT1_2, 1); // sine RMS ≈ 0.707
     expect(f[1]).toBeGreaterThan(0);
     expect(f[2]).toBeGreaterThan(0);
   });
 
   test('empty frame yields zeros', () => {
-    expect(diar.frameFeatures(new Float32Array(0), SR)).toEqual([0, 0, 0]);
+    expect(diar.frameFeatures(new Float32Array(0))).toEqual([0, 0, 0]);
   });
 });
 
@@ -105,6 +105,14 @@ describe('diarizeChannel', () => {
 
     // The silent gap must stay unattributed.
     expect(at(3.5)).toBeUndefined();
+  });
+
+  test('confidence reflects the segment own energy, not the boundary frame', () => {
+    const segments = diar.diarizeChannel(makeTwoSpeakerSignal(), SR);
+    const at = (t) => segments.find((s) => t >= s.start && t < s.end);
+    // The loud tone flushes on a silent boundary frame; its confidence must
+    // come from its own (maximal) energy, not get floored at the 0.68 base.
+    expect(at(1.5).confidence).toBeGreaterThan(0.9);
   });
 
   test('summarizeSpeakers aggregates talk time per speaker', () => {

--- a/tests/diarization.test.js
+++ b/tests/diarization.test.js
@@ -142,5 +142,8 @@ describe('diarizeChannel', () => {
 
   test('invalid sample rate throws a descriptive RangeError', () => {
     expect(() => diar.diarizeChannel(new Float32Array(SR), 0)).toThrow(RangeError);
+    // Rates that round the analysis hop to zero samples must fail fast,
+    // not spin the feature loop forever.
+    expect(() => diar.diarizeChannel(new Float32Array(100), 3)).toThrow(RangeError);
   });
 });

--- a/tests/diarization.test.js
+++ b/tests/diarization.test.js
@@ -1,0 +1,138 @@
+/**
+ * VoiceIsolate Pro — Speaker Diarization Core Tests (Layer 1)
+ *
+ * Exercises src/core/diarization.js against synthetic audio with two
+ * acoustically distinct "speakers" separated by silence:
+ *
+ *   0–3 s   low tone   (220 Hz sine — low ZCR)
+ *   3–4 s   silence
+ *   4–7 s   bright noise-like signal (high ZCR / flatness)
+ *
+ * The module is pure (no DOM/Web Audio), loaded as ESM via dynamic import
+ * under --experimental-vm-modules (same pattern as stem-split-core.test.js).
+ */
+
+'use strict';
+
+const SR = 48000;
+
+let diar;
+
+beforeAll(async () => {
+  diar = await import('../src/core/diarization.js');
+});
+
+function makeTwoSpeakerSignal() {
+  const samples = new Float32Array(7 * SR);
+  for (let i = 0; i < 3 * SR; i++) {
+    samples[i] = 0.5 * Math.sin((2 * Math.PI * 220 * i) / SR);
+  }
+  // 3–4 s stays zero (silence)
+  let seed = 42;
+  const rand = () => {
+    // Deterministic LCG so the test never flakes.
+    seed = (seed * 1664525 + 1013904223) >>> 0;
+    return seed / 0xffffffff;
+  };
+  for (let i = 4 * SR; i < 7 * SR; i++) {
+    samples[i] = 0.3 * (rand() * 2 - 1);
+  }
+  return samples;
+}
+
+describe('frameFeatures', () => {
+  test('returns [rms, zcr, flatness]; silence is near-zero energy', () => {
+    const silent = diar.frameFeatures(new Float32Array(9600), SR);
+    expect(silent[0]).toBe(0);
+
+    const tone = new Float32Array(9600);
+    for (let i = 0; i < tone.length; i++) tone[i] = Math.sin((2 * Math.PI * 220 * i) / SR);
+    const f = diar.frameFeatures(tone, SR);
+    expect(f[0]).toBeCloseTo(Math.SQRT1_2, 1); // sine RMS ≈ 0.707
+    expect(f[1]).toBeGreaterThan(0);
+    expect(f[2]).toBeGreaterThan(0);
+  });
+
+  test('empty frame yields zeros', () => {
+    expect(diar.frameFeatures(new Float32Array(0), SR)).toEqual([0, 0, 0]);
+  });
+});
+
+describe('kMeans', () => {
+  test('separates two obvious clusters deterministically', () => {
+    const features = [
+      [0, 0], [0.05, 0.02], [0.02, 0.04],
+      [1, 1], [0.95, 0.97], [0.98, 1.02],
+    ];
+    const labels = diar.kMeans(features, 2);
+    expect(labels[0]).toBe(labels[1]);
+    expect(labels[0]).toBe(labels[2]);
+    expect(labels[3]).toBe(labels[4]);
+    expect(labels[3]).toBe(labels[5]);
+    expect(labels[0]).not.toBe(labels[3]);
+    // Deterministic init → identical output on re-run.
+    expect([...diar.kMeans(features, 2)]).toEqual([...labels]);
+  });
+
+  test('handles empty input', () => {
+    expect(diar.kMeans([], 2)).toHaveLength(0);
+  });
+});
+
+describe('diarizeChannel', () => {
+  test('finds two distinct speakers split by silence', () => {
+    const segments = diar.diarizeChannel(makeTwoSpeakerSignal(), SR);
+    expect(segments.length).toBeGreaterThanOrEqual(2);
+
+    // Output contract: ordered, non-overlapping, ≥ MIN_SEGMENT_SEC long.
+    for (let i = 0; i < segments.length; i++) {
+      const s = segments[i];
+      expect(s.end - s.start).toBeGreaterThanOrEqual(diar.MIN_SEGMENT_SEC);
+      expect(s.speakerId).toMatch(/^S\d$/);
+      expect(s.label).toBe(`Speaker ${s.speakerId}`);
+      expect(s.confidence).toBeGreaterThan(0);
+      expect(s.confidence).toBeLessThanOrEqual(1);
+      if (i > 0) expect(s.start).toBeGreaterThanOrEqual(segments[i - 1].end);
+    }
+
+    // The two halves must be attributed to different speakers.
+    const at = (t) => segments.find((s) => t >= s.start && t < s.end);
+    const tonal = at(1.5);
+    const noisy = at(5.5);
+    expect(tonal).toBeDefined();
+    expect(noisy).toBeDefined();
+    expect(tonal.speakerId).not.toBe(noisy.speakerId);
+
+    // The silent gap must stay unattributed.
+    expect(at(3.5)).toBeUndefined();
+  });
+
+  test('summarizeSpeakers aggregates talk time per speaker', () => {
+    const segments = diar.diarizeChannel(makeTwoSpeakerSignal(), SR);
+    const speakers = diar.summarizeSpeakers(segments);
+    expect(speakers.length).toBeGreaterThanOrEqual(2);
+    const total = speakers.reduce((sum, s) => sum + s.talkTime, 0);
+    // ~6 s of speech in a 7 s file (1 s is silence).
+    expect(total).toBeGreaterThan(4.5);
+    expect(total).toBeLessThan(6.6);
+    for (const s of speakers) {
+      expect(s.segmentCount).toBeGreaterThan(0);
+      expect(s.label).toBe(`Speaker ${s.speakerId}`);
+    }
+  });
+
+  test('degenerate inputs return empty results instead of throwing', () => {
+    expect(diar.diarizeChannel(new Float32Array(0), SR)).toEqual([]);
+    expect(diar.diarizeChannel(new Float32Array(100), SR)).toEqual([]); // < 1 window
+    expect(diar.summarizeSpeakers([])).toEqual([]);
+    expect(diar.summarizeSpeakers(null)).toEqual([]);
+  });
+
+  test('pure silence produces no speakers', () => {
+    expect(diar.diarizeChannel(new Float32Array(2 * SR), SR)).toEqual([]);
+  });
+
+  test('invalid sample rate throws a descriptive RangeError', () => {
+    expect(() => diar.diarizeChannel(new Float32Array(SR), 0)).toThrow(RangeError);
+  });
+});

--- a/tests/speaker-controls.test.js
+++ b/tests/speaker-controls.test.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+/* global document -- provided by the jsdom test environment */
+
 let SpeakerControls;
 
 beforeAll(async () => {

--- a/tests/speaker-controls.test.js
+++ b/tests/speaker-controls.test.js
@@ -1,0 +1,122 @@
+/**
+ * @jest-environment jsdom
+ *
+ * VoiceIsolate Pro — SpeakerControls (Layer 4) DOM tests.
+ *
+ * Verifies the per-speaker cards render from mixer state and that every
+ * interaction routes exclusively through PlaybackMixer's per-speaker API
+ * (the CLAUDE.md §1.1 contract: presentation → AudioParams only).
+ */
+
+'use strict';
+
+let SpeakerControls;
+
+beforeAll(async () => {
+  ({ SpeakerControls } = await import('../src/presentation/SpeakerControls.js'));
+});
+
+/** Minimal mixer double exposing only the per-speaker surface. */
+function mockMixer(ids = ['S1', 'S2']) {
+  const state = new Map(ids.map((id) => [id, { volume: 1, muted: false }]));
+  let solo = null;
+  return {
+    speakerIds: jest.fn(() => [...state.keys()]),
+    getSpeakerState: jest.fn((id) => {
+      const s = state.get(id);
+      return s ? { ...s, solo: solo === id } : null;
+    }),
+    setSpeakerVolume: jest.fn((id, pct) => { state.get(id).volume = pct / 100; }),
+    setSpeakerMuted: jest.fn((id, muted) => { state.get(id).muted = muted; }),
+    setSpeakerSolo: jest.fn((id) => { solo = id; }),
+  };
+}
+
+describe('SpeakerControls', () => {
+  let mixer;
+  let container;
+  let controls;
+
+  beforeEach(() => {
+    mixer = mockMixer();
+    container = document.createElement('div');
+    controls = new SpeakerControls(mixer, container);
+  });
+
+  test('requires a mixer and a container', () => {
+    expect(() => new SpeakerControls(null, container)).toThrow(TypeError);
+    expect(() => new SpeakerControls(mixer, null)).toThrow(TypeError);
+  });
+
+  test('renders one card per speaker with label and talk time', () => {
+    const count = controls.render([
+      { speakerId: 'S1', label: 'Speaker S1', talkTime: 12.34 },
+      { speakerId: 'S2', label: 'Speaker S2', talkTime: 5.6 },
+    ]);
+    expect(count).toBe(2);
+    const cards = container.querySelectorAll('.speaker-card');
+    expect(cards).toHaveLength(2);
+    expect(cards[0].textContent).toContain('Speaker S1');
+    expect(cards[0].textContent).toContain('12.3s');
+    expect(cards[1].dataset.speakerId).toBe('S2');
+  });
+
+  test('renders an empty notice when no speakers exist', () => {
+    mixer = mockMixer([]);
+    controls = new SpeakerControls(mixer, container);
+    expect(controls.render([])).toBe(0);
+    expect(container.querySelector('.speaker-empty')).not.toBeNull();
+  });
+
+  test('mute button toggles through mixer.setSpeakerMuted and repaints', () => {
+    controls.render();
+    const card = container.querySelector('[data-speaker-id="S1"]');
+    const muteBtn = card.querySelector('.speaker-mute-btn');
+    expect(muteBtn.textContent).toBe('Mute');
+
+    muteBtn.click();
+    expect(mixer.setSpeakerMuted).toHaveBeenCalledWith('S1', true);
+    expect(muteBtn.textContent).toBe('Muted');
+    expect(muteBtn.getAttribute('aria-pressed')).toBe('true');
+    expect(card.classList.contains('speaker-card-muted')).toBe(true);
+
+    muteBtn.click();
+    expect(mixer.setSpeakerMuted).toHaveBeenLastCalledWith('S1', false);
+    expect(muteBtn.textContent).toBe('Mute');
+  });
+
+  test('solo button is exclusive: soloing S1 repaints S2, re-click clears', () => {
+    controls.render();
+    const soloS1 = container.querySelector('[data-speaker-id="S1"] .speaker-solo-btn');
+    const soloS2 = container.querySelector('[data-speaker-id="S2"] .speaker-solo-btn');
+
+    soloS1.click();
+    expect(mixer.setSpeakerSolo).toHaveBeenCalledWith('S1');
+    expect(soloS1.textContent).toBe('Soloed');
+    expect(soloS2.textContent).toBe('Solo');
+
+    soloS2.click();
+    expect(mixer.setSpeakerSolo).toHaveBeenLastCalledWith('S2');
+    expect(soloS1.textContent).toBe('Solo');
+    expect(soloS2.textContent).toBe('Soloed');
+
+    soloS2.click(); // re-click clears solo
+    expect(mixer.setSpeakerSolo).toHaveBeenLastCalledWith(null);
+  });
+
+  test('volume slider drives mixer.setSpeakerVolume and the readout', () => {
+    controls.render();
+    const card = container.querySelector('[data-speaker-id="S2"]');
+    const slider = card.querySelector('input[type="range"]');
+    slider.value = '35';
+    slider.dispatchEvent(new Event('input', { bubbles: true }));
+    expect(mixer.setSpeakerVolume).toHaveBeenCalledWith('S2', 35);
+    expect(card.querySelector('.slider-val').textContent).toBe('35%');
+  });
+
+  test('clear() empties the grid', () => {
+    controls.render();
+    controls.clear();
+    expect(container.children).toHaveLength(0);
+  });
+});

--- a/tests/speaker-controls.test.js
+++ b/tests/speaker-controls.test.js
@@ -18,9 +18,10 @@ beforeAll(async () => {
   ({ SpeakerControls } = await import('../src/presentation/SpeakerControls.js'));
 });
 
-/** Minimal mixer double exposing only the per-speaker surface. */
+/** Minimal mixer double exposing only the per-speaker surface.
+ *  volume is a 0–100 percentage on both getter and setter (mixer contract). */
 function mockMixer(ids = ['S1', 'S2']) {
-  const state = new Map(ids.map((id) => [id, { volume: 1, muted: false }]));
+  const state = new Map(ids.map((id) => [id, { volume: 100, muted: false }]));
   let solo = null;
   return {
     speakerIds: jest.fn(() => [...state.keys()]),
@@ -28,7 +29,7 @@ function mockMixer(ids = ['S1', 'S2']) {
       const s = state.get(id);
       return s ? { ...s, solo: solo === id } : null;
     }),
-    setSpeakerVolume: jest.fn((id, pct) => { state.get(id).volume = pct / 100; }),
+    setSpeakerVolume: jest.fn((id, pct) => { state.get(id).volume = pct; }),
     setSpeakerMuted: jest.fn((id, muted) => { state.get(id).muted = muted; }),
     setSpeakerSolo: jest.fn((id) => { solo = id; }),
   };

--- a/tests/stem-split-core.test.js
+++ b/tests/stem-split-core.test.js
@@ -272,7 +272,8 @@ describe('PlaybackMixer (Layer 3) — Live-Mix control surface', () => {
   test('loadSpeakerSegments registers speakers with default state', () => {
     mixer.loadSpeakerSegments(SEGMENTS);
     expect(mixer.speakerIds()).toEqual(['S1', 'S2']);
-    expect(mixer.getSpeakerState('S1')).toEqual({ volume: 1, muted: false, solo: false });
+    // volume reads back as the 0–100 percentage setSpeakerVolume accepts.
+    expect(mixer.getSpeakerState('S1')).toEqual({ volume: 100, muted: false, solo: false });
     expect(mixer.getSpeakerState('nope')).toBeNull();
     expect(mixer.getSpeakerSegments()).toHaveLength(2);
   });
@@ -332,8 +333,10 @@ describe('PlaybackMixer (Layer 3) — Live-Mix control surface', () => {
     mixer.setSpeakerVolume('S1', 40);
     const calls = mixer.speakerGain.gain.setTargetAtTime.mock.calls;
     expect(calls.some(([v, t]) => Math.abs(v - 0.4) < 1e-9 && Math.abs(t - 0.21) < 1e-6)).toBe(true);
+    // Round-trip: the getter returns the same scale the setter accepts.
+    expect(mixer.getSpeakerState('S1').volume).toBe(40);
     mixer.setSpeakerVolume('S1', 900);
-    expect(mixer.getSpeakerState('S1').volume).toBe(1);
+    expect(mixer.getSpeakerState('S1').volume).toBe(100);
   });
 
   test('contiguous segments share one boundary ramp (no AudioParam collision)', async () => {

--- a/tests/stem-split-core.test.js
+++ b/tests/stem-split-core.test.js
@@ -336,6 +336,25 @@ describe('PlaybackMixer (Layer 3) — Live-Mix control surface', () => {
     expect(mixer.getSpeakerState('S1').volume).toBe(1);
   });
 
+  test('contiguous segments share one boundary ramp (no AudioParam collision)', async () => {
+    mixer.loadStems(stems(), stems());
+    mixer.loadSpeakerSegments([
+      { speakerId: 'S1', start: 0.2, end: 0.5 },
+      { speakerId: 'S2', start: 0.5, end: 0.9 }, // starts exactly at S1's end
+    ]);
+    await mixer.play();
+    mixer.speakerGain.gain.setTargetAtTime.mockClear();
+
+    mixer.setSpeakerMuted('S2', true);
+    const calls = mixer.speakerGain.gain.setTargetAtTime.mock.calls;
+    // S2's mute ramp owns the shared boundary (0.5 → ctx time 0.51)…
+    expect(calls.some(([v, t]) => v === 0 && Math.abs(t - 0.51) < 1e-6)).toBe(true);
+    // …with no competing restore-to-1 event at the same instant.
+    expect(calls.some(([v, t]) => v === 1 && Math.abs(t - 0.51) < 1e-6)).toBe(false);
+    // The restore lands only after the contiguous run ends.
+    expect(calls.some(([v, t]) => v === 1 && Math.abs(t - 0.91) < 1e-6)).toBe(true);
+  });
+
   test('loading new stems clears stale diarization state', () => {
     mixer.loadSpeakerSegments(SEGMENTS);
     expect(mixer.speakerIds()).toHaveLength(2);

--- a/tests/stem-split-core.test.js
+++ b/tests/stem-split-core.test.js
@@ -235,4 +235,120 @@ describe('PlaybackMixer (Layer 3) — Live-Mix control surface', () => {
   test('play() without stems rejects loudly', async () => {
     await expect(mixer.play()).rejects.toThrow(/No stems loaded/);
   });
+
+  // ── Stem mute lanes ────────────────────────────────────────────────────────
+
+  test('voice/noise mute lanes default open and toggle without touching sliders', () => {
+    expect(mixer.voiceMuteGain.gain.value).toBe(1);
+    expect(mixer.noiseMuteGain.gain.value).toBe(1);
+    expect(mixer.isVoiceMuted()).toBe(false);
+
+    mixer.setVoiceLevel(80); // slider state that mute must preserve
+    mixer.setVoiceMuted(true);
+    expect(mixer.isVoiceMuted()).toBe(true);
+    expect(mixer.voiceMuteGain.gain.value).toBe(0);
+    expect(mixer.cleanGain.gain.value).toBeCloseTo(0.8); // untouched
+
+    mixer.setVoiceMuted(false);
+    expect(mixer.voiceMuteGain.gain.value).toBe(1);
+    expect(mixer.cleanGain.gain.value).toBeCloseTo(0.8);
+  });
+
+  test('while playing, mute toggles smooth via setTargetAtTime', async () => {
+    mixer.loadStems(stems(), stems());
+    await mixer.play();
+    mixer.setNoiseMuted(true);
+    expect(mixer.isNoiseMuted()).toBe(true);
+    expect(mixer.noiseMuteGain.gain.setTargetAtTime.mock.calls.at(-1)[0]).toBe(0);
+  });
+
+  // ── Per-speaker lane ───────────────────────────────────────────────────────
+
+  const SEGMENTS = [
+    { speakerId: 'S1', label: 'Speaker S1', start: 0.2, end: 0.5, confidence: 0.9 },
+    { speakerId: 'S2', label: 'Speaker S2', start: 0.6, end: 0.9, confidence: 0.9 },
+  ];
+
+  test('loadSpeakerSegments registers speakers with default state', () => {
+    mixer.loadSpeakerSegments(SEGMENTS);
+    expect(mixer.speakerIds()).toEqual(['S1', 'S2']);
+    expect(mixer.getSpeakerState('S1')).toEqual({ volume: 1, muted: false, solo: false });
+    expect(mixer.getSpeakerState('nope')).toBeNull();
+    expect(mixer.getSpeakerSegments()).toHaveLength(2);
+  });
+
+  test('malformed segments are dropped, valid ones sorted by start', () => {
+    mixer.loadSpeakerSegments([
+      { speakerId: 'S2', start: 0.6, end: 0.9 },
+      { speakerId: 'S1', start: 0.2, end: 0.5 },
+      { speakerId: 'bad', start: 0.5, end: 0.5 },   // zero-length
+      { speakerId: 42, start: 0, end: 1 },          // non-string id
+      null,
+    ]);
+    expect(mixer.getSpeakerSegments().map((s) => s.speakerId)).toEqual(['S1', 'S2']);
+  });
+
+  test('muting a speaker while playing schedules a zero-gain ramp over its segments', async () => {
+    mixer.loadStems(stems(), stems());
+    mixer.loadSpeakerSegments(SEGMENTS);
+    await mixer.play();
+
+    mixer.setSpeakerMuted('S1', true);
+    const calls = mixer.speakerGain.gain.setTargetAtTime.mock.calls;
+    // _startedAt = (currentTime + 0.01) − offset 0 → segment times shift by 0.01.
+    const mutedRamp = calls.find(([v, t]) => v === 0 && Math.abs(t - 0.21) < 1e-6);
+    const restore = calls.find(([v, t]) => v === 1 && Math.abs(t - 0.51) < 1e-6);
+    expect(mutedRamp).toBeDefined();
+    expect(restore).toBeDefined();
+    expect(mixer.speakerGain.gain.cancelScheduledValues).toHaveBeenCalled();
+    expect(mixer.getSpeakerState('S1').muted).toBe(true);
+  });
+
+  test('solo silences every other speaker; clearing solo restores them', async () => {
+    mixer.loadStems(stems(), stems());
+    mixer.loadSpeakerSegments(SEGMENTS);
+    await mixer.play();
+
+    mixer.setSpeakerSolo('S2');
+    expect(mixer.getSoloSpeaker()).toBe('S2');
+    expect(mixer.getSpeakerState('S1').solo).toBe(false);
+    expect(mixer.getSpeakerState('S2').solo).toBe(true);
+    let calls = mixer.speakerGain.gain.setTargetAtTime.mock.calls;
+    // S1's segment (0.2–0.5 → 0.21) must ramp to 0, S2's (0.6 → 0.61) stays 1.
+    expect(calls.some(([v, t]) => v === 0 && Math.abs(t - 0.21) < 1e-6)).toBe(true);
+    expect(calls.some(([v, t]) => v === 1 && Math.abs(t - 0.61) < 1e-6)).toBe(true);
+
+    mixer.speakerGain.gain.setTargetAtTime.mockClear();
+    mixer.setSpeakerSolo(null);
+    expect(mixer.getSoloSpeaker()).toBeNull();
+    calls = mixer.speakerGain.gain.setTargetAtTime.mock.calls;
+    expect(calls.some(([v, t]) => v === 1 && Math.abs(t - 0.21) < 1e-6)).toBe(true);
+  });
+
+  test('per-speaker volume scales its segments and is clamped', async () => {
+    mixer.loadStems(stems(), stems());
+    mixer.loadSpeakerSegments(SEGMENTS);
+    await mixer.play();
+    mixer.setSpeakerVolume('S1', 40);
+    const calls = mixer.speakerGain.gain.setTargetAtTime.mock.calls;
+    expect(calls.some(([v, t]) => Math.abs(v - 0.4) < 1e-9 && Math.abs(t - 0.21) < 1e-6)).toBe(true);
+    mixer.setSpeakerVolume('S1', 900);
+    expect(mixer.getSpeakerState('S1').volume).toBe(1);
+  });
+
+  test('loading new stems clears stale diarization state', () => {
+    mixer.loadSpeakerSegments(SEGMENTS);
+    expect(mixer.speakerIds()).toHaveLength(2);
+    mixer.loadStems(stems(), stems());
+    expect(mixer.speakerIds()).toEqual([]);
+    expect(mixer.getSpeakerSegments()).toEqual([]);
+  });
+
+  test('idle speaker lane stays transparent (gain pinned to 1)', () => {
+    mixer.loadSpeakerSegments(SEGMENTS);
+    mixer.setSpeakerMuted('S1', true);
+    // Not playing → no smoothing toward a frozen clock, just a clean value.
+    expect(mixer.speakerGain.gain.value).toBe(1);
+    expect(mixer.speakerGain.gain.setTargetAtTime).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Why

An audit of the voice-isolation/mute capability found:

- The canonical Stem-Split & Live-Mix pipeline (`/`) isolates voice vs. background correctly, but had no explicit mute controls (only sliders).
- Per-speaker mute/solo existed **only as dead legacy code**: `public/app/isolation-controls.js` and `diarization-timeline.js` are never imported by any page, their `ml-worker.js` is never spawned, and the `PipelineOrchestrator` they depended on is deliberately deleted (CLAUDE.md §5 freeze).

Per CLAUDE.md ("new work targets `src/`"), this PR implements the capability in the 4-layer architecture instead of resurrecting the frozen legacy path.

## What

| Layer | Change |
|---|---|
| 1 · core | `src/core/diarization.js` — pure feature + k-means speaker segmentation (ported from the legacy prototype, with a correctness fix: silent frames are excluded from clustering/normalisation so they can no longer absorb a cluster and collapse real speakers together) |
| 2 · workers | `src/workers/DiarizationWorker.js` — module worker; segmentation runs once per file on the clean stem, off the main thread |
| 3 · pipeline | `PlaybackMixer` gains dedicated **voice/background mute lanes** (mute never disturbs slider state) and a **per-speaker gain lane** driven by scheduled AudioParam automation over diarization segments: `setVoiceMuted`, `setNoiseMuted`, `loadSpeakerSegments`, `setSpeakerMuted`, `setSpeakerSolo`, `setSpeakerVolume` — zero ML re-runs, per the §1 contract |
| 4 · presentation | `SpeakerControls` per-speaker cards (volume / mute / solo); landing page gets **Mute Voice** / **Mute Background** toggles and a **3 · Speakers** panel with timeout + graceful fallback |

Also: ESLint flat-config entry for module workers, CLAUDE.md §2 table updated, E2E smoke extended.

## Verification

- `pnpm test`: 63 suites / **1752 tests green** (45 cover the new surface: diarization core, mixer mute + speaker automation, SpeakerControls DOM)
- `pnpm lint`: clean (0 errors; 22 pre-existing legacy warnings)
- `pnpm validate`: all structural checks pass
- `node scripts/landing-smoke.cjs` (headless Chromium, real ONNX inference, real Web Audio): **all checks passed**, including mute lanes hitting 0 while slider state is preserved, speaker cards rendering from diarization, and mute/solo driving mixer state — with zero console errors

https://claude.ai/code/session_01WA1uUGQtFnmw1pm81iCeom

---
_Generated by [Claude Code](https://claude.ai/code/session_01WA1uUGQtFnmw1pm81iCeom)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add stem mute toggles and per-speaker diarization controls to the Stem-Split pipeline
> - Adds Voice and Background mute toggles to the playback UI, wired to dedicated `voiceMuteGain`/`noiseMuteGain` lanes in [`PlaybackMixer`](https://github.com/Joker5514/VoiceIsolate-Pro/pull/591/files#diff-646b05066f8ea1ef7558ebf5da2f3de3eeaafd7d18d7ab2f5254089e2577b0b7) without affecting slider levels.
> - Introduces a diarization pipeline in [`src/core/diarization.js`](https://github.com/Joker5514/VoiceIsolate-Pro/pull/591/files#diff-8adf835bc7863a8920f1e4776b0b2c04d43a620ffe8c7393b98015580752b8fc) that segments a clean mono stem into per-speaker intervals using RMS/ZCR/spectral-flatness features and k-means clustering.
> - Runs diarization off the main thread via [`DiarizationWorker`](https://github.com/Joker5514/VoiceIsolate-Pro/pull/591/files#diff-307c6a023e0a6d5055eb204d88d96515046f25bbfcec9a9c81ef9d0a76be6971), with request correlation, timeout protection (60s), and structured error propagation.
> - Adds a Speakers panel with per-speaker cards (mute, solo, volume slider) rendered by [`SpeakerControls`](https://github.com/Joker5514/VoiceIsolate-Pro/pull/591/files#diff-75f71b52df8ad6dfb43bf593a2f8166320be5aa86f42fbc7146e4d8633e7f24c), wired to `PlaybackMixer` gain automation at segment boundaries.
> - Loading new stems clears prior diarization state; passthrough-mode audio skips diarization and shows a status message instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ff7f947.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Speaker diarization: Automatically detects and identifies individual speakers in your audio files
  * Per-speaker controls: Adjust volume, mute, or solo individual speakers with dedicated UI controls
  * Enhanced stem muting: New toggle buttons to independently mute voice or background audio tracks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->