### PR TITLE
Fix Live-Mix sliders appearing unwired before processing

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -81,27 +81,27 @@
       <div class="slider-grid">
         <div class="slider-row">
           <label for="noiseReductionSlider">Noise Reduction</label>
-          <input type="range" id="noiseReductionSlider" min="0" max="100" value="100" step="1">
+          <input type="range" id="noiseReductionSlider" min="0" max="100" value="100" step="1" disabled>
           <span class="slider-val" id="noiseReductionVal">100%</span>
         </div>
         <div class="slider-row">
           <label for="voiceLevelSlider">Voice Level</label>
-          <input type="range" id="voiceLevelSlider" min="0" max="200" value="100" step="1">
+          <input type="range" id="voiceLevelSlider" min="0" max="200" value="100" step="1" disabled>
           <span class="slider-val" id="voiceLevelVal">100%</span>
         </div>
         <div class="slider-row">
           <label for="volumeSlider">Output Volume</label>
-          <input type="range" id="volumeSlider" min="0" max="100" value="100" step="1">
+          <input type="range" id="volumeSlider" min="0" max="100" value="100" step="1" disabled>
           <span class="slider-val" id="volumeVal">100%</span>
         </div>
         <div class="slider-row">
           <label for="eqLowSlider">EQ Low Shelf</label>
-          <input type="range" id="eqLowSlider" min="-24" max="24" value="0" step="1">
+          <input type="range" id="eqLowSlider" min="-24" max="24" value="0" step="1" disabled>
           <span class="slider-val" id="eqLowVal">0 dB</span>
         </div>
         <div class="slider-row">
           <label for="eqHighSlider">EQ High Shelf</label>
-          <input type="range" id="eqHighSlider" min="-24" max="24" value="0" step="1">
+          <input type="range" id="eqHighSlider" min="-24" max="24" value="0" step="1" disabled>
           <span class="slider-val" id="eqHighVal">0 dB</span>
         </div>
       </div>

