### PR TITLE
fix(security/config): deny microphone in render.yaml; align Node engine with docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
   },
   "packageManager": "pnpm@10.0.0",
   "engines": {
-    "node": "24.x",
+    "node": ">=22",
     "pnpm": ">=10.0.0"
   },
   "dependencies": {

--- a/render.yaml
+++ b/render.yaml
@@ -26,10 +26,10 @@ services:
         value: strict-origin-when-cross-origin
       - path: /*
         name: Content-Security-Policy
-        value: "default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' /_vercel/; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob:; media-src 'self' blob: mediastream:; connect-src 'self' blob: https://va.vercel-scripts.com https://blob.vercel-storage.com https://*.public.blob.vercel-storage.com; worker-src 'self' blob:; frame-ancestors 'none';"
+        value: "default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' /_vercel/; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob:; media-src 'self' blob:; connect-src 'self' blob: https://va.vercel-scripts.com https://blob.vercel-storage.com https://*.public.blob.vercel-storage.com; worker-src 'self' blob:; frame-ancestors 'none';"
       - path: /*
         name: Strict-Transport-Security
         value: "max-age=63072000; includeSubDomains"
       - path: /*
         name: Permissions-Policy
-        value: "microphone=(self), camera=(), geolocation=(), payment=(), usb=()"
+        value: "microphone=(), camera=(), geolocation=(), payment=(), usb=()"

--- a/tests/deployment-config.test.js
+++ b/tests/deployment-config.test.js
@@ -415,6 +415,16 @@ describe('render.yaml — other security headers still present', () => {
     expect(yaml).toContain('Referrer-Policy');
     expect(yaml).toContain('strict-origin-when-cross-origin');
   });
+
+  test('Permissions-Policy denies the microphone (live-mic ingestion is forbidden — CLAUDE.md §1.1)', () => {
+    const ppMatch = yaml.match(/name:\s*Permissions-Policy[\s\S]*?value:\s*"([^"]+)"/);
+    expect(ppMatch).not.toBeNull();
+    const permissionsPolicy = ppMatch[1];
+    // Must deny the microphone outright — never microphone=(self) / =* / =(...).
+    expect(permissionsPolicy).toContain('microphone=()');
+    expect(permissionsPolicy).not.toMatch(/microphone=\((?!\))/);
+    expect(permissionsPolicy).not.toMatch(/microphone=\*/);
+  });
 });
 
 // ─── .jules/sentinel.md ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Full code audit + debug/test pass of the Stem-Split & Live-Mix codebase. The project was already functionally green on every gate; the audit surfaced two config inconsistencies against the documented architecture (CLAUDE.md), both fixed here.

### 1. `render.yaml` granted microphone access (security regression)
`render.yaml` served `Permissions-Policy: microphone=(self)`, which **grants** the page microphone access. This directly contradicts **CLAUDE.md §1.1/§3** — live-mic ingestion was removed by design and the microphone must be denied (`microphone=()`). It also diverged from `vercel.json` and `server/securityHeaders.js`, which both correctly use `microphone=()`. No test guarded render.yaml's `Permissions-Policy`, so the regression slipped through.

- Changed to `microphone=()`.
- Also removed the `mediastream:` token from render's `media-src` — another live-mic remnant — so render's CSP matches `vercel.json`'s `media-src 'self' blob:`.
- Added a `deployment-config` regression test asserting render.yaml denies the microphone outright (rejects `microphone=(self)`, `=*`, `=(…)`).

### 2. `package.json` engine pin contradicted the docs
`engines.node` was pinned to `"24.x"`, while README, **CLAUDE.md §6**, and `.devcontainer` all document/use **Node ≥ 22**. This produced a spurious `Unsupported engine` warning on every command in a documented-supported environment. Relaxed to `">=22"`; the Node 24 deploy workflows still satisfy it.

## Verification

| Gate | Result |
|---|---|
| `pnpm test` | ✅ 1755 passed / 63 suites (was 1754; +1 new guard test) |
| `pnpm validate` | ✅ All checks passed |
| `pnpm lint` | ✅ 0 errors (22 pre-existing warnings in frozen legacy code) |
| Landing E2E smoke (`scripts/landing-smoke.cjs`) | ✅ ALL CHECKS PASSED |
| Live smoke (`scripts/live-smoke.cjs`) | ✅ PASS |
| Model SHA-256 integrity | ✅ both shipped models match the pinned manifest hashes |
| `Unsupported engine` warning | ✅ gone |

## Notes
- No application/runtime code changed — fixes are confined to deployment config, the Node engine field, and a test.
- 22 ESLint warnings remain in `public/app/*` legacy code, which is in deliberate maintenance freeze per CLAUDE.md §5; left untouched.

https://claude.ai/code/session_01P3uP5LBvDqpbPZNbBZ4Kyt

---
_Generated by [Claude Code](https://claude.ai/code/session_01P3uP5LBvDqpbPZNbBZ4Kyt)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Deny microphone access in Permissions-Policy and remove mediastream from CSP
> - Sets `microphone=()` in Permissions-Policy (was `microphone=(self)`) and removes `mediastream:` from the `media-src` CSP directive in [render.yaml](https://github.com/Joker5514/VoiceIsolate-Pro/pull/594/files#diff-a64cf250b418ab8feee6c682a3d8cbd3b72cf24d4a241adeaf35c98b84045f93).
> - Adds a test in [tests/deployment-config.test.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/594/files#diff-d8c406b273c237e550c231ff4129c57f795327a79d29cb7493806bb29f4ad654) asserting the Permissions-Policy header denies microphone access.
> - Relaxes the Node.js engine requirement in [package.json](https://github.com/Joker5514/VoiceIsolate-Pro/pull/594/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) from `24.x` to `>=22` to align with documentation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0a4259f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Expanded Node.js runtime compatibility to support versions 22 and later

* **Security**
  * Enhanced HTTP security headers with stricter microphone access restrictions
  * Updated content security policy media source directives

<!-- end of auto-generated comment: release notes by coderabbit.ai -->