### PR TITLE
Tier-B: de-esser (playback-only AudioWorklet, true sidechain)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,15 +110,17 @@ Rules:
     are still detected (`SILENCE_RMS` is intentionally low).
   - `PlaybackMixer.setSpeakerVolume` accepts **0–200** (>100 = up to +6 dB
     ENHANCE) so a faint/whispered speaker can be boosted. Still AudioParam-only.
-  - `src/workers/GateProcessor.js` is a **playback-only** `AudioWorklet`
-    (`registerProcessor('vip-gate')`) — a real-time noise gate on the loaded
-    stems, controlled by k-rate AudioParams (threshold/range/attack/release) so
-    sliders drive it like any other Live-Mix control. Web Audio has no built-in
-    gate/expander, so it must be a worklet. This is **not** the removed live-mic
-    pipeline: it never ingests a microphone and never re-runs ML. It is the one
-    worklet permitted in `src/`, allowlisted by `ALLOWED_WORKLETS` in
+  - `src/workers/GateProcessor.js` (`registerProcessor('vip-gate')`) and
+    `src/workers/DeEsserProcessor.js` (`registerProcessor('vip-deesser')`) are
+    **playback-only** `AudioWorklet`s — a real-time noise gate and de-esser on
+    the loaded stems, controlled by k-rate AudioParams so sliders drive them
+    like any other Live-Mix control. Web Audio has no built-in gate/expander,
+    and a built-in de-esser comb-filters (DynamicsCompressorNode lookahead), so
+    both must be worklets. These are **not** the removed live-mic pipeline: they
+    never ingest a microphone and never re-run ML. They are the only worklets
+    permitted in `src/`, allowlisted by `ALLOWED_WORKLETS` in
     `scripts/validate.js`; any other `audioWorklet.addModule` target (or a
-    dynamic one) and `getUserMedia` remain forbidden. Do not delete it or
+    dynamic one) and `getUserMedia` remain forbidden. Do not delete them or
     re-tighten the allowlist as a "live-pipeline" regression.
 
 ---

--- a/public/index.html
+++ b/public/index.html
@@ -214,6 +214,16 @@
           <input type="range" id="gateReleaseSlider" min="0" max="1000" value="100" step="10" disabled>
           <span class="slider-val" id="gateReleaseVal">100 ms</span>
         </div>
+        <div class="slider-row">
+          <label for="deEsserFreqSlider">De-Esser Freq</label>
+          <input type="range" id="deEsserFreqSlider" min="2000" max="12000" value="6000" step="100" disabled>
+          <span class="slider-val" id="deEsserFreqVal">6000 Hz</span>
+        </div>
+        <div class="slider-row">
+          <label for="deEsserAmountSlider">De-Esser Amount</label>
+          <input type="range" id="deEsserAmountSlider" min="0" max="100" value="0" step="1" disabled>
+          <span class="slider-val" id="deEsserAmountVal">0%</span>
+        </div>
       </div>
     </section>
 

--- a/public/landing.js
+++ b/public/landing.js
@@ -41,9 +41,10 @@ const ui = {
     $('compThresholdSlider'), $('compRatioSlider'), $('compAttackSlider'),
     $('compReleaseSlider'), $('compKneeSlider'), $('makeupGainSlider'),
     $('stereoWidthSlider'),
-    // Tier-B: noise gate
+    // Tier-B: noise gate + de-esser
     $('gateThresholdSlider'), $('gateRangeSlider'),
     $('gateAttackSlider'), $('gateReleaseSlider'),
+    $('deEsserFreqSlider'), $('deEsserAmountSlider'),
   ],
   statusDot: $('statusDot'),
   statusText: $('statusText'),
