### PR TITLE
Tier-B: real-time noise gate via a playback-only AudioWorklet

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,16 @@ Rules:
     are still detected (`SILENCE_RMS` is intentionally low).
   - `PlaybackMixer.setSpeakerVolume` accepts **0–200** (>100 = up to +6 dB
     ENHANCE) so a faint/whispered speaker can be boosted. Still AudioParam-only.
+  - `src/workers/GateProcessor.js` is a **playback-only** `AudioWorklet`
+    (`registerProcessor('vip-gate')`) — a real-time noise gate on the loaded
+    stems, controlled by k-rate AudioParams (threshold/range/attack/release) so
+    sliders drive it like any other Live-Mix control. Web Audio has no built-in
+    gate/expander, so it must be a worklet. This is **not** the removed live-mic
+    pipeline: it never ingests a microphone and never re-runs ML. It is the one
+    worklet permitted in `src/`, allowlisted by `ALLOWED_WORKLETS` in
+    `scripts/validate.js`; any other `audioWorklet.addModule` target (or a
+    dynamic one) and `getUserMedia` remain forbidden. Do not delete it or
+    re-tighten the allowlist as a "live-pipeline" regression.
 
 ---
 

--- a/public/index.html
+++ b/public/index.html
@@ -194,6 +194,26 @@
           <input type="range" id="stereoWidthSlider" min="0" max="200" value="100" step="1" disabled>
           <span class="slider-val" id="stereoWidthVal">100%</span>
         </div>
+        <div class="slider-row">
+          <label for="gateThresholdSlider">Gate Threshold</label>
+          <input type="range" id="gateThresholdSlider" min="-100" max="0" value="-45" step="1" disabled>
+          <span class="slider-val" id="gateThresholdVal">-45 dB</span>
+        </div>
+        <div class="slider-row">
+          <label for="gateRangeSlider">Gate Range</label>
+          <input type="range" id="gateRangeSlider" min="0" max="80" value="0" step="1" disabled>
+          <span class="slider-val" id="gateRangeVal">0 dB</span>
+        </div>
+        <div class="slider-row">
+          <label for="gateAttackSlider">Gate Attack</label>
+          <input type="range" id="gateAttackSlider" min="0" max="200" value="5" step="1" disabled>
+          <span class="slider-val" id="gateAttackVal">5 ms</span>
+        </div>
+        <div class="slider-row">
+          <label for="gateReleaseSlider">Gate Release</label>
+          <input type="range" id="gateReleaseSlider" min="0" max="1000" value="100" step="10" disabled>
+          <span class="slider-val" id="gateReleaseVal">100 ms</span>
+        </div>
       </div>
     </section>
 

--- a/public/landing.js
+++ b/public/landing.js
@@ -41,6 +41,9 @@ const ui = {
     $('compThresholdSlider'), $('compRatioSlider'), $('compAttackSlider'),
     $('compReleaseSlider'), $('compKneeSlider'), $('makeupGainSlider'),
     $('stereoWidthSlider'),
+    // Tier-B: noise gate
+    $('gateThresholdSlider'), $('gateRangeSlider'),
+    $('gateAttackSlider'), $('gateReleaseSlider'),
   ],
   statusDot: $('statusDot'),
   statusText: $('statusText'),
