### PR TITLE
🎨 Palette: Add confirmation dialog for clearing workspace

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -16,3 +16,6 @@
 ## 2026-05-18 - [Custom Modal Keyboard Accessibility & ARIA States Update]
 **Learning:** When implementing 'Enter' to submit within custom UI modals, scope the keydown listener to the specific input field (e.g., verifying `e.target.id`) rather than the entire modal document/container to prevent intercepting and hijacking Enter key presses on other interactive elements like buttons.
 **Action:** When implementing modal keyboard accessibility, ensure `Enter` key events do not globally override native button click events by strictly limiting the event scope to text inputs.
+## 2026-05-19 - [Destructive UI Actions]
+**Learning:** Destructive UI actions like clearing a workspace or deleting files can result in data loss if invoked accidentally.
+**Action:** Always wrap destructive UI actions in a confirmation dialog (e.g., `confirm()`) if there is unsaved state to prevent accidental data loss.

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -779,7 +779,10 @@ class VoiceIsolatePro {
         this.handleFile(e.dataTransfer.files[0]);
       });
     }
-    bind('clearFile', d.clearFile, 'click', () => this._clearFile());
+    bind('clearFile', d.clearFile, 'click', () => {
+      if (this.inputBuffer && !confirm('Are you sure you want to clear the workspace? Any unsaved changes will be lost.')) return;
+      this._clearFile();
+    });
 
     // Process buttons
     bind('processBtn', d.processBtn, 'click', () => this.runPipeline());


### PR DESCRIPTION
Closing as superseded by #614, which covers the same confirmation dialog for clearing the workspace (and also adds the Reset Controls confirmation). #614 has already been merged.