### PR TITLE
Wire design-system components into the Live-Mix UI

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -28,7 +28,7 @@
         </svg>
       </div>
       <span class="app-title">VoiceIsolate Pro</span>
-      <span class="arch-badge">STEM-SPLIT &amp; LIVE-MIX</span>
+      <span class="arch-badge" id="archBadgeMount">STEM-SPLIT &amp; LIVE-MIX</span>
     </div>
     <div class="titlebar-right">
       <a href="/app/" class="eng-mode-link">Engineer Mode</a>
@@ -37,22 +37,24 @@
 
   <main class="main-area">
     <!-- ── STEP 1: Upload ──────────────────────────────────────────────── -->
-    <section class="panel" aria-labelledby="uploadLabel">
+    <section class="panel vip-card" aria-labelledby="uploadLabel">
       <h2 id="uploadLabel" class="section-label">1 · Upload</h2>
       <p class="hint">Audio or video. Decoded and resampled to 48&nbsp;kHz on your device — nothing is uploaded anywhere.</p>
       <div class="upload-row">
-        <input type="file" id="fileInput" accept="audio/*,video/*" aria-label="Choose audio or video file">
+        <input type="file" id="fileInput" class="vip-input" accept="audio/*,video/*" aria-label="Choose audio or video file">
         <label for="modelSelect" class="inline-label">Model</label>
-        <select id="modelSelect" aria-label="Separation model">
+        <select id="modelSelect" class="vip-select" aria-label="Separation model">
           <option value="max_isolation">Maximum Isolation — Vocals → Denoise (chained)</option>
           <option value="bsrnn_vocals">Vocal Isolation — Band-Split RNN (~4 MB)</option>
           <option value="rnnoise">Noise Suppression — BiGRU mask (~2 MB)</option>
         </select>
-        <button id="processBtn" class="btn btn-primary" type="button" disabled>Separate Stems</button>
+        <button id="processBtn" class="vip-btn vip-btn--primary" type="button" disabled>Separate Stems</button>
       </div>
       <div class="status-row">
-        <div class="status-dot" id="statusDot"></div>
-        <span id="statusText" role="status" aria-live="polite">Idle — choose a file to begin</span>
+        <span id="statusPillMount" role="status" aria-live="polite">
+          <span class="status-dot"></span>
+          <span>Idle — choose a file to begin</span>
+        </span>
       </div>
       <!--
         Realtime processing indicator. Powered by the VoiceIsolate Pro design-
@@ -63,7 +65,7 @@
     </section>
 
     <!-- ── STEP 2: Live-Mix playback ───────────────────────────────────── -->
-    <section class="panel" aria-labelledby="mixLabel">
+    <section class="panel vip-card" aria-labelledby="mixLabel">
       <h2 id="mixLabel" class="section-label">2 · Live Mix</h2>
       <p class="hint">Stems play through the Web Audio graph. Sliders act instantly on GainNodes — the AI never re-runs.</p>
 
@@ -80,13 +82,19 @@
       </div>
 
       <div class="transport-row">
-        <button id="playBtn" class="btn" type="button" disabled>&#9654; Play</button>
-        <button id="pauseBtn" class="btn" type="button" disabled>&#10074;&#10074; Pause</button>
-        <button id="stopBtn" class="btn" type="button" disabled>&#9632; Stop</button>
-        <button id="muteVoiceBtn" class="btn btn-toggle" type="button" disabled aria-pressed="false">Mute Voice</button>
-        <button id="muteNoiseBtn" class="btn btn-toggle" type="button" disabled aria-pressed="false">Mute Background</button>
+        <button id="playBtn" class="vip-iconbtn" type="button" disabled aria-label="Play" title="Play">&#9654;</button>
+        <button id="pauseBtn" class="vip-iconbtn" type="button" disabled aria-label="Pause" title="Pause">&#10074;&#10074;</button>
+        <button id="stopBtn" class="vip-iconbtn" type="button" disabled aria-label="Stop" title="Stop">&#9632;</button>
+        <button id="muteVoiceBtn" class="vip-switch" type="button" role="switch" aria-checked="false" disabled>
+          <span class="vip-switch__track"><span class="vip-switch__thumb"></span></span>
+          <span class="vip-switch__label">Mute Voice</span>
+        </button>
+        <button id="muteNoiseBtn" class="vip-switch" type="button" role="switch" aria-checked="false" disabled>
+          <span class="vip-switch__track"><span class="vip-switch__thumb"></span></span>
+          <span class="vip-switch__label">Mute Background</span>
+        </button>
         <label for="presetSelect" class="inline-label">Preset</label>
