### PR TITLE
Fix Engineer Mode real-time sliders (gate range/hold, de-esser amount, HP/LP Q)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,8 @@ overrides:
   micromatch: '>=4.0.8'
   esbuild: '>=0.25.0'
   form-data: '>=4.0.6'
+  qs: '>=6.13.0'
+  ip-address: '>=10.1.1'
 
 importers:
 
@@ -48,6 +50,9 @@ importers:
       express-rate-limit:
         specifier: ^8.3.2
         version: 8.3.2(express@5.2.1)
+      lamejs:
+        specifier: ^1.2.1
+        version: 1.2.1
       onnxruntime-web:
         specifier: 1.25.1
         version: 1.25.1
@@ -1545,8 +1550,8 @@ packages:
     resolution: {integrity: sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
-  ip-address@10.1.0:
-    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -1816,6 +1821,9 @@ packages:
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
+
+  lamejs@1.2.1:
+    resolution: {integrity: sha512-s7bxvjvYthw6oPLCm5pFxvA84wUROODB8jEO2+CE1adhKgrIvVOlmMgY8zyugxGrvRaDHNJanOiS21/emty6dQ==}
 
   leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
@@ -2489,6 +2497,9 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  use-strict@1.0.1:
+    resolution: {integrity: sha512-IeiWvvEXfW5ltKVMkxq6FvNf2LojMKvB2OCeja6+ct24S1XOmQw2dGr2JyndwACWAGJva9B7yPHwAmeA9QCqAQ==}
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -3946,7 +3957,7 @@ snapshots:
   express-rate-limit@8.3.2(express@5.2.1):
     dependencies:
       express: 5.2.1
-      ip-address: 10.1.0
+      ip-address: 10.2.0
 
   express@5.2.1:
     dependencies:
@@ -4242,7 +4253,7 @@ snapshots:
 
   ini@4.1.3: {}
 
-  ip-address@10.1.0: {}
+  ip-address@10.2.0: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -4696,6 +4707,10 @@ snapshots:
   kleur@3.0.3: {}
 
   kleur@4.1.5: {}
+
+  lamejs@1.2.1:
+    dependencies:
+      use-strict: 1.0.1
 
   leven@3.1.0: {}
 
@@ -5198,7 +5213,7 @@ snapshots:
 
   socks@2.8.7:
     dependencies:
-      ip-address: 10.1.0
+      ip-address: 10.2.0
       smart-buffer: 4.2.0
 
   source-map-support@0.5.13:
@@ -5437,6 +5452,8 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  use-strict@1.0.1: {}
 
   util-deprecate@1.0.2: {}
 

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -753,7 +753,7 @@ class VoiceIsolatePro {
     if (this._bridge && typeof this._bridge.applyParam === 'function') {
       try {
         if (this._bridge.applyParam(id, value)) return;
-      } catch (_) {
+      } catch {
         /* fall through to legacy handling */
       }
     }

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -738,54 +738,32 @@ class VoiceIsolatePro {
   }
 
   onSlider(id, value) {
-    console.log(`[APP] onSlider called: id="${id}", value=${value}`);
-    console.log(`[APP] Bridge status: _bridge=${!!this._bridge}, _bridgePromise=${!!this._bridgePromise}, applyParam=${typeof this._bridge?.applyParam}`);
-    
     // Real-time path: route the slider straight to the Live-Mix bridge. When
     // the bridge handles it, the change is an immediate AudioParam update — no
     // Reprocess, no ML re-run (CLAUDE.md §1). Unsupported ids (spectral/worker
     // effects) fall through and still apply on the next Reprocess.
-    
-    // If bridge is initializing, wait for it (fixes race condition where sliders
-    // fire before async _ensureBridge() completes)
+
+    // If the bridge is still initializing, wait for it so early slider moves are
+    // not dropped (race where sliders fire before async _ensureBridge resolves).
     if (!this._bridge && this._bridgePromise) {
-      console.log(`[APP] Bridge initializing, waiting for it to complete...`);
-      this._bridgePromise.then(() => {
-        console.log(`[APP] Bridge ready, retrying onSlider("${id}", ${value})`);
-        this.onSlider(id, value);
-      }).catch(() => {
-        console.warn(`[APP] Bridge initialization failed, using legacy path`);
-      });
+      this._bridgePromise.then(() => this.onSlider(id, value)).catch(() => {});
       return;
     }
-    
+
     if (this._bridge && typeof this._bridge.applyParam === 'function') {
       try {
-        console.log(`[APP] Calling _bridge.applyParam("${id}", ${value})`);
-        const handled = this._bridge.applyParam(id, value);
-        console.log(`[APP] _bridge.applyParam returned: ${handled}`);
-        if (handled) {
-          console.log(`[APP] Parameter "${id}" handled by bridge, returning`);
-          return;
-        }
-        console.log(`[APP] Parameter "${id}" not handled by bridge, falling through`);
-      } catch (err) {
-        console.error(`[APP] _bridge.applyParam threw error:`, err);
+        if (this._bridge.applyParam(id, value)) return;
+      } catch (_) {
         /* fall through to legacy handling */
       }
-    } else {
-      console.warn(`[APP] Bridge not available for real-time updates`);
     }
 
-    console.log(`[APP] Checking legacy handlers for "${id}"`);
     const orch = window._vipOrch;
     if (id === 'outGain' && this._outGainNode && this.currentSource && this.ctx) {
-      console.log(`[APP] Applying outGain via _outGainNode`);
       const gain = Math.pow(10, value / 20);
       this._outGainNode.gain.setTargetAtTime(gain, this.ctx.currentTime, 0.01);
     }
     if (id === 'outWidth' && this.isPlaying) {
-      console.log(`[APP] Applying outWidth via play() restart`);
       const speed = numFromInput(this.dom && this.dom.tpSpeed, 1) || 1;
       if (this.ctx) {
         this.playOffset += (this.ctx.currentTime - this.playStartTime) * speed;
@@ -797,10 +775,7 @@ class VoiceIsolatePro {
       this.play();
     }
     if (orch && typeof orch.onSlider === 'function') {
-      console.log(`[APP] Calling orchestrator.onSlider("${id}", ${value})`);
       orch.onSlider(id, value);
-    } else {
-      console.log(`[APP] No orchestrator available for "${id}"`);
     }
   }
 
@@ -1966,33 +1941,18 @@ class VoiceIsolatePro {
    * @returns {Promise<object|null>}
    */
   async _ensureBridge() {
-    console.log(`[APP] _ensureBridge: _bridge=${!!this._bridge}, _bridgePromise=${!!this._bridgePromise}, _bridgeFailed=${this._bridgeFailed}, ctx=${!!this.ctx}`);
-    
-    if (this._bridge) {
-      console.log(`[APP] Bridge already exists, returning it`);
-      return this._bridge;
-    }
-    if (this._bridgePromise) {
-      console.log(`[APP] Bridge initialization in progress, returning promise`);
-      return this._bridgePromise;
-    }
-    if (this._bridgeFailed || !this.ctx) {
-      console.warn(`[APP] Bridge unavailable: failed=${this._bridgeFailed}, ctx=${!!this.ctx}`);
-      return null;
-    }
-    
-    console.log(`[APP] Starting bridge initialization...`);
+    if (this._bridge) return this._bridge;
+    if (this._bridgePromise) return this._bridgePromise;
+    if (this._bridgeFailed || !this.ctx) return null;
+
     this._bridgePromise = (async () => {
       try {
         const mod = await import('/src/pipeline/EngineerModeBridge.js');
-        console.log(`[APP] EngineerModeBridge module loaded`);
         this._bridge = new mod.EngineerModeBridge({ context: this.ctx });
-        console.log(`[APP] EngineerModeBridge instance created`);
         structuredLog('info', '[VIP] Live-Mix bridge ready — rt sliders are now real-time.');
         return this._bridge;
       } catch (err) {
         this._bridgeFailed = true;
-        console.error(`[APP] Bridge initialization failed:`, err);
         structuredLog('warn', '[VIP] Live-Mix bridge unavailable; sliders apply on Reprocess.', { err: err && err.message });
         return null;
       } finally {
@@ -2003,47 +1963,34 @@ class VoiceIsolatePro {
   }
 
   buildLiveChain(buf) {
-    console.log(`[APP] buildLiveChain: bridge=${!!this._bridge}, buf=${!!buf}`);
-    
     // Preferred path: play through the real-time Live-Mix bridge so every
     // rt:true slider is a live AudioParam (no Reprocess, no ML re-run).
     const bridge = this._bridge;
     if (bridge && typeof bridge.loadBuffer === 'function') {
-      console.log(`[APP] Using bridge for live playback`);
       try {
         if (this._bridgeBuf !== buf) {
-          console.log(`[APP] Loading buffer into bridge (new buffer)`);
           bridge.loadBuffer(buf);
           this._bridgeBuf = buf;
           // Seed the graph from the current slider positions.
           const params = window.VIP_PARAMS || {};
-          console.log(`[APP] Seeding bridge with ${Object.keys(params).length} parameters`);
           if (typeof bridge.applyParams === 'function') bridge.applyParams(params);
-        } else {
-          console.log(`[APP] Buffer already loaded in bridge`);
         }
         // Honour the current scrub position, then start.
-        console.log(`[APP] Starting bridge playback at offset ${this.playOffset || 0}`);
         Promise.resolve(bridge.seek(this.playOffset || 0))
           .then(() => bridge.play())
           .catch((err) => {
-            console.error(`[APP] Bridge play failed:`, err);
             structuredLog('warn', '[VIP] bridge play failed', { err: err && err.message });
           });
         this.currentSource = null;
         this._outGainNode = null;
         return;
       } catch (err) {
-        console.error(`[APP] Bridge buildLiveChain failed:`, err);
         structuredLog('warn', '[VIP] bridge buildLiveChain failed; using offline graph.', { err: err && err.message });
       }
-    } else {
-      console.log(`[APP] Bridge not available: bridge=${!!bridge}, loadBuffer=${typeof bridge?.loadBuffer}`);
     }
-    
+
     // Kick off bridge init for next time if it is not ready yet.
     if (!bridge && !this._bridgeFailed) {
-      console.log(`[APP] Initiating bridge for next time`);
       this._ensureBridge();
     }
 

--- a/public/app/slider-map.js
+++ b/public/app/slider-map.js
@@ -1,10 +1,19 @@
 /**
  * VoiceIsolate Pro — slider-map.js
- * Canonical slider registry and DOM builder.
+ * Canonical slider/stage data for Engineer Mode.
  *
- * This file is the single source of truth for the 52-slider Engineer Mode UI.
- * It replaces the old patch-style duplication by exporting the slider registry,
- * DOM builders, and worklet/worker dispatch routing in one place.
+ * This is a **pure data module** — no Web Audio API, no SharedArrayBuffer, no
+ * DOM, no side effects. It exports the two structures `app.js` imports:
+ *   • SLIDER_REGISTRY — the ordered 52-slider list used to index the shared
+ *     parameter buffer (id → transform → target).
+ *   • STAGES — the 32-stage Deca-Pass pipeline labels.
+ *
+ * The slider DOM is built by `app.js` (_renderSliders), and real-time slider
+ * values are routed through `app.onSlider` → the Live-Mix bridge
+ * (src/pipeline/EngineerModeBridge.js). The old in-module DOM builders and the
+ * worklet/worker `dispatchParam` routing were removed with the live-pipeline
+ * orchestrator (CLAUDE.md §1.1 / §5) — they dispatched to nodes that no longer
+ * exist. Do not reintroduce them here.
  */
 
 export const STAGES = [
@@ -41,93 +50,6 @@ export const STAGES = [
   'S31: Waveform Update',
   'S32: Final Export Ready',
 ];
-
-export const SLIDERS = {
-  gate: [
-    { id:'gateThresh', label:'Threshold', min:-80, max:-5, val:-42, step:1, unit:' dB', rt:true, desc:'Signal level below which audio is gated' },
-    { id:'gateRange', label:'Range', min:-80, max:-5, val:-60, step:1, unit:' dB', rt:true, desc:'Maximum gain reduction applied by the gate' },
-    { id:'gateAttack', label:'Attack', min:0, max:500, val:5, step:1, unit:' ms', rt:true, desc:'Time for gate to open on signal detection' },
-    { id:'gateRelease', label:'Release', min:50, max:2000, val:200, step:10, unit:' ms', rt:true, desc:'Time for gate to close after signal drops' },
-    { id:'gateHold', label:'Hold', min:0, max:500, val:50, step:1, unit:' ms', rt:true, desc:'Hold time before release phase begins' },
-    { id:'gateLookahead', label:'Lookahead', min:0, max:50, val:5, step:1, unit:' ms', rt:false, desc:'Lookahead window for predictive gating' },
-  ],
-  nr: [
-    { id:'nrAmount', label:'NR Amount', min:0, max:100, val:78, step:1, unit:'%', rt:false, desc:'Spectral noise reduction strength' },
-    { id:'nrSensitivity', label:'Sensitivity', min:0, max:100, val:60, step:1, unit:'%', rt:false, desc:'Noise floor detection sensitivity' },
-    { id:'nrSpectralSub', label:'Spectral Sub', min:0, max:100, val:50, step:1, unit:'%', rt:false, desc:'Spectral subtraction strength' },
-    { id:'nrFloor', label:'NR Floor', min:-96, max:-30, val:-72, step:1, unit:' dB', rt:false, desc:'Noise reduction floor limit' },
-    { id:'nrSmoothing', label:'Smoothing', min:0, max:100, val:70, step:1, unit:'%', rt:false, desc:'Temporal smoothing of spectral noise estimate' },
-  ],
-  eq: [
-    { id:'eqSub', label:'Sub', min:-12, max:12, val:0, step:0.5, unit:' dB', rt:true, desc:'Sub-bass EQ (20-60 Hz)' },
-    { id:'eqBass', label:'Bass', min:-12, max:12, val:0, step:0.5, unit:' dB', rt:true, desc:'Bass EQ (60-200 Hz)' },
-    { id:'eqWarmth', label:'Warmth', min:-12, max:12, val:0, step:0.5, unit:' dB', rt:true, desc:'Warmth EQ (200-500 Hz)' },
-    { id:'eqBody', label:'Body', min:-12, max:12, val:0, step:0.5, unit:' dB', rt:true, desc:'Body EQ (500-1k Hz)' },
-    { id:'eqLowMid', label:'Low Mid', min:-12, max:12, val:0, step:0.5, unit:' dB', rt:true, desc:'Low-mid EQ (1-2 kHz)' },
-    { id:'eqMid', label:'Mid', min:-12, max:12, val:0, step:0.5, unit:' dB', rt:true, desc:'Mid EQ (2-4 kHz)' },
-    { id:'eqPresence', label:'Presence', min:-12, max:12, val:0, step:0.5, unit:' dB', rt:true, desc:'Presence EQ (4-6 kHz)' },
-    { id:'eqClarity', label:'Clarity', min:-12, max:12, val:0, step:0.5, unit:' dB', rt:true, desc:'Clarity EQ (6-10 kHz)' },
-    { id:'eqAir', label:'Air', min:-12, max:12, val:0, step:0.5, unit:' dB', rt:true, desc:'Air EQ (10-16 kHz)' },
-    { id:'eqBrill', label:'Brilliance', min:-12, max:12, val:0, step:0.5, unit:' dB', rt:true, desc:'Brilliance EQ (16-20 kHz)' },
-  ],
-  dyn: [
-    { id:'compThresh', label:'Threshold', min:-60, max:0, val:-24, step:1, unit:' dB', rt:true, desc:'Compressor threshold level' },
-    { id:'compRatio', label:'Ratio', min:1, max:20, val:4, step:0.5, unit:':1', rt:true, desc:'Compression ratio' },
-    { id:'compAttack', label:'Attack', min:1, max:200, val:10, step:1, unit:' ms', rt:true, desc:'Compressor attack time' },
-    { id:'compRelease', label:'Release', min:10, max:1000, val:150, step:10, unit:' ms', rt:true, desc:'Compressor release time' },
-    { id:'compKnee', label:'Knee', min:0, max:30, val:6, step:1, unit:' dB', rt:true, desc:'Compressor knee width' },
-    { id:'compMakeup', label:'Makeup', min:0, max:30, val:0, step:0.5, unit:' dB', rt:true, desc:'Makeup gain after compression' },
-    { id:'limThresh', label:'Lim Thresh', min:-12, max:0, val:-1, step:0.5, unit:' dB', rt:true, desc:'Brickwall limiter threshold' },
-    { id:'limRelease', label:'Lim Release', min:10, max:500, val:50, step:5, unit:' ms', rt:true, desc:'Limiter release time' },
-  ],
-  spec: [
-    { id:'hpFreq', label:'HP Freq', min:20, max:2000, val:80, step:1, unit:' Hz', rt:true, desc:'High-pass filter cutoff frequency' },
-    { id:'hpQ', label:'HP Q', min:0.1, max:10, val:0.7, step:0.1, unit:'', rt:true, desc:'High-pass filter resonance' },
-    { id:'lpFreq', label:'LP Freq', min:4000, max:20000, val:18000, step:100, unit:' Hz', rt:true, desc:'Low-pass filter cutoff frequency' },
-    { id:'lpQ', label:'LP Q', min:0.1, max:10, val:0.7, step:0.1, unit:'', rt:true, desc:'Low-pass filter resonance' },
-    { id:'deEssFreq', label:'De-ess Freq', min:2000, max:12000, val:6000, step:100, unit:' Hz', rt:true, desc:'De-esser detection frequency' },
-    { id:'deEssAmt', label:'De-ess Amt', min:0, max:30, val:0, step:1, unit:' dB', rt:true, desc:'De-esser reduction amount' },
-    { id:'specTilt', label:'Spec Tilt', min:-6, max:6, val:0, step:0.5, unit:' dB', rt:true, desc:'Spectral tilt' },
-    { id:'formantShift', label:'Formant Shift', min:-6, max:6, val:0, step:0.5, unit:' st', rt:false, desc:'Formant shift in semitones' },
-  ],
-  adv: [
-    { id:'derevAmt', label:'Dereverb', min:0, max:100, val:0, step:1, unit:'%', rt:false, desc:'Dereverberation strength' },
-    { id:'derevDecay', label:'Rev Decay', min:0, max:100, val:50, step:1, unit:'%', rt:false, desc:'Estimated reverb decay time reference' },
-    { id:'harmRecov', label:'Harm Recovery', min:0, max:100, val:0, step:1, unit:'%', rt:false, desc:'Harmonic recovery via neural vocoder' },
-    { id:'harmOrder', label:'Harm Order', min:1, max:10, val:3, step:1, unit:'', rt:false, desc:'Harmonic series order' },
-    { id:'stereoWidth', label:'Stereo Width', min:0, max:200, val:100, step:1, unit:'%', rt:true, desc:'Stereo width of output signal' },
-    { id:'phaseCorr', label:'Phase Corr', min:0, max:100, val:0, step:1, unit:'%', rt:false, desc:'Phase correlation correction strength' },
-  ],
-  sep: [
-    { id:'voiceIso', label:'Voice Iso', min:0, max:100, val:80, step:1, unit:'%', rt:false, desc:'Voice isolation strength' },
-    { id:'bgSuppress', label:'BG Suppress', min:0, max:100, val:50, step:1, unit:'%', rt:false, desc:'Background suppression level' },
-    { id:'voiceFocusLo', label:'Focus Lo', min:80, max:500, val:120, step:10, unit:' Hz', rt:false, desc:'Lower bound of voice focus band' },
-    { id:'voiceFocusHi', label:'Focus Hi', min:1000, max:8000, val:3400, step:100, unit:' Hz', rt:false, desc:'Upper bound of voice focus band' },
-    { id:'crosstalkCancel', label:'Crosstalk', min:0, max:100, val:0, step:1, unit:'%', rt:false, desc:'Crosstalk cancellation between channels' },
-  ],
-  out: [
-    { id:'outGain', label:'Output Gain', min:-24, max:24, val:0, step:0.5, unit:' dB', rt:true, desc:'Final output gain trim' },
-    { id:'dryWet', label:'Dry/Wet', min:0, max:100, val:100, step:1, unit:'%', rt:true, desc:'Blend between dry input and processed output' },
-    { id:'ditherAmt', label:'Dither', min:0, max:10, val:1, step:0.1, unit:' bits', rt:false, desc:'Dither noise amplitude in bits' },
-    { id:'outWidth', label:'Out Width', min:0, max:200, val:100, step:1, unit:'%', rt:true, desc:'Output stereo width' },
-  ],
-};
-
-export const TAB_PANEL_MAP = {
-  gate:'tab-gate', nr:'tab-nr', eq:'tab-eq', dyn:'tab-dyn',
-  spec:'tab-spec', adv:'tab-adv', sep:'tab-sep', out:'tab-out',
-};
-
-export const SLIDER_TARGETS = {
-  gateThresh:'worklet', gateRange:'worklet', gateAttack:'worklet', gateRelease:'worklet', gateHold:'worklet', gateLookahead:'local',
-  nrAmount:'both', nrSensitivity:'worker', nrSpectralSub:'worker', nrFloor:'worker', nrSmoothing:'worker',
-  eqSub:'worklet', eqBass:'worklet', eqWarmth:'worklet', eqBody:'worklet', eqLowMid:'worklet', eqMid:'worklet', eqPresence:'worklet', eqClarity:'worklet', eqAir:'worklet', eqBrill:'worklet',
-  compThresh:'worklet', compRatio:'worklet', compAttack:'worklet', compRelease:'worklet', compKnee:'worklet', compMakeup:'worklet', limThresh:'worklet', limRelease:'worklet',
-  hpFreq:'worklet', hpQ:'worklet', lpFreq:'worklet', lpQ:'worklet', deEssFreq:'worklet', deEssAmt:'worklet', specTilt:'worklet', formantShift:'worker',
-  derevAmt:'worker', derevDecay:'worker', harmRecov:'worker', harmOrder:'worker', stereoWidth:'worklet', phaseCorr:'worker',
-  voiceIso:'worker', bgSuppress:'worker', voiceFocusLo:'worker', voiceFocusHi:'worker', crosstalkCancel:'worker',
-  outGain:'worklet', dryWet:'worklet', ditherAmt:'worklet', outWidth:'worklet',
-};
 
 export const SLIDER_REGISTRY = [
   { id: 'gateThresh',      key: 'gateThresh',      transform: v => v, target: 'worklet' },
@@ -183,127 +105,3 @@ export const SLIDER_REGISTRY = [
   { id: 'ditherAmt',       key: 'ditherAmt',       transform: v => v, target: 'worklet' },
   { id: 'outWidth',        key: 'outWidth',        transform: v => v, target: 'worklet' },
 ];
-
-export function dispatchParam(id, rawVal, app = window._vipOrch || window._vipApp || window.vip) {
-  const target = SLIDER_TARGETS[id] || 'local';
-  const payload = { [id]: rawVal };
-  const worklet = app?.workletNode;
-  const worker = app?.mlWorker;
-  if ((target === 'worklet' || target === 'both') && worklet) {
-    try { worklet.port.postMessage({ type: 'params', payload }); } catch (_) {}
-  }
-  if ((target === 'worker' || target === 'both') && worker) {
-    try { worker.postMessage({ type: 'setParams', payload }); } catch (_) {}
-  }
-}
-
-export function setPct(input, spec) {
-  const range = spec.max - spec.min;
-  const v = parseFloat(input.value);
-  const pct = range > 0 ? ((v - spec.min) / range) * 100 : 50;
-  input.style.setProperty('--pct', pct.toFixed(2) + '%');
-}
-
-export function buildRow(spec, onChange) {
-  const row = document.createElement('div');
-  row.className = 'sr-row';
-
-  const label = document.createElement('label');
-  label.className = 'sr-label';
-  label.htmlFor = 'sl_' + spec.id;
-  label.textContent = spec.label;
-  label.title = spec.desc || '';
-  if (spec.rt) {
-    const badge = document.createElement('span');
-    badge.className = 'rt-badge';
-    badge.textContent = 'RT';
-    label.appendChild(badge);
-  }
-  row.appendChild(label);
-
-  const input = document.createElement('input');
-  input.type = 'range';
-  input.id = 'sl_' + spec.id;
-  input.min = spec.min;
-  input.max = spec.max;
-  input.step = spec.step;
-  input.value = spec.val;
-  if (spec.rt) input.classList.add('realtime');
-  input.setAttribute('aria-label', spec.label);
-  setPct(input, spec);
-  row.appendChild(input);
-
-  const valueEl = document.createElement('span');
-  valueEl.className = 'sr-val';
-  valueEl.id = 'val_' + spec.id;
-  valueEl.textContent = spec.val + (spec.unit || '');
-  row.appendChild(valueEl);
-
-  input.addEventListener('input', () => {
-    const v = parseFloat(input.value);
-    setPct(input, spec);
-    valueEl.textContent = v + (spec.unit || '');
-    window.VIP_PARAMS = window.VIP_PARAMS || {};
-    window.VIP_PARAMS[spec.id] = v;
-    dispatchParam(spec.id, v);
-    if (typeof onChange === 'function') onChange(spec, v, input, valueEl);
-  });
-
-  return row;
-}
-
-export function buildPanels(root = document, onChange) {
-  for (const [tab, specs] of Object.entries(SLIDERS)) {
-    const panel = root.getElementById(TAB_PANEL_MAP[tab]);
-    if (!panel) continue;
-    panel.innerHTML = '';
-    const wrap = document.createElement('div');
-    wrap.className = 'sr';
-    for (const spec of specs) wrap.appendChild(buildRow(spec, onChange));
-    panel.appendChild(wrap);
-  }
-  window.VIP_SLIDER_REGISTRY = Object.values(SLIDERS).flat();
-  window.VIP_PARAMS = window.VIP_PARAMS || {};
-  for (const spec of window.VIP_SLIDER_REGISTRY) {
-    if (!(spec.id in window.VIP_PARAMS)) window.VIP_PARAMS[spec.id] = spec.val;
-  }
-}
-
-export function onAppReady(init) {
-  if (typeof init !== 'function') return;
-  if (typeof window === 'undefined') {
-    init();
-    return;
-  }
-  if (window.__vipAppReady) {
-    init();
-    return;
-  }
-  window.addEventListener('app:ready', () => { init(); }, { once: true });
-}
-
-export function runAudit(root = document) {
-  const win = typeof window !== 'undefined' ? window : null;
-  const sliders = root.querySelectorAll('.sr-row input[type="range"]');
-  const missingPanels = Object.values(TAB_PANEL_MAP).filter((id) => !root.querySelector(`#${id}`));
-  const missingPct = Array.from(sliders).filter((el) => !el.style.getPropertyValue('--pct')).length;
-  const result = {
-    pass: 0,
-    fail: 0,
-    checks: {
-      sliderCount: sliders.length,
-      missingPanels,
-      missingPct,
-      registryCount: win?.VIP_SLIDER_REGISTRY?.length || 0,
-    },
-  };
-  if (sliders.length >= 52) result.pass++; else result.fail++;
-  if (missingPanels.length === 0) result.pass++; else result.fail++;
-  if (missingPct === 0) result.pass++; else result.fail++;
-  if ((win?.VIP_SLIDER_REGISTRY?.length || 0) >= 52) result.pass++; else result.fail++;
-  if (win) {
-    win.VIP_AUDIT_RESULTS = result;
-    win.VIP_runAudit = () => result;
-  }
-  return result;
-}

--- a/public/app/vip-fixes.js
+++ b/public/app/vip-fixes.js
@@ -508,29 +508,19 @@
 
       slider.addEventListener('input', () => {
         const v = parseFloat(slider.value);
-        console.log(`[VIP-FIXES] Slider input event: id="${id}", value=${v}, isFinite=${Number.isFinite(v)}`);
-        
-        if (!Number.isFinite(v)) {
-          console.warn(`[VIP-FIXES] Invalid slider value for "${id}": ${slider.value}`);
-          return;
-        }
-        
+        if (!Number.isFinite(v)) return;
+
         window.VIP_PARAMS = window.VIP_PARAMS || {};
         window.VIP_PARAMS[id] = v;
         if (app.params) app.params[id] = v;
-        
-        // Call app.onSlider() to trigger real-time bridge (CLAUDE.md §1)
-        // This routes RT-flagged params through the Live-Mix AudioParam updates
-        console.log(`[VIP-FIXES] Checking app.onSlider: app=${!!app}, typeof=${typeof app?.onSlider}`);
+
+        // Route through app.onSlider() so RT-flagged params hit the Live-Mix
+        // bridge's AudioParams in real time (CLAUDE.md §1).
         if (app && typeof app.onSlider === 'function') {
-          console.log(`[VIP-FIXES] Calling app.onSlider("${id}", ${v})`);
           app.onSlider(id, v);
-          console.log(`[VIP-FIXES] app.onSlider() returned, exiting handler`);
           return; // onSlider handles orchestrator/worklet routing
         }
-        
-        console.warn(`[VIP-FIXES] app.onSlider not available, falling back to legacy path`);
-        
+
         // Fallback: direct orchestrator/worklet dispatch if app.onSlider unavailable
         const orch = window._vipOrch;
         if (orch?.updateParams) { orch.updateParams(orch._normalizeRawParams({ [id]: v })); return; }

--- a/src/pipeline/EngineerModeBridge.js
+++ b/src/pipeline/EngineerModeBridge.js
@@ -64,7 +64,9 @@ const PARAM_MAP = Object.freeze({
 
   // ── HP / LP filters ─────────────────────────────────────────────────────
   hpFreq: (m, v) => m.setHighpass(v),
+  hpQ: (m, v) => m.setHighpassQ(v),
   lpFreq: (m, v) => m.setLowpass(v),
+  lpQ: (m, v) => m.setLowpassQ(v),
 
   // ── De-esser (legacy amount is 0–30 dB → 0–100%) ────────────────────────
   deEssFreq: (m, v) => m.setDeEsserFreq(v),
@@ -130,30 +132,11 @@ export class EngineerModeBridge {
    * @returns {boolean} true if the id mapped to a control
    */
   applyParam(id, value) {
-    console.log(`[BRIDGE] applyParam called: id="${id}", value=${value}`);
     const apply = PARAM_MAP[id];
-    
-    if (!apply) {
-      console.log(`[BRIDGE] Parameter "${id}" not in PARAM_MAP (unsupported), returning false`);
-      return false;
-    }
-    
-    console.log(`[BRIDGE] Parameter "${id}" found in PARAM_MAP`);
+    if (!apply) return false;
     const v = Number(value);
-    
-    if (!Number.isFinite(v)) {
-      console.warn(`[BRIDGE] Invalid value for "${id}": ${value}, returning false`);
-      return false;
-    }
-    
-    console.log(`[BRIDGE] Applying "${id}"=${v} to mixer, loaded=${this._loaded}`);
-    try {
-      apply(this.mixer, v);
-      console.log(`[BRIDGE] Successfully applied "${id}"=${v}`);
-    } catch (err) {
-      console.error(`[BRIDGE] Error applying "${id}"=${v}:`, err);
-      throw err;
-    }
+    if (!Number.isFinite(v)) return false;
+    apply(this.mixer, v);
     return true;
   }
 

--- a/src/pipeline/PlaybackMixer.js
+++ b/src/pipeline/PlaybackMixer.js
@@ -362,14 +362,9 @@ export class PlaybackMixer {
 
   /** Remember a gate parameter and apply it to the live worklet if present. */
   _setGateParam(name, value) {
-    console.log(`[MIXER] _setGateParam: name="${name}", value=${value}, gate=${!!this.gate}`);
     this._gateParams[name] = value;
-    if (!this.gate) {
-      console.warn(`[MIXER] Gate worklet not available`);
-      return;
-    }
+    if (!this.gate) return;
     const param = this.gate.parameters.get(name);
-    console.log(`[MIXER] Gate parameter "${name}" found: ${!!param}`);
     if (param) this._applyParam(param, value);
   }
 
@@ -485,13 +480,9 @@ export class PlaybackMixer {
    */
   _applyParam(param, target) {
     const now = this.ctx.currentTime;
-    console.log(`[MIXER] _applyParam: param=${param?.constructor?.name}, target=${target}, isPlaying=${this._isPlaying}, currentTime=${now}`);
-    
     if (this._isPlaying) {
-      console.log(`[MIXER] Setting param via setTargetAtTime (smoothed)`);
       param.setTargetAtTime(target, now, PARAM_SMOOTHING);
     } else {
-      console.log(`[MIXER] Setting param directly (not playing)`);
       param.cancelScheduledValues(now);
       param.value = target;
     }
@@ -563,9 +554,19 @@ export class PlaybackMixer {
     this._applyParam(this.highpass.frequency, clamp(hz, 20, 2000));
   }
 
+  /** High-pass resonance / steepness (0.1 … 10). 0.7 ≈ a smooth Butterworth roll-off. */
+  setHighpassQ(q) {
+    this._applyParam(this.highpass.Q, clamp(q, 0.1, 10));
+  }
+
   /** Low-pass cutoff in Hz (1000 … 20000). 20 kHz ≈ off. */
   setLowpass(hz) {
     this._applyParam(this.lowpass.frequency, clamp(hz, 1000, 20000));
+  }
+
+  /** Low-pass resonance / steepness (0.1 … 10). 0.7 ≈ a smooth Butterworth roll-off. */
+  setLowpassQ(q) {
+    this._applyParam(this.lowpass.Q, clamp(q, 0.1, 10));
   }
 
   /** Bus compressor threshold in dB (−60 … 0). 0 = no compression. */
@@ -620,15 +621,9 @@ export class PlaybackMixer {
    * @param {number} db
    */
   setGraphicEq(band, db) {
-    console.log(`[MIXER] setGraphicEq: band="${band}", db=${db}`);
     const node = this.graphicBands.get(band);
-    if (!node) {
-      console.warn(`[MIXER] Graphic EQ band "${band}" not found`);
-      return;
-    }
-    const clamped = clamp(db, -12, 12);
-    console.log(`[MIXER] Applying EQ band "${band}": ${clamped} dB`);
-    this._applyParam(node.gain, clamped);
+    if (!node) return;
+    this._applyParam(node.gain, clamp(db, -12, 12));
   }
 
   /**

--- a/src/workers/DeEsserProcessor.js
+++ b/src/workers/DeEsserProcessor.js
@@ -150,10 +150,11 @@ class DeEsserProcessor extends AudioWorkletProcessor {
       return true;
     }
 
-    // Get parameter values (k-rate, so one value per block). `amount` is read
-    // defensively so the processor still runs if a caller omits it.
+    // Get parameter values (k-rate, so one value per block). Both params are read
+    // defensively against their descriptor defaults so the processor still runs
+    // if a caller (or a mock/test) omits one.
     const amount = parameters.amount ? parameters.amount[0] : 0; // 0-1, de-essing strength
-    const frequency = parameters.frequency[0]; // Hz, sibilant frequency center
+    const frequency = parameters.frequency ? parameters.frequency[0] : 6000; // Hz, sibilant frequency center
 
     // Update sample rate from global if available
     if (typeof sampleRate !== 'undefined') {

--- a/src/workers/DeEsserProcessor.js
+++ b/src/workers/DeEsserProcessor.js
@@ -16,8 +16,10 @@ class DeEsserProcessor extends AudioWorkletProcessor {
   static get parameterDescriptors() {
     return [
       {
-        name: 'level',
-        defaultValue: 0.5,
+        // De-essing strength, 0–1. 0 = off (fully transparent), 1 = maximum
+        // sibilance reduction. Named to match PlaybackMixer.setDeEsserAmount.
+        name: 'amount',
+        defaultValue: 0,
         minValue: 0,
         maxValue: 1,
         automationRate: 'k-rate'
@@ -148,8 +150,9 @@ class DeEsserProcessor extends AudioWorkletProcessor {
       return true;
     }
 
-    // Get parameter values (k-rate, so one value per block)
-    const level = parameters.level[0]; // 0-1, amount of de-essing
+    // Get parameter values (k-rate, so one value per block). `amount` is read
+    // defensively so the processor still runs if a caller omits it.
+    const amount = parameters.amount ? parameters.amount[0] : 0; // 0-1, de-essing strength
     const frequency = parameters.frequency[0]; // Hz, sibilant frequency center
 
     // Update sample rate from global if available
@@ -213,9 +216,9 @@ class DeEsserProcessor extends AudioWorkletProcessor {
           // Calculate how much above threshold
           const excessDb = 20 * Math.log10(this.sibilantEnvelope[channel] / sibilantThreshold);
           
-          // Linear reduction: higher level = more dB reduction
-          // level=0 → 0 dB, level=1 → full excessDb reduction
-          const gainReductionDb = excessDb * level;
+          // Linear reduction: higher amount = more dB reduction
+          // amount=0 → 0 dB, amount=1 → full excessDb reduction
+          const gainReductionDb = excessDb * amount;
           
           // Convert back to linear
           targetGain = 10 ** (-gainReductionDb / 20);
@@ -247,5 +250,3 @@ class DeEsserProcessor extends AudioWorkletProcessor {
 
 // Register the processor with the audio worklet
 registerProcessor('vip-deesser', DeEsserProcessor);
-
-// Made with Bob

--- a/src/workers/GateProcessor.js
+++ b/src/workers/GateProcessor.js
@@ -122,12 +122,13 @@ class GateProcessor extends AudioWorkletProcessor {
       return true;
     }
 
-    // Get parameter values (k-rate, so one value per block). `range` and `hold`
-    // are read defensively so the processor still runs if a caller omits them.
-    const thresholdDb = parameters.threshold[0];
+    // Get parameter values (k-rate, so one value per block). Every param is read
+    // defensively against its descriptor default so the processor still runs if
+    // a caller (or a mock/test) omits one.
+    const thresholdDb = parameters.threshold ? parameters.threshold[0] : -40;
     const rangeDb = parameters.range ? parameters.range[0] : 0;
-    const attackMs = parameters.attack[0];
-    const releaseMs = parameters.release[0];
+    const attackMs = parameters.attack ? parameters.attack[0] : 10;
+    const releaseMs = parameters.release ? parameters.release[0] : 100;
     const holdMs = parameters.hold ? parameters.hold[0] : 0;
 
     // Update sample rate from the actual buffer length and expected duration

--- a/src/workers/GateProcessor.js
+++ b/src/workers/GateProcessor.js
@@ -22,6 +22,15 @@ class GateProcessor extends AudioWorkletProcessor {
         automationRate: 'k-rate'
       },
       {
+        // Attenuation depth applied while the gate is closed, in dB.
+        // 0 = gate off (closed gain is unity → fully transparent).
+        name: 'range',
+        defaultValue: 0,
+        minValue: 0,
+        maxValue: 80,
+        automationRate: 'k-rate'
+      },
+      {
         name: 'attack',
         defaultValue: 10,
         minValue: 0,
@@ -34,6 +43,15 @@ class GateProcessor extends AudioWorkletProcessor {
         minValue: 0,
         maxValue: 5000,
         automationRate: 'k-rate'
+      },
+      {
+        // Minimum time the gate is held open after the signal drops below
+        // threshold, in ms — stops the gate "chattering" on breathy speech.
+        name: 'hold',
+        defaultValue: 0,
+        minValue: 0,
+        maxValue: 1000,
+        automationRate: 'k-rate'
       }
     ];
   }
@@ -43,13 +61,16 @@ class GateProcessor extends AudioWorkletProcessor {
    */
   constructor() {
     super();
-    
+
     // Envelope follower state for each channel
     this.envelopes = [0, 0];
-    
+
     // Current gain reduction for each channel
     this.currentGain = [1, 1];
-    
+
+    // Remaining hold time, in samples, for each channel
+    this.holdCounter = [0, 0];
+
     // Sample rate (will be set on first process call)
     this.sampleRate = 48000; // Default, will be updated
   }
@@ -101,10 +122,13 @@ class GateProcessor extends AudioWorkletProcessor {
       return true;
     }
 
-    // Get parameter values (k-rate, so one value per block)
+    // Get parameter values (k-rate, so one value per block). `range` and `hold`
+    // are read defensively so the processor still runs if a caller omits them.
     const thresholdDb = parameters.threshold[0];
+    const rangeDb = parameters.range ? parameters.range[0] : 0;
     const attackMs = parameters.attack[0];
     const releaseMs = parameters.release[0];
+    const holdMs = parameters.hold ? parameters.hold[0] : 0;
 
     // Update sample rate from the actual buffer length and expected duration
     if (input[0]) {
@@ -117,14 +141,19 @@ class GateProcessor extends AudioWorkletProcessor {
 
     // Convert threshold to linear
     const thresholdLinear = this.dbToLinear(thresholdDb);
+    // Closed-gate gain: attenuate by `range` dB. range = 0 → gain 1 (gate off,
+    // fully transparent); range = 80 → −80 dB (effectively silent).
+    const floorGain = this.dbToLinear(-rangeDb);
+    // Hold time converted to whole samples.
+    const holdSamples = Math.max(0, Math.round(holdMs * 0.001 * this.sampleRate));
 
     // Process each channel
     const channelCount = Math.min(input.length, output.length, 2);
-    
+
     for (let channel = 0; channel < channelCount; channel++) {
       const inputChannel = input[channel];
       const outputChannel = output[channel];
-      
+
       if (!inputChannel || !outputChannel) continue;
 
       const blockSize = inputChannel.length;
@@ -132,7 +161,7 @@ class GateProcessor extends AudioWorkletProcessor {
       // Process each sample
       for (let i = 0; i < blockSize; i++) {
         const sample = inputChannel[i];
-        
+
         // Handle edge cases
         if (!isFinite(sample)) {
           outputChannel[i] = 0;
@@ -141,35 +170,41 @@ class GateProcessor extends AudioWorkletProcessor {
 
         // Calculate envelope (absolute value for level detection)
         const inputLevel = Math.abs(sample);
-        
+
         // Envelope follower with attack/release
         if (inputLevel > this.envelopes[channel]) {
           // Attack: signal is rising
-          this.envelopes[channel] = attackCoeff * this.envelopes[channel] + 
+          this.envelopes[channel] = attackCoeff * this.envelopes[channel] +
                                     (1 - attackCoeff) * inputLevel;
         } else {
           // Release: signal is falling
-          this.envelopes[channel] = releaseCoeff * this.envelopes[channel] + 
+          this.envelopes[channel] = releaseCoeff * this.envelopes[channel] +
                                     (1 - releaseCoeff) * inputLevel;
         }
 
-        // Determine target gain based on threshold
-        let targetGain;
+        // Gate open/closed decision, honouring the hold time. While the
+        // envelope is above threshold the gate is open and the hold timer is
+        // re-armed; once it drops, the gate stays open until the timer expires.
+        let open;
         if (this.envelopes[channel] > thresholdLinear) {
-          // Signal above threshold: full gain
-          targetGain = 1;
+          this.holdCounter[channel] = holdSamples;
+          open = true;
+        } else if (this.holdCounter[channel] > 0) {
+          this.holdCounter[channel]--;
+          open = true;
         } else {
-          // Signal below threshold: gate closed (attenuate)
-          // Use ratio of envelope to threshold for smooth transition
-          const ratio = this.envelopes[channel] / thresholdLinear;
-          // Smooth curve: ratio^2 for gentler gating
-          targetGain = ratio * ratio;
+          open = false;
         }
 
-        // Smooth gain changes to avoid clicks
-        const gainSmoothCoeff = 0.9999; // Very fast smoothing for gain
-        this.currentGain[channel] = gainSmoothCoeff * this.currentGain[channel] + 
-                                    (1 - gainSmoothCoeff) * targetGain;
+        // Open → unity; closed → the range floor.
+        const targetGain = open ? 1 : floorGain;
+
+        // Smooth gain changes with the attack coefficient when opening and the
+        // release coefficient when closing, so the gate's timing controls
+        // shape the actual envelope (and avoid clicks).
+        const coeff = targetGain > this.currentGain[channel] ? attackCoeff : releaseCoeff;
+        this.currentGain[channel] = coeff * this.currentGain[channel] +
+                                    (1 - coeff) * targetGain;
 
         // Apply gain to output
         outputChannel[i] = sample * this.currentGain[channel];
@@ -183,5 +218,3 @@ class GateProcessor extends AudioWorkletProcessor {
 
 // Register the processor with the audio worklet
 registerProcessor('vip-gate', GateProcessor);
-
-// Made with Bob

--- a/tests/deesser-processor.test.js
+++ b/tests/deesser-processor.test.js
@@ -2,7 +2,7 @@
  * VoiceIsolate Pro — DeEsser Processor Tests
  * 
  * Tests the DeEsserProcessor AudioWorklet implementation:
- * - Parameter clamping (level, frequency)
+ * - Parameter clamping (amount, frequency)
  * - Audio processing logic (sibilant detection and reduction)
  * - Biquad filter implementation
  * - Edge cases (silence, clipping, boundary values)
@@ -52,15 +52,15 @@ describe('DeEsserProcessor', () => {
   });
 
   describe('Parameter Descriptors', () => {
-    it('should define level parameter with correct range', () => {
+    it('should define amount parameter defaulting to 0 (de-esser off)', () => {
       const descriptors = DeEsserProcessor.parameterDescriptors;
-      const level = descriptors.find(d => d.name === 'level');
+      const amount = descriptors.find(d => d.name === 'amount');
 
-      expect(level).toBeDefined();
-      expect(level.defaultValue).toBe(0.5);
-      expect(level.minValue).toBe(0);
-      expect(level.maxValue).toBe(1);
-      expect(level.automationRate).toBe('k-rate');
+      expect(amount).toBeDefined();
+      expect(amount.defaultValue).toBe(0);
+      expect(amount.minValue).toBe(0);
+      expect(amount.maxValue).toBe(1);
+      expect(amount.automationRate).toBe('k-rate');
     });
 
     it('should define frequency parameter with correct range', () => {
@@ -191,7 +191,7 @@ describe('DeEsserProcessor', () => {
       const inputs = [[new Float32Array(blockSize), new Float32Array(blockSize)]];
       const outputs = [[new Float32Array(blockSize), new Float32Array(blockSize)]];
       const parameters = {
-        level: [0.5],
+        amount: [0.5],
         frequency: [6000],
       };
 
@@ -214,7 +214,7 @@ describe('DeEsserProcessor', () => {
       }
 
       const parameters = {
-        level: [0.5],
+        amount: [0.5],
         frequency: [6000],
       };
 
@@ -232,7 +232,7 @@ describe('DeEsserProcessor', () => {
       inputs[0][0].fill(0.1);
 
       const parameters = {
-        level: [0.5],
+        amount: [0.5],
         frequency: [6000],
       };
 
@@ -251,7 +251,7 @@ describe('DeEsserProcessor', () => {
       inputs[0][1].fill(0.2);
 
       const parameters = {
-        level: [0.5],
+        amount: [0.5],
         frequency: [6000],
       };
 
@@ -275,7 +275,7 @@ describe('DeEsserProcessor', () => {
 
       // First process with one frequency
       let parameters = {
-        level: [0.5],
+        amount: [0.5],
         frequency: [6000],
       };
 
@@ -284,7 +284,7 @@ describe('DeEsserProcessor', () => {
 
       // Process with different frequency
       parameters = {
-        level: [0.5],
+        amount: [0.5],
         frequency: [8000],
       };
 
@@ -303,7 +303,7 @@ describe('DeEsserProcessor', () => {
       inputs[0][0].fill(0.1);
 
       const parameters = {
-        level: [0.5],
+        amount: [0.5],
         frequency: [6000],
       };
 
@@ -320,7 +320,7 @@ describe('DeEsserProcessor', () => {
   });
 
   describe('De-essing Behavior', () => {
-    it('should reduce gain when level is high', () => {
+    it('should reduce gain when amount is high', () => {
       const blockSize = 128;
       const inputs = [[new Float32Array(blockSize)]];
       const outputs = [[new Float32Array(blockSize)]];
@@ -331,7 +331,7 @@ describe('DeEsserProcessor', () => {
       }
 
       const parameters = {
-        level: [1.0], // Maximum de-essing
+        amount: [1.0], // Maximum de-essing
         frequency: [6000],
       };
 
@@ -344,7 +344,7 @@ describe('DeEsserProcessor', () => {
       expect(processor.currentGain[0]).toBeLessThan(1.0);
     });
 
-    it('should apply less reduction when level is low', () => {
+    it('should apply less reduction when amount is low', () => {
       const blockSize = 128;
       const inputs = [[new Float32Array(blockSize)]];
       const outputs = [[new Float32Array(blockSize)]];
@@ -353,9 +353,9 @@ describe('DeEsserProcessor', () => {
         inputs[0][0][i] = Math.sin(2 * Math.PI * 7000 * i / 48000) * 0.5;
       }
 
-      // Low level - minimal de-essing
+      // Low amount - minimal de-essing
       const parameters = {
-        level: [0.1],
+        amount: [0.1],
         frequency: [6000],
       };
 
@@ -368,7 +368,7 @@ describe('DeEsserProcessor', () => {
       expect(processor.currentGain[0]).toBeGreaterThan(0.8);
     });
 
-    it('should not affect signal when level is 0', () => {
+    it('should not affect signal when amount is 0', () => {
       const blockSize = 128;
       const inputs = [[new Float32Array(blockSize)]];
       const outputs = [[new Float32Array(blockSize)]];
@@ -376,13 +376,13 @@ describe('DeEsserProcessor', () => {
       inputs[0][0].fill(0.5);
 
       const parameters = {
-        level: [0],
+        amount: [0],
         frequency: [6000],
       };
 
       processor.process(inputs, outputs, parameters);
 
-      // With level 0, gain should remain at 1.0
+      // With amount 0, gain should remain at 1.0
       expect(processor.currentGain[0]).toBeCloseTo(1.0, 2);
     });
   });
@@ -392,7 +392,7 @@ describe('DeEsserProcessor', () => {
       const inputs = [[]];
       const outputs = [[]];
       const parameters = {
-        level: [0.5],
+        amount: [0.5],
         frequency: [6000],
       };
 
@@ -405,7 +405,7 @@ describe('DeEsserProcessor', () => {
       const inputs = [null];
       const outputs = [[new Float32Array(128)]];
       const parameters = {
-        level: [0.5],
+        amount: [0.5],
         frequency: [6000],
       };
 
@@ -424,7 +424,7 @@ describe('DeEsserProcessor', () => {
       inputs[0][0][2] = -Infinity;
 
       const parameters = {
-        level: [0.5],
+        amount: [0.5],
         frequency: [6000],
       };
 
@@ -445,7 +445,7 @@ describe('DeEsserProcessor', () => {
 
       // Minimum frequency
       let parameters = {
-        level: [0.5],
+        amount: [0.5],
         frequency: [3500],
       };
 
@@ -454,7 +454,7 @@ describe('DeEsserProcessor', () => {
 
       // Maximum frequency
       parameters = {
-        level: [0.5],
+        amount: [0.5],
         frequency: [10000],
       };
 
@@ -462,25 +462,25 @@ describe('DeEsserProcessor', () => {
       expect(result).toBe(true);
     });
 
-    it('should handle extreme level values', () => {
+    it('should handle extreme amount values', () => {
       const blockSize = 128;
       const inputs = [[new Float32Array(blockSize)]];
       const outputs = [[new Float32Array(blockSize)]];
 
       inputs[0][0].fill(0.1);
 
-      // Minimum level
+      // Minimum amount
       let parameters = {
-        level: [0],
+        amount: [0],
         frequency: [6000],
       };
 
       let result = processor.process(inputs, outputs, parameters);
       expect(result).toBe(true);
 
-      // Maximum level
+      // Maximum amount
       parameters = {
-        level: [1],
+        amount: [1],
         frequency: [6000],
       };
 
@@ -497,7 +497,7 @@ describe('DeEsserProcessor', () => {
       inputs[0][0].fill(2.0);
 
       const parameters = {
-        level: [0.5],
+        amount: [0.5],
         frequency: [6000],
       };
 
@@ -513,7 +513,7 @@ describe('DeEsserProcessor', () => {
       const outputs = [[new Float32Array(blockSize)]];
 
       const parameters = {
-        level: [0.5],
+        amount: [0.5],
         frequency: [6000],
       };
 
@@ -542,7 +542,7 @@ describe('DeEsserProcessor', () => {
       inputs[0][0].fill(0.1);
 
       const parameters = {
-        level: [0.5],
+        amount: [0.5],
         frequency: [6000],
       };
 
@@ -566,7 +566,7 @@ describe('DeEsserProcessor', () => {
       }
 
       const parameters = {
-        level: [0.5],
+        amount: [0.5],
         frequency: [6000],
       };
 
@@ -585,7 +585,7 @@ describe('DeEsserProcessor', () => {
       const outputs = [[new Float32Array(blockSize)]];
 
       const parameters = {
-        level: [0.5],
+        amount: [0.5],
         frequency: [6000],
       };
 

--- a/tests/engineer-mode-bridge.test.js
+++ b/tests/engineer-mode-bridge.test.js
@@ -130,6 +130,15 @@ describe('PlaybackMixer — Engineer Mode parity controls', () => {
     mixer.setGateHold(9999); // clamp 0..500
     expect(mixer._gateParams.hold).toBe(500);
   });
+
+  test('HP/LP Q setters drive the filter resonance and clamp to 0.1…10', () => {
+    mixer.setHighpassQ(2.5);
+    expect(mixer.highpass.Q.value).toBeCloseTo(2.5);
+    mixer.setHighpassQ(99); // clamp high
+    expect(mixer.highpass.Q.value).toBeCloseTo(10);
+    mixer.setLowpassQ(0.05); // clamp low
+    expect(mixer.lowpass.Q.value).toBeCloseTo(0.1);
+  });
 });
 
 describe('EngineerModeBridge', () => {
@@ -193,16 +202,25 @@ describe('EngineerModeBridge', () => {
     expect(spy).toHaveBeenCalledWith(50);
   });
 
+  test('hp/lp Q sliders drive the filter resonance controls', () => {
+    const hp = jest.spyOn(mixer, 'setHighpassQ');
+    const lp = jest.spyOn(mixer, 'setLowpassQ');
+    expect(bridge.applyParam('hpQ', 2)).toBe(true);
+    expect(bridge.applyParam('lpQ', 3)).toBe(true);
+    expect(hp).toHaveBeenCalledWith(2);
+    expect(lp).toHaveBeenCalledWith(3);
+  });
+
   test('unsupported ids and non-finite values are ignored', () => {
-    expect(bridge.applyParam('hpQ', 2)).toBe(false);       // stub, no mixer control
-    expect(bridge.applyParam('nrAmount', 50)).toBe(false); // worker param
-    expect(bridge.applyParam('eqMid', NaN)).toBe(false);   // non-finite
+    expect(bridge.applyParam('formantShift', 2)).toBe(false); // worker param, no mixer control
+    expect(bridge.applyParam('nrAmount', 50)).toBe(false);    // worker param
+    expect(bridge.applyParam('eqMid', NaN)).toBe(false);      // non-finite
     expect(bridge.applyParam('eqMid', 4)).toBe(true);
   });
 
   test('applyParams applies a whole slider map', () => {
     const spy = jest.spyOn(mixer, 'setGraphicEq');
-    bridge.applyParams({ eqBass: 2, eqMid: -3, hpQ: 1 });
+    bridge.applyParams({ eqBass: 2, eqMid: -3, formantShift: 1 });
     expect(spy).toHaveBeenCalledWith('bass', 2);
     expect(spy).toHaveBeenCalledWith('mid', -3);
   });

--- a/tests/gate-processor.test.js
+++ b/tests/gate-processor.test.js
@@ -62,6 +62,28 @@ describe('GateProcessor', () => {
       expect(threshold.automationRate).toBe('k-rate');
     });
 
+    it('should define range parameter defaulting to 0 (gate off)', () => {
+      const descriptors = GateProcessor.parameterDescriptors;
+      const range = descriptors.find(d => d.name === 'range');
+
+      expect(range).toBeDefined();
+      expect(range.defaultValue).toBe(0);
+      expect(range.minValue).toBe(0);
+      expect(range.maxValue).toBe(80);
+      expect(range.automationRate).toBe('k-rate');
+    });
+
+    it('should define hold parameter with correct range', () => {
+      const descriptors = GateProcessor.parameterDescriptors;
+      const hold = descriptors.find(d => d.name === 'hold');
+
+      expect(hold).toBeDefined();
+      expect(hold.defaultValue).toBe(0);
+      expect(hold.minValue).toBe(0);
+      expect(hold.maxValue).toBe(1000);
+      expect(hold.automationRate).toBe('k-rate');
+    });
+
     it('should define attack parameter with correct range', () => {
       const descriptors = GateProcessor.parameterDescriptors;
       const attack = descriptors.find(d => d.name === 'attack');
@@ -89,6 +111,7 @@ describe('GateProcessor', () => {
     it('should initialize with default state', () => {
       expect(processor.envelopes).toEqual([0, 0]);
       expect(processor.currentGain).toEqual([1, 1]);
+      expect(processor.holdCounter).toEqual([0, 0]);
       expect(processor.sampleRate).toBe(48000);
     });
   });
@@ -172,15 +195,64 @@ describe('GateProcessor', () => {
 
       const parameters = {
         threshold: [-40],
+        range: [60],   // attenuate 60 dB when closed
         attack: [10],
         release: [100],
       };
 
+      // Run enough blocks for the release ramp to fully close the gate.
+      for (let i = 0; i < 30; i++) processor.process(inputs, outputs, parameters);
+
+      // Gate should be closed, so output should be heavily attenuated
+      const avgOutput = outputs[0][0].reduce((a, b) => a + Math.abs(b), 0) / blockSize;
+      expect(avgOutput).toBeLessThan(0.0005);
+    });
+
+    it('should stay transparent when range is 0 (gate off)', () => {
+      const blockSize = 128;
+      const inputs = [[new Float32Array(blockSize)]];
+      const outputs = [[new Float32Array(blockSize)]];
+
+      // Signal below threshold — but with range 0 the gate must not attenuate.
+      inputs[0][0].fill(0.001);
+
+      const parameters = {
+        threshold: [-40],
+        range: [0],
+        attack: [10],
+        release: [100],
+      };
+
+      for (let i = 0; i < 30; i++) processor.process(inputs, outputs, parameters);
+
+      // Closed-gate gain is unity, so output ≈ input.
+      const avgOutput = outputs[0][0].reduce((a, b) => a + b, 0) / blockSize;
+      expect(avgOutput).toBeCloseTo(0.001, 4);
+    });
+
+    it('should hold the gate open for the hold time after signal drops', () => {
+      const blockSize = 128;
+      const inputs = [[new Float32Array(blockSize)]];
+      const outputs = [[new Float32Array(blockSize)]];
+
+      // ~85 ms hold at 48 kHz ≈ 4080 samples ≈ 32 blocks of 128.
+      const parameters = {
+        threshold: [-40],
+        range: [60],
+        attack: [0],
+        release: [0],
+        hold: [85],
+      };
+
+      // Open the gate with a loud block, which arms the hold timer.
+      inputs[0][0].fill(0.5);
       processor.process(inputs, outputs, parameters);
 
-      // Gate should be closed, so output should be attenuated
-      const avgOutput = outputs[0][0].reduce((a, b) => a + b, 0) / blockSize;
-      expect(avgOutput).toBeLessThan(0.001); // Heavily attenuated
+      // Now feed silence: the gate must stay open (full gain) during the hold.
+      inputs[0][0].fill(0);
+      processor.process(inputs, outputs, parameters);
+      expect(processor.currentGain[0]).toBeGreaterThan(0.9);
+      expect(processor.holdCounter[0]).toBeGreaterThan(0);
     });
 
     it('should handle mono input', () => {
@@ -213,15 +285,16 @@ describe('GateProcessor', () => {
 
       const parameters = {
         threshold: [-40],
+        range: [60],
         attack: [10],
         release: [100],
       };
 
-      processor.process(inputs, outputs, parameters);
+      for (let i = 0; i < 30; i++) processor.process(inputs, outputs, parameters);
 
-      // Left should have more output than right
-      const leftAvg = outputs[0][0].reduce((a, b) => a + b, 0) / blockSize;
-      const rightAvg = outputs[0][1].reduce((a, b) => a + b, 0) / blockSize;
+      // Left should stay open (passes), right should be gated down.
+      const leftAvg = outputs[0][0].reduce((a, b) => a + Math.abs(b), 0) / blockSize;
+      const rightAvg = outputs[0][1].reduce((a, b) => a + Math.abs(b), 0) / blockSize;
       expect(leftAvg).toBeGreaterThan(rightAvg);
     });
   });
@@ -288,6 +361,7 @@ describe('GateProcessor', () => {
       // Very low threshold - gate should always be open
       let parameters = {
         threshold: [-100],
+        range: [60],
         attack: [10],
         release: [100],
       };
@@ -303,13 +377,14 @@ describe('GateProcessor', () => {
       // Very high threshold - gate should be closed
       parameters = {
         threshold: [0],
+        range: [60],
         attack: [10],
         release: [100],
       };
 
-      processor.process(inputs, outputs, parameters);
-      avgOutput = outputs[0][0].reduce((a, b) => a + b, 0) / blockSize;
-      expect(avgOutput).toBeLessThan(0.1);
+      for (let i = 0; i < 30; i++) processor.process(inputs, outputs, parameters);
+      avgOutput = outputs[0][0].reduce((a, b) => a + Math.abs(b), 0) / blockSize;
+      expect(avgOutput).toBeLessThan(0.05);
     });
 
     it('should handle zero attack time', () => {


### PR DESCRIPTION
## Problem

The `rt:true` Engineer Mode sliders are supposed to update the Live-Mix graph in real time: DOM `input` → `app.onSlider` → `EngineerModeBridge` → `PlaybackMixer` AudioParams (CLAUDE.md §1). Several were silently dead because the playback worklets didn't expose the parameters the mixer was setting.

I reproduced this in headless Chromium (real DOM `input` events on the actual slider elements) and traced each rt slider one by one. The EQ / dynamics / output / tilt / width sliders already worked; the broken ones were all on the two AudioWorklets.

## Root causes & fixes

**Noise gate (`gateRange`, `gateHold`) — dead**
`GateProcessor` only declared `threshold` / `attack` / `release`. The mixer also sets `range` (closed-gate attenuation depth) and `hold`, so those two sliders looked up non-existent AudioParams and did nothing. Worse, with no `range` control the gate could never be turned off — it always attenuated below threshold (`ratio²`), so it wasn't transparent by default.
→ Added `range` (0 = off → unity closed-gain) and `hold` params, and reworked the gate envelope: open → unity, closed → the range floor, with a hold timer and attack/release-shaped gain smoothing.

**De-esser (`deEssAmt`) — dead + always-on**
`DeEsserProcessor` declared the strength param as `level` (default `0.5`), but the mixer sets `amount`. So `deEssAmt` did nothing **and** the de-esser ran at 50% on every loaded file.
→ Renamed to `amount`, default `0` (off / transparent).

**HP/LP resonance (`hpQ`, `lpQ`) — unmapped**
Both are `rt:true` but had no mixer control, so moving them did nothing live.
→ Added `PlaybackMixer.setHighpassQ` / `setLowpassQ` and mapped `hpQ` / `lpQ` in the bridge. The HP/LP `BiquadFilterNode.Q` is now a live AudioParam.

## Verification

Headless Chromium, driving the **real** DOM `input` path while playing through the bridge — every rt slider now moves its live AudioParam, with no console errors:

```
✓ eqMid → +9 dB        ✓ gateRange → 40 dB (was DEAD)   ✓ deEssAmt → ~1.0 (was DEAD)
✓ gateThresh → -30 dB  ✓ gateHold → 120 ms (was DEAD)   ✓ hpQ → 3 (was DEAD)
✓ deEssFreq → 8000 Hz  ✓ lpQ → 4 (was DEAD)             ✓ compRatio → 8
✓ limThresh → -3/20:1  ✓ specTilt → +3   ✓ outGain → +6 dB   ✓ dryWet .4/.6   ✓ width 1.5
✅ ALL RT SLIDERS WORKING
```

## Cleanup (dead code)

- Removed the debug `console.log` spam left behind while chasing this bug (`EngineerModeBridge`, `PlaybackMixer`, `app.js` `onSlider`/`_ensureBridge`/`buildLiveChain`, `vip-fixes.js`).
- Trimmed `slider-map.js` to the pure data module it documents itself as (`SLIDER_REGISTRY` + `STAGES`). The in-module DOM builders and the dead `dispatchParam` / `SLIDER_TARGETS` routing dispatched to the **removed** orchestrator's worklet/worker and were unused by the live app (which builds sliders in `app.js` and routes through `onSlider`).

## Tests

- `pnpm test` → **2106 passing** (+6 new: gate `range`/`hold`/transparency/hold-timer, de-esser `amount`, HP/LP Q).
- `pnpm validate` → all checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015jwJWs56wenNfnHghqYS55

---
_Generated by [Claude Code](https://claude.ai/code/session_015jwJWs56wenNfnHghqYS55)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Engineer Mode real-time sliders for gate range/hold, de-esser amount, and HP/LP filter Q
> - Adds `GateProcessor` parameters `range` (attenuation depth, 0–80 dB) and `hold` (0–1000 ms) with per-channel hold tracking and envelope-shaped transitions via attack/release coefficients
> - Renames `DeEsserProcessor` parameter `level` to `amount` (0–1, default 0 = off); existing audio graphs must update to target `amount`
> - Adds `PlaybackMixer.setHighpassQ` and `setLowpassQ` methods (Q clamped to 0.1–10) and wires them through `EngineerModeBridge` via new `hpQ`/`lpQ` slider mappings
> - Removes extensive console logging across `app.js`, `slider-map.js`, `vip-fixes.js`, `EngineerModeBridge.js`, and `PlaybackMixer.js`
> - Risk: `DeEsserProcessor` rename from `level` to `amount` is a breaking change for any caller targeting the old parameter name
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 80b60d0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->