### PR TITLE
test(transport/video): fix _ensureBridge crash from async play()

### DIFF
--- a/tests/transport.test.js
+++ b/tests/transport.test.js
@@ -322,13 +322,17 @@ describe('Transport Methods', () => {
       mockContext.startSpectro = jest.fn();
       mockContext.startFreq = jest.fn();
       mockContext.tickTime = jest.fn();
+      // play() is async and awaits the Live-Mix bridge (CLAUDE.md §1 / app.js
+      // _ensureBridge). Stub it so the partial mock context resolves like the
+      // real prototype method instead of throwing "not a function".
+      mockContext._ensureBridge = jest.fn().mockResolvedValue(null);
     });
 
-    it('returns early when there is no buffer', () => {
+    it('returns early when there is no buffer', async () => {
       mockContext.inputBuffer = null;
       mockContext.outputBuffer = null;
 
-      const result = VoiceIsolatePro.prototype.play.call(mockContext);
+      const result = await VoiceIsolatePro.prototype.play.call(mockContext);
 
       // expect(mockContext.stop).toHaveBeenCalled();
       expect(mockContext.ensureCtx).toHaveBeenCalled();
@@ -337,10 +341,10 @@ describe('Transport Methods', () => {
       expect(mockContext.isPlaying).toBe(false);
     });
 
-    it('sets up play correctly when buffer exists', () => {
+    it('sets up play correctly when buffer exists', async () => {
       mockContext.inputBuffer = { some: 'buffer' };
 
-      VoiceIsolatePro.prototype.play.call(mockContext);
+      await VoiceIsolatePro.prototype.play.call(mockContext);
 
       expect(mockContext.buildLiveChain).toHaveBeenCalledWith(mockContext.inputBuffer);
       expect(mockContext.isPlaying).toBe(true);
@@ -351,18 +355,18 @@ describe('Transport Methods', () => {
       expect(mockContext.tickTime).toHaveBeenCalled();
     });
 
-    it('uses outputBuffer when in processed mode', () => {
+    it('uses outputBuffer when in processed mode', async () => {
       mockContext.inputBuffer = { some: 'buffer' };
       mockContext.outputBuffer = { some: 'processed buffer' };
       mockContext.abMode = 'processed';
 
-      VoiceIsolatePro.prototype.play.call(mockContext);
+      await VoiceIsolatePro.prototype.play.call(mockContext);
 
       expect(mockContext.buildLiveChain).toHaveBeenCalledWith(mockContext.outputBuffer);
       expect(mockContext.dom.tpABLabel.textContent).toBe('Processed');
     });
 
-    it('sets up video playback when isVideo is true', () => {
+    it('sets up video playback when isVideo is true', async () => {
       mockContext.inputBuffer = { some: 'buffer' };
       mockContext.isVideo = true;
       mockContext.playOffset = 42;
@@ -374,7 +378,7 @@ describe('Transport Methods', () => {
         play: jest.fn().mockResolvedValue()
       };
 
-      VoiceIsolatePro.prototype.play.call(mockContext);
+      await VoiceIsolatePro.prototype.play.call(mockContext);
 
       expect(mockContext.dom.videoPlayer.currentTime).toBe(42);
       expect(mockContext.dom.videoPlayer.playbackRate).toBe(1.5);
@@ -390,10 +394,9 @@ describe('Transport Methods', () => {
         play: jest.fn().mockRejectedValue(new Error('play blocked'))
       };
 
-      // Should not throw
-      expect(() => {
-        VoiceIsolatePro.prototype.play.call(mockContext);
-      }).not.toThrow();
+      // The internal videoPlayer.play() rejection is swallowed by .catch(), so
+      // the async play() resolves cleanly rather than rejecting.
+      await expect(VoiceIsolatePro.prototype.play.call(mockContext)).resolves.toBeUndefined();
 
       expect(mockContext.dom.videoPlayer.play).toHaveBeenCalled();
     });

--- a/tests/video-playback.test.js
+++ b/tests/video-playback.test.js
@@ -185,7 +185,13 @@ describe('Video Playback Error Handling', () => {
     vip.startDiagnostics = jest.fn();
     vip.tickTime = jest.fn();
     vip.ensureCtx = jest.fn();
+    vip._updateTransportUI = jest.fn();
+    vip.renderStaticVisuals = jest.fn();
     vip.ctx = { currentTime: 0 };
+    // play() awaits the Live-Mix bridge (CLAUDE.md §1 / app.js _ensureBridge),
+    // which lazily dynamic-imports a module that does not resolve under the test
+    // VM. Stub it so the async flow is deterministic instead of timing-dependent.
+    vip._ensureBridge = jest.fn().mockResolvedValue(null);
 
     // This is the important part: mock play() to return a rejected promise
     // Without the .catch() in the source code, this would cause an UnhandledPromiseRejectionWarning
@@ -195,12 +201,9 @@ describe('Video Playback Error Handling', () => {
     // Spy on the console to see if the error is unhandled (it shouldn't be)
     const consoleSpy = jest.spyOn(console, 'error');
 
-    // Execute
-    // Note: We don't await because play() is synchronous, and the promise rejection happens asynchronously
-    vip.play();
-
-    // Wait a tick for promises to resolve/reject
-    await new Promise(resolve => setTimeout(resolve, 0));
+    // Execute. play() is async (it awaits the bridge), so await it directly —
+    // the internal videoPlayer.play() rejection is swallowed by .catch().
+    await vip.play();
 
     // Assertions
     expect(mockPlay).toHaveBeenCalled();

--- a/tests/video.test.js
+++ b/tests/video.test.js
@@ -32,7 +32,7 @@ describe('VoiceIsolatePro Video Playback', () => {
     VoiceIsolatePro = sandbox.module.exports;
   });
 
-  test('handles video play promise rejection gracefully', () => {
+  test('handles video play promise rejection gracefully', async () => {
     const play = VoiceIsolatePro.prototype.play;
 
     const catchMock = jest.fn();
@@ -41,6 +41,10 @@ describe('VoiceIsolatePro Video Playback', () => {
     const mockThis = {
       stop: jest.fn(),
       ensureCtx: jest.fn(),
+      // play() awaits the Live-Mix bridge (CLAUDE.md §1 / app.js _ensureBridge);
+      // stub it on the partial mock so the async method resolves rather than
+      // throwing "this._ensureBridge is not a function".
+      _ensureBridge: jest.fn().mockResolvedValue(null),
       abMode: 'original',
       inputBuffer: {},
       buildLiveChain: jest.fn(),
@@ -63,7 +67,7 @@ describe('VoiceIsolatePro Video Playback', () => {
       playOffset: 0
     };
 
-    play.call(mockThis);
+    await play.call(mockThis);
 
     expect(playMock).toHaveBeenCalled();
     expect(catchMock).toHaveBeenCalled();


### PR DESCRIPTION
## Fix the pre-existing `_ensureBridge` test-process crash

### Symptom
Running the legacy transport/video suites crashed the **entire Jest process** (not just one test):

```
TypeError: this._ensureBridge is not a function
    at Object.play (evalmachine.<anonymous>:4018)
Node.js v22.22.2   ← whole process exits
```

### Root cause
`public/app/app.js` `play()` is now **`async`** and `await`s `this._ensureBridge()` — the deliberate Live-Mix bridge wait so `rt:true` sliders are live on first play (`CLAUDE.md` §1). The legacy tests predated that change: they invoke `play()` **synchronously** against partial `mockContext`/`mockThis` objects (via `.call()`) that never stub `_ensureBridge`. The resulting `TypeError` became an **unhandled promise rejection**, which Node turns into a process-level crash that takes down the whole run.

### Fix — test-only
`public/app/` is in maintenance freeze and the async bridge-wait is intentional, so the fix is entirely in the tests:

- **`tests/transport.test.js`** — stub `_ensureBridge` on the `play` mock context; make the `play` cases `async` and `await` the now-async method (incl. `resolves.toBeUndefined()` for the rejection-swallowing case).
- **`tests/video.test.js`** — stub `_ensureBridge` on the mock context; `await play.call(...)`.
- **`tests/video-playback.test.js`** — uses a real instance whose `_ensureBridge` does a dynamic `import()` that doesn't resolve under the test VM; mock it for determinism, `await play()` instead of a flaky `setTimeout` tick, and stub the remaining visual hooks.

No production/behavior changes; no architecture changes.

### Verification
- Targeted suites: **3 passed, 29 tests** — no process crash.
- Full suite: **78 suites, 2106 tests passing**.
- `pnpm lint` clean · `pnpm validate` all checks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018nYPnmox8X2botfDFNc5Kj

---
_Generated by [Claude Code](https://claude.ai/code/session_018nYPnmox8X2botfDFNc5Kj)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `_ensureBridge` crash in transport and video playback tests by stubbing async bridge
> Tests for `play()` were crashing because `_ensureBridge` was not stubbed, causing the async `await` inside `play()` to throw a `TypeError`. Three test files are updated:
> - [tests/transport.test.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/628/files#diff-6c91739df35600e543f6ecac3b06c4a2452facf65e2ab6a54cbc88413ca6b255): adds `_ensureBridge` stub in `beforeEach` and converts all `play()` test cases to `async`/`await`.
> - [tests/video-playback.test.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/628/files#diff-4b42f8fd185a2e227e8a4c26b17627acf86e7a4e9accc81494b96524dd00ccf5): stubs `_ensureBridge`, `_updateTransportUI`, and `renderStaticVisuals` in `beforeAll`, and replaces the manual microtask delay with a direct `await vip.play()`.
> - [tests/video.test.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/628/files#diff-6810a725789672f4b3fb56b12fd2b26a67536908ba108fa96f22138cdf2e5693): adds `_ensureBridge` stub on `mockThis` and awaits `play.call(mockThis)` to prevent the `TypeError`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 094a985.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->