### PR TITLE
🎨 Palette: Add confirmation dialog for destructive clear action

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -16,3 +16,7 @@
 ## 2026-05-18 - [Custom Modal Keyboard Accessibility & ARIA States Update]
 **Learning:** When implementing 'Enter' to submit within custom UI modals, scope the keydown listener to the specific input field (e.g., verifying `e.target.id`) rather than the entire modal document/container to prevent intercepting and hijacking Enter key presses on other interactive elements like buttons.
 **Action:** When implementing modal keyboard accessibility, ensure `Enter` key events do not globally override native button click events by strictly limiting the event scope to text inputs.
+
+## 2026-05-20 - [Destructive Action Confirmation]
+**Learning:** Actions that discard user state or work (like clearing a loaded file and its processed outputs) can be accidentally triggered, leading to a frustrating loss of data.
+**Action:** Always wrap destructive actions in a confirmation dialog (e.g., `confirm()`) if there is unsaved state, preventing accidental clicks from wiping out the user's progress.

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -779,7 +779,12 @@ class VoiceIsolatePro {
         this.handleFile(e.dataTransfer.files[0]);
       });
     }
-    bind('clearFile', d.clearFile, 'click', () => this._clearFile());
+    bind('clearFile', d.clearFile, 'click', () => {
+      if (this.inputBuffer) {
+        if (!confirm('Clear current file and discard all changes?')) return;
+      }
+      this._clearFile();
+    });
 
     // Process buttons
     bind('processBtn', d.processBtn, 'click', () => this.runPipeline());


### PR DESCRIPTION
Closing as superseded by #614, which covers the same confirmation dialog for the Clear File action and has already been merged.