### PR TITLE
🎨 Palette: Add focus outline and ARIA labels to switch components

### DIFF
--- a/public/app/voice-isolator.html
+++ b/public/app/voice-isolator.html
@@ -385,6 +385,7 @@
             height: 20px;
         }
         .switch input { opacity: 0; width: 0; height: 0; }
+        .switch input:focus-visible + .slider { outline: 2px solid var(--accent); outline-offset: 2px; }
         .slider {
             position: absolute;
             cursor: pointer;
@@ -615,7 +616,7 @@
                 <div class="switch-row">
                     <span>Monitor Output</span>
                     <label class="switch">
-                        <input type="checkbox">
+                        <input type="checkbox" aria-label="Monitor Output">
                         <span class="slider"></span>
                     </label>
                 </div>
@@ -623,7 +624,7 @@
                 <div class="switch-row">
                     <span>Bypass Processing</span>
                     <label class="switch">
-                        <input type="checkbox">
+                        <input type="checkbox" aria-label="Bypass Processing">
                         <span class="slider"></span>
                     </label>
                 </div>


### PR DESCRIPTION
💡 **What:**
Added a `:focus-visible` outline state to the custom toggle switches and explicit `aria-label`s to the hidden checkbox inputs in `voice-isolator.html`.

🎯 **Why:**
When hiding native inputs with `opacity: 0` to create custom switches, the browser's default keyboard focus indicators become invisible, breaking keyboard navigation. Adding a `:focus-visible` state restores this visual cue for keyboard users. Furthermore, since the descriptive text for these switches is located in a sibling `<span>` rather than within the `<label>`, the hidden inputs lacked an accessible name for screen readers. The `aria-label`s resolve this.

📸 **Before/After:**
*(Visual changes verified via Playwright screenshot: `verification.png` shows the new teal focus outline on the Bypass Processing switch when focused.)*

♿ **Accessibility:**
- Restored visible focus indicators for keyboard users navigating the "Output" panel switches.
- Provided explicit accessible names to the switch inputs for screen reader users.

---
*PR created automatically by Jules for task [17928812728907521097](https://jules.google.com/task/17928812728907521097) started by @Joker5514*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add keyboard focus outline and `aria-label` attributes to toggle switches in voice isolator
> Adds a `:focus-visible` CSS rule to [voice-isolator.html](https://github.com/Joker5514/VoiceIsolate-Pro/pull/598/files#diff-8818df63949de67b2361890cedf0309a5fbebcf7a92b01981186312bc36792e6) so toggle switches display a visible outline when keyboard-focused. Adds `aria-label` attributes to the 'Monitor Output' and 'Bypass Processing' checkbox inputs so assistive technologies can identify them.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ac65b68.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->