### PR TITLE
Tier-C: offline spectral cleanup (noise reduction + dereverb)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,8 +83,10 @@ Layer 1  src/core/           Pure primitives. No DOM, no Web Audio, no I/O.
 | `src/core/BufferPool.js` | 1 | Pre-allocated `Float32Array` pool (128 / 2048 / 4096) — zero-GC DSP. |
 | `src/core/ModelManifest.js` | 1 | Canonical model metadata: URLs, sizes, SHA-256 integrity hashes, I/O specs. |
 | `src/core/diarization.js` | 1 | Pure speaker diarization (frame features + k-means) run once per file on the clean stem. |
+| `src/core/SpectralCleanup.js` | 1 | Pure **offline** STFT post-passes run once per file on the clean stem: `reduceNoise()` (spectral subtraction + minimum-statistics noise floor) and `dereverb()` (decaying-tail subtraction). Strength is a processing parameter, **never a live slider**. |
 | `src/workers/MLWorker.js` | 2 | Fetch → verify SHA-256 → cache in IndexedDB → run offline ONNX inference (overlap-add) → emit stems. |
 | `src/workers/DiarizationWorker.js` | 2 | Module worker (`{ type: 'module' }`) wrapping `diarization.js` — keeps segmentation off the main thread. |
+| `src/workers/SpectralCleanupWorker.js` | 2 | Module worker (`{ type: 'module' }`) wrapping `SpectralCleanup.js` — runs the offline NR/dereverb passes off the main thread. |
 | `src/pipeline/FileIngestion.js` | 3 | Accept audio/video blobs, decode, resample to 48 kHz via `OfflineAudioContext`. |
 | `src/pipeline/PlaybackMixer.js` | 3 | The Live-Mix graph: stem sources → speaker lane → gains → mute lanes → EQ → destination. Exports `setNoiseReduction()`, `setVoiceMuted()`, `setSpeakerMuted()` etc. |
 | `src/presentation/SliderUI.js` | 4 | Slider event listeners, `requestAnimationFrame`-coalesced updates into `PlaybackMixer`. |

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -238,7 +238,7 @@ export default [
   {
     // Layer 2 — module workers (spawned with { type: 'module' }); they import
     // src/core/ directly, so sourceType flips back to 'module'.
-    files: ['src/workers/DiarizationWorker.js'],
+    files: ['src/workers/DiarizationWorker.js', 'src/workers/SpectralCleanupWorker.js'],
     languageOptions: {
       ecmaVersion: 2022,
       sourceType: 'module',

--- a/src/core/SpectralCleanup.js
+++ b/src/core/SpectralCleanup.js
@@ -188,10 +188,35 @@ function sanitize(buf) {
  */
 function estimateNoiseMag(samples, N, hop) {
   const bins = N / 2 + 1;
+  const win = hann(N);
+  const frames = frameCount(samples.length, N, hop);
+
+  // Pass 1 (time domain, cheap): per-frame windowed energy → an adaptive
+  // activity floor. Without it, minimum statistics is sabotaged not only by
+  // absolute digital silence (which would pin every bin's minimum at 0 and
+  // disable reduction for the whole file) but also by partial edge frames whose
+  // only signal sits where the Hann window ≈ 0 — tiny-but-nonzero energy that
+  // still drags the per-bin minimum far below the true noise floor. Excluding
+  // frames below a fraction of the median energy handles silence, fades, and
+  // those partial frames in one robust step.
+  const energy = new Float32Array(frames);
+  for (let f = 0; f < frames; f++) {
+    const start = f * hop;
+    const avail = Math.max(0, Math.min(N, samples.length - start));
+    let e = 0;
+    for (let i = 0; i < avail; i++) { const s = samples[start + i] * win[i]; e += s * s; }
+    energy[f] = e;
+  }
+  const active = Array.from(energy).filter((e) => e > 1e-12).sort((a, b) => a - b);
+  const median = active.length ? active[active.length >> 1] : 0;
+  const threshold = median * 0.1;
+
+  // Pass 2 (FFT): minimum statistics over active frames only.
   const smooth = new Float32Array(bins);
   const minPow = new Float32Array(bins).fill(Infinity);
   let first = true;
-  forwardSTFT(samples, N, hop, (re, im) => {
+  forwardSTFT(samples, N, hop, (re, im, _bins, f) => {
+    if (energy[f] <= 0 || energy[f] < threshold) return;
     for (let k = 0; k < bins; k++) {
       const pow = re[k] * re[k] + im[k] * im[k];
       smooth[k] = first ? pow : 0.7 * smooth[k] + 0.3 * pow;
@@ -238,7 +263,7 @@ export function reduceNoise(samples, opts = {}) {
 
   const out = overlapProcess(input, N, hop, (re, im) => {
     for (let k = 0; k < bins; k++) {
-      const mag = Math.hypot(re[k], im[k]);
+      const mag = Math.sqrt(re[k] * re[k] + im[k] * im[k]); // sqrt: hypot's overflow guard isn't needed here
       let g = mag > 1e-12 ? (mag - oversub * noiseMag[k]) / mag : 0;
       g = clamp01(g);
       if (g < FLOOR) g = FLOOR;
@@ -281,10 +306,11 @@ export function dereverb(samples, opts = {}) {
   const rt60 = opts.rt60 || 0.4;
   const bins = N / 2 + 1;
 
-  // Per-hop tail decay: 60 dB over rt60 seconds → factor^(hop/sr) loses
-  // (3·hop)/(rt60·sr) decades each frame.
+  // Per-hop tail decay on POWER (tail holds re²+im²): a 60 dB power decay over
+  // rt60 is a factor of 10⁻⁶, so the per-frame factor loses (6·hop)/(rt60·sr)
+  // decades. (−3 would model a 30 dB power decay → an effective RT60 of 2·rt60.)
   const hopTime = hop / sr;
-  const decay = Math.pow(10, -3 * hopTime / rt60);
+  const decay = Math.pow(10, -6 * hopTime / rt60);
   const beta = 1 + amount;   // over-subtraction of the tail estimate
   const FLOOR = 0.1;         // keep ≥ -20 dB so onsets/timbre survive
 

--- a/src/core/SpectralCleanup.js
+++ b/src/core/SpectralCleanup.js
@@ -1,0 +1,320 @@
+/**
+ * VoiceIsolate Pro — Spectral Cleanup (Layer 1: Core)
+ *
+ * Pure, offline STFT-domain enhancement run **once per file** during Phase-1
+ * ingestion (CLAUDE.md §1) — NOT real-time playback DSP. Two non-ML passes
+ * that complement the ML stems:
+ *
+ *   • reduceNoise() — spectral-subtraction denoise with a per-bin noise floor
+ *     estimated by minimum statistics, plus temporal gain smoothing to suppress
+ *     musical noise. Strips stationary hiss/hum the mask network leaves behind.
+ *   • dereverb()    — single-channel reverb suppression: subtract a per-bin
+ *     decaying-tail estimate so late reverberation between onsets is attenuated.
+ *
+ * Both take the `amount` (0–1) as a *processing parameter* decided before the
+ * pass, never a live slider — they are heavy STFT passes and must not re-run on
+ * UI events (that is what the Live-Mix Web Audio graph is for). The result is a
+ * new, cleaner Float32Array stem that then feeds the playback graph.
+ *
+ * Pure module: no DOM, no Web Audio, no I/O. Importable from Node, workers, and
+ * the browser. Operates on a single channel; the worker maps over channels.
+ */
+'use strict';
+
+import { SAMPLE_RATE, FRAME_SIZE, HOP_SIZE } from './audio-config.js';
+
+// ─── FFT primitives (radix-2, power-of-two) ──────────────────────────────────
+// Self-contained copy of the proven transform: src/core/ must not depend on the
+// classic MLWorker (which can't export ESM), so the math lives here too.
+
+const _hannCache = Object.create(null);
+function hann(n) {
+  if (_hannCache[n]) return _hannCache[n];
+  const w = new Float32Array(n);
+  for (let i = 0; i < n; i++) w[i] = 0.5 * (1 - Math.cos((2 * Math.PI * i) / (n - 1)));
+  _hannCache[n] = w;
+  return w;
+}
+
+const _fftCache = Object.create(null);
+function fftTables(n) {
+  if (_fftCache[n]) return _fftCache[n];
+  const rev = new Uint32Array(n);
+  const bits = Math.log2(n);
+  for (let i = 0; i < n; i++) {
+    let r = 0;
+    for (let b = 0; b < bits; b++) r |= ((i >> b) & 1) << (bits - 1 - b);
+    rev[i] = r;
+  }
+  const cos = new Float32Array(n / 2);
+  const sin = new Float32Array(n / 2);
+  for (let i = 0; i < n / 2; i++) {
+    cos[i] = Math.cos((-2 * Math.PI * i) / n);
+    sin[i] = Math.sin((-2 * Math.PI * i) / n);
+  }
+  _fftCache[n] = { rev, cos, sin };
+  return _fftCache[n];
+}
+
+/** In-place iterative radix-2 complex FFT; inverse conjugates twiddles + scales 1/n. */
+function fftInPlace(re, im, inverse) {
+  const n = re.length;
+  const { rev, cos, sin } = fftTables(n);
+  for (let i = 0; i < n; i++) {
+    const r = rev[i];
+    if (r > i) {
+      let t = re[i]; re[i] = re[r]; re[r] = t;
+      t = im[i]; im[i] = im[r]; im[r] = t;
+    }
+  }
+  for (let size = 2; size <= n; size <<= 1) {
+    const half = size >> 1;
+    const step = n / size;
+    for (let i = 0; i < n; i += size) {
+      for (let j = 0, k = 0; j < half; j++, k += step) {
+        const wr = cos[k];
+        const wi = inverse ? -sin[k] : sin[k];
+        const a = i + j;
+        const b = a + half;
+        const tr = re[b] * wr - im[b] * wi;
+        const ti = re[b] * wi + im[b] * wr;
+        re[b] = re[a] - tr; im[b] = im[a] - ti;
+        re[a] += tr; im[a] += ti;
+      }
+    }
+  }
+  if (inverse) {
+    for (let i = 0; i < n; i++) { re[i] /= n; im[i] /= n; }
+  }
+}
+
+// ─── STFT scaffolding ────────────────────────────────────────────────────────
+
+function frameCount(length, N, hop) {
+  return Math.max(1, Math.ceil(Math.max(0, length - N) / hop) + 1);
+}
+
+/**
+ * Forward-STFT a channel, invoking visit(re, im, bins, frameIndex) per frame
+ * with the Hann-windowed half-spectrum. Reconstruction is the caller's job
+ * (used by the noise-floor pre-pass, which needs magnitudes only).
+ */
+function forwardSTFT(samples, N, hop, visit) {
+  const win = hann(N);
+  const bins = N / 2 + 1;
+  const re = new Float32Array(N);
+  const im = new Float32Array(N);
+  const frames = frameCount(samples.length, N, hop);
+  for (let f = 0; f < frames; f++) {
+    const start = f * hop;
+    const avail = Math.max(0, Math.min(N, samples.length - start));
+    re.fill(0); im.fill(0);
+    for (let i = 0; i < avail; i++) re[i] = samples[start + i] * win[i];
+    fftInPlace(re, im, false);
+    visit(re, im, bins, f);
+  }
+}
+
+/**
+ * STFT → per-frame transform → masked iSTFT overlap-add. `transform(re, im,
+ * bins, frame)` mutates the half-spectrum bins [0, bins) in place; the upper
+ * half is rebuilt by Hermitian symmetry before the inverse FFT. COLA is
+ * restored by dividing the accumulated output by the summed window² envelope.
+ *
+ * @returns {Float32Array} reconstructed channel, same length as `samples`
+ */
+function overlapProcess(samples, N, hop, transform) {
+  const win = hann(N);
+  const bins = N / 2 + 1;
+  const re = new Float32Array(N);
+  const im = new Float32Array(N);
+  const out = new Float32Array(samples.length);
+  const norm = new Float32Array(samples.length);
+  const frames = frameCount(samples.length, N, hop);
+
+  for (let f = 0; f < frames; f++) {
+    const start = f * hop;
+    const avail = Math.max(0, Math.min(N, samples.length - start));
+    re.fill(0); im.fill(0);
+    for (let i = 0; i < avail; i++) re[i] = samples[start + i] * win[i];
+    fftInPlace(re, im, false);
+
+    transform(re, im, bins, f);
+
+    // Rebuild the Hermitian-symmetric upper half from the modified lower half.
+    for (let k = bins; k < N; k++) {
+      re[k] = re[N - k];
+      im[k] = -im[N - k];
+    }
+    fftInPlace(re, im, true);
+
+    for (let i = 0; i < avail; i++) {
+      out[start + i] += re[i] * win[i];
+      norm[start + i] += win[i] * win[i];
+    }
+  }
+  // Normalize by the summed window² envelope. At the very edges only one or two
+  // frames overlap, so dividing by that tiny norm would amplify the per-bin
+  // gain's frame-edge ringing into a click. Floor the divisor at half the
+  // steady-state overlap: edges are gently attenuated instead of blown up.
+  let maxNorm = 0;
+  for (let i = 0; i < norm.length; i++) if (norm[i] > maxNorm) maxNorm = norm[i];
+  const floorNorm = 0.5 * maxNorm;
+  if (floorNorm > 0) {
+    for (let i = 0; i < out.length; i++) out[i] /= Math.max(norm[i], floorNorm);
+  }
+  return out;
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function clamp01(x) { return x < 0 ? 0 : x > 1 ? 1 : x; }
+
+/** Replace any non-finite sample with 0 so a bad frame can't poison playback. */
+function sanitize(buf) {
+  for (let i = 0; i < buf.length; i++) {
+    if (!Number.isFinite(buf[i])) buf[i] = 0;
+  }
+  return buf;
+}
+
+// ─── Noise reduction (spectral subtraction + minimum statistics) ─────────────
+
+/**
+ * Estimate a per-bin noise magnitude floor by minimum statistics: track the
+ * running minimum of a lightly time-smoothed power spectrum (the smoothing
+ * keeps the minimum off momentary spectral nulls), then bias-compensate upward
+ * (minimum statistics underestimates the true noise level).
+ */
+function estimateNoiseMag(samples, N, hop) {
+  const bins = N / 2 + 1;
+  const smooth = new Float32Array(bins);
+  const minPow = new Float32Array(bins).fill(Infinity);
+  let first = true;
+  forwardSTFT(samples, N, hop, (re, im) => {
+    for (let k = 0; k < bins; k++) {
+      const pow = re[k] * re[k] + im[k] * im[k];
+      smooth[k] = first ? pow : 0.7 * smooth[k] + 0.3 * pow;
+      if (smooth[k] < minPow[k]) minPow[k] = smooth[k];
+    }
+    first = false;
+  });
+  const noiseMag = new Float32Array(bins);
+  const BIAS = 1.4; // compensate the downward bias of minimum statistics
+  for (let k = 0; k < bins; k++) {
+    noiseMag[k] = Number.isFinite(minPow[k]) ? Math.sqrt(minPow[k]) * BIAS : 0;
+  }
+  return noiseMag;
+}
+
+/**
+ * Spectral noise reduction. Estimates a stationary per-bin noise floor, then
+ * applies a smoothed spectral-subtraction gain so bins near the floor are
+ * attenuated while louder content passes. `amount` blends the gain toward unity
+ * so 0 is fully transparent and 1 is maximally aggressive.
+ *
+ * @param {Float32Array} samples  one channel at SAMPLE_RATE
+ * @param {object} [opts]
+ * @param {number} [opts.amount=0]      0–1 reduction strength (0 = off)
+ * @param {number} [opts.sampleRate]    informational; STFT is rate-agnostic
+ * @param {number} [opts.frameSize=FRAME_SIZE]
+ * @param {number} [opts.hopSize=HOP_SIZE]
+ * @returns {Float32Array} denoised channel (new buffer, same length)
+ */
+export function reduceNoise(samples, opts = {}) {
+  const input = samples instanceof Float32Array ? samples : new Float32Array(samples || []);
+  const amount = clamp01(opts.amount ?? 0);
+  if (amount <= 0 || input.length === 0) return new Float32Array(input);
+
+  const N = opts.frameSize || FRAME_SIZE;
+  const hop = opts.hopSize || HOP_SIZE;
+  const bins = N / 2 + 1;
+  const noiseMag = estimateNoiseMag(input, N, hop);
+
+  const oversub = 1.5 + amount;     // β: over-subtraction factor 1.5 → 2.5
+  const FLOOR = 0.05;               // residual gain — leaves a touch of noise (no pumping)
+  const GSMOOTH = 0.5;              // temporal gain smoothing (musical-noise suppression)
+  const prevGain = new Float32Array(bins).fill(1);
+
+  const out = overlapProcess(input, N, hop, (re, im) => {
+    for (let k = 0; k < bins; k++) {
+      const mag = Math.hypot(re[k], im[k]);
+      let g = mag > 1e-12 ? (mag - oversub * noiseMag[k]) / mag : 0;
+      g = clamp01(g);
+      if (g < FLOOR) g = FLOOR;
+      g = GSMOOTH * prevGain[k] + (1 - GSMOOTH) * g;
+      prevGain[k] = g;
+      const blended = 1 - amount * (1 - g); // amount 0 → 1 (transparent)
+      re[k] *= blended;
+      im[k] *= blended;
+    }
+  });
+  return sanitize(out);
+}
+
+// ─── Dereverberation (decaying-tail spectral subtraction) ────────────────────
+
+/**
+ * Single-channel reverb suppression. Models late reverberation per bin as a
+ * decaying envelope of past energy and subtracts it, so the lingering tail
+ * after each onset is attenuated while fresh onsets (which exceed the decayed
+ * estimate) pass through. `amount` sets both the over-subtraction and a blend
+ * toward unity, so 0 is transparent.
+ *
+ * @param {Float32Array} samples  one channel at SAMPLE_RATE
+ * @param {object} [opts]
+ * @param {number} [opts.amount=0]       0–1 suppression strength (0 = off)
+ * @param {number} [opts.rt60=0.4]       assumed reverb decay time (seconds)
+ * @param {number} [opts.sampleRate=SAMPLE_RATE]
+ * @param {number} [opts.frameSize=FRAME_SIZE]
+ * @param {number} [opts.hopSize=HOP_SIZE]
+ * @returns {Float32Array} dereverberated channel (new buffer, same length)
+ */
+export function dereverb(samples, opts = {}) {
+  const input = samples instanceof Float32Array ? samples : new Float32Array(samples || []);
+  const amount = clamp01(opts.amount ?? 0);
+  if (amount <= 0 || input.length === 0) return new Float32Array(input);
+
+  const N = opts.frameSize || FRAME_SIZE;
+  const hop = opts.hopSize || HOP_SIZE;
+  const sr = opts.sampleRate || SAMPLE_RATE;
+  const rt60 = opts.rt60 || 0.4;
+  const bins = N / 2 + 1;
+
+  // Per-hop tail decay: 60 dB over rt60 seconds → factor^(hop/sr) loses
+  // (3·hop)/(rt60·sr) decades each frame.
+  const hopTime = hop / sr;
+  const decay = Math.pow(10, -3 * hopTime / rt60);
+  const beta = 1 + amount;   // over-subtraction of the tail estimate
+  const FLOOR = 0.1;         // keep ≥ -20 dB so onsets/timbre survive
+
+  // Prediction delay (frames): the late-reverb estimate lags the signal so the
+  // DIRECT sound of an onset is never subtracted by its own energy — only the
+  // tail it leaves behind is. `tail` is a per-bin decaying power envelope; we
+  // subtract a copy from D frames ago, projected forward by the decay.
+  const D = 3;
+  const decayD = Math.pow(decay, D);
+  const tail = new Float32Array(bins);
+  const ring = Array.from({ length: D }, () => new Float32Array(bins));
+  let ringPos = 0;
+
+  const out = overlapProcess(input, N, hop, (re, im) => {
+    const delayed = ring[ringPos];
+    for (let k = 0; k < bins; k++) {
+      const pow = re[k] * re[k] + im[k] * im[k];
+      const predictedTail = decayD * delayed[k];     // reverb level now from D frames ago
+      const reverbPart = Math.min(pow, predictedTail);
+      let cleanPow = pow - beta * reverbPart;
+      if (cleanPow < FLOOR * pow) cleanPow = FLOOR * pow;
+      const g = pow > 1e-12 ? Math.sqrt(cleanPow / pow) : 1;
+      const blended = 1 - amount * (1 - g);
+      re[k] *= blended;
+      im[k] *= blended;
+      // The reverberant input feeds the decaying tail envelope for later frames.
+      tail[k] = Math.max(decay * tail[k], pow);
+    }
+    delayed.set(tail);                  // snapshot this frame's tail …
+    ringPos = (ringPos + 1) % D;        // … to be read D frames from now
+  });
+  return sanitize(out);
+}

--- a/src/workers/SpectralCleanupWorker.js
+++ b/src/workers/SpectralCleanupWorker.js
@@ -1,0 +1,57 @@
+/**
+ * VoiceIsolate Pro — Spectral Cleanup Worker (Layer 2: Workers)
+ *
+ * Module worker (spawned with { type: 'module' }) that runs the pure offline
+ * spectral-cleanup core off the main thread so long files never jank the UI.
+ * No ONNX, no DOM, no microphone — STFT-domain noise reduction + dereverb,
+ * computed once per processed file on the CLEAN voice stem (CLAUDE.md §1).
+ *
+ * Protocol (postMessage):
+ *   → { type: 'cleanup', requestId, channels: Float32Array[], sampleRate,
+ *       noiseReduction?: number (0–1), dereverb?: number (0–1) }
+ *   ← { type: 'cleaned', requestId, channels: Float32Array[], sampleRate }
+ *   ← { type: 'error', requestId?, message }
+ *
+ * Both strengths are processing parameters fixed for this pass — never live
+ * sliders. Each stage is a no-op at 0, so passing both 0 returns copies.
+ */
+'use strict';
+
+import { reduceNoise, dereverb } from '../core/SpectralCleanup.js';
+
+self.onmessage = (event) => {
+  const msg = event.data || {};
+  try {
+    switch (msg.type) {
+      case 'cleanup': {
+        const sampleRate = msg.sampleRate;
+        const nr = Number(msg.noiseReduction) || 0;
+        const dr = Number(msg.dereverb) || 0;
+        const channels = (msg.channels || []).map((ch) => {
+          let out = ch instanceof Float32Array ? ch : new Float32Array(ch || []);
+          // Denoise first (removes the stationary floor), then dereverb.
+          if (nr > 0) out = reduceNoise(out, { amount: nr, sampleRate });
+          if (dr > 0) out = dereverb(out, { amount: dr, sampleRate });
+          return out;
+        });
+        self.postMessage(
+          { type: 'cleaned', requestId: msg.requestId, channels, sampleRate },
+          channels.map((c) => c.buffer),
+        );
+        break;
+      }
+      default:
+        self.postMessage({
+          type: 'error',
+          requestId: msg.requestId,
+          message: `Unknown message type '${msg.type}'`,
+        });
+    }
+  } catch (err) {
+    self.postMessage({
+      type: 'error',
+      requestId: msg.requestId,
+      message: err?.message || String(err),
+    });
+  }
+};

--- a/tests/spectral-cleanup-core.test.js
+++ b/tests/spectral-cleanup-core.test.js
@@ -111,6 +111,23 @@ describe('reduceNoise', () => {
     expect(burstAfter).toBeGreaterThan(burstBefore * 0.7);
   });
 
+  test('digital-silence segments do not disable reduction (noise floor not zeroed)', () => {
+    // A leading + trailing block of absolute silence would pin every bin's
+    // minimum power at 0 and globally disable NR. The silence guard skips them.
+    const n = 3 * SR;
+    const x = new Float32Array(n);
+    const rnd = noiseGen(777);
+    for (let i = 0; i < n; i++) x[i] = 0.03 * rnd();
+    x.fill(0, 0, 0.5 * SR);            // 0.5 s leading digital silence
+    x.fill(0, 2.5 * SR, n);           // 0.5 s trailing digital silence
+    const y = sc.reduceNoise(x, { amount: 1, sampleRate: SR });
+    expect(allFinite(y)).toBe(true);
+    // The noisy middle must still be attenuated (not passed through untouched).
+    const before = rms(x, 1.2 * SR, 1.8 * SR);
+    const after = rms(y, 1.2 * SR, 1.8 * SR);
+    expect(after).toBeLessThan(before * 0.6);
+  });
+
   test('stronger amount removes more noise', () => {
     const x = makeNoisyBurst();
     const lo = sc.reduceNoise(x, { amount: 0.3, sampleRate: SR });

--- a/tests/spectral-cleanup-core.test.js
+++ b/tests/spectral-cleanup-core.test.js
@@ -1,0 +1,181 @@
+/**
+ * VoiceIsolate Pro — Spectral Cleanup Core Tests (Layer 1)
+ *
+ * Exercises src/core/SpectralCleanup.js (offline Phase-1 DSP):
+ *   • bypass / transparency at amount 0
+ *   • near-transparency at tiny amount → validates STFT COLA reconstruction
+ *   • reduceNoise: attenuates a stationary noise floor while preserving a burst
+ *   • dereverb: shortens an exponentially decaying tail, preserves the onset
+ *   • length + finiteness invariants
+ *
+ * Pure ESM module, loaded via dynamic import under --experimental-vm-modules
+ * (same pattern as diarization.test.js).
+ */
+'use strict';
+
+const SR = 48000;
+
+let sc;
+
+beforeAll(async () => {
+  sc = await import('../src/core/SpectralCleanup.js');
+});
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+
+function rms(buf, from = 0, to = buf.length) {
+  // Floor bounds: `2.2 * SR` is a non-integer float, and indexing a
+  // Float32Array off-grid yields undefined → NaN. Keep indices integral.
+  from = Math.floor(from);
+  to = Math.floor(to);
+  let s = 0;
+  for (let i = from; i < to; i++) s += buf[i] * buf[i];
+  return Math.sqrt(s / Math.max(1, to - from));
+}
+
+function allFinite(buf) {
+  for (let i = 0; i < buf.length; i++) if (!Number.isFinite(buf[i])) return false;
+  return true;
+}
+
+// Deterministic pseudo-random noise (mulberry32) so tests never flake.
+function noiseGen(seed) {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0; a = (a + 0x6D2B79F5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return (((t ^ (t >>> 14)) >>> 0) / 4294967296 - 0.5) * 2;
+  };
+}
+
+// ── transparency / COLA ──────────────────────────────────────────────────────
+
+describe('transparency & reconstruction', () => {
+  test('reduceNoise(amount 0) returns an exact copy', () => {
+    const x = new Float32Array(SR);
+    for (let i = 0; i < x.length; i++) x[i] = 0.3 * Math.sin((2 * Math.PI * 440 * i) / SR);
+    const y = sc.reduceNoise(x, { amount: 0, sampleRate: SR });
+    expect(y).not.toBe(x);                 // new buffer
+    expect(Array.from(y)).toEqual(Array.from(x));
+  });
+
+  test('dereverb(amount 0) returns an exact copy', () => {
+    const x = new Float32Array(2048).map((_, i) => Math.sin(i / 5));
+    const y = sc.dereverb(x, { amount: 0 });
+    expect(Array.from(y)).toEqual(Array.from(x));
+  });
+
+  test('tiny amount ≈ identity (STFT overlap-add reconstructs the signal)', () => {
+    const x = new Float32Array(SR);
+    for (let i = 0; i < x.length; i++) {
+      // sweep so many bins are exercised
+      x[i] = 0.4 * Math.sin((2 * Math.PI * (200 + 0.05 * i) * i) / SR);
+    }
+    const y = sc.reduceNoise(x, { amount: 1e-6, sampleRate: SR });
+    // Compare an interior region (skip COLA ramp at the very edges).
+    const a = 4096; const b = x.length - 4096;
+    let maxErr = 0;
+    for (let i = a; i < b; i++) maxErr = Math.max(maxErr, Math.abs(y[i] - x[i]));
+    expect(maxErr).toBeLessThan(1e-3);
+  });
+});
+
+// ── noise reduction ──────────────────────────────────────────────────────────
+
+describe('reduceNoise', () => {
+  // 3 s: stationary low-level noise throughout + a loud tone burst in [1s,2s).
+  function makeNoisyBurst() {
+    const n = 3 * SR;
+    const x = new Float32Array(n);
+    const rnd = noiseGen(12345);
+    for (let i = 0; i < n; i++) x[i] = 0.03 * rnd();           // noise floor
+    for (let i = SR; i < 2 * SR; i++) x[i] += 0.5 * Math.sin((2 * Math.PI * 600 * i) / SR);
+    return x;
+  }
+
+  test('attenuates the noise-only region while largely preserving the burst', () => {
+    const x = makeNoisyBurst();
+    const y = sc.reduceNoise(x, { amount: 1, sampleRate: SR });
+    expect(y.length).toBe(x.length);
+    expect(allFinite(y)).toBe(true);
+
+    // Noise-only region [2.2s, 2.8s): should drop substantially.
+    const noiseBefore = rms(x, 2.2 * SR, 2.8 * SR);
+    const noiseAfter = rms(y, 2.2 * SR, 2.8 * SR);
+    expect(noiseAfter).toBeLessThan(noiseBefore * 0.6);
+
+    // Burst region [1.2s, 1.8s): tone energy should be largely retained.
+    const burstBefore = rms(x, 1.2 * SR, 1.8 * SR);
+    const burstAfter = rms(y, 1.2 * SR, 1.8 * SR);
+    expect(burstAfter).toBeGreaterThan(burstBefore * 0.7);
+  });
+
+  test('stronger amount removes more noise', () => {
+    const x = makeNoisyBurst();
+    const lo = sc.reduceNoise(x, { amount: 0.3, sampleRate: SR });
+    const hi = sc.reduceNoise(x, { amount: 1, sampleRate: SR });
+    const r = (b) => rms(b, 2.2 * SR, 2.8 * SR);
+    expect(r(hi)).toBeLessThan(r(lo));
+    expect(r(lo)).toBeLessThan(r(x));
+  });
+});
+
+// ── dereverb ─────────────────────────────────────────────────────────────────
+
+describe('dereverb', () => {
+  // A 600 Hz tone gated to a short onset, then an exponentially decaying tail
+  // (a crude single-bin "reverb"): onset [0,0.1s], decay over the next ~1s.
+  function makeDecayingTail() {
+    const n = 2 * SR;
+    const x = new Float32Array(n);
+    const onset = 0.1 * SR;
+    for (let i = 0; i < n; i++) {
+      const tone = Math.sin((2 * Math.PI * 600 * i) / SR);
+      const env = i < onset ? 1 : Math.exp(-(i - onset) / (0.25 * SR));
+      x[i] = 0.5 * env * tone;
+    }
+    return x;
+  }
+
+  test('shortens the decaying tail relative to the onset', () => {
+    const x = makeDecayingTail();
+    const y = sc.dereverb(x, { amount: 1, sampleRate: SR, rt60: 0.3 });
+    expect(y.length).toBe(x.length);
+    expect(allFinite(y)).toBe(true);
+
+    const onsetBefore = rms(x, 0, 0.1 * SR);
+    const onsetAfter = rms(y, 0, 0.1 * SR);
+    const tailBefore = rms(x, 0.6 * SR, 1.2 * SR);
+    const tailAfter = rms(y, 0.6 * SR, 1.2 * SR);
+
+    // Tail/onset ratio must shrink — the late tail is suppressed more than the onset.
+    const ratioBefore = tailBefore / (onsetBefore + 1e-12);
+    const ratioAfter = tailAfter / (onsetAfter + 1e-12);
+    expect(ratioAfter).toBeLessThan(ratioBefore * 0.9);
+    // Onset itself is largely preserved.
+    expect(onsetAfter).toBeGreaterThan(onsetBefore * 0.6);
+  });
+});
+
+// ── invariants ───────────────────────────────────────────────────────────────
+
+describe('invariants', () => {
+  test('empty input yields empty output', () => {
+    expect(sc.reduceNoise(new Float32Array(0), { amount: 1 }).length).toBe(0);
+    expect(sc.dereverb(new Float32Array(0), { amount: 1 }).length).toBe(0);
+  });
+
+  test('short input (< frame size) is handled', () => {
+    const x = new Float32Array(500).map((_, i) => 0.2 * Math.sin(i / 3));
+    const y = sc.reduceNoise(x, { amount: 1, sampleRate: SR });
+    expect(y.length).toBe(500);
+    expect(allFinite(y)).toBe(true);
+  });
+
+  test('accepts a plain array and returns a Float32Array', () => {
+    const y = sc.reduceNoise([0, 0.1, -0.1, 0.2], { amount: 0.5 });
+    expect(y).toBeInstanceOf(Float32Array);
+    expect(y.length).toBe(4);
+  });
+});


### PR DESCRIPTION
## What & why

Starts **Tier-C** — the offline spectral cleanup passes that complement the ML stems. Unlike Tier-A/B (live Web Audio effects), these are **Phase-1, once-per-file DSP** (CLAUDE.md §1): heavy STFT passes whose strength is a *processing parameter*, **never a live slider**. They run on the clean voice stem, mirroring the diarization core + module-worker pattern exactly.

## What's included
- **`src/core/SpectralCleanup.js`** (Layer 1, pure ESM)
  - `reduceNoise()` — spectral subtraction with a per-bin noise floor estimated by **minimum statistics**, plus temporal gain smoothing to suppress musical noise. Strips stationary hiss/hum the mask network leaves behind.
  - `dereverb()` — single-channel reverb suppression: subtract a per-bin **decaying-tail** estimate with a **prediction delay** so direct-sound onsets are preserved and only the lagging tail is attenuated.
  - Shared STFT/iSTFT overlap-add with **edge-safe normalization** (floors the window² divisor at half steady-state) — fixed a 6× frame-edge transient that would have clicked at stem boundaries.
  - `amount` (0–1) blends gain toward unity, so **0 is fully transparent**.
- **`src/workers/SpectralCleanupWorker.js`** (Layer 2) — `{ type: 'module' }` worker running the passes off the main thread (denoise → dereverb per channel).
- **Tests** (`tests/spectral-cleanup-core.test.js`, 9) — transparency/COLA reconstruction, noise-floor reduction with burst preservation, tail shortening with onset preservation, length/finiteness invariants.
- **`eslint.config.js`** — register the new module worker as `sourceType: 'module'`.
- **`CLAUDE.md §2`** — document both offline modules.

## Architecture compliance
- ✅ Offline / once-per-file (no slider re-triggers inference).
- ✅ Pure `src/core/` (no DOM/Web Audio/I/O); module worker imports it directly.
- ✅ No `getUserMedia`, no `audioWorklet.addModule` — not a playback worklet.

## Verification
- `pnpm validate` ✅ · `pnpm lint` ✅ 0 errors · `pnpm test` ✅ **1820/1820** (+9)
- ⚠️ The NR/dereverb **audio quality** wants a browser listen-test on real material; unit tests cover behavior/invariants, not perceptual quality.

## Not in this PR
Wiring these passes into ingestion/UI orchestration — the `src/` presentation layer isn't the shipped surface yet, so this lands the tested DSP foundation first (same staging as diarization). Follow-up can route the worker into `FileIngestion` once the new UI shell goes live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDEdHgcC8mwr6J2erPhraz

---
_Generated by [Claude Code](https://claude.ai/code/session_01BDEdHgcC8mwr6J2erPhraz)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add offline spectral noise reduction and dereverberation processing
> - Adds [`SpectralCleanup.js`](https://github.com/Joker5514/VoiceIsolate-Pro/pull/609/files#diff-1d6cacd4b3305690138c4dccb5d1373b65d0567e8f3d815dc1994649a7b01747) implementing a self-contained STFT pipeline (radix-2 FFT, Hann windowing, COLA overlap-add) with two exported functions: `reduceNoise` (minimum-statistics spectral subtraction) and `dereverb` (per-bin decaying tail prediction), each taking a channel buffer and a 0–1 strength amount.
> - Adds [`SpectralCleanupWorker.js`](https://github.com/Joker5514/VoiceIsolate-Pro/pull/609/files#diff-736cb731e49a6816a67ca0f055e1b23f0576c1647e9bababcece2e1d6f92825a) to run cleanup off the main thread; accepts `{type:'cleanup', channels, noiseReduction?, dereverb?}` and returns cleaned buffers via transferable `ArrayBuffer`s.
> - Adds Jest tests in [`tests/spectral-cleanup-core.test.js`](https://github.com/Joker5514/VoiceIsolate-Pro/pull/609/files#diff-111eace6431ed4263d87f6589ef1ff7dbd2504022585c2f019b5a29c08df0157) covering transparency at amount 0, near-identity COLA verification, synthetic noisy burst and decaying tail behavior, and empty/short input invariants.
> - Behavioral Change: amount 0 for either function returns an exact copy of the input rather than skipping processing entirely.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bfa11b2. (Automatic summaries will resume when PR exits draft mode or review begins).</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added offline noise reduction and dereverberation capabilities for enhanced audio processing.

* **Tests**
  * Added test suite for new audio cleanup features.

* **Chores**
  * Updated documentation and configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->