### PR TITLE
chore(modernize): harden deps + validator, zero lint, fix test, add reimagine plan

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,19 +3,16 @@
 # Never commit .env to version control. Never hardcode any of these in source.
 
 # ─── Security (Layer 0) ───────────────────────────────────────────────────────
-# Admin API access secret. Generate:
-#   node -e "console.log(require('crypto').randomBytes(48).toString('base64url'))"
-ADMIN_SECRET=
-
-# JWT signing secret for license tokens (min 32 chars). Generate:
+# JWT signing secret for license + sync tokens (HMAC-SHA256, min 32 chars).
+# This is the ONLY server secret the code reads for token signing — see
+# api-routes/monetization.js and api-routes/sync.js. REQUIRED in production:
+# the server throws on boot if it is unset. Generate:
 #   node -e "console.log(require('crypto').randomBytes(64).toString('hex'))"
-JWT_SECRET=
-
-# Idempotency key salt for webhook deduplication (Stripe replay protection).
-WEBHOOK_IDEMPOTENCY_KEY=
-
-# Back-compat alias used by api-routes/monetization.js (set equal to JWT_SECRET).
 LICENSE_JWT_SECRET=
+
+# Note: there is no separate ADMIN_SECRET / JWT_SECRET / WEBHOOK_IDEMPOTENCY_KEY.
+# No admin route exists, and Stripe webhook idempotency is keyed off the Stripe
+# event.id (see api-routes/monetization.js), not a configured key.
 
 # ─── Stripe (only needed for paywall features) ────────────────────────────────
 # https://dashboard.stripe.com/apikeys — test keys for local development.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,9 +136,11 @@ Rules:
   `Content-Security-Policy` (no `'unsafe-inline'` scripts outside the scoped
   legacy exception), `X-Content-Type-Options: nosniff`,
   `X-Frame-Options: DENY`, `Permissions-Policy: microphone=()`.
-- Server secrets: `ADMIN_SECRET`, `JWT_SECRET`, `WEBHOOK_IDEMPOTENCY_KEY` (see
-  `.env.example`). **Never** commit values; never invent fallback secrets that
-  ship to production.
+- Server secrets actually read by code: `LICENSE_JWT_SECRET` (license + sync JWT
+  signing, HMAC-SHA256) and the Stripe pair `STRIPE_SECRET_KEY` /
+  `STRIPE_WEBHOOK_SECRET` (see `.env.example`). Stripe webhook idempotency is
+  keyed off the Stripe `event.id`, not a separate secret. **Never** commit
+  values; never invent fallback secrets that ship to production.
 - There is **no** auth API in this repo anymore. `api-routes/auth.js`, the
   client `public/app/auth.js`, and the dev license stub
   `public/app/license-manager.js` were deliberately deleted. Do not recreate