-        <select id="presetSelect" aria-label="Mix preset" disabled>
+        <select id="presetSelect" class="vip-select" aria-label="Mix preset" disabled>
           <option value="voice-clarity" selected>Voice Clarity</option>
           <option value="balanced">Balanced</option>
           <option value="podcast-warm">Podcast Warm</option>
@@ -102,6 +110,13 @@
         <div class="vis-label">Live output spectrum <span class="vis-hint">— reacts to every slider in real time</span></div>
         <canvas id="specCanvas" class="vis-canvas" height="110" aria-label="Live output spectrum"></canvas>
       </div>
+
+      <!--
+        Output level meter. Powered by the design-system LevelMeter component;
+        landing.js taps the mixer's post-master AnalyserNode and drives the
+        fill from real RMS each animation frame (hidden until stems load).
+      -->
+      <div id="outputMeterMount" class="output-meter" hidden></div>
 
       <div class="slider-grid">
         <div class="slider-row">
@@ -223,7 +238,7 @@
     </section>
 
     <!-- ── STEP 3: Per-speaker isolation ───────────────────────────────── -->
-    <section class="panel" id="speakersPanel" aria-labelledby="speakersLabel" hidden>
+    <section class="panel vip-card" id="speakersPanel" aria-labelledby="speakersLabel" hidden>
       <h2 id="speakersLabel" class="section-label">3 · Speakers</h2>
       <p class="hint">
         Speakers detected on the isolated voice stem — entirely on your device.
@@ -236,7 +251,7 @@
       <div id="speakerCardsGrid" class="speaker-grid" aria-label="Per-speaker controls"></div>
     </section>
 
-    <section class="panel privacy-panel">
+    <section class="panel vip-card privacy-panel">
       <h2 class="section-label">Privacy</h2>
       <p class="hint">
         100% local processing — ONNX models run in a Web Worker on your device

--- a/public/landing.css
+++ b/public/landing.css
@@ -730,7 +730,8 @@ input[type="range"]:disabled { opacity: 0.34; cursor: not-allowed; }
   top: 0; left: 0; bottom: 0;
   width: 0%;
   background: linear-gradient(to right, var(--ok), var(--warn) 78%, var(--danger));
-  transition: width 0.06s linear;
+  /* No width transition: the fill is driven every animation frame from JS, so
+     a CSS transition would constantly restart and stutter behind the writes. */
 }
 .vip-meter__val { font: var(--fw-medium) var(--fs-2xs)/1 var(--font-mono); color: var(--text-2); flex: none; min-width: 42px; text-align: right; }
 

--- a/public/landing.css
+++ b/public/landing.css
@@ -15,6 +15,7 @@
   --red-500: #ef4444;
   --red-400: #f87171;
   --red-wash: rgba(220,38,38,0.06);
+  --signal-peak: #fcd34d;
 
   --ok:     #34d399;
   --warn:   #eab308;
@@ -61,6 +62,9 @@
   --radius-lg: 10px;
   --radius-xl: 14px;
 
+  --sp-1: 4px;
+  --sp-2: 8px;
+  --sp-3: 12px;
   --sp-4: 16px;
   --sp-5: 20px;
   --sp-6: 24px;
@@ -494,3 +498,242 @@ input[type="range"]:disabled { opacity: 0.34; cursor: not-allowed; }
     animation-duration: 0.001ms !important;
   }
 }