@@ -323,6 +324,8 @@ const READOUTS = [
   ['gateRangeSlider', 'gateRangeVal', (v) => `${v} dB`],
   ['gateAttackSlider', 'gateAttackVal', (v) => `${v} ms`],
   ['gateReleaseSlider', 'gateReleaseVal', (v) => `${v} ms`],
+  ['deEsserFreqSlider', 'deEsserFreqVal', (v) => `${v} Hz`],
+  ['deEsserAmountSlider', 'deEsserAmountVal', (v) => `${v}%`],
 ];
 
 function wireReadouts() {

--- a/scripts/validate.js
+++ b/scripts/validate.js
@@ -124,7 +124,7 @@ const offenders = [];
 // Playback-only DSP worklets explicitly permitted in src/ (NOT live-mic). See
 // CLAUDE.md §2.1. Any other worklet path — or a non-literal/dynamic module arg
 // — is still rejected, and getUserMedia stays banned outright.
-const ALLOWED_WORKLETS = ['/src/workers/GateProcessor.js'];
+const ALLOWED_WORKLETS = ['/src/workers/GateProcessor.js', '/src/workers/DeEsserProcessor.js'];
 const scanDirs = [
   ['public/app', appDir],
   ['src', path.resolve(__dirname, '..', 'src')],

--- a/src/pipeline/PlaybackMixer.js
+++ b/src/pipeline/PlaybackMixer.js
@@ -9,8 +9,8 @@
  *
  *   [Tier-A bus] = gate ─► highpass ─► lowpass ─► lowShelf ─► eqLowMid ─► eqMid
  *                  ─► eqHighMid ─► highShelf ─► compressor ─► makeupGain
- *                  ─► [stereo-width mid/side matrix] ─► Master ─► Analyser
- *                  ─► destination
+ *                  ─► de-esser ─► [stereo-width mid/side matrix] ─► Master
+ *                  ─► Analyser ─► destination
  *
  * The Tier-A console (HP/LP filters, 5-band EQ, bus compressor) is shared by
  * both stems and defaults to fully transparent — adding it never changes how
@@ -73,6 +73,14 @@ export class PlaybackMixer {
     this.eqHighMid = this.ctx.createBiquadFilter();
     this.compressor = this.ctx.createDynamicsCompressor();
     this.makeupGain = this.ctx.createGain();
+    // ── De-esser (subtractive split-band; transparent at amount 0) ───────
+    // The dry signal always passes; we subtract only the sibilance a fast
+    // high-band compressor squashes: out = dry + amount·(compHigh − origHigh).
+    this.deEssHP = this.ctx.createBiquadFilter();      // sibilance band (high-pass)
+    this.deEssComp = this.ctx.createDynamicsCompressor();
+    this.deEssOrigNeg = this.ctx.createGain();         // −origHigh
+    this.deEssAmount = this.ctx.createGain();          // ← control: scales the reduction
+    this.deEssOut = this.ctx.createGain();             // dry + amount·(compHigh − origHigh)
     // ── Stereo-width mid/side matrix (transparent at width = 100%) ────────
     this.stereoIn = this.ctx.createGain();        // force 2ch: mono up-mix → L=R
     this.msSplit = this.ctx.createChannelSplitter(2);
@@ -110,6 +118,18 @@ export class PlaybackMixer {
     this.compressor.ratio.value = 1;
     this.compressor.attack.value = 0.02;
     this.compressor.release.value = 0.25;
+    // De-esser: high-pass the sibilance band into a fast, aggressive compressor.
+    // Fixed dynamics; the user controls frequency + amount. amount 0 = bypass.
+    this.deEssHP.type = HP_FILTER_TYPE;
+    this.deEssHP.frequency.value = 6000;
+    this.deEssComp.threshold.value = -35;
+    this.deEssComp.knee.value = 0;
+    this.deEssComp.ratio.value = 6;
+    this.deEssComp.attack.value = 0.0005;
+    this.deEssComp.release.value = 0.05;
+    this.deEssOrigNeg.gain.value = -1;
+    this.deEssAmount.gain.value = 0;   // 0 = no reduction → transparent
+    this.deEssOut.gain.value = 1;
     // Stereo-width matrix: fixed coefficients + the single width control.
     this.stereoIn.channelCount = 2;
     this.stereoIn.channelCountMode = 'explicit';
@@ -138,8 +158,17 @@ export class PlaybackMixer {
     this.eqHighMid.connect(this.highShelf);
     this.highShelf.connect(this.compressor);
     this.compressor.connect(this.makeupGain);
-    // Stereo-width mid/side matrix: makeup → stereoIn → split → M/S → merge → master.
-    this.makeupGain.connect(this.stereoIn);
+    // De-esser: dry passes straight through; the sibilance reduction (compHigh −
+    // origHigh), scaled by amount, is summed in. amount 0 → deEssOut == dry.
+    this.makeupGain.connect(this.deEssOut);          // dry (full signal)
+    this.makeupGain.connect(this.deEssHP);           // sidechain: sibilance band
+    this.deEssHP.connect(this.deEssComp);
+    this.deEssComp.connect(this.deEssAmount);        // +compHigh
+    this.deEssHP.connect(this.deEssOrigNeg);
+    this.deEssOrigNeg.connect(this.deEssAmount);     // −origHigh
+    this.deEssAmount.connect(this.deEssOut);
+    // Stereo-width mid/side matrix: deEssOut → stereoIn → split → M/S → merge → master.
+    this.deEssOut.connect(this.stereoIn);
     this.stereoIn.connect(this.msSplit);
     // Mid = (L + R) · 0.5  (both split legs sum into midGain)
     this.msSplit.connect(this.midGain, 0);
@@ -479,6 +508,14 @@ export class PlaybackMixer {
   /** Noise-gate release in ms (0 … 1000). */
   setGateRelease(ms) { this._setGateParam('release', clamp(ms, 0, 1000)); }
 
+  /** De-esser band frequency in Hz (2000 … 12000): where sibilance reduction starts. */
+  setDeEsserFreq(hz) { this._applyParam(this.deEssHP.frequency, clamp(hz, 2000, 12000)); }
+
+  /** De-esser amount as a percentage (0 … 100). 0 = off (transparent). */
+  setDeEsserAmount(percentage) {
+    this._applyParam(this.deEssAmount.gain, clamp(percentage, 0, 100) / 100);
+  }
+
   /**
    * Hard-mute the voice stem without disturbing the Voice Level slider.
    * @param {boolean} muted
@@ -669,6 +706,7 @@ export class PlaybackMixer {
       this.highpass, this.lowpass,
       this.lowShelf, this.eqLowMid, this.eqMid, this.eqHighMid,
       this.highShelf, this.compressor, this.makeupGain,
+      this.deEssHP, this.deEssComp, this.deEssOrigNeg, this.deEssAmount, this.deEssOut,
       this.stereoIn, this.msSplit, this.sideRNeg, this.midGain, this.sideGain,
       this.widthGain, this.sideSNeg, this.leftSum, this.rightSum, this.msMerge,
       this.masterGain, this.analyser]) {

--- a/src/pipeline/PlaybackMixer.js
+++ b/src/pipeline/PlaybackMixer.js
@@ -78,6 +78,11 @@ export class PlaybackMixer {
     // high-band compressor squashes: out = dry + amount·(compHigh − origHigh).
     this.deEssHP = this.ctx.createBiquadFilter();      // sibilance band (high-pass)
     this.deEssComp = this.ctx.createDynamicsCompressor();
+    // DynamicsCompressorNode adds ~5 ms lookahead latency; delay the dry and
+    // original-high paths to match so the subtraction stays phase-aligned (no
+    // comb filtering). createDelay is guarded for the non-Web-Audio test mock.
+    this.deEssDelayDry = typeof this.ctx.createDelay === 'function' ? this.ctx.createDelay(0.1) : null;
+    this.deEssDelayOrig = typeof this.ctx.createDelay === 'function' ? this.ctx.createDelay(0.1) : null;
     this.deEssOrigNeg = this.ctx.createGain();         // −origHigh
     this.deEssAmount = this.ctx.createGain();          // ← control: scales the reduction
     this.deEssOut = this.ctx.createGain();             // dry + amount·(compHigh − origHigh)
@@ -127,6 +132,8 @@ export class PlaybackMixer {
     this.deEssComp.ratio.value = 6;
     this.deEssComp.attack.value = 0.0005;
     this.deEssComp.release.value = 0.05;
+    if (this.deEssDelayDry) this.deEssDelayDry.delayTime.value = 0.005;   // match compressor lookahead
+    if (this.deEssDelayOrig) this.deEssDelayOrig.delayTime.value = 0.005;
     this.deEssOrigNeg.gain.value = -1;
     this.deEssAmount.gain.value = 0;   // 0 = no reduction → transparent
     this.deEssOut.gain.value = 1;
@@ -160,11 +167,22 @@ export class PlaybackMixer {
     this.compressor.connect(this.makeupGain);
     // De-esser: dry passes straight through; the sibilance reduction (compHigh −
     // origHigh), scaled by amount, is summed in. amount 0 → deEssOut == dry.
-    this.makeupGain.connect(this.deEssOut);          // dry (full signal)
+    // Dry + original-high are delayed to align with the compressor's lookahead.
+    if (this.deEssDelayDry) {
+      this.makeupGain.connect(this.deEssDelayDry);
+      this.deEssDelayDry.connect(this.deEssOut);     // dry (full signal, delayed)
+    } else {
+      this.makeupGain.connect(this.deEssOut);        // dry (fallback: no delay node)
+    }
     this.makeupGain.connect(this.deEssHP);           // sidechain: sibilance band
     this.deEssHP.connect(this.deEssComp);
-    this.deEssComp.connect(this.deEssAmount);        // +compHigh
-    this.deEssHP.connect(this.deEssOrigNeg);
+    this.deEssComp.connect(this.deEssAmount);        // +compHigh (5 ms lookahead)
+    if (this.deEssDelayOrig) {
+      this.deEssHP.connect(this.deEssDelayOrig);
+      this.deEssDelayOrig.connect(this.deEssOrigNeg); // origHigh (delayed to match)
+    } else {
+      this.deEssHP.connect(this.deEssOrigNeg);
+    }
     this.deEssOrigNeg.connect(this.deEssAmount);     // −origHigh
     this.deEssAmount.connect(this.deEssOut);
     // Stereo-width mid/side matrix: deEssOut → stereoIn → split → M/S → merge → master.
@@ -706,7 +724,8 @@ export class PlaybackMixer {
       this.highpass, this.lowpass,
       this.lowShelf, this.eqLowMid, this.eqMid, this.eqHighMid,
       this.highShelf, this.compressor, this.makeupGain,
-      this.deEssHP, this.deEssComp, this.deEssOrigNeg, this.deEssAmount, this.deEssOut,
+      this.deEssHP, this.deEssComp, this.deEssDelayDry, this.deEssDelayOrig,
+      this.deEssOrigNeg, this.deEssAmount, this.deEssOut,
       this.stereoIn, this.msSplit, this.sideRNeg, this.midGain, this.sideGain,
       this.widthGain, this.sideSNeg, this.leftSum, this.rightSum, this.msMerge,
       this.masterGain, this.analyser]) {

--- a/src/pipeline/PlaybackMixer.js
+++ b/src/pipeline/PlaybackMixer.js
@@ -73,19 +73,10 @@ export class PlaybackMixer {
     this.eqHighMid = this.ctx.createBiquadFilter();
     this.compressor = this.ctx.createDynamicsCompressor();
     this.makeupGain = this.ctx.createGain();
-    // ── De-esser (subtractive split-band; transparent at amount 0) ───────
-    // The dry signal always passes; we subtract only the sibilance a fast
-    // high-band compressor squashes: out = dry + amount·(compHigh − origHigh).
-    this.deEssHP = this.ctx.createBiquadFilter();      // sibilance band (high-pass)
-    this.deEssComp = this.ctx.createDynamicsCompressor();
-    // DynamicsCompressorNode adds ~5 ms lookahead latency; delay the dry and
-    // original-high paths to match so the subtraction stays phase-aligned (no
-    // comb filtering). createDelay is guarded for the non-Web-Audio test mock.
-    this.deEssDelayDry = typeof this.ctx.createDelay === 'function' ? this.ctx.createDelay(0.1) : null;
-    this.deEssDelayOrig = typeof this.ctx.createDelay === 'function' ? this.ctx.createDelay(0.1) : null;
-    this.deEssOrigNeg = this.ctx.createGain();         // −origHigh
-    this.deEssAmount = this.ctx.createGain();          // ← control: scales the reduction
-    this.deEssOut = this.ctx.createGain();             // dry + amount·(compHigh − origHigh)
+    // De-esser slot: makeupGain → deEsserInput → stereo matrix. The de-esser
+    // worklet (true sidechain, no lookahead) is spliced between them once it
+    // loads (see _loadDeEsser); until then deEsserInput is a pass-through.
+    this.deEsserInput = this.ctx.createGain();
     // ── Stereo-width mid/side matrix (transparent at width = 100%) ────────
     this.stereoIn = this.ctx.createGain();        // force 2ch: mono up-mix → L=R
     this.msSplit = this.ctx.createChannelSplitter(2);
@@ -123,20 +114,6 @@ export class PlaybackMixer {
     this.compressor.ratio.value = 1;
     this.compressor.attack.value = 0.02;
     this.compressor.release.value = 0.25;
-    // De-esser: high-pass the sibilance band into a fast, aggressive compressor.
-    // Fixed dynamics; the user controls frequency + amount. amount 0 = bypass.
-    this.deEssHP.type = HP_FILTER_TYPE;
-    this.deEssHP.frequency.value = 6000;
-    this.deEssComp.threshold.value = -35;
-    this.deEssComp.knee.value = 0;
-    this.deEssComp.ratio.value = 6;
-    this.deEssComp.attack.value = 0.0005;
-    this.deEssComp.release.value = 0.05;
-    if (this.deEssDelayDry) this.deEssDelayDry.delayTime.value = 0.005;   // match compressor lookahead
-    if (this.deEssDelayOrig) this.deEssDelayOrig.delayTime.value = 0.005;
-    this.deEssOrigNeg.gain.value = -1;
-    this.deEssAmount.gain.value = 0;   // 0 = no reduction → transparent
-    this.deEssOut.gain.value = 1;
     // Stereo-width matrix: fixed coefficients + the single width control.
     this.stereoIn.channelCount = 2;
     this.stereoIn.channelCountMode = 'explicit';
@@ -165,28 +142,10 @@ export class PlaybackMixer {
     this.eqHighMid.connect(this.highShelf);
     this.highShelf.connect(this.compressor);
     this.compressor.connect(this.makeupGain);
-    // De-esser: dry passes straight through; the sibilance reduction (compHigh −
-    // origHigh), scaled by amount, is summed in. amount 0 → deEssOut == dry.
-    // Dry + original-high are delayed to align with the compressor's lookahead.
-    if (this.deEssDelayDry) {
-      this.makeupGain.connect(this.deEssDelayDry);
-      this.deEssDelayDry.connect(this.deEssOut);     // dry (full signal, delayed)
-    } else {
-      this.makeupGain.connect(this.deEssOut);        // dry (fallback: no delay node)
-    }
-    this.makeupGain.connect(this.deEssHP);           // sidechain: sibilance band
-    this.deEssHP.connect(this.deEssComp);
-    this.deEssComp.connect(this.deEssAmount);        // +compHigh (5 ms lookahead)
-    if (this.deEssDelayOrig) {
-      this.deEssHP.connect(this.deEssDelayOrig);
-      this.deEssDelayOrig.connect(this.deEssOrigNeg); // origHigh (delayed to match)
-    } else {
-      this.deEssHP.connect(this.deEssOrigNeg);
-    }
-    this.deEssOrigNeg.connect(this.deEssAmount);     // −origHigh
-    this.deEssAmount.connect(this.deEssOut);
-    // Stereo-width mid/side matrix: deEssOut → stereoIn → split → M/S → merge → master.
-    this.deEssOut.connect(this.stereoIn);
+    // De-esser slot (worklet spliced in on load): makeupGain → deEsserInput → stereo.
+    this.makeupGain.connect(this.deEsserInput);
+    // Stereo-width mid/side matrix: deEsserInput → stereoIn → split → M/S → merge → master.
+    this.deEsserInput.connect(this.stereoIn);
     this.stereoIn.connect(this.msSplit);
     // Mid = (L + R) · 0.5  (both split legs sum into midGain)
     this.msSplit.connect(this.midGain, 0);
@@ -218,13 +177,17 @@ export class PlaybackMixer {
     this.noiseMuteGain.gain.value = 1;
     this.makeupGain.gain.value = 1;   // 0 dB — transparent until raised
 
-    // ── Noise gate (playback-only worklet; spliced in asynchronously) ─────
-    // Default range 0 dB = bypass, so the gate is transparent until engaged.
-    /** @type {AudioWorkletNode|null} */ this.gate = null;
+    // ── Playback-only worklets (gate + de-esser), spliced in asynchronously ─
+    // Both default to bypass (gate range 0 / de-esser amount 0) → transparent
+    // until engaged. Load promises are kept so dispose() can await them
+    // (avoids a splice-after-dispose race).
     this._disposed = false;
+    /** @type {AudioWorkletNode|null} */ this.gate = null;
     this._gateParams = { threshold: -45, range: 0, attack: 5, release: 100 };
-    // Keep the load promise so dispose() can await it (avoids a splice-after-dispose race).
     this._gatePromise = this._loadGate();
+    /** @type {AudioWorkletNode|null} */ this.deEsser = null;
+    this._deEsserParams = { frequency: 6000, amount: 0 };
+    this._deEsserPromise = this._loadDeEsser();
 
     // ── Transport state ──────────────────────────────────────────────────
     /** @type {AudioBuffer|null} */ this.cleanBuffer = null;
@@ -274,6 +237,40 @@ export class PlaybackMixer {
     } catch (err) {
       console.error('[VIP][PlaybackMixer] noise-gate worklet failed to load; bypassing.', err);
     }
+  }
+
+  /**
+   * Load and splice in the de-esser worklet (deEsserInput → deEsser → stereo).
+   * Same graceful no-op/bypass contract as _loadGate.
+   */
+  async _loadDeEsser() {
+    const aw = this.ctx.audioWorklet;
+    const NodeCtor = globalThis.AudioWorkletNode;
+    if (!aw || typeof aw.addModule !== 'function' || typeof NodeCtor !== 'function') return;
+    try {
+      // Literal call (not via the `aw` alias) so validate.js's allowlist sees it.
+      await this.ctx.audioWorklet.addModule('/src/workers/DeEsserProcessor.js');
+      if (this._disposed) return; // disposed mid-load — don't touch a torn-down graph
+      const deEsser = new NodeCtor(this.ctx, 'vip-deesser');
+      this.deEsserInput.disconnect(this.stereoIn);
+      this.deEsserInput.connect(deEsser);
+      deEsser.connect(this.stereoIn);
+      for (const [name, value] of Object.entries(this._deEsserParams)) {
+        const p = deEsser.parameters.get(name);
+        if (p) p.value = value;
+      }
+      this.deEsser = deEsser;
+    } catch (err) {
+      console.error('[VIP][PlaybackMixer] de-esser worklet failed to load; bypassing.', err);
+    }
+  }
+
+  /** Remember a de-esser parameter and apply it to the live worklet if present. */
+  _setDeEsserParam(name, value) {
+    this._deEsserParams[name] = value;
+    if (!this.deEsser) return;
+    const param = this.deEsser.parameters.get(name);
+    if (param) this._applyParam(param, value);
   }
 
   /** Remember a gate parameter and apply it to the live worklet if present. */
@@ -527,11 +524,11 @@ export class PlaybackMixer {
   setGateRelease(ms) { this._setGateParam('release', clamp(ms, 0, 1000)); }
 
   /** De-esser band frequency in Hz (2000 … 12000): where sibilance reduction starts. */
-  setDeEsserFreq(hz) { this._applyParam(this.deEssHP.frequency, clamp(hz, 2000, 12000)); }
+  setDeEsserFreq(hz) { this._setDeEsserParam('frequency', clamp(hz, 2000, 12000)); }
 
   /** De-esser amount as a percentage (0 … 100). 0 = off (transparent). */
   setDeEsserAmount(percentage) {
-    this._applyParam(this.deEssAmount.gain, clamp(percentage, 0, 100) / 100);
+    this._setDeEsserParam('amount', clamp(percentage, 0, 100) / 100);
   }
 
   /**
@@ -716,16 +713,15 @@ export class PlaybackMixer {
     this._disposed = true;
     this.stop();
     // Let any in-flight gate-worklet load settle (it bails on _disposed) before teardown.
-    if (this._gatePromise) {
-      try { await this._gatePromise; } catch { /* ignore */ }
+    for (const p of [this._gatePromise, this._deEsserPromise]) {
+      if (p) { try { await p; } catch { /* ignore */ } }
     }
     for (const node of [this.speakerGain, this.cleanGain, this.voiceMuteGain,
       this.noiseGain, this.noiseMuteGain, this.gateInput, this.gate,
       this.highpass, this.lowpass,
       this.lowShelf, this.eqLowMid, this.eqMid, this.eqHighMid,
       this.highShelf, this.compressor, this.makeupGain,
-      this.deEssHP, this.deEssComp, this.deEssDelayDry, this.deEssDelayOrig,
-      this.deEssOrigNeg, this.deEssAmount, this.deEssOut,
+      this.deEsserInput, this.deEsser,
       this.stereoIn, this.msSplit, this.sideRNeg, this.midGain, this.sideGain,
       this.widthGain, this.sideSNeg, this.leftSum, this.rightSum, this.msMerge,
       this.masterGain, this.analyser]) {

--- a/src/presentation/SliderUI.js
+++ b/src/presentation/SliderUI.js
@@ -47,6 +47,9 @@ const SLIDER_BINDINGS = Object.freeze([
   { id: 'gateRangeSlider', method: 'setGateRange', initial: 0 },
   { id: 'gateAttackSlider', method: 'setGateAttack', initial: 5 },
   { id: 'gateReleaseSlider', method: 'setGateRelease', initial: 100 },
+  // Tier-B: de-esser
+  { id: 'deEsserFreqSlider', method: 'setDeEsserFreq', initial: 6000 },
+  { id: 'deEsserAmountSlider', method: 'setDeEsserAmount', initial: 0 },
 ]);
 
 export class SliderUI {

--- a/src/workers/DeEsserProcessor.js
+++ b/src/workers/DeEsserProcessor.js
@@ -1,0 +1,109 @@
+/* global AudioWorkletProcessor, registerProcessor, sampleRate */
+/**
+ * VoiceIsolate Pro — De-Esser AudioWorklet (Layer 2: playback DSP)
+ *
+ * A real-time, sample-accurate de-esser for the Live-Mix playback bus —
+ * **playback-only**, exactly like GateProcessor: it processes loaded stems,
+ * never a microphone, never re-runs ML. The second (and only other) worklet
+ * permitted in src/, allowlisted in scripts/validate.js (CLAUDE.md §2.1).
+ *
+ * Why a worklet rather than built-in nodes: a built-in split-band design must
+ * route the sibilance band through a DynamicsCompressorNode, whose ~5 ms
+ * lookahead misaligns it from the dry path and comb-filters the highs. Doing
+ * the detection + reduction per sample avoids that entirely.
+ *
+ * Method (complementary filter, no latency, transparent by construction):
+ *   low  = one-pole lowpass(x) at `frequency`
+ *   high = x − low                      (so low + high == x exactly)
+ *   out  = low + g·high                 (reduce only the sibilance band)
+ * where g (1 → reduced) follows the high-band envelope: when it exceeds a
+ * fixed threshold, g = (thr/env)^amount. amount 0 → g≡1 → fully transparent;
+ * and g≡1 whenever the high band is quiet, so non-sibilant audio is untouched
+ * at any amount.
+ *
+ * AudioParams (k-rate) so sliders drive it like any other Live-Mix control:
+ *   - frequency (Hz): low/high split point (sibilance band start)
+ *   - amount (0–1):   de-essing strength; 0 = off
+ */
+'use strict';
+
+const SIBILANCE_THRESHOLD = 0.05; // ≈ −26 dBFS high-band level where reduction begins
+
+class DeEsserProcessor extends AudioWorkletProcessor {
+  static get parameterDescriptors() {
+    return [
+      { name: 'frequency', defaultValue: 6000, minValue: 2000, maxValue: 12000, automationRate: 'k-rate' },
+      { name: 'amount', defaultValue: 0, minValue: 0, maxValue: 1, automationRate: 'k-rate' },
+    ];
+  }
+
+  constructor() {
+    super();
+    this._lp = new Float32Array(2);   // per-channel one-pole lowpass state
+    this._high = new Float32Array(2); // scratch: current-sample high band per channel
+    this._env = 0;                    // shared high-band envelope
+    this._gain = 1;                   // smoothed reduction gain
+  }
+
+  process(inputs, outputs, parameters) {
+    const input = inputs[0];
+    const output = outputs[0];
+    if (!input || input.length === 0 || !output || output.length === 0) return true;
+    const inCh = input.length;
+    const outCh = output.length;
+    const nSamp = output[0].length;
+
+    const amount = parameters.amount[0];
+    // Bypass fast-path: amount 0 → no reduction → pass through untouched.
+    if (amount <= 0) {
+      for (let c = 0; c < outCh; c++) {
+        if (input[c]) output[c].set(input[c]);
+        else output[c].fill(0);
+      }
+      this._env = 0;
+      this._gain = 1;
+      return true;
+    }
+
+    if (this._lp.length < inCh) this._lp = new Float32Array(inCh);
+    if (this._high.length < inCh) this._high = new Float32Array(inCh);
+
+    const a = Math.exp(-2 * Math.PI * parameters.frequency[0] / sampleRate); // one-pole LP coef
+    const atk = Math.exp(-1 / (0.0005 * sampleRate)); // 0.5 ms detector/gain attack
+    const rel = Math.exp(-1 / (0.05 * sampleRate));   // 50 ms release
+    const thr = SIBILANCE_THRESHOLD;
+
+    let env = this._env;
+    let gain = this._gain;
+    for (let i = 0; i < nSamp; i++) {
+      // Split each channel into low/high; track the peak |high| for detection.
+      let hpk = 0;
+      for (let c = 0; c < inCh; c++) {
+        const x = input[c] ? input[c][i] : 0;
+        const lp = a * this._lp[c] + (1 - a) * x;
+        this._lp[c] = lp;
+        const high = x - lp;
+        this._high[c] = high;
+        const ah = high < 0 ? -high : high;
+        if (ah > hpk) hpk = ah;
+      }
+      // Envelope (fast attack, slow release) on the high band.
+      env = hpk > env ? atk * env + (1 - atk) * hpk : rel * env + (1 - rel) * hpk;
+      // Target reduction gain for the high band; 1 (no cut) until env exceeds thr.
+      const target = env > thr ? Math.pow(thr / env, amount) : 1;
+      const coef = target < gain ? atk : rel;
+      gain = coef * gain + (1 - coef) * target;
+      // out = low + g·high; low = x − high so the sum is exact when g = 1.
+      for (let c = 0; c < outCh; c++) {
+        const x = input[c] ? input[c][i] : 0;
+        const high = c < inCh ? this._high[c] : 0;
+        output[c][i] = (x - high) + gain * high;
+      }
+    }
+    this._env = env;
+    this._gain = gain;
+    return true;
+  }
+}
+
+registerProcessor('vip-deesser', DeEsserProcessor);

--- a/tests/architectural-invariants.test.js
+++ b/tests/architectural-invariants.test.js
@@ -82,7 +82,7 @@ describe('CLAUDE.md §1.1 — live real-time pipeline stays removed', () => {
     // The live-mic worklet pipeline stays removed; the one permitted worklet is
     // the playback-only noise gate (CLAUDE.md §2.1, scripts/validate.js). Any
     // other module path — or a dynamic argument — is still forbidden.
-    const ALLOWED_WORKLETS = ['/src/workers/GateProcessor.js'];
+    const ALLOWED_WORKLETS = ['/src/workers/GateProcessor.js', '/src/workers/DeEsserProcessor.js'];
     const offenders = [];
     for (const f of [...walkJs(APP_DIR), ...walkJs(SRC_DIR)]) {
       const src = fs.readFileSync(f, 'utf8');

--- a/tests/slider-ui.test.js
+++ b/tests/slider-ui.test.js
@@ -46,6 +46,8 @@ function mockMixer() {
     setGateRange(v) { this.calls.push(['setGateRange', v]); },
     setGateAttack(v) { this.calls.push(['setGateAttack', v]); },
     setGateRelease(v) { this.calls.push(['setGateRelease', v]); },
+    setDeEsserFreq(v) { this.calls.push(['setDeEsserFreq', v]); },
+    setDeEsserAmount(v) { this.calls.push(['setDeEsserAmount', v]); },
   };
 }
 
@@ -76,6 +78,8 @@ const SLIDER_SPECS = {
   gateRangeSlider: { min: 0, max: 80, value: 0 },
   gateAttackSlider: { min: 0, max: 200, value: 5 },
   gateReleaseSlider: { min: 0, max: 1000, value: 100 },
+  deEsserFreqSlider: { min: 2000, max: 12000, value: 6000 },
+  deEsserAmountSlider: { min: 0, max: 100, value: 0 },
 };
 function buildSliders(values = {}) {
   document.body.innerHTML = '';
@@ -144,6 +148,8 @@ describe('SliderUI', () => {
       ['setGateRange', 0],
       ['setGateAttack', 5],
       ['setGateRelease', 100],
+      ['setDeEsserFreq', 6000],
+      ['setDeEsserAmount', 0],
     ]);
   });
 

--- a/tests/stem-split-core.test.js
+++ b/tests/stem-split-core.test.js
@@ -280,6 +280,19 @@ describe('PlaybackMixer (Layer 3) — Live-Mix control surface', () => {
     expect(mixer._gateParams.release).toBe(0);
   });
 
+  test('de-esser: transparent by default; setters clamp', () => {
+    expect(mixer.deEssAmount.gain.value).toBe(0);     // amount 0 = bypass
+    expect(mixer.deEssHP.frequency.value).toBe(6000);
+    mixer.setDeEsserAmount(150);                       // clamps to 100 → 1.0
+    expect(mixer.deEssAmount.gain.value).toBe(1);
+    mixer.setDeEsserAmount(-10);                       // clamps to 0
+    expect(mixer.deEssAmount.gain.value).toBe(0);
+    mixer.setDeEsserFreq(500);                          // clamps to 2000
+    expect(mixer.deEssHP.frequency.value).toBe(2000);
+    mixer.setDeEsserFreq(99999);                        // clamps to 12000
+    expect(mixer.deEssHP.frequency.value).toBe(12000);
+  });
+
   test('loadStems builds sample-locked buffers; transport round-trips', async () => {
     mixer.loadStems(stems(), stems());
     expect(mixer.duration()).toBeCloseTo(1);

--- a/tests/stem-split-core.test.js
+++ b/tests/stem-split-core.test.js
@@ -280,17 +280,21 @@ describe('PlaybackMixer (Layer 3) — Live-Mix control surface', () => {
     expect(mixer._gateParams.release).toBe(0);
   });
 
-  test('de-esser: transparent by default; setters clamp', () => {
-    expect(mixer.deEssAmount.gain.value).toBe(0);     // amount 0 = bypass
-    expect(mixer.deEssHP.frequency.value).toBe(6000);
-    mixer.setDeEsserAmount(150);                       // clamps to 100 → 1.0
-    expect(mixer.deEssAmount.gain.value).toBe(1);
-    mixer.setDeEsserAmount(-10);                       // clamps to 0
-    expect(mixer.deEssAmount.gain.value).toBe(0);
+  test('de-esser worklet: bypassed by default; setters clamp + convert', () => {
+    // No AudioWorklet in the mock → the de-esser stays bypassed (null) and
+    // deEsserInput passes through; setters store/clamp into _deEsserParams.
+    expect(mixer.deEsser).toBe(null);
+    expect(mixer.deEsserInput).toBeDefined();
+    expect(mixer._deEsserParams.amount).toBe(0);       // amount 0 = transparent
+    expect(mixer._deEsserParams.frequency).toBe(6000);
+    mixer.setDeEsserAmount(150);                        // 150% → clamps to 100 → 1.0
+    expect(mixer._deEsserParams.amount).toBe(1);
+    mixer.setDeEsserAmount(-10);                        // clamps to 0
+    expect(mixer._deEsserParams.amount).toBe(0);
     mixer.setDeEsserFreq(500);                          // clamps to 2000
-    expect(mixer.deEssHP.frequency.value).toBe(2000);
+    expect(mixer._deEsserParams.frequency).toBe(2000);
     mixer.setDeEsserFreq(99999);                        // clamps to 12000
-    expect(mixer.deEssHP.frequency.value).toBe(12000);
+    expect(mixer._deEsserParams.frequency).toBe(12000);
   });
 
   test('loadStems builds sample-locked buffers; transport round-trips', async () => {


### PR DESCRIPTION
## What & why

Completes **Tier-B** with a **de-esser**, implemented as a second **playback-only `AudioWorklet`** (`vip-deesser`) — the proper fix chosen over a built-in design. (The first commits used a built-in split-band compressor; review correctly flagged that `DynamicsCompressorNode`'s ~5 ms lookahead comb-filters the highs. A worklet avoids that entirely.)

## How it works
Per-sample, no lookahead, transparent by construction:
```
low  = one-pole lowpass(x) at `frequency`
high = x − low                     (so low + high == x exactly)
out  = low + g·high                (reduce only the sibilance band)
g = (thr/env)^amount  when the high-band envelope exceeds thr, else 1
```
`amount 0 → g≡1 → fully transparent`; and `g≡1` whenever the high band is quiet, so non-sibilant audio is untouched at any amount. No `DynamicsCompressorNode`, no delay nodes, no comb filtering.

## Changes
- **`src/workers/DeEsserProcessor.js`** — `registerProcessor('vip-deesser')`, k-rate AudioParams `frequency` + `amount`.
- **`PlaybackMixer.js`** — `deEsserInput` slot; worklet spliced in asynchronously (`deEsserInput → deEsser → stereoIn`), mirroring the gate; bypass when AudioWorklet is unavailable; `dispose()` awaits both worklet load promises.
- **`SliderUI.js` / `index.html` / `landing.js`** — De-Esser Freq + Amount controls (sliders → 23 total).
- **`scripts/validate.js`** + **`tests/architectural-invariants.test.js`** — allowlist `DeEsserProcessor.js` as the second permitted worklet (everything else, and `getUserMedia`, still forbidden).
- **`CLAUDE.md §2.1`** — documents both playback worklets.

## Verification
- `pnpm validate` ✅ · `pnpm lint` ✅ 0 errors · `pnpm test` ✅ **1811/1811** · 23 sliders ↔ 23 readouts
- ⚠️ Worklet audio can't render in the node test mock — **browser listen-test recommended**.

This completes the full live console: **EQ · filters · compressor · stereo width · gate · de-esser.** Tier-C (spectral NR, dereverb) stays offline-only by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDEdHgcC8mwr6J2erPhraz

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add playback-only de-esser AudioWorklet with true sidechain to the Live-Mix pipeline
> - Adds [DeEsserProcessor.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/608/files#diff-9cf99ed73e6d6a56af6855da23e3baf194776c11d3ff207745c3bf7f49389374), a new `AudioWorkletProcessor` registered as `vip-deesser`, implementing complementary filtering with envelope-controlled high-band gain reduction and a transparent bypass when `amount=0`.
> - Inserts the de-esser into [PlaybackMixer.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/608/files#diff-646b05066f8ea1ef7558ebf5da2f3de3eeaafd7d18d7ab2f5254089e2577b0b7) between `makeupGain` and the stereo-width matrix; it loads dynamically without interrupting playback and falls back to bypass if `AudioWorklet` is unavailable.
> - Exposes `setDeEsserFreq` (2000–12000 Hz, clamped) and `setDeEsserAmount` (0–100%, normalized to 0–1) on `PlaybackMixer`, wired to two new UI sliders via [SliderUI.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/608/files#diff-0cb8f952de2865f8757842b01940d8ff2b5d273d0be9e3c165bb6158d1c765ba).
> - Adds `DeEsserProcessor.js` to the `ALLOWED_WORKLETS` allowlist in both [validate.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/608/files#diff-0d7f74eada294edb89d7900af2f1a111706f4a4dd2f0de9504471b9c60508439) and the architectural-invariants test.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cec79a6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two de-esser controls to the Live Mix slider grid: "De-Esser Freq" and "De-Esser Amount" sliders for controlling sibilance reduction during playback.
  * De-esser sliders are disabled by default and integrate with the existing noise gate controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->