@@ -316,6 +319,10 @@ const READOUTS = [
   ['compKneeSlider', 'compKneeVal', (v) => `${v} dB`],
   ['makeupGainSlider', 'makeupGainVal', (v) => `${v} dB`],
   ['stereoWidthSlider', 'stereoWidthVal', (v) => `${v}%`],
+  ['gateThresholdSlider', 'gateThresholdVal', (v) => `${v} dB`],
+  ['gateRangeSlider', 'gateRangeVal', (v) => `${v} dB`],
+  ['gateAttackSlider', 'gateAttackVal', (v) => `${v} ms`],
+  ['gateReleaseSlider', 'gateReleaseVal', (v) => `${v} ms`],
 ];
 
 function wireReadouts() {

--- a/scripts/validate.js
+++ b/scripts/validate.js
@@ -121,6 +121,10 @@ check(fs.readFileSync(path.resolve(__dirname, '..', 'src/core/audio-config.js'),
 // Hard prohibitions (CLAUDE.md §1.1) — the live-mic pipeline must stay dead.
 const appDir = path.resolve(__dirname, '..', 'public/app');
 const offenders = [];
+// Playback-only DSP worklets explicitly permitted in src/ (NOT live-mic). See
+// CLAUDE.md §2.1. Any other worklet path — or a non-literal/dynamic module arg
+// — is still rejected, and getUserMedia stays banned outright.
+const ALLOWED_WORKLETS = ['/src/workers/GateProcessor.js'];
 const scanDirs = [
   ['public/app', appDir],
   ['src', path.resolve(__dirname, '..', 'src')],
@@ -129,7 +133,21 @@ for (const [label, dir] of scanDirs) {
   for (const f of walkJs(dir)) {
     const src = fs.readFileSync(f, 'utf8');
     if (/getUserMedia\s*\(/.test(src)) offenders.push(`${label}/${path.relative(dir, f)} (getUserMedia)`);
-    if (/audioWorklet\.addModule\s*\(/.test(src)) offenders.push(`${label}/${path.relative(dir, f)} (audioWorklet.addModule)`);
+    if (/audioWorklet\.addModule\s*\(/.test(src)) {
+      // Every addModule call must load an allowlisted playback worklet via a
+      // string literal; any other path or a dynamic argument is forbidden.
+      const argRe = /audioWorklet\.addModule\s*\(\s*['"]([^'"]+)['"]/g;
+      let m;
+      let verified = false;
+      let allAllowed = true;
+      while ((m = argRe.exec(src))) {
+        verified = true;
+        if (!ALLOWED_WORKLETS.includes(m[1])) allAllowed = false;
+      }
+      if (!verified || !allAllowed) {
+        offenders.push(`${label}/${path.relative(dir, f)} (audioWorklet.addModule)`);
+      }
+    }
   }
 }
 const landingHtml = fs.readFileSync(path.resolve(__dirname, '..', 'public/index.html'), 'utf8');

--- a/src/pipeline/PlaybackMixer.js
+++ b/src/pipeline/PlaybackMixer.js
@@ -174,8 +174,10 @@ export class PlaybackMixer {
     // ── Noise gate (playback-only worklet; spliced in asynchronously) ─────
     // Default range 0 dB = bypass, so the gate is transparent until engaged.
     /** @type {AudioWorkletNode|null} */ this.gate = null;
+    this._disposed = false;
     this._gateParams = { threshold: -45, range: 0, attack: 5, release: 100 };
-    this._loadGate();
+    // Keep the load promise so dispose() can await it (avoids a splice-after-dispose race).
+    this._gatePromise = this._loadGate();
 
     // ── Transport state ──────────────────────────────────────────────────
     /** @type {AudioBuffer|null} */ this.cleanBuffer = null;
@@ -212,6 +214,7 @@ export class PlaybackMixer {
     try {
       // Literal call (not via the `aw` alias) so validate.js's allowlist sees it.
       await this.ctx.audioWorklet.addModule('/src/workers/GateProcessor.js');
+      if (this._disposed) return; // disposed mid-load — don't touch a torn-down graph
       const gate = new NodeCtor(this.ctx, 'vip-gate');
       this.gateInput.disconnect(this.highpass);
       this.gateInput.connect(gate);
@@ -229,7 +232,9 @@ export class PlaybackMixer {
   /** Remember a gate parameter and apply it to the live worklet if present. */
   _setGateParam(name, value) {
     this._gateParams[name] = value;
-    if (this.gate) this._applyParam(this.gate.parameters.get(name), value);
+    if (!this.gate) return;
+    const param = this.gate.parameters.get(name);
+    if (param) this._applyParam(param, value);
   }
 
   // ─── Stem loading ──────────────────────────────────────────────────────
@@ -653,7 +658,12 @@ export class PlaybackMixer {
 
   /** Release all audio resources. The instance is unusable afterwards. */
   async dispose() {
+    this._disposed = true;
     this.stop();
+    // Let any in-flight gate-worklet load settle (it bails on _disposed) before teardown.
+    if (this._gatePromise) {
+      try { await this._gatePromise; } catch { /* ignore */ }
+    }
     for (const node of [this.speakerGain, this.cleanGain, this.voiceMuteGain,
       this.noiseGain, this.noiseMuteGain, this.gateInput, this.gate,
       this.highpass, this.lowpass,

--- a/src/pipeline/PlaybackMixer.js
+++ b/src/pipeline/PlaybackMixer.js
@@ -7,7 +7,7 @@
  *                                                                  ├─► [Tier-A bus]
  *   Noise stem ─► Source ───────────────► NoiseGain ─► NoiseMute ─┘
  *
- *   [Tier-A bus] = highpass ─► lowpass ─► lowShelf ─► eqLowMid ─► eqMid
+ *   [Tier-A bus] = gate ─► highpass ─► lowpass ─► lowShelf ─► eqLowMid ─► eqMid
  *                  ─► eqHighMid ─► highShelf ─► compressor ─► makeupGain
  *                  ─► [stereo-width mid/side matrix] ─► Master ─► Analyser
  *                  ─► destination
@@ -59,6 +59,10 @@ export class PlaybackMixer {
     this.voiceMuteGain = this.ctx.createGain();
     this.noiseGain = this.ctx.createGain();
     this.noiseMuteGain = this.ctx.createGain();
+    // Gate slot: both stems feed gateInput, which feeds the EQ chain. The
+    // noise-gate worklet is spliced between them once it loads (see _loadGate);
+    // until then gateInput is a transparent pass-through.
+    this.gateInput = this.ctx.createGain();
     this.lowShelf = this.ctx.createBiquadFilter();
     this.highShelf = this.ctx.createBiquadFilter();
     // ── Tier-A console (shared master bus; all default transparent) ──────
@@ -122,9 +126,10 @@ export class PlaybackMixer {
     this.speakerGain.connect(this.cleanGain);
     this.cleanGain.connect(this.voiceMuteGain);
     this.noiseGain.connect(this.noiseMuteGain);
-    // Both stems join the shared master chain at the high-pass filter.
-    this.voiceMuteGain.connect(this.highpass);
-    this.noiseMuteGain.connect(this.highpass);
+    // Both stems join the shared master bus at the gate slot, then the EQ chain.
+    this.voiceMuteGain.connect(this.gateInput);
+    this.noiseMuteGain.connect(this.gateInput);
+    this.gateInput.connect(this.highpass);
     this.highpass.connect(this.lowpass);
     this.lowpass.connect(this.lowShelf);
     this.lowShelf.connect(this.eqLowMid);
@@ -166,6 +171,12 @@ export class PlaybackMixer {
     this.noiseMuteGain.gain.value = 1;
     this.makeupGain.gain.value = 1;   // 0 dB — transparent until raised
 
+    // ── Noise gate (playback-only worklet; spliced in asynchronously) ─────
+    // Default range 0 dB = bypass, so the gate is transparent until engaged.
+    /** @type {AudioWorkletNode|null} */ this.gate = null;
+    this._gateParams = { threshold: -45, range: 0, attack: 5, release: 100 };
+    this._loadGate();
+
     // ── Transport state ──────────────────────────────────────────────────
     /** @type {AudioBuffer|null} */ this.cleanBuffer = null;
     /** @type {AudioBuffer|null} */ this.noiseBuffer = null;
@@ -184,6 +195,41 @@ export class PlaybackMixer {
     this._speakers = new Map();
     /** @type {string|null} */
     this._soloId = null;
+  }
+
+  // ─── Noise gate worklet ────────────────────────────────────────────────
+
+  /**
+   * Load and splice in the noise-gate worklet between the stems and the EQ
+   * chain (gateInput → gate → highpass). No-op when AudioWorklet is
+   * unavailable (e.g. the test mock) and graceful on failure — gateInput then
+   * stays a transparent pass-through, so playback is unaffected.
+   */
+  async _loadGate() {
+    const aw = this.ctx.audioWorklet;
+    const NodeCtor = globalThis.AudioWorkletNode;
+    if (!aw || typeof aw.addModule !== 'function' || typeof NodeCtor !== 'function') return;
+    try {
+      // Literal call (not via the `aw` alias) so validate.js's allowlist sees it.
+      await this.ctx.audioWorklet.addModule('/src/workers/GateProcessor.js');
+      const gate = new NodeCtor(this.ctx, 'vip-gate');
+      this.gateInput.disconnect(this.highpass);
+      this.gateInput.connect(gate);
+      gate.connect(this.highpass);
+      for (const [name, value] of Object.entries(this._gateParams)) {
+        const p = gate.parameters.get(name);
+        if (p) p.value = value;
+      }
+      this.gate = gate;
+    } catch (err) {
+      console.error('[VIP][PlaybackMixer] noise-gate worklet failed to load; bypassing.', err);
+    }
+  }
+
+  /** Remember a gate parameter and apply it to the live worklet if present. */
+  _setGateParam(name, value) {
+    this._gateParams[name] = value;
+    if (this.gate) this._applyParam(this.gate.parameters.get(name), value);
   }
 
   // ─── Stem loading ──────────────────────────────────────────────────────
@@ -416,6 +462,18 @@ export class PlaybackMixer {
     this._applyParam(this.widthGain.gain, clamp(percentage, 0, 200) / 100);
   }
 
+  /** Noise-gate threshold in dB (−100 … 0): level below which it attenuates. */
+  setGateThreshold(db) { this._setGateParam('threshold', clamp(db, -100, 0)); }
+
+  /** Noise-gate range in dB (0 … 80): attenuation depth when closed. 0 = off. */
+  setGateRange(db) { this._setGateParam('range', clamp(db, 0, 80)); }
+
+  /** Noise-gate attack in ms (0 … 200). */
+  setGateAttack(ms) { this._setGateParam('attack', clamp(ms, 0, 200)); }
+
+  /** Noise-gate release in ms (0 … 1000). */
+  setGateRelease(ms) { this._setGateParam('release', clamp(ms, 0, 1000)); }
+
   /**
    * Hard-mute the voice stem without disturbing the Voice Level slider.
    * @param {boolean} muted
@@ -597,12 +655,14 @@ export class PlaybackMixer {
   async dispose() {
     this.stop();
     for (const node of [this.speakerGain, this.cleanGain, this.voiceMuteGain,
-      this.noiseGain, this.noiseMuteGain, this.highpass, this.lowpass,
+      this.noiseGain, this.noiseMuteGain, this.gateInput, this.gate,
+      this.highpass, this.lowpass,
       this.lowShelf, this.eqLowMid, this.eqMid, this.eqHighMid,
       this.highShelf, this.compressor, this.makeupGain,
       this.stereoIn, this.msSplit, this.sideRNeg, this.midGain, this.sideGain,
       this.widthGain, this.sideSNeg, this.leftSum, this.rightSum, this.msMerge,
       this.masterGain, this.analyser]) {
+      if (!node) continue;
       try { node.disconnect(); } catch { /* already disconnected */ }
     }
     try { await this.ctx.close(); } catch { /* already closed */ }

--- a/src/presentation/SliderUI.js
+++ b/src/presentation/SliderUI.js
@@ -42,6 +42,11 @@ const SLIDER_BINDINGS = Object.freeze([
   { id: 'compKneeSlider', method: 'setCompKnee', initial: 0 },
   { id: 'makeupGainSlider', method: 'setMakeupGain', initial: 0 },
   { id: 'stereoWidthSlider', method: 'setStereoWidth', initial: 100 },
+  // Tier-B: noise gate (playback worklet)
+  { id: 'gateThresholdSlider', method: 'setGateThreshold', initial: -45 },
+  { id: 'gateRangeSlider', method: 'setGateRange', initial: 0 },
+  { id: 'gateAttackSlider', method: 'setGateAttack', initial: 5 },
+  { id: 'gateReleaseSlider', method: 'setGateRelease', initial: 100 },
 ]);
 
 export class SliderUI {

--- a/src/workers/GateProcessor.js
+++ b/src/workers/GateProcessor.js
@@ -43,14 +43,18 @@ class GateProcessor extends AudioWorkletProcessor {
   process(inputs, outputs, parameters) {
     const input = inputs[0];
     const output = outputs[0];
-    if (!input || input.length === 0) return true;
-    const nCh = input.length;
-    const nSamp = input[0].length;
+    if (!input || input.length === 0 || !output || output.length === 0) return true;
+    const inCh = input.length;
+    const outCh = output.length;
+    const nSamp = output[0].length;
 
     const rangeDb = parameters.range[0];
     // Bypass fast-path: range 0 → never attenuate → pass through untouched.
     if (rangeDb <= 0) {
-      for (let c = 0; c < nCh; c++) output[c].set(input[c]);
+      for (let c = 0; c < outCh; c++) {
+        if (input[c]) output[c].set(input[c]);
+        else output[c].fill(0);
+      }
       this._env = 0;
       this._gain = 1;
       return true;
@@ -67,8 +71,9 @@ class GateProcessor extends AudioWorkletProcessor {
     for (let i = 0; i < nSamp; i++) {
       // Control signal = peak across channels (keeps L/R gated together).
       let x = 0;
-      for (let c = 0; c < nCh; c++) {
-        const a = Math.abs(input[c][i]);
+      for (let c = 0; c < inCh; c++) {
+        const ch = input[c];
+        const a = ch ? Math.abs(ch[i]) : 0;
         if (a > x) x = a;
       }
       // Fast-attack / slow-release envelope follower.
@@ -77,7 +82,7 @@ class GateProcessor extends AudioWorkletProcessor {
       // Ramp the gain toward the target (attack when opening, release when closing).
       const coef = target > gain ? atk : rel;
       gain = coef * gain + (1 - coef) * target;
-      for (let c = 0; c < nCh; c++) output[c][i] = input[c][i] * gain;
+      for (let c = 0; c < outCh; c++) output[c][i] = (input[c] ? input[c][i] : 0) * gain;
     }
     this._env = env;
     this._gain = gain;

--- a/src/workers/GateProcessor.js
+++ b/src/workers/GateProcessor.js
@@ -1,0 +1,88 @@
+/* global AudioWorkletProcessor, registerProcessor, sampleRate */
+/**
+ * VoiceIsolate Pro — Noise-Gate AudioWorklet (Layer 2: playback DSP)
+ *
+ * A real-time downward noise gate for the Live-Mix playback bus. It is a
+ * **playback-only** worklet: it processes already-loaded stems during
+ * playback exactly like the EQ/compressor nodes — it NEVER ingests a
+ * microphone and NEVER re-runs ML. This is the one worklet permitted in
+ * src/ (allowlisted in scripts/validate.js); the removed live-mic pipeline
+ * stays removed (CLAUDE.md §1.1 / §2.1).
+ *
+ * Web Audio has no built-in expander/gate (DynamicsCompressorNode only acts
+ * *above* a threshold), so the gate needs sample-level envelope following —
+ * hence a worklet rather than built-in nodes.
+ *
+ * Control is AudioParam-only (k-rate), so the UI sliders drive it through the
+ * same setTargetAtTime path as every other Live-Mix control:
+ *   - threshold (dB): level below which the gate attenuates
+ *   - range (dB):     attenuation depth when closed; 0 = bypass (transparent)
+ *   - attack (ms):    how fast the gate opens
+ *   - release (ms):   how fast the gate closes
+ *
+ * Default range = 0 dB → the gate is fully transparent until engaged.
+ */
+'use strict';
+
+class GateProcessor extends AudioWorkletProcessor {
+  static get parameterDescriptors() {
+    return [
+      { name: 'threshold', defaultValue: -45, minValue: -100, maxValue: 0, automationRate: 'k-rate' },
+      { name: 'range', defaultValue: 0, minValue: 0, maxValue: 80, automationRate: 'k-rate' },
+      { name: 'attack', defaultValue: 5, minValue: 0, maxValue: 200, automationRate: 'k-rate' },
+      { name: 'release', defaultValue: 100, minValue: 0, maxValue: 1000, automationRate: 'k-rate' },
+    ];
+  }
+
+  constructor() {
+    super();
+    this._env = 0;  // envelope-follower state (linear)
+    this._gain = 1; // smoothed gate gain (linear)
+  }
+
+  process(inputs, outputs, parameters) {
+    const input = inputs[0];
+    const output = outputs[0];
+    if (!input || input.length === 0) return true;
+    const nCh = input.length;
+    const nSamp = input[0].length;
+
+    const rangeDb = parameters.range[0];
+    // Bypass fast-path: range 0 → never attenuate → pass through untouched.
+    if (rangeDb <= 0) {
+      for (let c = 0; c < nCh; c++) output[c].set(input[c]);
+      this._env = 0;
+      this._gain = 1;
+      return true;
+    }
+
+    const thrLin = Math.pow(10, parameters.threshold[0] / 20);
+    const floor = Math.pow(10, -rangeDb / 20); // gain when fully closed
+    // One-pole envelope/gain coefficients from the time constants (per sample).
+    const atk = Math.exp(-1 / (Math.max(0.05, parameters.attack[0]) * 0.001 * sampleRate));
+    const rel = Math.exp(-1 / (Math.max(1, parameters.release[0]) * 0.001 * sampleRate));
+
+    let env = this._env;
+    let gain = this._gain;
+    for (let i = 0; i < nSamp; i++) {
+      // Control signal = peak across channels (keeps L/R gated together).
+      let x = 0;
+      for (let c = 0; c < nCh; c++) {
+        const a = Math.abs(input[c][i]);
+        if (a > x) x = a;
+      }
+      // Fast-attack / slow-release envelope follower.
+      env = x > env ? atk * env + (1 - atk) * x : rel * env + (1 - rel) * x;
+      const target = env >= thrLin ? 1 : floor;
+      // Ramp the gain toward the target (attack when opening, release when closing).
+      const coef = target > gain ? atk : rel;
+      gain = coef * gain + (1 - coef) * target;
+      for (let c = 0; c < nCh; c++) output[c][i] = input[c][i] * gain;
+    }
+    this._env = env;
+    this._gain = gain;
+    return true;
+  }
+}
+
+registerProcessor('vip-gate', GateProcessor);

--- a/tests/architectural-invariants.test.js
+++ b/tests/architectural-invariants.test.js
@@ -78,11 +78,24 @@ describe('CLAUDE.md §1.1 — live real-time pipeline stays removed', () => {
     return out;
   };
 
-  test('no file calls audioWorklet.addModule() (worklet pipeline removed)', () => {
+  test('audioWorklet.addModule() only loads the allowlisted playback gate worklet', () => {
+    // The live-mic worklet pipeline stays removed; the one permitted worklet is
+    // the playback-only noise gate (CLAUDE.md §2.1, scripts/validate.js). Any
+    // other module path — or a dynamic argument — is still forbidden.
+    const ALLOWED_WORKLETS = ['/src/workers/GateProcessor.js'];
     const offenders = [];
     for (const f of [...walkJs(APP_DIR), ...walkJs(SRC_DIR)]) {
       const src = fs.readFileSync(f, 'utf8');
-      if (/audioWorklet\.addModule\s*\(/.test(src)) offenders.push(path.relative(ROOT, f));
+      if (!/audioWorklet\.addModule\s*\(/.test(src)) continue;
+      const argRe = /audioWorklet\.addModule\s*\(\s*['"]([^'"]+)['"]/g;
+      let m;
+      let verified = false;
+      let allAllowed = true;
+      while ((m = argRe.exec(src))) {
+        verified = true;
+        if (!ALLOWED_WORKLETS.includes(m[1])) allAllowed = false;
+      }
+      if (!verified || !allAllowed) offenders.push(path.relative(ROOT, f));
     }
     expect(offenders).toEqual([]);
   });

--- a/tests/slider-ui.test.js
+++ b/tests/slider-ui.test.js
@@ -42,6 +42,10 @@ function mockMixer() {
     setCompKnee(v) { this.calls.push(['setCompKnee', v]); },
     setMakeupGain(v) { this.calls.push(['setMakeupGain', v]); },
     setStereoWidth(v) { this.calls.push(['setStereoWidth', v]); },
+    setGateThreshold(v) { this.calls.push(['setGateThreshold', v]); },
+    setGateRange(v) { this.calls.push(['setGateRange', v]); },
+    setGateAttack(v) { this.calls.push(['setGateAttack', v]); },
+    setGateRelease(v) { this.calls.push(['setGateRelease', v]); },
   };
 }
 
@@ -68,6 +72,10 @@ const SLIDER_SPECS = {
   compKneeSlider: { min: 0, max: 40, value: 0 },
   makeupGainSlider: { min: 0, max: 24, value: 0 },
   stereoWidthSlider: { min: 0, max: 200, value: 100 },
+  gateThresholdSlider: { min: -100, max: 0, value: -45 },
+  gateRangeSlider: { min: 0, max: 80, value: 0 },
+  gateAttackSlider: { min: 0, max: 200, value: 5 },
+  gateReleaseSlider: { min: 0, max: 1000, value: 100 },
 };
 function buildSliders(values = {}) {
   document.body.innerHTML = '';
@@ -132,6 +140,10 @@ describe('SliderUI', () => {
       ['setCompKnee', 0],
       ['setMakeupGain', 0],
       ['setStereoWidth', 100],
+      ['setGateThreshold', -45],
+      ['setGateRange', 0],
+      ['setGateAttack', 5],
+      ['setGateRelease', 100],
     ]);
   });
 

--- a/tests/stem-split-core.test.js
+++ b/tests/stem-split-core.test.js
@@ -264,6 +264,22 @@ describe('PlaybackMixer (Layer 3) — Live-Mix control surface', () => {
     expect(mixer.widthGain.gain.value).toBe(2);
   });
 
+  test('noise gate: bypassed by default; setters clamp and store params', () => {
+    // The mock context has no AudioWorklet, so the gate stays bypassed (null)
+    // and gateInput passes through — playback is unaffected.
+    expect(mixer.gate).toBe(null);
+    expect(mixer.gateInput).toBeDefined();
+    expect(mixer._gateParams.range).toBe(0); // 0 dB range = transparent default
+    mixer.setGateThreshold(-200);            // clamps to -100
+    expect(mixer._gateParams.threshold).toBe(-100);
+    mixer.setGateRange(999);                 // clamps to 80
+    expect(mixer._gateParams.range).toBe(80);
+    mixer.setGateAttack(999);                // clamps to 200
+    expect(mixer._gateParams.attack).toBe(200);
+    mixer.setGateRelease(-5);                // clamps to 0
+    expect(mixer._gateParams.release).toBe(0);
+  });
+
   test('loadStems builds sample-locked buffers; transport round-trips', async () => {
     mixer.loadStems(stems(), stems());
     expect(mixer.duration()).toBeCloseTo(1);


### PR DESCRIPTION
## What & why

Tier-B, part 1: a **real-time downward noise gate** for the Live-Mix console.

Web Audio has no built-in gate/expander (`DynamicsCompressorNode` only acts *above* a threshold), so a gate needs sample-level envelope following — i.e. an **`AudioWorklet`**. Per the decision to relax the guard, this adds **one** allowlisted, **playback-only** worklet; the removed live-mic pipeline stays removed.

## Changes
- **`src/workers/GateProcessor.js`** — `registerProcessor('vip-gate')`, an envelope-follower gate with **k-rate AudioParams** (`threshold`/`range`/`attack`/`release`) so sliders drive it through the same `setTargetAtTime` path as every other control. `range = 0 dB` is a true bypass → **transparent by default**. It never touches a mic, never re-runs ML.
- **`scripts/validate.js`** + **`tests/architectural-invariants.test.js`** — replace the blanket `audioWorklet.addModule` ban with an `ALLOWED_WORKLETS` allowlist (`/src/workers/GateProcessor.js` only). Any other path, a **dynamic** argument, and `getUserMedia` all remain forbidden.
- **`PlaybackMixer.js`** — a `gateInput` slot feeds the EQ chain; the worklet loads asynchronously and is spliced in (`gateInput → gate → highpass`). Graceful **bypass** when AudioWorklet is unavailable (test mock / unsupported). New `setGate{Threshold,Range,Attack,Release}` setters clamp + store, applying to the live node once it loads.
- **`SliderUI.js` / `index.html` / `landing.js`** — 4 gate controls with readouts (sliders 17 → 21).
- **`CLAUDE.md §2.1`** — documents the gate as a deliberate playback-only worklet so it isn't re-tightened as a "live-pipeline" regression.

## Verification
- `pnpm validate` ✅ (allowlist) · `pnpm lint` ✅ 0 errors (worklet linted) · `pnpm test` ✅ **1810/1810**
- Landing markup: 21 sliders ↔ 21 readouts
- ⚠️ The worklet's audio behavior can't render in the node test mock (same limitation as the stereo-width matrix) — **a manual browser listen-test is recommended** (load a file, raise Gate Range, confirm quiet passages duck and speech passes).

## Follow-up
De-esser (the other Tier-B item) — implementable with built-in split-band nodes, no worklet — as the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDEdHgcC8mwr6J2erPhraz

---
_Generated by [Claude Code](https://claude.ai/code/session_01BDEdHgcC8mwr6J2erPhraz)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add real-time noise gate to playback via a `GateProcessor` AudioWorklet
> - Adds [GateProcessor.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/607/files#diff-36c7b2c3f7de343582e2b224b66e68316709f01e5a146d0fd313d294d78d138b), an AudioWorklet processor registered as `'vip-gate'` that implements a downward noise gate with k-rate `threshold`, `range`, `attack`, and `release` AudioParams.
> - [PlaybackMixer.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/607/files#diff-646b05066f8ea1ef7558ebf5da2f3de3eeaafd7d18d7ab2f5254089e2577b0b7) inserts a `gateInput` GainNode before the EQ chain and asynchronously loads the worklet via `_loadGate()`; if the worklet is unavailable or fails to load, the graph passes through unchanged.
> - Four gate sliders (threshold, range, attack, release) are added to the Live-Mix panel in [index.html](https://github.com/Joker5514/VoiceIsolate-Pro/pull/607/files#diff-c2cc24bc9001b11b6add48a4cd8f893d5d6c6e4d1bd254158bd14ab997f552cd) and bound to the corresponding `PlaybackMixer` setters via [SliderUI.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/607/files#diff-0cb8f952de2865f8757842b01940d8ff2b5d273d0be9e3c165bb6158d1c765ba).
> - [scripts/validate.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/607/files#diff-0d7f74eada294edb89d7900af2f1a111706f4a4dd2f0de9504471b9c60508439) introduces `ALLOWED_WORKLETS` so `audioWorklet.addModule` calls are rejected unless they use a string literal pointing to `/src/workers/GateProcessor.js`.
> - Behavioral Change: gate is bypassed by default (`range = 0`); attenuation only begins when `range > 0`, so existing playback is unaffected until a user moves the range slider.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e83ed68.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a noise gate control to the Live-Mix interface with four adjustable parameters: threshold (dB), range (dB), attack (ms), and release (ms).

* **Documentation**
  * Added architectural documentation defining noise gate implementation specifications and requirements.

* **Tests**
  * Added test coverage for noise gate functionality and validation rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->