+
+/* ════════════════════════════════════════════════════════════════════════
+   DESIGN-SYSTEM COMPONENTS  (VoiceIsolate Pro DS — _ds_bundle.js)
+   Styling for the DS components wired into the Live-Mix surface by
+   landing.js. ProcessLoader is styled above; these cover the rest of the
+   bundle. Kept visually consistent with the native .btn / .panel house
+   style so DS-rendered and native controls read as one UI.
+   ════════════════════════════════════════════════════════════════════════ */
+
+/* ── Badge ────────────────────────────────────────────────────────────── */
+.vip-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-1);
+  font: var(--fw-bold) var(--fs-3xs)/1 var(--font-mono);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--red-400);
+  background: var(--red-wash);
+  border: 1px solid var(--border-red);
+  border-radius: var(--radius-sm);
+  padding: 4px 7px;
+  white-space: nowrap;
+}
+.vip-badge__dot {
+  width: 5px; height: 5px; border-radius: 50%;
+  background: currentColor;
+  box-shadow: 0 0 5px currentColor;
+}
+.vip-badge--accent { color: var(--red-400); }
+.vip-badge--ok     { color: var(--ok);  border-color: rgba(52,211,153,0.3);  background: rgba(52,211,153,0.07); }
+.vip-badge--warn   { color: var(--warn); border-color: rgba(234,179,8,0.3);  background: rgba(234,179,8,0.07); }
+.vip-badge--danger { color: var(--danger); border-color: rgba(239,68,68,0.3); background: rgba(239,68,68,0.08); }
+
+/* ── StatusPill — engine/process state with glowing dot (data-state) ───── */
+.vip-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-2);
+  font: var(--fw-medium) var(--fs-sm)/1 var(--font-ui);
+  color: var(--text-2);
+}
+.vip-pill::before {
+  content: '';
+  width: 8px; height: 8px; border-radius: 50%; flex: none;
+  background: var(--text-dim);
+  transition: background var(--dur-base) var(--ease-out),
+              box-shadow var(--dur-base) var(--ease-out);
+}
+.vip-pill[data-state="active"]  { color: var(--text-hi); }
+.vip-pill[data-state="active"]::before  { background: var(--ok); box-shadow: 0 0 6px var(--ok); }
+.vip-pill[data-state="warn"]::before    { background: var(--warn); box-shadow: 0 0 6px rgba(234,179,8,0.6); }
+.vip-pill[data-state="error"]   { color: var(--text); }
+.vip-pill[data-state="error"]::before   { background: var(--danger); box-shadow: 0 0 6px rgba(239,68,68,0.6); }
+.vip-pill[data-state="pending"]::before { background: var(--text-dim); }
+
+/* ── Button ───────────────────────────────────────────────────────────── */
+.vip-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font: var(--fw-semibold) var(--fs-sm)/1 var(--font-ui);
+  background: var(--surface-3);
+  color: var(--text-2);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+  padding: 7px 14px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition:
+    color var(--dur-fast) var(--ease-out),
+    border-color var(--dur-fast) var(--ease-out),
+    background var(--dur-fast) var(--ease-out);
+}
+.vip-btn:hover:not(:disabled) {
+  color: var(--text-hi);
+  border-color: var(--border-red);
+  background: var(--hover-fill);
+}
+.vip-btn:active:not(:disabled) { transform: translateY(0.5px); }
+.vip-btn:disabled { opacity: 0.34; cursor: not-allowed; }
+.vip-btn--primary {
+  background: var(--red-600);
+  border-color: var(--red-600);
+  color: #fff;
+  box-shadow: var(--shadow-sm);
+}
+.vip-btn--primary:hover:not(:disabled) { background: var(--red-500); border-color: var(--red-500); }
+.vip-btn--ghost { background: transparent; border-color: transparent; }
+.vip-btn--danger { background: var(--danger); border-color: var(--danger); color: #fff; }
+.vip-btn--sm { padding: 5px 10px; font-size: var(--fs-xs); }
+.vip-btn--lg { padding: 9px 18px; font-size: var(--fs-md); }
+.vip-btn--block { display: flex; width: 100%; justify-content: center; }
+.vip-btn--rec { border-color: var(--red-600); color: var(--red-400); }
+
+/* ── IconButton ───────────────────────────────────────────────────────── */
+.vip-iconbtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px; height: 34px;
+  font-size: var(--fs-md);
+  background: var(--surface-3);
+  color: var(--text-2);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition:
+    color var(--dur-fast) var(--ease-out),
+    border-color var(--dur-fast) var(--ease-out),
+    background var(--dur-fast) var(--ease-out);
+}
+.vip-iconbtn:hover:not(:disabled) { color: var(--text-hi); border-color: var(--border-red); background: var(--hover-fill); }
+.vip-iconbtn:active:not(:disabled) { transform: translateY(0.5px); }
+.vip-iconbtn:disabled { opacity: 0.34; cursor: not-allowed; }
+.vip-iconbtn--sm { width: 28px; height: 28px; font-size: var(--fs-sm); }
+.vip-iconbtn--lg { width: 40px; height: 40px; font-size: var(--fs-lg); }
+.vip-iconbtn--active { border-color: var(--red-600); color: var(--red-400); background: var(--red-wash); }
+
+/* ── Switch ───────────────────────────────────────────────────────────── */
+.vip-switch {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-2);
+  background: none;
+  border: none;
+  padding: 4px 2px;
+  cursor: pointer;
+  color: var(--text-2);
+  font: var(--fw-semibold) var(--fs-sm)/1 var(--font-ui);
+}
+.vip-switch:disabled { opacity: 0.34; cursor: not-allowed; }
+.vip-switch__track {
+  position: relative;
+  width: 34px; height: 18px; flex: none;
+  background: var(--surface-3);
+  border: 1px solid var(--border-strong);
+  border-radius: 999px;
+  transition: background var(--dur-base) var(--ease-out),
+              border-color var(--dur-base) var(--ease-out);
+}
+.vip-switch__thumb {
+  position: absolute;
+  top: 1px; left: 1px;
+  width: 14px; height: 14px; border-radius: 50%;
+  background: var(--text-dim);
+  transition: transform var(--dur-base) var(--ease-out),
+              background var(--dur-base) var(--ease-out);
+}
+.vip-switch--on .vip-switch__track { background: var(--red-wash); border-color: var(--red-600); }
+.vip-switch--on .vip-switch__thumb { transform: translateX(16px); background: var(--red-500); }
+.vip-switch--on .vip-switch__label { color: var(--red-400); }
+
+/* ── Input / Field / Select ───────────────────────────────────────────── */
+.vip-field { display: inline-flex; flex-direction: column; gap: 4px; }
+.vip-field__label { font: var(--fw-medium) var(--fs-xs)/1 var(--font-ui); color: var(--text-dim); }
+.vip-field__hint  { font: var(--fw-regular) var(--fs-2xs)/1.3 var(--font-ui); color: var(--text-dim); }
+.vip-input, .vip-select {
+  font: var(--fw-regular) var(--fs-base)/1 var(--font-ui);
+  background: var(--surface-3);
+  color: var(--text);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+  padding: 7px 10px;
+  transition: border-color var(--dur-fast) var(--ease-out);
+}
+.vip-input:focus, .vip-select:focus { border-color: var(--border-focus); outline: none; }
+.vip-input--mono { font-family: var(--font-mono); }
+
+/* ── Card ─────────────────────────────────────────────────────────────── */
+.vip-card {
+  background: var(--surface-1);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+}
+.vip-card--hover { transition: border-color var(--dur-base) var(--ease-out); }
+.vip-card--hover:hover { border-color: var(--border-red); }
+.vip-card--well { background: var(--well-bg); box-shadow: none; }
+.vip-card__head { display: flex; align-items: flex-start; justify-content: space-between; padding: var(--sp-7) var(--sp-7) 0; }
+.vip-card__kicker { margin: 0 0 4px; font: var(--fw-semibold) var(--fs-2xs)/1 var(--font-mono); letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-dim); }
+.vip-card__title { margin: 0; font: var(--fw-semibold) var(--fs-lg)/1.2 var(--font-ui); color: var(--text-hi); }
+
+/* ── ParamSlider — signature red value-fill track ─────────────────────── */
+.vip-slider__input {
+  -webkit-appearance: none;
+  appearance: none;
+  height: 4px;
+  border-radius: 2px;
+  background: linear-gradient(
+    to right,
+    var(--red-600) 0,
+    var(--red-600) var(--pct, 0%),
+    var(--surface-3) var(--pct, 0%),
+    var(--surface-3) 100%
+  );
+  cursor: pointer;
+}
+.vip-slider__input::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 13px; height: 13px; border-radius: 50%;
+  background: var(--red-500);
+  border: 2px solid var(--bg);
+  box-shadow: var(--shadow-sm);
+}
+.vip-slider__input::-moz-range-thumb {
+  width: 13px; height: 13px; border: 2px solid var(--bg); border-radius: 50%;
+  background: var(--red-500);
+}
+.vip-slider__input:disabled { opacity: 0.4; cursor: not-allowed; }
+
+/* ── LevelMeter — real output level (RMS fill + peak marker) ───────────── */
+.vip-meter {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+}
+.vip-meter__label { font: var(--fw-medium) var(--fs-xs)/1 var(--font-ui); color: var(--text-dim); flex: none; }
+.vip-meter__track {
+  position: relative;
+  flex: 1;
+  height: 8px;
+  background: var(--surface-3);
+  border: 1px solid var(--border-strong);
+  border-radius: 999px;
+  overflow: hidden;
+}
+.vip-meter__fill {
+  position: absolute;
+  top: 0; left: 0; bottom: 0;
+  width: 0%;
+  background: linear-gradient(to right, var(--ok), var(--warn) 78%, var(--danger));
+  transition: width 0.06s linear;
+}
+.vip-meter__val { font: var(--fw-medium) var(--fs-2xs)/1 var(--font-mono); color: var(--text-2); flex: none; min-width: 42px; text-align: right; }
+
+/* Output-level meter row in the Live-Mix panel (hidden until stems load). */
+.output-meter { margin-top: 14px; }
+.output-meter[hidden] { display: none; }

