### PR TITLE
Add stereo-width control (mid/side matrix) to the Live-Mix console

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -189,6 +189,11 @@
           <input type="range" id="makeupGainSlider" min="0" max="24" value="0" step="1" disabled>
           <span class="slider-val" id="makeupGainVal">0 dB</span>
         </div>
+        <div class="slider-row">
+          <label for="stereoWidthSlider">Stereo Width</label>
+          <input type="range" id="stereoWidthSlider" min="0" max="200" value="100" step="1" disabled>
+          <span class="slider-val" id="stereoWidthVal">100%</span>
+        </div>
       </div>
     </section>
 

--- a/public/landing.js
+++ b/public/landing.js
@@ -40,6 +40,7 @@ const ui = {
     $('highpassSlider'), $('lowpassSlider'),
     $('compThresholdSlider'), $('compRatioSlider'), $('compAttackSlider'),
     $('compReleaseSlider'), $('compKneeSlider'), $('makeupGainSlider'),
+    $('stereoWidthSlider'),
   ],
   statusDot: $('statusDot'),
   statusText: $('statusText'),
@@ -315,6 +316,7 @@ const READOUTS = [
   ['compReleaseSlider', 'compReleaseVal', (v) => `${v} ms`],
   ['compKneeSlider', 'compKneeVal', (v) => `${v} dB`],
   ['makeupGainSlider', 'makeupGainVal', (v) => `${v} dB`],
+  ['stereoWidthSlider', 'stereoWidthVal', (v) => `${v}%`],
 ];
 
 function wireReadouts() {

--- a/src/pipeline/PlaybackMixer.js
+++ b/src/pipeline/PlaybackMixer.js
@@ -9,7 +9,8 @@
  *
  *   [Tier-A bus] = highpass ─► lowpass ─► lowShelf ─► eqLowMid ─► eqMid
  *                  ─► eqHighMid ─► highShelf ─► compressor ─► makeupGain
- *                  ─► Master ─► Analyser ─► destination
+ *                  ─► [stereo-width mid/side matrix] ─► Master ─► Analyser
+ *                  ─► destination
  *
  * The Tier-A console (HP/LP filters, 5-band EQ, bus compressor) is shared by
  * both stems and defaults to fully transparent — adding it never changes how
@@ -68,6 +69,17 @@ export class PlaybackMixer {
     this.eqHighMid = this.ctx.createBiquadFilter();
     this.compressor = this.ctx.createDynamicsCompressor();
     this.makeupGain = this.ctx.createGain();
+    // ── Stereo-width mid/side matrix (transparent at width = 100%) ────────
+    this.stereoIn = this.ctx.createGain();        // force 2ch: mono up-mix → L=R
+    this.msSplit = this.ctx.createChannelSplitter(2);
+    this.sideRNeg = this.ctx.createGain();        // −R, for Side = (L−R)/2
+    this.midGain = this.ctx.createGain();         // Mid  = (L+R)/2
+    this.sideGain = this.ctx.createGain();        // Side = (L−R)/2
+    this.widthGain = this.ctx.createGain();       // ← control: w·Side
+    this.sideSNeg = this.ctx.createGain();        // −w·Side, for R' = M − w·S
+    this.leftSum = this.ctx.createGain();         // L' = M + w·Side
+    this.rightSum = this.ctx.createGain();        // R' = M − w·Side
+    this.msMerge = this.ctx.createChannelMerger(2);
     this.masterGain = this.ctx.createGain();
     this.analyser = this.ctx.createAnalyser();
 
@@ -94,6 +106,17 @@ export class PlaybackMixer {
     this.compressor.ratio.value = 1;
     this.compressor.attack.value = 0.02;
     this.compressor.release.value = 0.25;
+    // Stereo-width matrix: fixed coefficients + the single width control.
+    this.stereoIn.channelCount = 2;
+    this.stereoIn.channelCountMode = 'explicit';
+    this.stereoIn.channelInterpretation = 'speakers'; // mono up-mixes to L=R
+    this.midGain.gain.value = 0.5;
+    this.sideGain.gain.value = 0.5;
+    this.sideRNeg.gain.value = -1;
+    this.sideSNeg.gain.value = -1;
+    this.leftSum.gain.value = 1;
+    this.rightSum.gain.value = 1;
+    this.widthGain.gain.value = 1;   // width 100% → Side unchanged → transparent
     this.analyser.fftSize = 2048;
 
     this.speakerGain.connect(this.cleanGain);
@@ -110,7 +133,27 @@ export class PlaybackMixer {
     this.eqHighMid.connect(this.highShelf);
     this.highShelf.connect(this.compressor);
     this.compressor.connect(this.makeupGain);
-    this.makeupGain.connect(this.masterGain);
+    // Stereo-width mid/side matrix: makeup → stereoIn → split → M/S → merge → master.
+    this.makeupGain.connect(this.stereoIn);
+    this.stereoIn.connect(this.msSplit);
+    // Mid = (L + R) · 0.5  (both split legs sum into midGain)
+    this.msSplit.connect(this.midGain, 0);
+    this.msSplit.connect(this.midGain, 1);
+    // Side = (L − R) · 0.5  (R is negated before summing with L)
+    this.msSplit.connect(this.sideGain, 0);
+    this.msSplit.connect(this.sideRNeg, 1);
+    this.sideRNeg.connect(this.sideGain);
+    // Width scales Side; a negated copy feeds the right leg.
+    this.sideGain.connect(this.widthGain);
+    this.widthGain.connect(this.sideSNeg);
+    // L' = M + w·S   ;   R' = M − w·S
+    this.midGain.connect(this.leftSum);
+    this.widthGain.connect(this.leftSum);
+    this.midGain.connect(this.rightSum);
+    this.sideSNeg.connect(this.rightSum);
+    this.leftSum.connect(this.msMerge, 0, 0);
+    this.rightSum.connect(this.msMerge, 0, 1);
+    this.msMerge.connect(this.masterGain);
     this.masterGain.connect(this.analyser);
     this.analyser.connect(this.ctx.destination);
 
@@ -365,6 +408,15 @@ export class PlaybackMixer {
   }
 
   /**
+   * Stereo width as a percentage (0 … 200). 100 = unchanged; 0 = mono (sides
+   * collapsed); 200 = doubled width. Drives the Side-signal gain in the mid/side
+   * matrix — a mono source stays mono at any setting (its Side is silent).
+   */
+  setStereoWidth(percentage) {
+    this._applyParam(this.widthGain.gain, clamp(percentage, 0, 200) / 100);
+  }
+
+  /**
    * Hard-mute the voice stem without disturbing the Voice Level slider.
    * @param {boolean} muted
    */
@@ -548,6 +600,8 @@ export class PlaybackMixer {
       this.noiseGain, this.noiseMuteGain, this.highpass, this.lowpass,
       this.lowShelf, this.eqLowMid, this.eqMid, this.eqHighMid,
       this.highShelf, this.compressor, this.makeupGain,
+      this.stereoIn, this.msSplit, this.sideRNeg, this.midGain, this.sideGain,
+      this.widthGain, this.sideSNeg, this.leftSum, this.rightSum, this.msMerge,
       this.masterGain, this.analyser]) {
       try { node.disconnect(); } catch { /* already disconnected */ }
     }

--- a/src/presentation/SliderUI.js
+++ b/src/presentation/SliderUI.js
@@ -41,6 +41,7 @@ const SLIDER_BINDINGS = Object.freeze([
   { id: 'compReleaseSlider', method: 'setCompRelease', initial: 250 },
   { id: 'compKneeSlider', method: 'setCompKnee', initial: 0 },
   { id: 'makeupGainSlider', method: 'setMakeupGain', initial: 0 },
+  { id: 'stereoWidthSlider', method: 'setStereoWidth', initial: 100 },
 ]);
 
 export class SliderUI {

--- a/tests/slider-ui.test.js
+++ b/tests/slider-ui.test.js
@@ -41,6 +41,7 @@ function mockMixer() {
     setCompRelease(v) { this.calls.push(['setCompRelease', v]); },
     setCompKnee(v) { this.calls.push(['setCompKnee', v]); },
     setMakeupGain(v) { this.calls.push(['setMakeupGain', v]); },
+    setStereoWidth(v) { this.calls.push(['setStereoWidth', v]); },
   };
 }
 
@@ -66,6 +67,7 @@ const SLIDER_SPECS = {
   compReleaseSlider: { min: 0, max: 1000, value: 250 },
   compKneeSlider: { min: 0, max: 40, value: 0 },
   makeupGainSlider: { min: 0, max: 24, value: 0 },
+  stereoWidthSlider: { min: 0, max: 200, value: 100 },
 };
 function buildSliders(values = {}) {
   document.body.innerHTML = '';
@@ -129,6 +131,7 @@ describe('SliderUI', () => {
       ['setCompRelease', 250],
       ['setCompKnee', 0],
       ['setMakeupGain', 0],
+      ['setStereoWidth', 100],
     ]);
   });
 

--- a/tests/stem-split-core.test.js
+++ b/tests/stem-split-core.test.js
@@ -161,6 +161,8 @@ function mockContext() {
       type: '', frequency: mockParam(), gain: mockParam(), Q: mockParam(),
     }),
     createAnalyser: () => mockNode({ fftSize: 0 }),
+    createChannelSplitter: () => mockNode(),
+    createChannelMerger: () => mockNode(),
     createDynamicsCompressor: () => mockNode({
       threshold: mockParam(), knee: mockParam(), ratio: mockParam(),
       attack: mockParam(), release: mockParam(), reduction: 0,
@@ -232,6 +234,7 @@ describe('PlaybackMixer (Layer 3) — Live-Mix control surface', () => {
     expect(mixer.compressor.ratio.value).toBe(1);
     expect(mixer.compressor.threshold.value).toBe(0);
     expect(mixer.makeupGain.gain.value).toBe(1);
+    expect(mixer.widthGain.gain.value).toBe(1); // stereo width 100% = transparent
   });
 
   test('Tier-A setters clamp inputs and convert units (idle snap)', () => {
@@ -255,6 +258,10 @@ describe('PlaybackMixer (Layer 3) — Live-Mix control surface', () => {
     expect(mixer.compressor.knee.value).toBe(40);
     mixer.setMakeupGain(6);               // +6 dB → linear ~1.995
     expect(mixer.makeupGain.gain.value).toBeCloseTo(Math.pow(10, 6 / 20));
+    mixer.setStereoWidth(0);              // mono
+    expect(mixer.widthGain.gain.value).toBe(0);
+    mixer.setStereoWidth(500);            // clamps to 200 → 2×
+    expect(mixer.widthGain.gain.value).toBe(2);
   });
 
   test('loadStems builds sample-locked buffers; transport round-trips', async () => {


### PR DESCRIPTION
## What & why

Completes the **Tier-A console** with a **stereo-width** control — the remaining item from the slider-tradeoff analysis. Built as a **mid/side matrix** on the shared master bus, inserted between makeup gain and master, fully within the Live-Mix contract (AudioParam-only, no inference).

```
makeup → stereoIn (2ch, mono→L=R) → split → Mid=(L+R)/2, Side=(L−R)/2
       → widthGain (w·Side) → L'=M+wS, R'=M−wS → merge → master
```

## Changes
- **`PlaybackMixer.js`**: 10-node M/S matrix + `setStereoWidth(0–200%)` (100 = unchanged, 0 = mono, 200 = doubled). `dispose()` + graph diagram updated.
- **`SliderUI.js`** / **`index.html`** / **`landing.js`**: new `stereoWidthSlider` binding, row, readout, and enable-on-load (sliders 16 → 17).
- **Tests**: mock `createChannelSplitter`/`createChannelMerger`; assert transparent default (`widthGain = 1`) and clamping; extend the SliderUI `bind()` expectation.

## Correctness
- **Transparent by construction at width 100%**: `L' = M + S = L`, `R' = M − S = R`.
- **Mono-safe**: `stereoIn` forces a *speakers* up-mix (mono → L=R) so Side is silent and the matrix never drops a channel; mono stays mono at any width.
- ⚠️ The audio math is verified by construction (M/S identity at unity) — the unit-test node mock can't render audio, so a **manual stereo listen-test is recommended** before relying on it in production.

## Verification
- `pnpm validate` ✅ · `pnpm lint` ✅ 0 errors · `pnpm test` ✅ **1809/1809**
- Landing markup: 17 sliders ↔ 17 readouts, all matched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDEdHgcC8mwr6J2erPhraz

---
_Generated by [Claude Code](https://claude.ai/code/session_01BDEdHgcC8mwr6J2erPhraz)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add stereo-width control with mid/side matrix to the Live-Mix console
> - Inserts a mid/side processing matrix into the [PlaybackMixer](https://github.com/Joker5514/VoiceIsolate-Pro/pull/605/files#diff-646b05066f8ea1ef7558ebf5da2f3de3eeaafd7d18d7ab2f5254089e2577b0b7) master bus between `makeupGain` and `masterGain`, computing Mid=(L+R)/2 and Side=(L−R)/2, scaling the side signal by a width factor, then recombining to stereo.
> - Adds `PlaybackMixer.setStereoWidth(percentage)` accepting 0–200%, clamped, where 100% is transparent, 0% is mono, and 200% doubles the stereo width.
> - Wires the new `stereoWidthSlider` UI element in [index.html](https://github.com/Joker5514/VoiceIsolate-Pro/pull/605/files#diff-c2cc24bc9001b11b6add48a4cd8f893d5d6c6e4d1bd254158bd14ab997f552cd), [landing.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/605/files#diff-be23ec2b8a859b1c83e27ce227d9dd0c367c83c7a8f1a4b104128c882bdb30ab), and [SliderUI.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/605/files#diff-0cb8f952de2865f8757842b01940d8ff2b5d273d0be9e3c165bb6158d1c765ba) so it enables/disables with other mix controls and forwards input events to `setStereoWidth`.
> - Behavioral Change: the master bus now routes through ~10 additional Web Audio nodes at all times; the chain is transparent at the default width of 100%.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b1e34f9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Stereo Width slider to Live Mix controls, enabling real-time adjustment of stereo image width from 0% (mono) to 200%.

* **Tests**
  * Added test coverage for stereo width control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->