--- a/public/landing.js
+++ b/public/landing.js
@@ -30,6 +30,12 @@ const ui = {
   stopBtn: $('stopBtn'),
   muteVoiceBtn: $('muteVoiceBtn'),
   muteNoiseBtn: $('muteNoiseBtn'),
+  // Live-Mix sliders: disabled in markup until stems exist, then enabled in
+  // onStems() so they are never clickable-but-inert (no audio to mix yet).
+  mixSliders: [
+    $('noiseReductionSlider'), $('voiceLevelSlider'), $('volumeSlider'),
+    $('eqLowSlider'), $('eqHighSlider'),
+  ],
   statusDot: $('statusDot'),
   statusText: $('statusText'),
   progress: $('inferenceProgress'),
@@ -262,8 +268,11 @@ function onStems({ requestId, clean, noise, sampleRate, passthrough }) {
   visualizer.loadStems(clean, noise, mixer.duration());
   syncMuteButtons();
 
-  for (const btn of [ui.playBtn, ui.pauseBtn, ui.stopBtn,
-    ui.muteVoiceBtn, ui.muteNoiseBtn, ui.presetSelect]) btn.disabled = false;
+  for (const el of [ui.playBtn, ui.pauseBtn, ui.stopBtn,
+    ui.muteVoiceBtn, ui.muteNoiseBtn, ui.presetSelect,
+    ...ui.mixSliders]) {
+    if (el) el.disabled = false;
+  }
   setStatus(
     passthrough
       ? 'Model unavailable — passthrough stems loaded (original audio). Check that /app/models is being served.'

--- a/scripts/landing-smoke.cjs
+++ b/scripts/landing-smoke.cjs
@@ -98,6 +98,13 @@ async function main() {
       'muteVoiceBtn', 'muteNoiseBtn', 'speakersPanel', 'speakerCardsGrid']) {
       check(await page.locator(`#${id}`).count() === 1, `#${id} present`);
     }
+    // Live-Mix sliders start disabled (no stems to mix yet) so they are never
+    // clickable-but-inert before processing.
+    const mixSliderIds = ['noiseReductionSlider', 'voiceLevelSlider', 'volumeSlider', 'eqLowSlider', 'eqHighSlider'];
+    check(
+      await page.evaluate((ids) => ids.every((id) => document.getElementById(id).disabled), mixSliderIds),
+      'Live-Mix sliders disabled before processing'
+    );
 
     // ── Ingest + true inference ─────────────────────────────────────────────
     console.log('\nIngestion & inference (real model, no passthrough):');
@@ -117,6 +124,10 @@ async function main() {
     check(!statusAfter.includes('passthrough') && !statusAfter.includes('unavailable'),
       'REAL inference produced stems (not passthrough)');
     check(await page.evaluate(() => Boolean(globalThis.__vipDiagnostics?.mixer)), 'mixer + diagnostics exposed');
+    check(
+      await page.evaluate((ids) => ids.every((id) => !document.getElementById(id).disabled), mixSliderIds),
+      'Live-Mix sliders enabled once stems are ready'
+    );
 
     // Stems must differ from each other and be non-silent (real separation).
     const stemStats = await page.evaluate(() => {

--- a/tests/slider-ui.test.js
+++ b/tests/slider-ui.test.js
@@ -1,0 +1,195 @@
+/**
+ * @jest-environment jsdom
+ *
+ * VoiceIsolate Pro — SliderUI (Layer 4) DOM tests.
+ *
+ * Locks in the real-time control contract (CLAUDE.md §1/§1.1): each Live-Mix
+ * slider's `input` event drives exactly one PlaybackMixer AudioParam method,
+ * coalesced through a single requestAnimationFrame flush. Fast guard for the
+ * "sliders aren't wired" regression that the browser E2E (landing-smoke) also
+ * covers end-to-end.
+ */
+
+'use strict';
+
+/* global document -- provided by the jsdom test environment */
+
+let SliderUI;
+let SLIDER_BINDINGS;
+
+beforeAll(async () => {
+  ({ SliderUI, SLIDER_BINDINGS } = await import('../src/presentation/SliderUI.js'));
+});
+
+/** Mixer double recording every real-time control call. */
+function mockMixer() {
+  return {
+    calls: [],
+    setNoiseReduction(v) { this.calls.push(['setNoiseReduction', v]); },
+    setVoiceLevel(v) { this.calls.push(['setVoiceLevel', v]); },
+    setVolume(v) { this.calls.push(['setVolume', v]); },
+    setLowShelf(v) { this.calls.push(['setLowShelf', v]); },
+    setHighShelf(v) { this.calls.push(['setHighShelf', v]); },
+  };
+}
+
+/**
+ * Build the five Live-Mix sliders with the same min/max/step as the real
+ * markup (public/index.html) so jsdom's native range clamping matches the
+ * browser exactly.
+ */
+const SLIDER_SPECS = {
+  noiseReductionSlider: { min: 0, max: 100, value: 100 },
+  voiceLevelSlider: { min: 0, max: 200, value: 100 },
+  volumeSlider: { min: 0, max: 100, value: 100 },
+  eqLowSlider: { min: -24, max: 24, value: 0 },
+  eqHighSlider: { min: -24, max: 24, value: 0 },
+};
+function buildSliders(values = {}) {
+  document.body.innerHTML = '';
+  for (const [id, spec] of Object.entries(SLIDER_SPECS)) {
+    const el = document.createElement('input');
+    el.type = 'range';
+    el.id = id;
+    el.min = String(spec.min);
+    el.max = String(spec.max);
+    el.step = '1';
+    el.value = String(values[id] ?? spec.value);
+    document.body.appendChild(el);
+  }
+}
+
+/** Controllable rAF: queued callbacks flush only when flushRaf() is called. */
+let rafQueue;
+function installControllableRaf() {
+  rafQueue = [];
+  globalThis.requestAnimationFrame = (cb) => { rafQueue.push(cb); return rafQueue.length; };
+  globalThis.cancelAnimationFrame = (id) => { rafQueue[id - 1] = null; };
+}
+function flushRaf() {
+  const pending = rafQueue;
+  rafQueue = [];
+  for (const cb of pending) if (cb) cb(0);
+}
+
+describe('SliderUI', () => {
+  let mixer;
+
+  beforeEach(() => {
+    installControllableRaf();
+    mixer = mockMixer();
+    buildSliders();
+  });
+
+  test('requires a mixer instance', () => {
+    expect(() => new SliderUI(null)).toThrow(TypeError);
+  });
+
+  test('binds every present slider and initializes the graph from its value', () => {
+    const ui = new SliderUI(mixer);
+    const bound = ui.bind();
+    expect(bound).toBe(SLIDER_BINDINGS.length); // all 5 present
+    // bind() seeds the graph from each slider's current position.
+    expect(mixer.calls).toEqual([
+      ['setNoiseReduction', 100],
+      ['setVoiceLevel', 100],
+      ['setVolume', 100],
+      ['setLowShelf', 0],
+      ['setHighShelf', 0],
+    ]);
+  });
+
+  test('an input event drives the mapped AudioParam method in real time', () => {
+    const ui = new SliderUI(mixer);
+    ui.bind();
+    mixer.calls.length = 0; // drop the init calls
+
+    const noise = document.getElementById('noiseReductionSlider');
+    noise.value = '40';
+    noise.dispatchEvent(new Event('input'));
+    expect(mixer.calls).toEqual([]); // nothing until the frame flush
+    flushRaf();
+    expect(mixer.calls).toEqual([['setNoiseReduction', 40]]);
+  });
+
+  test('every slider routes to its own mixer method', () => {
+    const ui = new SliderUI(mixer);
+    ui.bind();
+    mixer.calls.length = 0;
+
+    const drive = (id, v) => {
+      const el = document.getElementById(id);
+      el.value = String(v);
+      el.dispatchEvent(new Event('input'));
+    };
+    drive('noiseReductionSlider', 10);
+    drive('voiceLevelSlider', 150);
+    drive('volumeSlider', 25);
+    drive('eqLowSlider', -12);
+    drive('eqHighSlider', 18);
+    flushRaf();
+
+    expect(mixer.calls).toEqual([
+      ['setNoiseReduction', 10],
+      ['setVoiceLevel', 150],
+      ['setVolume', 25],
+      ['setLowShelf', -12],
+      ['setHighShelf', 18],
+    ]);
+  });
+
+  test('rapid drag is coalesced to one flush carrying the latest value', () => {
+    const ui = new SliderUI(mixer);
+    ui.bind();
+    mixer.calls.length = 0;
+
+    const vol = document.getElementById('volumeSlider');
+    for (const v of [90, 80, 70, 60, 55]) {
+      vol.value = String(v);
+      vol.dispatchEvent(new Event('input'));
+    }
+    expect(rafQueue.filter(Boolean).length).toBe(1); // one frame scheduled, not five
+    flushRaf();
+    expect(mixer.calls).toEqual([['setVolume', 55]]);
+  });
+
+  test('onChange hook fires per input with id and value', () => {
+    const seen = [];
+    const ui = new SliderUI(mixer, { onChange: (id, v) => seen.push([id, v]) });
+    ui.bind();
+
+    const eq = document.getElementById('eqHighSlider');
+    eq.value = '6';
+    eq.dispatchEvent(new Event('input'));
+    expect(seen).toEqual([['eqHighSlider', 6]]);
+  });
+
+  test('absent sliders are skipped without throwing', () => {
+    document.getElementById('eqLowSlider').remove();
+    document.getElementById('eqHighSlider').remove();
+    const ui = new SliderUI(mixer);
+    expect(ui.bind()).toBe(SLIDER_BINDINGS.length - 2);
+  });
+
+  test('a missing mixer method is skipped with a warning, not a crash', () => {
+    delete mixer.setVolume;
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const ui = new SliderUI(mixer);
+    expect(ui.bind()).toBe(SLIDER_BINDINGS.length - 1);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  test('dispose() detaches listeners so later input is inert', () => {
+    const ui = new SliderUI(mixer);
+    ui.bind();
+    mixer.calls.length = 0;
+    ui.dispose();
+
+    const noise = document.getElementById('noiseReductionSlider');
+    noise.value = '0';
+    noise.dispatchEvent(new Event('input'));
+    flushRaf();
+    expect(mixer.calls).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Investigated the report that "sliders aren't wired." After verifying every real-time slider end-to-end, the root cause was a **UI enable-state bug on the landing page**, not a wiring break.

### What I checked
- **Landing page (`/`) — the real-time Stem-Split & Live-Mix UI:** All five Live-Mix sliders (Noise Reduction, Voice Level, Output Volume, EQ Low/High) **already drive their `AudioParam`s in real time** (`GainNode`/`BiquadFilter`). Confirmed by the browser E2E (`landing-smoke`) slider→AudioParam calibration sweep and a new fast unit suite. The per-speaker volume sliders are likewise wired live via `setSpeakerVolume`.
- **Legacy Engineer Mode (`/app/`):** Its 52 sliders feed the **offline** 32-stage DSP via `VIP_PARAMS` and apply on process/reprocess only. They are *not* real-time by design — the real-time orchestrator (`pipeline-orchestrator.js` / `window._vipOrch`) was deliberately deleted, and CLAUDE.md §1.1/§5 hard-prohibit restoring it or re-running ML/spectral inference from a slider event. Many of those controls (spectral isolation, gating, de-ess) physically can't be expressed as real-time `AudioParam` tweaks. **This PR does not touch the frozen legacy app.**

### The bug
The five Live-Mix sliders were rendered **enabled on page load**, but `PlaybackMixer`/`SliderUI` are only constructed in `onStems()`. So before a file was processed the sliders looked interactive yet did nothing — which reads as "not wired." (The transport buttons were already correctly `disabled` until stems load.)

### The fix
Make the enable-state honest, matching the existing transport-button pattern:
- `public/index.html`: mark the five sliders `disabled` on load.
- `public/landing.js`: enable them in `onStems()` alongside the transport controls, once stems exist and `SliderUI` has bound them. From that point they drive their `AudioParam`s in real time — no ML re-inference from sliders (Stem-Split & Live-Mix contract preserved).

### Regression guards
- **`tests/slider-ui.test.js`** (new, jsdom): covers `bind()` + graph seeding, per-slider routing to the correct mixer method, `requestAnimationFrame` coalescing (fast drag → one flush, latest value), `onChange`, missing-slider / missing-method handling, and `dispose()`.
- **`scripts/landing-smoke.cjs`**: asserts the sliders are disabled before processing and enabled once stems are ready.

### Verification
- `pnpm test` — **1763 passed** (was 1754; +9 new).
- `node scripts/validate.js` — all structural / architecture checks pass.
- `node scripts/landing-smoke.cjs` — full browser E2E green, including the slider→AudioParam real-time sweep, presets, mutes, per-speaker isolation, and zero console errors.
- ESLint — 0 errors.

> If you'd like the legacy Engineer Mode controls to respond in real time too, the architecturally-correct path is to migrate those controls onto the new `src/` `PlaybackMixer` layer (Web Audio nodes), rather than reviving the deleted offline orchestrator. Happy to scope that as a follow-up.

https://claude.ai/code/session_01UK3ffdwAGTR86wos7SEozY

---
_Generated by [Claude Code](https://claude.ai/code/session_01UK3ffdwAGTR86wos7SEozY)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disable Live-Mix sliders until stems are loaded
> - Adds the `disabled` attribute to five Live-Mix range inputs (`#noiseReductionSlider`, `#voiceLevelSlider`, `#volumeSlider`, `#eqLowSlider`, `#eqHighSlider`) in [index.html](https://github.com/Joker5514/VoiceIsolate-Pro/pull/596/files#diff-c2cc24bc9001b11b6add48a4cd8f893d5d6c6e4d1bd254158bd14ab997f552cd) so they are non-interactive on page load.
> - Enables these sliders in the `onStems` handler in [landing.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/596/files#diff-be23ec2b8a859b1c83e27ce227d9dd0c367c83c7a8f1a4b104128c882bdb30ab) alongside existing controls once stems are ready.
> - Adds e2e smoke test assertions in [landing-smoke.cjs](https://github.com/Joker5514/VoiceIsolate-Pro/pull/596/files#diff-c972a650f68ed98ac9ca024402a87f6ce7105c79b8e85514dc27b1e913e9c597) verifying sliders are disabled before processing and enabled after stems load.
> - Adds a Jest test suite in [slider-ui.test.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/596/files#diff-b8aaee04651bda2facd2f3379dcb9c50367131a74eca787bfd1521edd25dd93d) covering slider binding, input event mapping, rAF-coalesced updates, and `dispose()` cleanup.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 12e1a5f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Live-mix control sliders (Noise Reduction, Voice Level, Output Volume, EQ Low Shelf, EQ High Shelf) now start disabled on initial page load and are automatically enabled once audio stems are loaded and ready for processing.

* **Tests**
  * Added comprehensive test coverage for slider UI behavior and state transitions during audio processing, including E2E smoke tests validating initial disabled state and subsequent enabling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->