### PR TITLE
fix(upload): prevent race condition, enable same-file re-upload, add drag-and-drop

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -37,7 +37,7 @@
 
   <main class="main-area">
     <!-- ── STEP 1: Upload ──────────────────────────────────────────────── -->
-    <section class="panel vip-card" aria-labelledby="uploadLabel">
+    <section class="panel vip-card" id="uploadPanel" aria-labelledby="uploadLabel">
       <h2 id="uploadLabel" class="section-label">1 · Upload</h2>
       <p class="hint">Audio or video. Decoded and resampled to 48&nbsp;kHz on your device — nothing is uploaded anywhere.</p>
       <div class="upload-row">

--- a/public/landing.css
+++ b/public/landing.css
@@ -674,6 +674,18 @@ input[type="range"]:disabled { opacity: 0.34; cursor: not-allowed; }
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-sm);
 }
+
+/* ── Drag-and-drop upload panel ───────────────────────────────────────── */
+#uploadPanel {
+  transition: border-color var(--dur-base) var(--ease-out),
+              background var(--dur-base) var(--ease-out);
+}
+.upload-panel--dragging {
+  border-color: var(--border-focus) !important;
+  background: var(--red-wash) !important;
+  outline: 2px dashed var(--border-focus);
+  outline-offset: -3px;
+}
 .vip-card--hover { transition: border-color var(--dur-base) var(--ease-out); }
 .vip-card--hover:hover { border-color: var(--border-red); }
 .vip-card--well { background: var(--well-bg); box-shadow: none; }

--- a/public/landing.css
+++ b/public/landing.css
@@ -686,6 +686,9 @@ input[type="range"]:disabled { opacity: 0.34; cursor: not-allowed; }
   outline: 2px dashed var(--border-focus);
   outline-offset: -3px;
 }
+.upload-panel--dragging * {
+  pointer-events: none;
+}
 .vip-card--hover { transition: border-color var(--dur-base) var(--ease-out); }
 .vip-card--hover:hover { border-color: var(--border-red); }
 .vip-card--well { background: var(--well-bg); box-shadow: none; }

