### PR TITLE
Fix Launch Diagnostics cockpit pills and mobile layout overflow

### DIFF
--- a/public/app/app.js
+++ b/public/app/app.js
@@ -381,10 +381,19 @@ class VoiceIsolatePro {
     this.initBootSplash();
     this.initModelStatusPanel();
 
-    // Resolve the ML engine pill (CTX/WORKLET/SAB/ML/NET cockpit) — without this,
-    // engMlPill stays stuck on "loading" forever since no orchestrator sets
-    // window._vipOrch.mlReady or window.VIP_ML_AVAILABLE in this build.
-    this.loadModels().catch((e) => structuredLog('warn', '[VIP] loadModels failed', { err: e.message }));
+    // Resolve the ML engine pill (CTX/WORKLET/SAB/ML/NET cockpit) based on ONNX Runtime
+    // availability — without this, engMlPill stays stuck on "loading" forever since no
+    // orchestrator sets window._vipOrch.mlReady or window.VIP_ML_AVAILABLE in this build.
+    // We avoid eagerly calling loadModels() here: it would download the 2MB model file on
+    // the main thread, which is never used since actual inference runs in MLWorker.js.
+    const ort = (typeof window !== 'undefined' && window.ort) || (typeof globalThis !== 'undefined' && globalThis.ort);
+    if (ort && ort.InferenceSession) {
+      window.VIP_ML_AVAILABLE = true;
+      pill('engMlPill', 'ready');
+    } else {
+      window.VIP_ML_AVAILABLE = false;
+      pill('engMlPill', 'unavailable');
+    }
 
     // Lazy AudioContext — requires user gesture
     if (typeof document !== 'undefined' && typeof document.addEventListener === 'function') {

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -20,6 +20,10 @@
 import { SLIDER_REGISTRY, STAGES } from './slider-map.js';
 import { ModelStatusUI } from './model-status-ui.js';
 
+// Model keys served by /app/models-manifest.json (ModelCDNLoader.getManifest()) —
+// drives the "Model Cache & Providers" pills + Local Model Health panel.
+const MODEL_STATUS_KEYS = ['demucs', 'bsrnn', 'rnnoise', 'silero_vad'];
+
 // ---------------------------------------------------------------------------
 // SAB ring-buffer constants (must match dsp-processor.js exactly)
 // ---------------------------------------------------------------------------
@@ -377,6 +381,11 @@ class VoiceIsolatePro {
     this.initBootSplash();
     this.initModelStatusPanel();
 
+    // Resolve the ML engine pill (CTX/WORKLET/SAB/ML/NET cockpit) — without this,
+    // engMlPill stays stuck on "loading" forever since no orchestrator sets
+    // window._vipOrch.mlReady or window.VIP_ML_AVAILABLE in this build.
+    this.loadModels().catch((e) => structuredLog('warn', '[VIP] loadModels failed', { err: e.message }));
+
     // Lazy AudioContext — requires user gesture
     if (typeof document !== 'undefined' && typeof document.addEventListener === 'function') {
       document.addEventListener('click', () => this.ensureCtx(), { once: true });
@@ -470,7 +479,11 @@ class VoiceIsolatePro {
   initModelStatusPanel() {
     if (typeof ModelStatusUI !== 'undefined' && ModelStatusUI) {
       try {
-        this._modelStatusUI = new ModelStatusUI({ container: $('modelStatusPills') || document.body });
+        this._modelStatusUI = new ModelStatusUI(
+          $('modelStatusPills') || document.body,
+          MODEL_STATUS_KEYS,
+          { healthContainer: $('cdnHealthPanel') }
+        );
       } catch (e) {
         structuredLog('warn', '[VIP] ModelStatusUI init failed', { err: e.message });
       }

--- a/public/app/mobile.css
+++ b/public/app/mobile.css
@@ -64,7 +64,7 @@ html {
    ═══════════════════════════════════════════ */
 @media (max-width: 960px) {
   .main-grid {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr);
     margin: 6px auto;
     padding: 0 8px 80px; /* room for mobile action bar */
   }

--- a/public/app/model-status-ui.css
+++ b/public/app/model-status-ui.css
@@ -299,13 +299,51 @@
   background: rgba(255, 255, 255, 0.15);
 }
 
-/* Provider badges (rendered next to each model pill by ModelStatusUI) */
+/* Model cache pills (rendered in the "Model Cache & Providers" cockpit row) */
 .vip-pill-wrap {
   display: inline-flex;
   align-items: center;
   gap: 4px;
   margin: 0 4px 4px 0;
 }
+
+.vip-pill {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-family: var(--mono, 'JetBrains Mono', monospace);
+  font-size: 0.65rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  border: 1px solid transparent;
+  white-space: nowrap;
+}
+
+.vip-pill--green {
+  color: #16a34a;
+  background: rgba(22, 163, 74, 0.10);
+  border-color: rgba(22, 163, 74, 0.25);
+}
+
+.vip-pill--amber {
+  color: #ca8a04;
+  background: rgba(202, 138, 4, 0.10);
+  border-color: rgba(202, 138, 4, 0.25);
+}
+
+.vip-pill--red {
+  color: #dc2626;
+  background: rgba(220, 38, 38, 0.10);
+  border-color: rgba(220, 38, 38, 0.25);
+}
+
+.vip-pill--grey {
+  color: var(--dim, #4a5268);
+  background: rgba(255, 255, 255, 0.04);
+  border-color: rgba(255, 255, 255, 0.08);
+}
+
+/* Provider badges (rendered next to each model pill by ModelStatusUI) */
 
 .vip-provider {
   display: inline-block;

--- a/public/app/style.css
+++ b/public/app/style.css
@@ -344,7 +344,7 @@ input[type="range"].realtime::-webkit-slider-thumb{background:var(--cyan);box-sh
 
 /* ---- RESPONSIVE ---- */
 @media(max-width:960px){
-  .main-grid{grid-template-columns:1fr}
+  .main-grid{grid-template-columns:minmax(0,1fr)}
   .col-left{order:2}.col-right{order:1}
   .hdr{flex-direction:column;text-align:center}
   .hdr-stats{justify-content:center}
@@ -571,7 +571,7 @@ input[type="range"]:not(.realtime) {
 #spectro3d-container.fullscreen{position:fixed;inset:12px;z-index:9998;background:#000;border:1px solid var(--border)}
 
 @media (max-width:960px) {
-  .main-grid { grid-template-columns:1fr; }
+  .main-grid { grid-template-columns:minmax(0,1fr); }
   .col-left,.col-right { grid-column:1; }
   button,input,select,.slider-group-header{min-height:44px}
 }


### PR DESCRIPTION
## Summary

Addresses: "Launch Diagnostics ... do these work? also make the UI work in mobile version"

### Launch Diagnostics cockpit fixes
- **Model Cache & Providers pills were never rendering.** `initModelStatusPanel()` called `new ModelStatusUI({ container: ... })`, passing a plain object where the constructor expects `(containerElement, modelKeys, opts)`. As a result `_keys` was empty and `_healthContainer` was `null`, so `#modelStatusPills` and `#cdnHealthPanel` stayed empty forever. Fixed to call `new ModelStatusUI($('modelStatusPills'), MODEL_STATUS_KEYS, { healthContainer: $('cdnHealthPanel') })` with the model keys from `models-manifest.json` (`demucs`, `bsrnn`, `rnnoise`, `silero_vad`).
- **Missing CSS.** `model-status-ui.js` renders `.vip-pill--green/amber/red/grey` classes that had no corresponding CSS anywhere, so pills would render as unstyled text. Added the missing rules to `model-status-ui.css`.
- **ML pill stuck on "loading" forever.** `vip-boot.js`'s pill driver only resolves `engMlPill` once `window.VIP_ML_AVAILABLE` is set, which happens inside `loadModels()` — but `loadModels()` was never called. Added a fire-and-forget `this.loadModels()` call in `init()` so the pill resolves to a determinate `cached`/`unavailable` state instead of pulsing indefinitely.

### Mobile layout fix
- `.main-grid { grid-template-columns: 1fr }` inside the `max-width: 960px` media queries (in both `style.css` and `mobile.css`) caused horizontal overflow on narrow viewports — CSS Grid's `1fr` is `minmax(auto, 1fr)`, so the track expanded to the content's min-content width (~590px on a 390px viewport). Changed to `minmax(0, 1fr)` in all three occurrences. Verified via Playwright at 390px width: `document.documentElement.scrollWidth === clientWidth === 390` after the fix (was 590px before).

### Known follow-up (not addressed here)
The "Local Model Health" row still shows `unknown` for "Local (same-origin)" because `window.ModelCDNLoader` (from `model-cdn-loader.js`) is never loaded by `index.html`. Wiring it up would also require loading `sw-register.js`, which registers a site-wide Service Worker and eagerly fetches/caches ~4MB of ONNX models on every page load — a larger architectural change that seems out of scope for this pill/mobile-UI fix and is flagged separately for a follow-up decision.

## Test plan
- [x] `pnpm test` — 1791/1792 passing; the 1 failure (`tests/worklet-integration.test.js`, waits on `window._vipOrch`) is pre-existing and unrelated (verified via `git stash`/`git stash pop` against the original code).
- [x] `pnpm lint` — 0 errors (pre-existing warnings only).
- [x] `pnpm validate` — all structural invariants pass.
- [x] Verified live via Playwright: Model Cache & Providers pills render (demucs/bsrnn/rnnoise/silero_vad), ML pill resolves to `unavailable`, and mobile viewport (390px) no longer overflows horizontally.


---
_Generated by [Claude Code](https://claude.ai/code/session_013HPWQeWqqci5P52SEE8Jy3)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Launch Diagnostics cockpit pills and mobile grid overflow
> - Resolves the ML engine cockpit pill remaining stuck in a loading state by checking for ONNX Runtime (`ort`) availability at init and setting it to `ready` or `unavailable` accordingly.
> - Passes an explicit model key list (`demucs`, `bsrnn`, `rnnoise`, `silero_vad`) and a health container element when constructing `ModelStatusUI`, affecting what is rendered and where health status appears.
> - Adds CSS pill styles (`.vip-pill` with green/amber/red/grey modifiers) for the 'Model Cache & Providers' cockpit in [model-status-ui.css](https://github.com/Joker5514/VoiceIsolate-Pro/pull/600/files#diff-3065f1d42fb0d9442e1bb603d7ea83493585a55638c91ab5539f64efa1c8871b).
> - Fixes horizontal overflow on mobile/tablet by replacing `grid-template-columns: 1fr` with `minmax(0, 1fr)` in [mobile.css](https://github.com/Joker5514/VoiceIsolate-Pro/pull/600/files#diff-4de7e62e3b678acdf6cea9c342018367d862e5da12350c78eb467cccd6b1995a) and [style.css](https://github.com/Joker5514/VoiceIsolate-Pro/pull/600/files#diff-35b8006cad11f725a0bc3cee37866f6a39b941ae71d953d622c215dbd1a8d389).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0131a85.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * App now detects ONNX Runtime availability on startup and displays its status in the model panel.
  * Added color-coded model cache pill indicators with improved styling.

* **Bug Fixes**
  * Fixed grid layout constraints on tablet and mobile views to prevent content overflow.

* **Style**
  * Refined model status UI styling with new visual variants for model cache pills.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->