### PR TITLE
🎨 Palette: Add confirmations for destructive UI actions

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -16,3 +16,7 @@
 ## 2026-05-18 - [Custom Modal Keyboard Accessibility & ARIA States Update]
 **Learning:** When implementing 'Enter' to submit within custom UI modals, scope the keydown listener to the specific input field (e.g., verifying `e.target.id`) rather than the entire modal document/container to prevent intercepting and hijacking Enter key presses on other interactive elements like buttons.
 **Action:** When implementing modal keyboard accessibility, ensure `Enter` key events do not globally override native button click events by strictly limiting the event scope to text inputs.
+
+## 2026-05-20 - [Destructive Action Confirmations]
+**Learning:** Destructive actions (such as clearing a loaded file or resetting all UI control values) can cause unintended data loss. Implementing simple `confirm()` dialogs before these actions prevents accidental clicks from ruining user progress.
+**Action:** Always wrap destructive UI actions in a confirmation dialog (e.g., `confirm()`) if there is unsaved state to prevent accidental data loss.

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -779,7 +779,7 @@ class VoiceIsolatePro {
         this.handleFile(e.dataTransfer.files[0]);
       });
     }
-    bind('clearFile', d.clearFile, 'click', () => this._clearFile());
+    bind('clearFile', d.clearFile, 'click', () => { if (this.inputBuffer && !confirm('Are you sure you want to clear the current file? Unsaved processed audio will be lost.')) return; this._clearFile(); });
 
     // Process buttons
     bind('processBtn', d.processBtn, 'click', () => this.runPipeline());
@@ -854,6 +854,7 @@ class VoiceIsolatePro {
 
     // Reset sliders
     bind('resetSlidersBtn', d.resetSlidersBtn, 'click', () => {
+      if (!confirm('Are you sure you want to reset all controls to their default values?')) return;
       qsa('[id^="sl_"]').forEach(el => {
         const id = el.id.slice(3);
         const spec = SLIDER_BY_ID[id];


### PR DESCRIPTION
💡 **What:** Added native `confirm()` dialogs to the "Clear" file and "Reset Controls" buttons to prevent accidental data loss.

🎯 **Why:** Destructive actions can cause unintended loss of progress or loaded file context. Implementing simple confirmations significantly improves the user experience by acting as a safety net against accidental clicks.

📸 **Before/After:** Clicking "Clear" or "Reset Controls" used to immediately execute the action; now it asks for confirmation.
 
♿ **Accessibility:** Improves error prevention without negatively impacting screen readers.

---
*PR created automatically by Jules for task [4713837070495072040](https://jules.google.com/task/4713837070495072040) started by @Joker5514*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add confirmation dialogs for destructive UI actions in VoiceIsolatePro
> Adds `confirm()` prompts before two destructive actions in [app.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/614/files#diff-8a8b7ea624d7fccc12a516d122dcb07bd67c6a8f796c80e33b898ee6a7557650): clearing a loaded file and resetting all sliders to defaults. If the user cancels either prompt, the action is aborted. Behavioral Change: the Clear File and Reset Sliders buttons no longer act immediately — they require user confirmation first.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6e5d09e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->