--- a/docs/REIMAGINE-multi-frame-models.md
+++ b/docs/REIMAGINE-multi-frame-models.md
@@ -1,0 +1,129 @@
+# Reimagine Plan — Multi-Frame Model Separation (v25 candidate)
+
+> **Status: PROPOSAL / NOT IMPLEMENTED.** This is a reviewable design, not a
+> shipped change. No frozen architecture has been touched. Nothing here may be
+> merged without an explicit product decision and a follow-up implementation PR
+> per phase. It exists so the "reimagine" can be evaluated before any code moves.
+
+Authored as the design half of the modernization pass that shipped the safe
+hardening fixes (CVE pins, `validate.js` `public/lib/` scan, doc reconciliation,
+lint-to-zero). Those were applied; **this is deliberately deferred to planning.**
+
+---
+
+## 1. The ceiling we want to lift
+
+`ARCHITECTURE.md` and `CLAUDE.md §4` both name the constraint: the shipped models
+(`rnnoise_suppressor.onnx`, `bsrnn_vocals.onnx`) are **single-frame spectral-mask**
+networks. Their inference contract (`src/core/ModelManifest.js`) is:
+
+```
+input  'input'  float32 [batch, 2049]   STFT magnitude frames (fft 4096, hop 1024, Hann, 48 kHz)
+output 'output' float32 [batch, 2049]   sigmoid mask in [0,1] → multiplied into the complex spectrum → iSTFT
+```
+
+Each frame is masked **independently**. That caps quality: no temporal context,
+fixed window, and magnitude-only masking leaves phase untouched (musical-noise /
+"smearing" artifacts on transients and reverb tails). The mature separation
+families — **DeepFilterNet** (denoise), **MDX-Net** / **BS-Roformer** (vocals) —
+all consume a *multi-frame* context window and many also predict a *complex*
+mask, which is exactly the headroom we're missing.
+
+## 2. What MUST stay true (non-negotiable invariants)
+
+Any model upgrade has to land **inside** the existing architecture, not around
+it. From `CLAUDE.md`:
+
+| Invariant | Why it holds here |
+|---|---|
+| **Phase 1 offline / Phase 2 live-mix split** | New models still run **once per file** in `MLWorker`. Sliders never re-trigger inference. |
+| **No microphone, ever** | Inference input is the decoded file buffer. `Permissions-Policy: microphone=()` stays. |
+| **No CDN** | New `.onnx`/wasm fetched same-origin from `/app/models/`; ORT stays `/lib/ort.min.js`. |
+| **SHA-256 integrity** | Every new model gets a pinned `sha256` in `ModelManifest.js`, verified before session creation. `null` hash is dev-only. |
+| **Stems output contract** | Inference still emits a **clean stem**; the **noise stem** stays the sample-wise residual `input − clean`. Transferable `Float32Array`s. |
+| **4-layer purity** | Math stays in `src/core/`, execution in `src/workers/`, orchestration in `src/pipeline/`. No upward imports. |
+| **AudioParam-only sliders** | The live-mix graph is unchanged; this is a Phase-1 swap only. |
+
+If a candidate model can't satisfy all of these, it is rejected regardless of
+its benchmark numbers.
+
+## 3. The manifest already anticipates this
+
+`src/core/ModelManifest.js` is not single-frame by assumption — it carries a
+`strategy` discriminator and already scaffolds the two strategies a multi-frame
+upgrade needs, both currently `sha256: null` placeholders:
+
+- `demucs` → `strategy: 'waveform'` (raw-waveform separation, 44.1 kHz)
+- `bsrnn_complex` → `strategy: 'complex-spectrogram'` (4-D complex tensor I/O)
+
+So the reimagine is **mostly additive**: add a strategy implementation in the
+worker, add a hash-pinned manifest entry, and route to it — *not* a rewrite of
+the pipeline. The single-frame `spectral-mask` path stays as the always-available
+fallback.
+
+## 4. Candidate models
+
+| Task | Candidate | Format | Strategy | Notes |
+|---|---|---|---|---|
+| Denoise | **DeepFilterNet 2/3** | ONNX INT8 | new `deep-filter` (complex, multi-frame) | ERB + deep filtering; strong on non-stationary noise. |
+| Vocals | **MDX-Net** | ONNX INT8 | extend `spectral-mask` → multi-frame, or `complex-spectrogram` | Proven separation; large context window. |
+| Vocals (stretch) | **BS-Roformer** | ONNX | `complex-spectrogram` | SOTA quality, heaviest; WebGPU-gated. |
+| VAD | **Silero VAD** (keep) | ONNX fp32/int8 | `vad` | Already shipped; unchanged. |
+
+INT8 first: smaller download (the "100% local" promise means the user pays the
+bytes), faster WASM fallback, WebGPU when available.
+
+## 5. Phased rollout (each phase is its own PR, independently revertible)
+
+**Phase 0 — Harness (no model swap).** Generalize `MLWorker`'s overlap-add to a
+multi-frame context window (`contextFrames` from the manifest entry) and add a
+`strategy` dispatch seam. Drive it with the *existing* single-frame models by
+setting `contextFrames: 1` — output must be **bit-identical** to today. Pure
+refactor, fully covered by current tests + a new golden-output test.
+
+**Phase 1 — Complex masking on a known model.** Export `bsrnn_vocals` to its
+complex-spectrogram variant (`scripts/export_bsrnn_onnx.py` already targeted by
+the `bsrnn_complex` placeholder), pin its hash, implement `complex-spectrogram`,
+and gate it behind an explicit Maximum-Isolation opt-in. A/B against the
+single-frame mask on a fixed clip set.
+
+**Phase 2 — DeepFilterNet denoise.** Add the `deep-filter` strategy + INT8
+entry; chain it after vocals in the existing `modelIds: string[]` Maximum-Isolation
+chain (vocals → denoise) that `MLWorker` already supports. Noise stem stays the
+residual against the *original* input.
+
+**Phase 3 — MDX-Net / BS-Roformer (stretch).** WebGPU-preferred, WASM-fallback
+with a size/latency budget check; auto-downgrade to Phase-1 path when the
+execution provider or memory budget can't support it.
+
+## 6. Validation & rollback
+
+- **Integrity:** `pnpm models:validate` + `scripts/validate-onnx-models.js`; hash
+  pinned in the manifest; `MLWorker` refuses a mismatch. No `null` hash ships.
+- **Structural:** `pnpm validate` must stay green (no live-mic, no CDN, layer
+  purity, both legacy invariants intact).
+- **Correctness:** new golden-spectrogram tests per strategy; Phase-0 requires
+  bit-identical output for `contextFrames: 1`.
+- **Perf budget:** decode→stems wall-clock and peak memory measured per model on
+  WebGPU and WASM; a model that blows the budget stays opt-in, never default.
+- **Rollback:** every phase is additive behind a strategy/opt-in; reverting a
+  phase is deleting its manifest entry + dispatch arm. The single-frame
+  `spectral-mask` path is never removed.
+
+## 7. Explicitly out of scope
+
+- The removed live-microphone pipeline — **not** revived.
+- Any server-side audio processing — audio never leaves the device.
+- Touching the live-mix graph, sliders, or `public/app/` legacy shell.
+- Auth/licensing changes.
+
+## 8. Decision needed before any implementation
+
+1. Is INT8-first acceptable for v25, or do we want fp32 quality first and quantize
+   later?
+2. Vocals: extend `spectral-mask` to multi-frame, or jump straight to
+   `complex-spectrogram`?
+3. Download-size budget per model (drives WebGPU-only vs. universal availability).
+
+Until these are answered and a per-phase PR is opened and reviewed, **no code in
+this plan should be written.**

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -26,7 +26,7 @@ export default [
       },
     },
     rules: {
-      'no-unused-vars': ['warn', { argsIgnorePattern: '^_|^e$' }],
+      'no-unused-vars': ['warn', { argsIgnorePattern: '^_|^e$', caughtErrorsIgnorePattern: '^_' }],
       'no-undef': 'error',
       'no-empty': ['error', { allowEmptyCatch: true }],
     },
