### PR TITLE
🎨 Palette: [UX improvement] Add focus-visible styles to custom UI elements

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Missing Focus Styles for Upload Zone and Tab Buttons
+**Learning:** Custom UI interactive elements, specifically the file drop zone (`.upload-zone`) and visualization tabs (`.tab-btn`), are missing explicit `:focus-visible` styles. Because native inputs are hidden or these elements are built using custom `div`/`button` structures, they lose standard browser focus indicators, making keyboard navigation difficult for screen reader and keyboard users despite having standard ARIA roles implemented.
+**Action:** Always provide explicit `:focus-visible` styles for custom interactive elements (e.g., custom tabs, drop zones) to ensure keyboard accessibility.

--- a/public/app/style.css
+++ b/public/app/style.css
@@ -1075,6 +1075,10 @@ body::after {
   transform: scale(1.01);
 }
 .upload-zone:hover .upload-svg { color: var(--vip-neon-red); filter: drop-shadow(0 0 8px rgba(255,42,61,.55)); }
+.upload-zone:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--bg), 0 0 0 4px var(--vip-neon-red), 0 6px 18px rgba(255,42,61,.25);
+}
 @keyframes vip-upload-breathe {
   0%,100% { opacity: .35; transform: scale(1); }
   50%     { opacity: .75; transform: scale(1.04); }
@@ -1340,6 +1344,10 @@ body::after {
 .tab-btn:hover { color: #fff; background: rgba(0,255,231,.06); }
 .tab-btn.active { color: #fff; background: linear-gradient(180deg, rgba(255,42,61,.10), transparent); }
 .tab-btn.active::after { right: 12%; }
+.tab-btn:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 2px var(--vip-neon-cyan);
+}
 
 /* Visualization canvases — frame glow */
 .viz-canvas {

--- a/src/pipeline/media-decode.js
+++ b/src/pipeline/media-decode.js
@@ -48,7 +48,7 @@ async function decodeWithAudioData(blob) {
   }
 }
 
-function mediaElementTag(kind, blob) {
+function mediaElementTag(kind, _blob) {
   if (kind === 'video') return 'video';
   // .m4a is often mis-tagged video/mp4; always route audio extensions through <audio>.
   return 'audio';


### PR DESCRIPTION
💡 **What:** Added explicit `:focus-visible` styling to custom UI interactive elements (`.tab-btn` and `.upload-zone`). Also fixed an existing unused variable linter warning in `src/pipeline/media-decode.js`.
🎯 **Why:** To improve keyboard accessibility. Because these custom components hide native inputs or use structured divs/buttons, they previously lacked standard browser focus rings, making it difficult for screen reader users and keyboard navigators to identify the currently focused element.
📸 **Before/After:** Before, pressing `Tab` onto the upload zone or tab buttons showed no visual indicator. After, a distinct cyan/red glowing border highlights the element when focused via keyboard.
♿ **Accessibility:** Greatly enhances keyboard navigation support, ensuring users who navigate without a mouse can see where their focus is.

---
*PR created automatically by Jules for task [10486856416551922128](https://jules.google.com/task/10486856416551922128) started by @Joker5514*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visible keyboard focus indicators for upload areas and tab buttons to improve accessibility and keyboard navigation.
* **Documentation**
  * Added an accessibility note highlighting the need for explicit focus styles on custom interactive elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add focus-visible styles to upload zone and tab buttons for keyboard accessibility
> Adds custom `:focus-visible` CSS rules for `.upload-zone` and `.tab-btn` in [style.css](https://github.com/Joker5514/VoiceIsolate-Pro/pull/634/files#diff-35b8006cad11f725a0bc3cee37866f6a39b941ae71d953d622c215dbd1a8d389). Both rules remove the default browser outline and apply box-shadow-based focus rings to provide visible keyboard focus indicators on these custom UI elements.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bddfbd7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->