### PR TITLE
fix: guard EngineerModeBridge against use after dispose

### DIFF
--- a/src/pipeline/EngineerModeBridge.js
+++ b/src/pipeline/EngineerModeBridge.js
@@ -150,22 +150,25 @@ export class EngineerModeBridge {
     for (const id of Object.keys(params)) this.applyParam(id, params[id]);
   }
 
-  // ── Transport (delegated straight to the mixer) ──────────────────────────
-  play() { return this.mixer.play(); }
-  pause() { return this.mixer.pause(); }
-  stop() { return this.mixer.stop(); }
-  seek(seconds) { return this.mixer.seek(seconds); }
-  isPlaying() { return this.mixer.isPlaying(); }
-  currentTime() { return this.mixer.currentTime(); }
-  duration() { return this.mixer.duration(); }
-  getAnalyser() { return this.mixer.getAnalyser(); }
+  // ── Transport (delegated to the mixer; no-op safe defaults after dispose) ──
+  play() { return this.mixer ? this.mixer.play() : undefined; }
+  pause() { return this.mixer ? this.mixer.pause() : undefined; }
+  stop() { return this.mixer ? this.mixer.stop() : undefined; }
+  seek(seconds) { return this.mixer ? this.mixer.seek(seconds) : undefined; }
+  isPlaying() { return this.mixer ? this.mixer.isPlaying() : false; }
+  currentTime() { return this.mixer ? this.mixer.currentTime() : 0; }
+  duration() { return this.mixer ? this.mixer.duration() : 0; }
+  getAnalyser() { return this.mixer ? this.mixer.getAnalyser() : null; }
 
-  /** Release the underlying mixer and its AudioContext. */
+  /** Release the underlying mixer and its AudioContext. Idempotent. */
   async dispose() {
     this._loaded = false;
-    if (this.mixer) {
-      await this.mixer.dispose();
+    // Null the reference synchronously before awaiting so a concurrent
+    // dispose()/transport call can't touch a mixer mid-teardown.
+    const mixer = this.mixer;
+    if (mixer) {
       this.mixer = null;
+      await mixer.dispose();
     }
   }
 }

--- a/src/pipeline/EngineerModeBridge.js
+++ b/src/pipeline/EngineerModeBridge.js
@@ -132,6 +132,7 @@ export class EngineerModeBridge {
    * @returns {boolean} true if the id mapped to a control
    */
   applyParam(id, value) {
+    if (!this.mixer) return false;
     const apply = PARAM_MAP[id];
     if (!apply) return false;
     const v = Number(value);
@@ -162,7 +163,10 @@ export class EngineerModeBridge {
   /** Release the underlying mixer and its AudioContext. */
   async dispose() {
     this._loaded = false;
-    await this.mixer.dispose();
+    if (this.mixer) {
+      await this.mixer.dispose();
+      this.mixer = null;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Two small defensive guards in `EngineerModeBridge.js` so the bridge can't be used after disposal:

- **`applyParam()`** — returns `false` when `this.mixer` is null, so a slider/UI event arriving after the bridge was disposed can't call into a closed `AudioContext` / disconnected nodes.
- **`dispose()`** — nulls out `this.mixer` after releasing it, making disposal idempotent and giving `applyParam` something to check.

## Background

These were the two actionable items from a Gemini review on **#625**. That PR (a scaffold revert) is now **superseded** — `main` already removed the Next.js/Prisma scaffold (#624) and modernized further (#626). These two guards are the only delta from #625 not already on `main`, so they're ported here as a focused change branched off `main`. #625 is being closed as obsolete.

## Verification

- ✅ `pnpm validate` — passes
- ✅ `engineer-mode-bridge` suite — 16/16 pass
- ✅ `pnpm lint` — clean for `EngineerModeBridge.js`

## Note (pre-existing, out of scope)

`tests/transport.test.js` and `tests/video.test.js` currently fail to run on `main` with `TypeError: this._ensureBridge is not a function`. This reproduces on pristine `main` (verified via `git stash`) and is **unrelated** to this change — flagging it separately rather than expanding this PR's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDTdnmTiR7V8qMjzLN1Y47)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Guard `EngineerModeBridge` methods against use after dispose
> Adds null-checks for `this.mixer` across all public methods in [EngineerModeBridge.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/627/files#diff-0c8af8284dcc939c28462d30d0ce9c632ed59f06ff8ae90dc0c19687501f4a5a) to prevent errors when methods are called after the bridge is disposed. Each method returns a safe default (`false`, `0`, `null`, or `undefined`) when no mixer is present. The `dispose` method is also made idempotent by nulling `this.mixer` synchronously before awaiting teardown, preventing concurrent calls from operating on a mixer mid-disposal.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7074830.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->