@@ -50,7 +50,7 @@ export default [
       },
     },
     rules: {
-      'no-unused-vars': ['warn', { argsIgnorePattern: '^_|^e$', varsIgnorePattern: '^SLIDER_REGISTRY$' }],
+      'no-unused-vars': ['warn', { argsIgnorePattern: '^_|^e$', varsIgnorePattern: '^SLIDER_REGISTRY$', caughtErrorsIgnorePattern: '^_' }],
       'no-undef': 'error',
       'no-empty': ['error', { allowEmptyCatch: true }],
       'semi': ['warn', 'always'],
@@ -65,7 +65,7 @@ export default [
       globals: { ...globals.browser },
     },
     rules: {
-      'no-unused-vars': ['warn', { argsIgnorePattern: '^_|^e$' }],
+      'no-unused-vars': ['warn', { argsIgnorePattern: '^_|^e$', caughtErrorsIgnorePattern: '^_' }],
       'no-undef': 'error',
       'no-empty': ['error', { allowEmptyCatch: true }],
       'semi': ['warn', 'always'],
@@ -80,7 +80,7 @@ export default [
       globals: { ...globals.browser },
     },
     rules: {
-      'no-unused-vars': ['warn', { argsIgnorePattern: '^_|^e$' }],
+      'no-unused-vars': ['warn', { argsIgnorePattern: '^_|^e$', caughtErrorsIgnorePattern: '^_' }],
       'no-undef': 'error',
       'no-empty': ['error', { allowEmptyCatch: true }],
       'semi': ['warn', 'always'],
@@ -103,7 +103,7 @@ export default [
       },
     },
     rules: {
-      'no-unused-vars': ['warn', { argsIgnorePattern: '^_|^e$' }],
+      'no-unused-vars': ['warn', { argsIgnorePattern: '^_|^e$', caughtErrorsIgnorePattern: '^_' }],
       'no-undef': 'error',
       'no-empty': ['error', { allowEmptyCatch: true }],
     },
@@ -120,7 +120,7 @@ export default [
       },
     },
     rules: {
-      'no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+      'no-unused-vars': ['warn', { argsIgnorePattern: '^_', caughtErrorsIgnorePattern: '^_' }],
       'no-undef': 'error',
       'no-empty': ['error', { allowEmptyCatch: true }],
     },
@@ -137,7 +137,7 @@ export default [
       },
     },
     rules: {
-      'no-unused-vars': ['warn', { argsIgnorePattern: '^_|^e$' }],
+      'no-unused-vars': ['warn', { argsIgnorePattern: '^_|^e$', caughtErrorsIgnorePattern: '^_' }],
       'no-undef': 'error',
       'no-empty': ['error', { allowEmptyCatch: true }],
     },