--- a/public/landing.js
+++ b/public/landing.js
@@ -557,9 +557,12 @@ function wireMuteButtons() {
 
 // ─── Output level meter (DS LevelMeter, real RMS from the mixer analyser) ────
 
-let _meterEl = null;   // mounted .vip-meter node; the RAF loop reuses its DOM
+let _meterEl = null;     // mounted .vip-meter node
+let _meterFill = null;   // cached .vip-meter__fill (driven each frame)
+let _meterRead = null;   // cached .vip-meter__val
 let _meterRAF = 0;
-let _meterTd = null;   // reusable time-domain scratch buffer
+let _meterTd = null;     // reusable time-domain scratch buffer
+let _meterIdle = false;  // true once the meter has been zeroed while paused
 
 /** dBFS amplitude (0..1) → LevelMeter 0..100 (value-100 = dBFS, -100 floor). */
 function meterValue(amp) {
@@ -570,6 +573,16 @@ function meterValue(amp) {
 function _meterTick() {
   _meterRAF = requestAnimationFrame(_meterTick);
   if (!mixer || !_meterEl) return;
+  // Idle when paused/stopped: drop to the floor once, then skip the analyser
+  // read and DOM writes until playback resumes (no work on a silent graph).
+  if (!mixer.isPlaying()) {
+    if (_meterIdle) return;
+    _meterIdle = true;
+    if (_meterFill) _meterFill.style.width = '0%';
+    if (_meterRead) _meterRead.textContent = '-∞';
+    return;
+  }
+  _meterIdle = false;
   let analyser;
   try { analyser = mixer.getAnalyser(); } catch { return; }
   if (!analyser) return;
@@ -579,10 +592,8 @@ function _meterTick() {
   let sumSq = 0;
   for (let i = 0; i < n; i++) { const s = _meterTd[i]; sumSq += s * s; }
   const v = meterValue(Math.sqrt(sumSq / n));
-  const fill = _meterEl.querySelector('.vip-meter__fill');
-  const read = _meterEl.querySelector('.vip-meter__val');
-  if (fill) fill.style.width = `${v}%`;
-  if (read) read.textContent = v <= 0 ? '-∞' : (v - 100).toFixed(1);
+  if (_meterFill) _meterFill.style.width = `${v}%`;
+  if (_meterRead) _meterRead.textContent = v <= 0 ? '-∞' : (v - 100).toFixed(1);
 }
 
 /** Reveal + mount the DS LevelMeter once; the RAF loop drives it from real audio. */
@@ -593,7 +604,13 @@ function startOutputMeter() {
   if (!_meterEl && DS && DS.LevelMeter) {
     try {
       const el = DS.LevelMeter({ label: 'Output', value: 0, unit: 'dB' });
-      if (el instanceof Node) { mount.replaceChildren(el); _meterEl = el; }
+      if (el instanceof Node) {
+        mount.replaceChildren(el);
+        _meterEl = el;
+        // Cache the dynamic nodes once so the RAF loop never re-queries the DOM.
+        _meterFill = el.querySelector('.vip-meter__fill');
+        _meterRead = el.querySelector('.vip-meter__val');
+      }
     } catch (err) {
       console.warn('[VIP] LevelMeter render error:', err);
     }

--- a/public/landing.js
+++ b/public/landing.js
@@ -46,8 +46,11 @@ const ui = {
     $('gateAttackSlider'), $('gateReleaseSlider'),
     $('deEsserFreqSlider'), $('deEsserAmountSlider'),
   ],
-  statusDot: $('statusDot'),
-  statusText: $('statusText'),
+  // DS StatusPill mounts here (setStatus re-renders it); the Badge and
+  // LevelMeter mount points are likewise populated by landing.js.
+  statusPillMount: $('statusPillMount'),
+  archBadgeMount: $('archBadgeMount'),
+  outputMeterMount: $('outputMeterMount'),
   // Realtime processing indicator — DS ProcessLoader component mounts here.
   procLoaderMount: $('procLoaderMount'),
   timeReadout: $('timeReadout'),
@@ -78,8 +81,7 @@ let videoUrl = null;
 const DIARIZATION_TIMEOUT_MS = 60000;
 
 function setStatus(msg, cls = '') {
-  ui.statusText.textContent = msg;
-  ui.statusDot.className = `status-dot${cls ? ` ${cls}` : ''}`;
+  renderStatusPill(STATE_FOR_CLS[cls] || 'pending', msg);
 }
 
 function fmtTime(s) {
@@ -92,6 +94,42 @@ function fmtTime(s) {
 // Design-system namespace populated by _ds_bundle.js (classic script, loads
 // before this module so the reference is valid at module init time).
 const DS = window.VoiceIsolateProDesignSystem_38f745;
+
+// Map the legacy status classes ('', 'warn', 'error', 'active') to the DS
+// StatusPill's data-state values.
+const STATE_FOR_CLS = { '': 'pending', warn: 'warn', error: 'error', active: 'active' };
+
+/** Render the DS StatusPill into the status row (falls back to dot + text). */
+function renderStatusPill(state, msg) {
+  const mount = ui.statusPillMount;
+  if (!mount) return;
+  if (DS && DS.StatusPill) {
+    try {
+      const el = DS.StatusPill({ state, children: msg });
+      if (el instanceof Node) { mount.replaceChildren(el); return; }
+    } catch (err) {
+      console.warn('[VIP] StatusPill render error:', err);
+    }
+  }
+  // Graceful fallback when the DS bundle is unavailable.
+  const dot = document.createElement('span');
+  dot.className = `status-dot${state === 'pending' ? '' : ` ${state}`}`;
+  const txt = document.createElement('span');
+  txt.textContent = msg;
+  mount.replaceChildren(dot, txt);
+}
+
+/** Swap the static header text badge for the DS Badge component when present. */
+function mountBadge() {
+  const mount = ui.archBadgeMount;
+  if (!mount || !(DS && DS.Badge)) return; // fallback: the static .arch-badge text
+  try {
+    const el = DS.Badge({ variant: 'accent', dot: true, children: 'STEM-SPLIT & LIVE-MIX' });
+    if (el instanceof Node) { mount.classList.remove('arch-badge'); mount.replaceChildren(el); }
+  } catch (err) {
+    console.warn('[VIP] Badge render error:', err);
+  }
+}
 
 const PROC_STAGES = [
   { id: 'decode',   label: 'Decode'   },
@@ -343,12 +381,27 @@ const READOUTS = [
   ['deEsserAmountSlider', 'deEsserAmountVal', (v) => `${v}%`],
 ];
 
+/** Paint the DS ParamSlider red value-fill (--pct) from the slider position. */
+function paintSliderFill(slider) {
+  const min = Number(slider.min) || 0;
+  const span = Number(slider.max) - min;
+  const pct = span > 0 ? ((Number(slider.value) - min) / span) * 100 : 0;
+  slider.style.setProperty('--pct', `${Math.max(0, Math.min(100, pct))}%`);
+}
+
 function wireReadouts() {
   for (const [sliderId, valId, fmt] of READOUTS) {
     const slider = $(sliderId);
     const val = $(valId);
     if (!slider || !val) continue;
-    slider.addEventListener('input', () => { val.textContent = fmt(slider.value); });
+    // Adopt the DS ParamSlider track (red value-fill) on the existing input —
+    // non-destructive: same id/range, so SliderUI binding + presets still apply.
+    slider.classList.add('vip-slider__input');
+    paintSliderFill(slider);
+    slider.addEventListener('input', () => {
+      val.textContent = fmt(slider.value);
+      paintSliderFill(slider);
+    });
   }
 }
 
@@ -450,6 +503,7 @@ function onStems({ requestId, clean, noise, sampleRate, passthrough }) {
   mixer.loadStems(clean, noise, sampleRate);
   visualizer.loadStems(clean, noise, mixer.duration());
   syncMuteButtons();
+  startOutputMeter();
 
   for (const el of [ui.playBtn, ui.pauseBtn, ui.stopBtn,
     ui.muteVoiceBtn, ui.muteNoiseBtn, ui.presetSelect,
@@ -478,13 +532,14 @@ function onStems({ requestId, clean, noise, sampleRate, passthrough }) {
 
 function syncMuteButtons() {
   if (!mixer) return;
-  const paint = (btn, muted, label) => {
-    btn.textContent = muted ? `Unmute ${label}` : `Mute ${label}`;
-    btn.classList.toggle('active', muted);
-    btn.setAttribute('aria-pressed', String(muted));
+  // DS Switch visual state: thumb position (--on) + aria-checked. The label
+  // stays static ("Mute Voice"/"Mute Background"); the thumb shows on/off.
+  const paint = (btn, muted) => {
+    btn.classList.toggle('vip-switch--on', muted);
+    btn.setAttribute('aria-checked', String(muted));
   };
-  paint(ui.muteVoiceBtn, mixer.isVoiceMuted(), 'Voice');
-  paint(ui.muteNoiseBtn, mixer.isNoiseMuted(), 'Background');
+  paint(ui.muteVoiceBtn, mixer.isVoiceMuted());
+  paint(ui.muteNoiseBtn, mixer.isNoiseMuted());
 }
 
 function wireMuteButtons() {
@@ -498,6 +553,52 @@ function wireMuteButtons() {
     mixer.setNoiseMuted(!mixer.isNoiseMuted());
     syncMuteButtons();
   });
+}
+
+// ─── Output level meter (DS LevelMeter, real RMS from the mixer analyser) ────
+
+let _meterEl = null;   // mounted .vip-meter node; the RAF loop reuses its DOM
+let _meterRAF = 0;
+let _meterTd = null;   // reusable time-domain scratch buffer
+
+/** dBFS amplitude (0..1) → LevelMeter 0..100 (value-100 = dBFS, -100 floor). */
+function meterValue(amp) {
+  if (amp <= 1e-5) return 0;
+  return Math.max(0, Math.min(100, 100 + 20 * Math.log10(amp)));
+}
+
+function _meterTick() {
+  _meterRAF = requestAnimationFrame(_meterTick);
+  if (!mixer || !_meterEl) return;
+  let analyser;
+  try { analyser = mixer.getAnalyser(); } catch { return; }
+  if (!analyser) return;
+  const n = analyser.fftSize;
+  if (!_meterTd || _meterTd.length !== n) _meterTd = new Float32Array(n);
+  analyser.getFloatTimeDomainData(_meterTd);
+  let sumSq = 0;
+  for (let i = 0; i < n; i++) { const s = _meterTd[i]; sumSq += s * s; }
+  const v = meterValue(Math.sqrt(sumSq / n));
+  const fill = _meterEl.querySelector('.vip-meter__fill');
+  const read = _meterEl.querySelector('.vip-meter__val');
+  if (fill) fill.style.width = `${v}%`;
+  if (read) read.textContent = v <= 0 ? '-∞' : (v - 100).toFixed(1);
+}
+
+/** Reveal + mount the DS LevelMeter once; the RAF loop drives it from real audio. */
+function startOutputMeter() {
+  const mount = ui.outputMeterMount;
+  if (!mount) return;
+  mount.hidden = false;
+  if (!_meterEl && DS && DS.LevelMeter) {
+    try {
+      const el = DS.LevelMeter({ label: 'Output', value: 0, unit: 'dB' });
+      if (el instanceof Node) { mount.replaceChildren(el); _meterEl = el; }
+    } catch (err) {
+      console.warn('[VIP] LevelMeter render error:', err);
+    }
+  }
+  if (!_meterRAF && _meterEl) _meterRAF = requestAnimationFrame(_meterTick);
 }
 
 function wireTransport() {
@@ -524,4 +625,5 @@ ui.presetSelect.addEventListener('change', () => applyPreset(ui.presetSelect.val
 wireReadouts();
 wireTransport();
 wireMuteButtons();
+mountBadge();
 setStatus('Idle — choose a file to begin', '');


### PR DESCRIPTION
## Summary

Adopts the VoiceIsolate Pro design-system bundle (`public/lib/_ds_bundle.js`, exported from the Claude Design project `38f7453e…`) across the **Live-Mix landing surface**. Before this PR, the bundle shipped 13 components but only **ProcessLoader** was wired; the other 12 were dead weight. This connects them.

All work lands on `public/index.html` + `public/landing.js` + `public/landing.css`. The frozen `public/app/` legacy UI is **untouched** (per `CLAUDE.md`).

> Context: the live `claude_design` MCP connector / `/design-login` could not run in this remote session (headless, no browser OAuth), but the project was already vendored locally as `_ds_bundle.js`, so implementation worked against that.

## What changed

| Component | How it's wired |
|---|---|
| **Badge** | Header `STEM-SPLIT & LIVE-MIX` chip — factory-mounted (`DS.Badge`) |
| **StatusPill** | Status row — `setStatus()` renders `DS.StatusPill` with a mapped `data-state` |
| **LevelMeter** | **New** output meter — `DS.LevelMeter` driven by real RMS from the mixer's post-master `AnalyserNode` (`getFloatTimeDomainData`) each animation frame |
| **Button / IconButton / Switch / Select / Input / Card** | Adopted **in place** on existing controls — every `id` + listener preserved, so `SliderUI` binding, presets, readouts and tests stay valid. Transport → icon buttons; mute toggles → switches |
| **ParamSlider** | Signature red value-fill (`--pct`) applied non-destructively to the 23 existing range inputs |

Also authored the matching component CSS in `landing.css` (only `vip-ploader` existed before) and the missing tokens (`--signal-peak`, `--sp-1..3`).

## Deliberately not done

- **DS `Spectrogram` / `Waveform`** render seeded **procedural placeholder** data with no prop to accept real audio. The page already shows *real* audio on those canvases via `LandingVisualizer`, so swapping them in would be a visual regression. Kept the real visualizers.
- Interactive controls are **enhanced in place** rather than replaced with factory-mounted nodes — this app is imperative/ID-based (no React tree), so preserving IDs is what keeps `SliderUI`, presets, and the test suite green. Pure-display components (Badge, StatusPill, LevelMeter) use the factories directly.

## Validation

- `pnpm validate` — ✅ all structural checks pass
- `pnpm lint` — ✅ 0 errors (24 pre-existing benign warnings, unchanged)
- `pnpm test` — ✅ **1836 tests / 67 suites pass**
- `pnpm build` — ✅ succeeds, bundle carried into `build/`

Graceful degradation preserved throughout: if the DS bundle is unavailable, each mount falls back to the prior native markup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CfMdSYct2hG8R8VuCdXfQ8

---
_Generated by [Claude Code](https://claude.ai/code/session_01CfMdSYct2hG8R8VuCdXfQ8)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Wire design-system components into the Live-Mix UI
> - Replaces legacy status dot/text DOM nodes with a DS `StatusPill` mounted via `statusPillMount`, with fallback to the previous dot+text behavior when the DS bundle is absent.
> - Replaces the static header arch-badge text with a DS `Badge` (accent variant) mounted via `archBadgeMount` on startup.
> - Adds a real-time output level meter driven by the mixer's `AnalyserNode` via `requestAnimationFrame`; the meter is hidden until stems are loaded and idles when playback is paused or stopped.
> - Applies `vip-*` CSS classes to inputs, selects, buttons, sliders, and cards in [index.html](https://github.com/Joker5514/VoiceIsolate-Pro/pull/619/files#diff-c2cc24bc9001b11b6add48a4cd8f893d5d6c6e4d1bd254158bd14ab997f552cd) and adds corresponding DS component styles to [landing.css](https://github.com/Joker5514/VoiceIsolate-Pro/pull/619/files#diff-0cfc64852aad421bc53736616a19dec3e5b249ad2f2509175077db2f108dbd66).
> - Converts mute buttons to `role="switch"` elements with `aria-checked` state and thumb/track spans; transport controls become icon-only buttons with `aria-label`.
> - Behavioral Change: `syncMuteButtons` no longer updates button text ('Mute'/'Unmute'); labels are now static and state is conveyed via `aria-checked` and the `vip-switch--on` class.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7964e58.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->