--- a/public/landing.js
+++ b/public/landing.js
@@ -438,7 +438,7 @@ function applyPreset(name) {
  * same file can be re-selected after a failed decode.
  */
 async function ingestFrom(file) {
-  if (!file) return;
+  if (!file || ui.fileInput.disabled) return;
   ui.processBtn.disabled = true;
   ui.fileInput.disabled = true;
   // Show the picture immediately for videos; hide the player for audio files.
@@ -663,12 +663,12 @@ function wireDragAndDrop() {
     zone.classList.add('upload-panel--dragging');
   });
 
-  zone.addEventListener('dragleave', (e) => {
-    // Only remove the class when the pointer leaves the panel entirely,
-    // not when it moves between child elements inside it.
-    if (!zone.contains(e.relatedTarget)) {
-      zone.classList.remove('upload-panel--dragging');
-    }
+  zone.addEventListener('dragleave', () => {
+    // pointer-events:none on .upload-panel--dragging > * (see landing.css)
+    // prevents child elements from absorbing drag events, so dragleave only
+    // fires when the pointer genuinely exits the panel — no relatedTarget
+    // check needed (and relatedTarget is null on Safari anyway).
+    zone.classList.remove('upload-panel--dragging');
   });
 
   zone.addEventListener('drop', (e) => {

--- a/public/landing.js
+++ b/public/landing.js
@@ -63,6 +63,8 @@ const ui = {
   speakersPanel: $('speakersPanel'),
   speakerStatus: $('speakerStatus'),
   speakerCardsGrid: $('speakerCardsGrid'),
+  // Upload panel — used as the drag-and-drop target.
+  uploadPanel: $('uploadPanel'),
 };
 
 let mixer = null;
@@ -429,10 +431,16 @@ function applyPreset(name) {
 
 // ─── Pipeline glue ───────────────────────────────────────────────────────────
 
-async function onFileChosen() {
-  const file = ui.fileInput.files && ui.fileInput.files[0];
+/**
+ * Shared ingestion entry point used by both the file-input change handler and
+ * the drag-and-drop drop handler. Guards against concurrent calls by disabling
+ * the file input for the duration, and resets its value in `finally` so the
+ * same file can be re-selected after a failed decode.
+ */
+async function ingestFrom(file) {
   if (!file) return;
   ui.processBtn.disabled = true;
+  ui.fileInput.disabled = true;
   // Show the picture immediately for videos; hide the player for audio files.
   if (isVideoFile(file)) loadVideo(file); else clearVideo();
   try {
@@ -455,7 +463,17 @@ async function onFileChosen() {
     console.error('[VIP][landing] ingestion failed:', err);
     setStatus(err.message, 'error');
     ingested = null;
+  } finally {
+    // Re-enable the input unconditionally so the user can always pick again.
+    // Resetting the value lets the browser fire 'change' even if the same
+    // file is re-chosen (e.g. after a failed decode or an external edit).
+    ui.fileInput.disabled = false;
+    ui.fileInput.value = '';
   }
+}
+
+async function onFileChosen() {
+  await ingestFrom(ui.fileInput.files && ui.fileInput.files[0]);
 }
 
 // UI-level model chains: run several models in series for maximum isolation.
@@ -634,6 +652,33 @@ function wireTransport() {
   }, 200);
 }
 
+// ─── Drag-and-drop upload ────────────────────────────────────────────────────
+
+function wireDragAndDrop() {
+  const zone = ui.uploadPanel;
+  if (!zone) return;
+
+  zone.addEventListener('dragover', (e) => {
+    e.preventDefault();
+    zone.classList.add('upload-panel--dragging');
+  });
+
+  zone.addEventListener('dragleave', (e) => {
+    // Only remove the class when the pointer leaves the panel entirely,
+    // not when it moves between child elements inside it.
+    if (!zone.contains(e.relatedTarget)) {
+      zone.classList.remove('upload-panel--dragging');
+    }
+  });
+
+  zone.addEventListener('drop', (e) => {
+    e.preventDefault();
+    zone.classList.remove('upload-panel--dragging');
+    const file = e.dataTransfer && e.dataTransfer.files && e.dataTransfer.files[0];
+    if (file) ingestFrom(file);
+  });
+}
+
 // ─── Boot ────────────────────────────────────────────────────────────────────
 
 ui.fileInput.addEventListener('change', onFileChosen);
@@ -642,5 +687,6 @@ ui.presetSelect.addEventListener('change', () => applyPreset(ui.presetSelect.val
 wireReadouts();
 wireTransport();
 wireMuteButtons();
+wireDragAndDrop();
 mountBadge();
 setStatus('Idle — choose a file to begin', '');

--- a/tests/audio-upload-fixes.test.js
+++ b/tests/audio-upload-fixes.test.js
@@ -1,0 +1,109 @@
+/**
+ * VoiceIsolate Pro — Audio Upload Bug-Fix Regression Tests
+ *
+ * Covers three issues fixed in landing.js:
+ *   1. Race condition: fileInput must be disabled during ingestion so that
+ *      rapid file selections cannot start concurrent ingestFile() calls.
+ *   2. Same-file re-upload: fileInput.value is reset after every ingestion
+ *      attempt (success or failure) so the browser fires 'change' again
+ *      when the user re-selects the same file.
+ *   3. Drag-and-drop: the upload panel handles dragover/dragleave/drop so
+ *      users can drop audio/video files directly onto the panel.
+ */
+'use strict';
+
+const fs   = require('fs');
+const path = require('path');
+
+const ROOT  = path.join(__dirname, '..');
+const html  = fs.readFileSync(path.join(ROOT, 'public/index.html'), 'utf8');
+const js    = fs.readFileSync(path.join(ROOT, 'public/landing.js'), 'utf8');
+const css   = fs.readFileSync(path.join(ROOT, 'public/landing.css'), 'utf8');
+
+// ── Bug 1: race condition guard ───────────────────────────────────────────────
+
+describe('Upload race condition guard', () => {
+  test('ingestFrom() disables the file input before awaiting ingestFile()', () => {
+    // The fix: ui.fileInput.disabled = true must appear inside ingestFrom,
+    // before the await, so a second file-picker open is impossible mid-decode.
+    expect(js).toContain('ui.fileInput.disabled = true');
+  });
+
+  test('file input is re-enabled in a finally block (always runs)', () => {
+    // Both success and error paths must restore the input; only a finally
+    // block guarantees this.
+    expect(js).toMatch(/finally\s*\{[^}]*ui\.fileInput\.disabled\s*=\s*false/s);
+  });
+
+  test('onFileChosen() delegates to ingestFrom()', () => {
+    // onFileChosen is now a thin wrapper so drag-and-drop can share the logic.
+    expect(js).toContain('function ingestFrom(');
+    expect(js).toContain('async function onFileChosen()');
+    expect(js).toContain('ingestFrom(ui.fileInput.files');
+  });
+});
+
+// ── Bug 2: same-file re-selection ────────────────────────────────────────────
+
+describe('Same-file re-upload', () => {
+  test("fileInput.value is reset to '' after every ingestion attempt", () => {
+    // Without this reset the browser won't fire 'change' for the same file.
+    expect(js).toContain("ui.fileInput.value = ''");
+  });
+
+  test('the reset happens in the finally block (also runs after errors)', () => {
+    expect(js).toMatch(/finally\s*\{[^}]*ui\.fileInput\.value\s*=\s*''/s);
+  });
+});
+
+// ── Bug 3: drag-and-drop ─────────────────────────────────────────────────────
+
+describe('Drag-and-drop upload', () => {
+  test('index.html gives the upload panel an id so JS can attach listeners', () => {
+    expect(html).toContain('id="uploadPanel"');
+  });
+
+  test('landing.js references uploadPanel in the ui map', () => {
+    expect(js).toContain("uploadPanel: $('uploadPanel')");
+  });
+
+  test('wireDragAndDrop() function is defined', () => {
+    expect(js).toContain('function wireDragAndDrop()');
+  });
+
+  test('wireDragAndDrop() is called at boot', () => {
+    expect(js).toContain('wireDragAndDrop()');
+    // Must appear after the function definition, not just be defined.
+    const defIdx  = js.indexOf('function wireDragAndDrop()');
+    const callIdx = js.lastIndexOf('wireDragAndDrop()');
+    expect(callIdx).toBeGreaterThan(defIdx);
+  });
+
+  test('dragover handler calls preventDefault() (prevents browser navigation)', () => {
+    expect(js).toMatch(/dragover[^}]*preventDefault\(\)/s);
+  });
+
+  test('dragleave handler checks relatedTarget to avoid false exits', () => {
+    expect(js).toContain('e.relatedTarget');
+  });
+
+  test('drop handler calls preventDefault() and reads dataTransfer.files', () => {
+    expect(js).toMatch(/drop[^}]*preventDefault\(\)/s);
+    expect(js).toContain('dataTransfer');
+    expect(js).toContain('dataTransfer.files');
+  });
+
+  test('drop handler passes the file to ingestFrom()', () => {
+    expect(js).toMatch(/drop[^}]*ingestFrom\(file\)/s);
+  });
+
+  test('landing.css defines the dragging visual state', () => {
+    expect(css).toContain('.upload-panel--dragging');
+    expect(css).toContain('#uploadPanel');
+  });
+
+  test('dragging class is added on dragover and removed on drop/dragleave', () => {
+    expect(js).toContain("classList.add('upload-panel--dragging')");
+    expect(js).toContain("classList.remove('upload-panel--dragging')");
+  });
+});

--- a/tests/audio-upload-fixes.test.js
+++ b/tests/audio-upload-fixes.test.js
@@ -29,6 +29,12 @@ describe('Upload race condition guard', () => {
     expect(js).toContain('ui.fileInput.disabled = true');
   });
 
+  test('ingestFrom() bails early when fileInput is already disabled', () => {
+    // Covers drag-and-drop concurrent calls AND drops during onProcess()
+    // (which also sets fileInput.disabled = true).
+    expect(js).toMatch(/if\s*\(!file\s*\|\|\s*ui\.fileInput\.disabled\)/);
+  });
+
   test('file input is re-enabled in a finally block (always runs)', () => {
     // Both success and error paths must restore the input; only a finally
     // block guarantees this.
@@ -83,8 +89,14 @@ describe('Drag-and-drop upload', () => {
     expect(js).toMatch(/dragover[^}]*preventDefault\(\)/s);
   });
 
-  test('dragleave handler checks relatedTarget to avoid false exits', () => {
-    expect(js).toContain('e.relatedTarget');
+  test('dragleave handler does not rely on relatedTarget (unreliable in Safari)', () => {
+    // pointer-events:none on children makes relatedTarget unnecessary.
+    expect(js).not.toContain('e.relatedTarget');
+  });
+
+  test('CSS prevents child elements from absorbing drag events (Safari fix)', () => {
+    expect(css).toContain('.upload-panel--dragging *');
+    expect(css).toContain('pointer-events: none');
   });
 
   test('drop handler calls preventDefault() and reads dataTransfer.files', () => {


### PR DESCRIPTION
## Summary

- **Race condition**: `fileInput` was never disabled during `ingestFile()`, so rapidly picking a second file could start a concurrent decode — whichever finished last set `ingested`, potentially loading the wrong audio
- **Same-file re-upload silently did nothing**: `fileInput.value` was never reset, so the browser skipped the `change` event if the user re-selected the same file (e.g. after a failed decode or after editing the file externally)
- **No drag-and-drop**: users could only upload via the native file picker; dropping a file on the panel was a universal expectation that was missing

## Changes

- **`public/landing.js`**: Extract `ingestFrom(file)` as the shared ingestion entry point. It disables `fileInput` before `await ingestFile()` and resets `fileInput.disabled = false` + `fileInput.value = ''` in a `finally` block. `onFileChosen()` becomes a one-liner that calls `ingestFrom`. New `wireDragAndDrop()` function attaches `dragover`/`dragleave`/`drop` listeners to `#uploadPanel` and forwards the dropped file to `ingestFrom`.
- **`public/index.html`**: Add `id="uploadPanel"` to the upload `<section>` so the JS can attach listeners.
- **`public/landing.css`**: Add `#uploadPanel` transition and `.upload-panel--dragging` class (dashed red border + red wash background) for the drag-over visual.
- **`tests/audio-upload-fixes.test.js`**: 15 static-source regression tests locking all three fixes.

## Test plan

- [ ] All 2121 tests pass (`pnpm test`)
- [ ] `pnpm lint` clean
- [ ] `pnpm validate` all checks pass
- [ ] Upload an audio file via the file picker — decodes and shows Ready status
- [ ] Upload the same file again immediately after — `change` fires and re-ingests
- [ ] Upload a corrupt file, then re-select it — `change` fires for retry
- [ ] Drag an audio/video file onto the upload panel — highlights red, then ingests on drop
- [ ] Drag a non-audio file — ingestion fails with a clear error, panel returns to normal

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Un1KUE4j4ua9T8AS3R6RvK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Un1KUE4j4ua9T8AS3R6RvK)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix race condition in file upload, allow same-file re-upload, and add drag-and-drop to upload panel
> - Adds `ingestFrom(file)` in [landing.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/631/files#diff-be23ec2b8a859b1c83e27ce227d9dd0c367c83c7a8f1a4b104128c882bdb30ab) to centralize ingestion logic; it disables the file input during processing and ignores new requests while busy, preventing concurrent ingestion.
> - Resets `fileInput.value` after each attempt so the same file can be re-selected without a page refresh.
> - Wires drag-and-drop onto `#uploadPanel` via a new `wireDragAndDrop()` function; dragging over triggers a visual highlight state defined in [landing.css](https://github.com/Joker5514/VoiceIsolate-Pro/pull/631/files#diff-0cfc64852aad421bc53736616a19dec3e5b249ad2f2509175077db2f108dbd66), and dropping passes the file to `ingestFrom`.
> - Sets `pointer-events: none` on children of `.upload-panel--dragging` to prevent child elements from absorbing drag events.
> - Adds regression tests in [tests/audio-upload-fixes.test.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/631/files#diff-3b1a26e54abfafe518e3f45ad6d2f79ad9e3b80d877dfbe57cb75b676ce3cdd1) covering the guard logic, finally-block cleanup, and drag-and-drop behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cf21be9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added drag-and-drop support to the upload area for easier file selection.
  * Improved upload feedback with a clear visual dragging state.
* **Bug Fixes**
  * Upload controls now reset correctly after each attempt, helping users re-select the same file if needed.
  * File input behavior is more reliable during uploads, with controls disabled and restored appropriately.
  * Video and audio previews are updated more consistently when a file is chosen or dropped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->