@@ -154,7 +154,7 @@ export default [
       },
     },
     rules: {
-      'no-unused-vars': ['warn', { argsIgnorePattern: '^_|^e$' }],
+      'no-unused-vars': ['warn', { argsIgnorePattern: '^_|^e$', caughtErrorsIgnorePattern: '^_' }],
       'no-undef': 'error',
       'no-empty': ['error', { allowEmptyCatch: true }],
       'semi': ['warn', 'always'],
@@ -173,7 +173,7 @@ export default [
       },
     },
     rules: {
-      'no-unused-vars': ['warn', { argsIgnorePattern: '^_|^e$' }],
+      'no-unused-vars': ['warn', { argsIgnorePattern: '^_|^e$', caughtErrorsIgnorePattern: '^_' }],
       'no-undef': 'error',
       'no-empty': ['error', { allowEmptyCatch: true }],
       'semi': ['warn', 'always'],
@@ -190,7 +190,7 @@ export default [
       globals: { ...globals.browser },
     },
     rules: {
-      'no-unused-vars': ['warn', { argsIgnorePattern: '^_|^e$' }],
+      'no-unused-vars': ['warn', { argsIgnorePattern: '^_|^e$', caughtErrorsIgnorePattern: '^_' }],
       'no-undef': 'error',
       'no-empty': ['error', { allowEmptyCatch: true }],
       'semi': ['warn', 'always'],
@@ -208,7 +208,7 @@ export default [
       globals: { ...globals.browser },
     },
     rules: {
-      'no-unused-vars': ['warn', { argsIgnorePattern: '^_|^e$' }],
+      'no-unused-vars': ['warn', { argsIgnorePattern: '^_|^e$', caughtErrorsIgnorePattern: '^_' }],
       'no-undef': 'error',
       'no-empty': ['error', { allowEmptyCatch: true }],
       'semi': ['warn', 'always'],
@@ -228,7 +228,7 @@ export default [
       },
     },
     rules: {
-      'no-unused-vars': ['warn', { argsIgnorePattern: '^_|^e$' }],
+      'no-unused-vars': ['warn', { argsIgnorePattern: '^_|^e$', caughtErrorsIgnorePattern: '^_' }],
       'no-undef': 'error',
       'no-empty': ['error', { allowEmptyCatch: true }],
       'semi': ['warn', 'always'],
@@ -252,7 +252,7 @@ export default [
       },
     },
     rules: {
-      'no-unused-vars': ['warn', { argsIgnorePattern: '^_|^e$' }],
+      'no-unused-vars': ['warn', { argsIgnorePattern: '^_|^e$', caughtErrorsIgnorePattern: '^_' }],
       'no-undef': 'error',
       'no-empty': ['error', { allowEmptyCatch: true }],
       'semi': ['warn', 'always'],
@@ -269,7 +269,7 @@ export default [
       globals: { ...globals.worker },
     },
     rules: {
-      'no-unused-vars': ['warn', { argsIgnorePattern: '^_|^e$' }],
+      'no-unused-vars': ['warn', { argsIgnorePattern: '^_|^e$', caughtErrorsIgnorePattern: '^_' }],
       'no-undef': 'error',
       'no-empty': ['error', { allowEmptyCatch: true }],
       'semi': ['warn', 'always'],
@@ -287,7 +287,7 @@ export default [
       globals: { ...globals.node },
     },
     rules: {
-      'no-unused-vars': ['warn', { argsIgnorePattern: '^_|^e$' }],
+      'no-unused-vars': ['warn', { argsIgnorePattern: '^_|^e$', caughtErrorsIgnorePattern: '^_' }],
       'no-undef': 'error',
       'no-empty': ['error', { allowEmptyCatch: true }],
     },
@@ -301,7 +301,7 @@ export default [
       globals: { ...globals.node },
     },
     rules: {
-      'no-unused-vars': ['warn', { argsIgnorePattern: '^_|^e$' }],
+      'no-unused-vars': ['warn', { argsIgnorePattern: '^_|^e$', caughtErrorsIgnorePattern: '^_' }],
       'no-undef': 'error',
       'no-empty': ['error', { allowEmptyCatch: true }],
     },
@@ -318,7 +318,7 @@ export default [
       },
     },
     rules: {
-      'no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+      'no-unused-vars': ['warn', { argsIgnorePattern: '^_', caughtErrorsIgnorePattern: '^_' }],
       'no-undef': 'error',
     },
   },
@@ -331,7 +331,7 @@ export default [
       globals: { ...globals.node },
     },
     rules: {
-      'no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+      'no-unused-vars': ['warn', { argsIgnorePattern: '^_', caughtErrorsIgnorePattern: '^_' }],
       'no-undef': 'error',
     },
   },

--- a/package.json
+++ b/package.json
@@ -132,7 +132,9 @@
       "cross-spawn": ">=7.0.5",
       "micromatch": ">=4.0.8",
       "esbuild": ">=0.25.0",
-      "form-data": ">=4.0.6"
+      "form-data": ">=4.0.6",
+      "qs": ">=6.15.2",
+      "ip-address": ">=10.1.1"
     }
   },
   "overrides": {
@@ -148,6 +150,8 @@
     "brace-expansion": ">=1.1.13",
     "flatted": ">=3.4.2",
     "form-data": ">=4.0.6",
-    "protobufjs": ">=8.4.1"
+    "protobufjs": ">=8.4.1",
+    "qs": ">=6.15.2",
+    "ip-address": ">=10.1.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,8 @@ overrides:
   micromatch: '>=4.0.8'
   esbuild: '>=0.25.0'
   form-data: '>=4.0.6'
+  qs: '>=6.15.2'
+  ip-address: '>=10.1.1'
 
 importers:
 
@@ -1478,10 +1480,6 @@ packages:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
 
-  hasown@2.0.2:
-    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
-    engines: {node: '>= 0.4'}
-
   hasown@2.0.4:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
@@ -1545,8 +1543,8 @@ packages:
     resolution: {integrity: sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
-  ip-address@10.1.0:
-    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -2160,8 +2158,8 @@ packages:
   pure-rand@7.0.1:
     resolution: {integrity: sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==}
 
-  qs@6.14.2:
-    resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
 
   range-parser@1.2.1:
@@ -3614,7 +3612,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.14.2
+      qs: 6.15.2
       raw-body: 3.0.2
       type-is: 2.0.1
     transitivePeerDependencies:
@@ -3946,7 +3944,7 @@ snapshots:
   express-rate-limit@8.3.2(express@5.2.1):
     dependencies:
       express: 5.2.1
-      ip-address: 10.1.0
+      ip-address: 10.2.0
 
   express@5.2.1:
     dependencies:
@@ -3970,7 +3968,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.14.2
+      qs: 6.15.2
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
@@ -4103,7 +4101,7 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       math-intrinsics: 1.1.0
 
   get-package-type@0.1.0: {}
@@ -4173,10 +4171,6 @@ snapshots:
     dependencies:
       has-symbols: 1.1.0
 
-  hasown@2.0.2:
-    dependencies:
-      function-bind: 1.1.2
-
   hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
@@ -4242,7 +4236,7 @@ snapshots:
 
   ini@4.1.3: {}
 
-  ip-address@10.1.0: {}
+  ip-address@10.2.0: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -5047,7 +5041,7 @@ snapshots:
 
   pure-rand@7.0.1: {}
 
-  qs@6.14.2:
+  qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
 
@@ -5198,7 +5192,7 @@ snapshots:
 
   socks@2.8.7:
     dependencies:
-      ip-address: 10.1.0
+      ip-address: 10.2.0
       smart-buffer: 4.2.0
 
   source-map-support@0.5.13:
@@ -5272,7 +5266,7 @@ snapshots:
       formidable: 3.5.4
       methods: 1.1.2
       mime: 2.6.0
-      qs: 6.14.2
+      qs: 6.15.2
     transitivePeerDependencies:
       - supports-color
 

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -35,6 +35,7 @@ const MODEL_STATUS_KEYS = ['demucs', 'bsrnn', 'rnnoise', 'silero_vad'];
 // Do not remove - they serve as the canonical reference for the entire pipeline.
 // ---------------------------------------------------------------------------
 const FFT_SIZE = 4096;
+// eslint-disable-next-line no-unused-vars -- pinned SAB/STFT reference constant; do NOT remove (see note above; parsed verbatim by tests/sab-protocol-fixes.test.js)
 const HOP_SIZE = 1024;
 const HALF_BINS = FFT_SIZE / 2 + 1;
 const SAB_HEADER_BYTES = Int32Array.BYTES_PER_ELEMENT * 5; // FLAG_SLOTS = 5
@@ -1151,7 +1152,7 @@ class VoiceIsolatePro {
       // Copy the ArrayBuffer so the original is not detached/consumed
       const abCopy = ab.slice(0);
       buffer = await this.ctx.decodeAudioData(abCopy);
-    } catch (err) {
+    } catch {
       // Video fallback
       if (isVideoFile) {
         try {
@@ -1161,7 +1162,7 @@ class VoiceIsolatePro {
           }
           if (this.dom && this.dom.videoCard) this.dom.videoCard.style.display = '';
           this.isVideo = true;
-        } catch (vidErr) {
+        } catch {
           if (this.dom && this.dom.fileInfo) this.dom.fileInfo.textContent = 'Cannot decode this video format';
           this.setStatus('ERROR');
           this.showNotification('Cannot decode: ' + file.name, 'error');
@@ -2321,7 +2322,6 @@ class VoiceIsolatePro {
 
   _updateProcessButtonsState() {
     const hasBuf = Boolean(this.inputBuffer || this.origBuffer);
-    const ready = this._ctxReady || this._workletReady || this._dspOnlyMode;
     const canProcess = hasBuf;
     if (this.dom.processBtn) this.dom.processBtn.disabled = !canProcess;
     if (this.dom.mobileProcessBtn) this.dom.mobileProcessBtn.disabled = !canProcess;

--- a/public/landing.js
+++ b/public/landing.js
@@ -170,14 +170,14 @@ function _renderProcLoader() {
  * (decode/resample have no known duration); the scan-bar animation always
  * runs so the UI remains active throughout.
  */
-function showSpinner(stage, { indeterminate = false } = {}) {
+function showSpinner(stage, { indeterminate: _indeterminate = false } = {}) {
   _procState = { active: stage.toLowerCase().includes('resamp') ? 1 : 0, progress: 0 };
   ui.procLoaderMount.hidden = false;
   _renderProcLoader();
 }
 
 /** Advance to the Separate stage and update the live progress percentage. */
-function setProgress(percent, stage) {
+function setProgress(percent, _stage) {
   const pct = Math.max(0, Math.min(100, Math.round(percent)));
   _procState = { active: 2, progress: pct };
   ui.procLoaderMount.hidden = false;

--- a/public/lib/README.md
+++ b/public/lib/README.md
@@ -12,7 +12,6 @@ in production**.
 | `three.min.js` | 603 KB | Three.js r128 (3D spectrogram, Engineer Mode) | committed manually |
 | `ort.min.js` + `ort.js` (+ maps) | ~4.3 MB | ONNX Runtime Web (`onnxruntime-web` npm) | auto-vendored |
 | `ort-wasm-simd-threaded*.wasm` | ~76 MB total | ONNX Runtime Web WASM backends | auto-vendored |
-| `ort-loader.js` | 2 KB | Custom loader wrapper | committed manually |
 
 ## Auto-vendoring
 

--- a/scripts/setup-ort.js
+++ b/scripts/setup-ort.js
@@ -59,8 +59,8 @@ if (SOFT_ENV) {
 
 // Files this script owns in DEST_DIR. Anything matching these patterns is
 // removed before copying so that wasm/JS files dropped between ORT releases
-// don't accumulate as stale 30 MB artifacts. Non-ORT files (ort-loader.js,
-// three.module.min.js, README.md, .gitkeep) do not match and are preserved.
+// don't accumulate as stale 30 MB artifacts. Non-ORT files (three.module.min.js,
+// README.md, .gitkeep) do not match and are preserved.
 // three.module.min.js (Three.js 0.184.0 ESM build) is managed by setup-three.js.
 const OWNED_PATTERNS = [
   /^ort-wasm[^/]*\.wasm$/,

--- a/scripts/validate.js
+++ b/scripts/validate.js
@@ -129,8 +129,10 @@ const ALLOWED_WORKLETS = ['/src/workers/GateProcessor.js', '/src/workers/DeEsser
 // shim). These are trusted build artifacts and a future upstream upgrade could
 // legitimately embed a string that looks like a CDN host, so the CDN-host scan
 // below skips them — but the getUserMedia / dynamic-worklet bans still apply to
-// every file, vendored or not.
-const VENDORED_BUNDLE = /(?:^|\/)(?:ort[.-][^/]*\.js|three[.-][^/]*\.js|_ds_bundle\.js|react-mini\.js)$|\.min\.js$/;
+// every file, vendored or not. The path-boundary and non-separator classes
+// accept both / and \ so the exclusion also holds on Windows (walkJs joins
+// paths with path.sep, which is \ there).
+const VENDORED_BUNDLE = /(?:^|[/\\])(?:ort[.-][^/\\]*\.js|three[.-][^/\\]*\.js|_ds_bundle\.js|react-mini\.js)$|\.min\.js$/;
 // Third-party CDN hosts that must never appear in shipped code: ORT and Three.js
 // are vendored locally under public/lib and the CSP blocks third-party script
 // origins, so any CDN reference is a regression (CLAUDE.md §1.1, §3).

--- a/scripts/validate.js
+++ b/scripts/validate.js
@@ -125,14 +125,31 @@ const offenders = [];
 // CLAUDE.md §2.1. Any other worklet path — or a non-literal/dynamic module arg
 // — is still rejected, and getUserMedia stays banned outright.
 const ALLOWED_WORKLETS = ['/src/workers/GateProcessor.js', '/src/workers/DeEsserProcessor.js'];
+// Vendored, minified third-party bundles (ORT, Three.js, design-system, React
+// shim). These are trusted build artifacts and a future upstream upgrade could
+// legitimately embed a string that looks like a CDN host, so the CDN-host scan
+// below skips them — but the getUserMedia / dynamic-worklet bans still apply to
+// every file, vendored or not.
+const VENDORED_BUNDLE = /(?:^|\/)(?:ort[.-][^/]*\.js|three[.-][^/]*\.js|_ds_bundle\.js|react-mini\.js)$|\.min\.js$/;
+// Third-party CDN hosts that must never appear in shipped code: ORT and Three.js
+// are vendored locally under public/lib and the CSP blocks third-party script
+// origins, so any CDN reference is a regression (CLAUDE.md §1.1, §3).
+const CDN_HOSTS = /https?:\/\/(?:cdn\.jsdelivr\.net|unpkg\.com|cdnjs\.cloudflare\.com|esm\.sh|cdn\.skypack\.dev|esm\.run|ga\.jspm\.io)/;
 const scanDirs = [
   ['public/app', appDir],
   ['src', path.resolve(__dirname, '..', 'src')],
+  // public/lib holds the vendored ORT/Three bundles; scan it too so a hand-added
+  // CDN loader shim here cannot slip past the "never CDN" guarantee (audit 2026-06-21).
+  ['public/lib', path.resolve(__dirname, '..', 'public/lib')],
 ];
 for (const [label, dir] of scanDirs) {
+  if (!fs.existsSync(dir)) continue;
   for (const f of walkJs(dir)) {
     const src = fs.readFileSync(f, 'utf8');
     if (/getUserMedia\s*\(/.test(src)) offenders.push(`${label}/${path.relative(dir, f)} (getUserMedia)`);
+    if (!VENDORED_BUNDLE.test(f) && CDN_HOSTS.test(src)) {
+      offenders.push(`${label}/${path.relative(dir, f)} (CDN reference)`);
+    }
     if (/audioWorklet\.addModule\s*\(/.test(src)) {
       // Every addModule call must load an allowlisted playback worklet via a
       // string literal; any other path or a dynamic argument is forbidden.

--- a/server/securityHeaders.js
+++ b/server/securityHeaders.js
@@ -2,7 +2,17 @@
  * VoiceIsolate Pro — Security Headers Middleware (Layer 0)
  *
  * Single source of truth for every HTTP security header served by the
- * Express dev server. Production (Vercel) mirrors these in vercel.json.
+ * Express dev server. Production (Vercel) does NOT mirror these 1:1 — it
+ * deliberately *extends* this policy in vercel.json with explicitly-scoped
+ * third-party origins that only exist in the deployed app:
+ *   - script-src adds https://www.gstatic.com (Firebase) and /_vercel/insights/
+ *     (Vercel Analytics).
+ *   - connect-src adds Vercel Blob (*.public.blob.vercel-storage.com),
+ *     Firebase (identitytoolkit / firestore / securetoken) and
+ *     api.revenuecat.com (in-app purchase validation).
+ * Audio still never leaves the device under either policy. Keep the two in
+ * sync intentionally: a new prod origin belongs in vercel.json with a comment,
+ * never silently here.
  *
  * Enforced policy:
  *   - Cross-Origin-Opener-Policy: same-origin   (cross-origin isolation)

--- a/src/pipeline/ExportOrchestrator.js
+++ b/src/pipeline/ExportOrchestrator.js
@@ -20,8 +20,6 @@
  */
 'use strict';
 
-import { SAMPLE_RATE } from '../core/audio-config.js';
-
 /**
  * @typedef {object} ExportOptions
  * @property {'clean'|'noise'|'both'} [stems='clean'] - Which stems to export

--- a/src/pipeline/ProcessingOrchestrator.js
+++ b/src/pipeline/ProcessingOrchestrator.js
@@ -15,7 +15,7 @@
  */
 'use strict';
 
-import { ingestFile, getModelIdsForMode } from './FileIngestion.js';
+import { ingestFile } from './FileIngestion.js';
 import { MODEL_MANIFEST } from '../core/ModelManifest.js';
 
 /**

--- a/src/workers/AudioEncoderWorker.js
+++ b/src/workers/AudioEncoderWorker.js
@@ -101,7 +101,7 @@ async function encodeMP3(channels, sampleRate, bitrate, onProgress) {
   try {
     // Try to import from node_modules (works in bundled environments)
     lamejs = await import('lamejs');
-  } catch (err) {
+  } catch {
     // Fallback: try global (if loaded via script tag)
     if (typeof self.lamejs !== 'undefined') {
       lamejs = self.lamejs;

--- a/tests/engineer-mode-completion.test.js
+++ b/tests/engineer-mode-completion.test.js
@@ -28,8 +28,13 @@ describe('Engineer Mode completion wiring', () => {
     expect(indexHtml).toContain('href="how-it-works.html"');
   });
 
-  test('index.html loads visuals.js and processing-overlay.js modules', () => {
-    expect(indexHtml).toContain("'./visuals.js'");
+  test('index.html loads visuals.js (classic, load-order-sensitive) and the processing-overlay module', () => {
+    // visuals.js is intentionally a classic blocking <script> so VIP_INFERNO_LUT
+    // and the premium init helpers are defined before visuals-bootstrap.js runs
+    // (see the "LOAD ORDER VERIFIED" comments in index.html). It must NOT be
+    // converted to a deferred/dynamic module. processing-overlay.js, by contrast,
+    // is pulled in as a dynamic ES module.
+    expect(indexHtml).toContain('src="./visuals.js"');
     expect(indexHtml).toContain("'./processing-overlay.js'");
   });
 


### PR DESCRIPTION
## Modernization pass (map → harden → reimagine → transform)

The architecture is deliberately frozen by `CLAUDE.md`, so this PR is **all low-risk hardening/hygiene** plus a **proposal-only** reimagine doc. No pipeline, live-mix, or `public/app/` behavior changes.

### 🛡️ Security / hardening
- **Pin transitive CVEs**: `qs>=6.15.2` (GHSA-q8mj-m7cp-5q26) and `ip-address>=10.1.1` (GHSA-v2v4-37r5-5v8g) via `pnpm.overrides`. `pnpm audit --prod` → **0 vulnerabilities**.
- **`validate.js` now scans `public/lib/`** (with an existence guard) and adds an explicit **CDN-host offender check**, so a hand-added CDN loader shim can no longer slip past the "never CDN" guarantee. Vendored minified bundles are excluded from the CDN check (false-positive-safe); the `getUserMedia`/dynamic-worklet bans still apply to every file. *(Verified: a planted `cdn.jsdelivr.net` ref in `public/lib/` is now caught.)*

### 📝 Docs reconciled to actual code
- `.env.example` + `CLAUDE.md §3`: the only signing secret the code reads is `LICENSE_JWT_SECRET` (+ `STRIPE_SECRET_KEY`/`STRIPE_WEBHOOK_SECRET`); webhook idempotency is keyed off the Stripe `event.id`. Removed the unused `ADMIN_SECRET`/`JWT_SECRET`/`WEBHOOK_IDEMPOTENCY_KEY` names.
- `securityHeaders.js`: clarified that prod (`vercel.json`) **extends** — not mirrors — the dev CSP, documenting the scoped analytics/Firebase/Blob/RevenueCat origins.
- Dropped stale `ort-loader.js` references (file already removed) from `public/lib/README.md` and `scripts/setup-ort.js`.

### ✨ Lint to zero (was 23 warnings)
- ESLint now honors the repo's `_`-prefix "intentionally ignored" convention for caught errors (`caughtErrorsIgnorePattern: '^_'`).
- Removed unused imports/vars and converted unused catch bindings to optional-catch in **active code** (`src/`, `landing.js`). `HOP_SIZE` is kept (pinned by tests, marked do-not-remove) with an inline `eslint-disable`.

### ✅ Test
- `engineer-mode-completion`: replaced a stale assertion — now asserts `visuals.js` stays a classic, load-order-sensitive `<script>` (intentional, per the `LOAD ORDER VERIFIED` comments) and `processing-overlay.js` a dynamic module.

### 💡 Reimagine (proposal only, **not implemented**)
- `docs/REIMAGINE-multi-frame-models.md`: phased plan to lift the single-frame STFT ceiling (DeepFilterNet / MDX-Net) **within** the frozen architecture — built on the manifest's existing `waveform`/`complex-spectrogram` strategy seams. Requires a product decision + per-phase PRs before any code.

### Gate status
- `pnpm validate` ✅ · `pnpm lint` ✅ 0 problems · `pnpm test` ✅ **2078 tests pass**
- ⚠️ `tests/transport.test.js` and `tests/video.test.js` fail **identically on the clean branch** — a pre-existing `_ensureBridge` eval-harness crash, unrelated to this PR and left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018nYPnmox8X2botfDFNc5Kj

---
_Generated by [Claude Code](https://claude.ai/code/session_018nYPnmox8X2botfDFNc5Kj)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden dependencies, fix lint across codebase, and add CDN-reference validation
> - Adds minimum version constraints for `qs` (>=6.15.2) and `ip-address` (>=10.1.1) in [package.json](https://github.com/Joker5514/VoiceIsolate-Pro/pull/626/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) to harden transitive dependencies.
> - Adds `caughtErrorsIgnorePattern: '^_'` to `no-unused-vars` across all ESLint overrides in [eslint.config.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/626/files#diff-a32a0887ed9d1d707bbb3b845b7df7fd40e673c47e7b60a3ebd896b68d3b8839), and prefixes or removes unused catch/variable identifiers throughout the codebase to achieve zero lint errors.
> - Extends [scripts/validate.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/626/files#diff-0d7f74eada294edb89d7900af2f1a111706f4a4dd2f0de9504471b9c60508439) to scan `public/lib` and flag CDN host references in non-vendored files, reporting them as `(CDN reference)` offenders.
> - Consolidates server secret documentation to `LICENSE_JWT_SECRET` only, removing references to `ADMIN_SECRET`, `JWT_SECRET`, and `WEBHOOK_IDEMPOTENCY_KEY` in [.env.example](https://github.com/Joker5514/VoiceIsolate-Pro/pull/626/files#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8c) and [CLAUDE.md](https://github.com/Joker5514/VoiceIsolate-Pro/pull/626/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7).
> - Adds [docs/REIMAGINE-multi-frame-models.md](https://github.com/Joker5514/VoiceIsolate-Pro/pull/626/files#diff-51de016f10eee137c47d0b6e51ded517c3aa9afb52cbbaed02a45718b2e422b9) as an unimplemented proposal for multi-frame model separation strategies.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ec8aab4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved file-processing behavior so the process button is available whenever a file is loaded.
  - Made error handling cleaner for unsupported or failed media decoding.
  - Tightened validation to better catch disallowed external web references in shipped code.

- **Documentation**
  - Updated environment and security docs to reflect the current required secrets and production policy details.
  - Added a design note outlining a proposed future audio-model roadmap.

- **Chores**
  - Updated linting and dependency override settings.
  - Cleaned up a few internal references and test expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->