### PR TITLE
fix: make deferred download cleanup teardown-safe (fixes flaky tests)

### DIFF
--- a/src/presentation/ExportControls.js
+++ b/src/presentation/ExportControls.js
@@ -451,10 +451,15 @@ export class ExportControls {
     document.body.appendChild(a);
     a.click();
     
-    // Clean up — use a.remove() so this is safe even if DOM is torn down first
+    // Clean up — best-effort and deferred, so it can fire after the page/URL
+    // have been torn down (navigation, or in tests after the DOM is closed and
+    // global.URL removed). Guard each step so a stray timer can't throw an
+    // uncaught error.
     setTimeout(() => {
-      a.remove();
-      URL.revokeObjectURL(url);
+      try { a.remove(); } catch { /* node/document already gone */ }
+      if (typeof URL !== 'undefined' && typeof URL.revokeObjectURL === 'function') {
+        URL.revokeObjectURL(url);
+      }
     }, 100);
   }
 

--- a/src/presentation/ExportControls.js
+++ b/src/presentation/ExportControls.js
@@ -36,6 +36,7 @@ export class ExportControls {
     this.orchestrator = new ExportOrchestrator(mixer);
     
     this._isExporting = false;
+    this._pendingTimers = new Set(); // deferred download-cleanup timers
     this._render();
     this._attachListeners();
   }
@@ -454,19 +455,22 @@ export class ExportControls {
     // Clean up — best-effort and deferred, so it can fire after the page/URL
     // have been torn down (navigation, or in tests after the DOM is closed and
     // global.URL removed). Guard each step so a stray timer can't throw an
-    // uncaught error.
-    setTimeout(() => {
+    // uncaught error, and track the timer so dispose() can cancel it.
+    const timer = setTimeout(() => {
+      this._pendingTimers.delete(timer);
       try { a.remove(); } catch { /* node/document already gone */ }
-      if (typeof URL !== 'undefined' && typeof URL.revokeObjectURL === 'function') {
-        URL.revokeObjectURL(url);
-      }
+      globalThis.URL?.revokeObjectURL?.(url);
     }, 100);
+    this._pendingTimers.add(timer);
   }
 
   /**
    * Clean up resources.
    */
   dispose() {
+    // Cancel any pending deferred download-cleanup timers.
+    for (const timer of this._pendingTimers) clearTimeout(timer);
+    this._pendingTimers.clear();
     if (this.orchestrator) {
       this.orchestrator.dispose();
     }


### PR DESCRIPTION
## Summary

Fixes the intermittent, suite-hopping test failures on `main` (the `TypeError: this._ensureBridge is not a function` and `export-orchestrator` failures flagged during #627).

## Root cause

`ExportControls._downloadBlob()` schedules a 100 ms cleanup timer that called `URL.revokeObjectURL()` **unconditionally**:

```js
setTimeout(() => {
  a.remove();
  URL.revokeObjectURL(url);   // throws if URL is gone
}, 100);
```

When that timer fires after the page/document have been torn down — in production on navigation, or in tests after a suite's `afterEach` runs `delete global.URL` (`tests/export-controls.test.js:84`) — it throws an uncaught `ReferenceError: URL is not defined` from a stray timer.

Because Jest runs suites in a shared worker process, that uncaught async error crashed **whichever suite happened to be running** when the leaked timer fired — which is why the failing suite kept moving (`export-orchestrator`, `transport`, `video`…). Under `--runInBand` it failed **deterministically**.

## Fix

Make the deferred cleanup teardown-safe (the existing comment already claimed this, but only `a.remove()` was covered):
- wrap `a.remove()` in try/catch (the node/document may already be gone),
- only call `URL.revokeObjectURL` when `URL` is still defined.

This is also the correct production behavior — a deferred object-URL revoke must not throw if the page navigated away before it fires.

## Verification

- ✅ `--runInBand` full suite (previously failed **every** time) — now passes
- ✅ Full suite **10/10 runs** green (7 parallel + 3 in-band), 78 suites / 2106 tests
- ✅ `pnpm validate` passes, `pnpm lint` clean for `ExportControls.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDTdnmTiR7V8qMjzLN1Y47)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix teardown-safety of deferred download cleanup in `ExportControls`
> - Tracks pending `setTimeout` handles in `this._pendingTimers` so they can be cancelled on disposal.
> - Guards the cleanup callback against missing DOM nodes (try/catch around `a.remove()`) and absent `URL.revokeObjectURL` (optional chaining via `globalThis.URL?.revokeObjectURL?.(url)`).
> - `ExportControls.dispose` now iterates `_pendingTimers` and calls `clearTimeout` on each before clearing the set, preventing callbacks from firing after teardown.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9cf2089.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->