### PR TITLE
feat: 3-layer audio file handoff bridge (blob URL → opener → sessionStorage)

### DIFF
--- a/public/app/handoff-bridge.js
+++ b/public/app/handoff-bridge.js
@@ -27,11 +27,14 @@ document.addEventListener('DOMContentLoaded', async () => {
       // ── LAYER 2: Blob URL ──────────────────────────────────────────────────
       // fetch() here targets a local blob: URL — never an external server.
       // Revoke immediately after reading to free memory.
-      const response = await fetch(blobUrl);
-      if (!response.ok) throw new Error(`Blob fetch failed: ${response.status}`);
-      const arrayBuffer = await response.arrayBuffer();
-      URL.revokeObjectURL(blobUrl);   // Free memory — blob no longer needed
-      await decodeAndLoadAudio(arrayBuffer, fileName);
+      try {
+        const response = await fetch(blobUrl);
+        if (!response.ok) throw new Error('Blob fetch failed: ' + response.status);
+        const arrayBuffer = await response.arrayBuffer();
+        await decodeAndLoadAudio(arrayBuffer, fileName);
+      } finally {
+        globalThis.URL?.revokeObjectURL?.(blobUrl); // Free memory — blob no longer needed
+      }
 
     } else if (file instanceof File) {
       // ── LAYER 1: File Object via window.opener ─────────────────────────────

--- a/public/app/handoff-bridge.js
+++ b/public/app/handoff-bridge.js
@@ -1,0 +1,194 @@
+// ============================================================
+// VoiceIsolate Pro — Audio File Handoff Bridge
+// public/app/handoff-bridge.js
+//
+// Handles 3-layer file transfer from landing page → /app
+// Priority: Layer 2 (blob URL) → Layer 1 (opener File) → Layer 3 (sessionStorage)
+//
+// Constraints:
+//   - 100% local: fetch() targets only local blob: URLs, never external servers
+//   - Single AudioContext at 48kHz (Demucs v4.1 / BSRNN compatibility)
+//   - Gracefully degrades to drop zone on all failure paths
+// ============================================================
+
+document.addEventListener('DOMContentLoaded', async () => {
+
+  // ── LAYER RESOLUTION ──────────────────────────────────────────────────────
+  const params   = new URLSearchParams(location.search);
+  const blobUrl  = params.get('blob');          // Layer 2 — most reliable post-navigation
+  const fileName = params.get('file') || 'audio-input';
+
+  // Layer 1 — direct File object injected by landing page via window.opener
+  const file = window.opener?.VIP_PENDING_FILE
+             || window.VIP_PENDING_FILE;
+
+  try {
+    if (blobUrl) {
+      // ── LAYER 2: Blob URL ──────────────────────────────────────────────────
+      // fetch() here targets a local blob: URL — never an external server.
+      // Revoke immediately after reading to free memory.
+      const response = await fetch(blobUrl);
+      if (!response.ok) throw new Error(`Blob fetch failed: ${response.status}`);
+      const arrayBuffer = await response.arrayBuffer();
+      URL.revokeObjectURL(blobUrl);   // Free memory — blob no longer needed
+      await decodeAndLoadAudio(arrayBuffer, fileName);
+
+    } else if (file instanceof File) {
+      // ── LAYER 1: File Object via window.opener ─────────────────────────────
+      const arrayBuffer = await file.arrayBuffer();
+      // Null out reference — don't hold the File in opener memory
+      if (window.opener) window.opener.VIP_PENDING_FILE = null;
+      window.VIP_PENDING_FILE = null;
+      await decodeAndLoadAudio(arrayBuffer, file.name);
+
+    } else {
+      // ── LAYER 3: sessionStorage Base64 DataURL fallback ───────────────────
+      const dataUrl = sessionStorage.getItem('vip_pending_data');
+      if (dataUrl) {
+        sessionStorage.removeItem('vip_pending_data'); // Consume-once semantics
+        await loadFromDataUrl(dataUrl);
+      } else {
+        // No file passed via any channel — show the empty drop zone UI
+        showDropZone();
+      }
+    }
+  } catch (err) {
+    console.error('[VIP] Handoff bridge error:', err);
+    showHandoffError(err.message);
+    showDropZone(); // Graceful degradation: let user re-upload manually
+  }
+
+});
+
+// ============================================================
+// decodeAndLoadAudio
+// Single entry point for all ArrayBuffer paths.
+// Initializes AudioContext at 48kHz, runs decodeAudioData,
+// then hands off the AudioBuffer to the 32-stage DSP pipeline.
+// ============================================================
+export async function decodeAndLoadAudio(arrayBuffer, name = 'audio') {
+  updateStatus(`Decoding "${name}"\u2026`, 'loading');
+
+  try {
+    // Initialize shared AudioContext (48kHz matches Demucs v4.1 / BSRNN input)
+    if (!window.vipAudioContext) {
+      window.vipAudioContext = new (window.AudioContext || window.webkitAudioContext)({
+        sampleRate: 48000,
+        latencyHint: 'playback'   // Creator/Forensic default; switch to 'interactive' for Live mode
+      });
+    }
+
+    const ctx = window.vipAudioContext;
+    if (ctx.state === 'suspended') await ctx.resume();
+
+    // decodeAudioData handles MP3, WAV, FLAC, OGG, M4A natively.
+    // Pass arrayBuffer.slice(0) — decodeAudioData detaches (neuters) its input,
+    // so the copy preserves the original for raw waveform rendering if needed.
+    const audioBuffer = await ctx.decodeAudioData(arrayBuffer.slice(0));
+
+    updateStatus(
+      `Loaded: ${name} (${audioBuffer.duration.toFixed(2)}s \u2022 ${audioBuffer.sampleRate}Hz \u2022 ${audioBuffer.numberOfChannels}ch)`,
+      'ready'
+    );
+    updateFileLabel(name);
+
+    // ── Hand off to the 32-stage DSP pipeline ─────────────────────────────
+    // initDSPPipeline is defined in app.js and wires the AudioBuffer into
+    // the AudioWorklet + ML inference chain.
+    if (typeof initDSPPipeline === 'function') {
+      await initDSPPipeline(audioBuffer);
+    } else {
+      console.warn('[VIP] initDSPPipeline not found — DSP pipeline not wired.');
+    }
+
+  } catch (err) {
+    if (err.name === 'EncodingError' || err.message?.includes('decode')) {
+      showHandoffError(`Could not decode "${name}". Supported formats: WAV, MP3, FLAC, OGG, M4A.`);
+    } else {
+      throw err; // Re-throw non-decode errors to outer handler
+    }
+  }
+}
+
+// ============================================================
+// loadFromDataUrl
+// Layer 3 fallback: converts base64 DataURL → ArrayBuffer.
+// Called when sessionStorage holds a vip_pending_data entry.
+// ============================================================
+export async function loadFromDataUrl(dataUrl) {
+  updateStatus('Restoring from session\u2026', 'loading');
+
+  // Extract MIME type to derive a filename with the correct extension
+  const [header, base64] = dataUrl.split(',');
+  const mimeMatch = header.match(/data:([^;]+)/);
+  const mime = mimeMatch ? mimeMatch[1] : 'audio/wav';
+  const ext  = mime.split('/')[1] || 'wav';
+  const name = `session-audio.${ext}`;
+
+  // Decode base64 string → Uint8Array → ArrayBuffer
+  const binaryStr = atob(base64);
+  const bytes     = new Uint8Array(binaryStr.length);
+  for (let i = 0; i < binaryStr.length; i++) {
+    bytes[i] = binaryStr.charCodeAt(i);
+  }
+
+  await decodeAndLoadAudio(bytes.buffer, name);
+}
+
+// ============================================================
+// Landing Page Sender (reference implementation)
+// Place this in your landing page JS, not in the app.
+//
+// Usage: call sendFileToApp(file) from your drop/pick handler.
+// ============================================================
+export async function sendFileToApp(file, appUrl = '/app/index.html') {
+  // Layer 2: Blob URL survives cross-page navigation (same origin)
+  const blobUrl  = URL.createObjectURL(file);
+  const target   = `${appUrl}?blob=${encodeURIComponent(blobUrl)}&file=${encodeURIComponent(file.name)}`;
+
+  // Layer 1: Attach to window so app can read via window.opener
+  window.VIP_PENDING_FILE = file;
+
+  // Layer 3: Encode to sessionStorage for same-tab soft navigations
+  // Guard: only encode files under 4MB to avoid QuotaExceededError
+  // (base64 encoding inflates size ~33%, so 4MB → ~5.3MB — near the 5MB quota)
+  if (file.size < 4 * 1024 * 1024) {
+    await new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload  = () => { sessionStorage.setItem('vip_pending_data', reader.result); resolve(); };
+      reader.onerror = reject;
+      reader.readAsDataURL(file);
+    });
+  }
+
+  // Open the app in a new tab (enables window.opener access for Layer 1)
+  window.open(target, '_blank');
+  // Note: blob URL is revoked by the app after consumption (Layer 2)
+}
+
+// ============================================================
+// UI Helpers — wire to actual DOM element IDs in index.html
+// ============================================================
+function updateStatus(message, state = 'idle') {
+  const el = document.getElementById('status-text');
+  if (!el) return;
+  el.textContent    = message;
+  el.dataset.state  = state;  // CSS can target [data-state="loading"], [data-state="ready"]
+}
+
+function updateFileLabel(name) {
+  const el = document.getElementById('file-name-label');
+  if (el) el.textContent = name;
+}
+
+function showDropZone() {
+  const dz = document.getElementById('drop-zone');
+  if (dz) dz.classList.remove('hidden');
+}
+
+function showHandoffError(msg) {
+  const el = document.getElementById('handoff-error');
+  if (!el) { console.error('[VIP Handoff Error]', msg); return; }
+  el.textContent = `\u26A0 ${msg}`;
+  el.classList.remove('hidden');
+}

--- a/public/app/handoff-bridge.js
+++ b/public/app/handoff-bridge.js
@@ -156,12 +156,23 @@ export async function sendFileToApp(file, appUrl = '/app/index.html') {
   // Guard: only encode files under 4MB to avoid QuotaExceededError
   // (base64 encoding inflates size ~33%, so 4MB → ~5.3MB — near the 5MB quota)
   if (file.size < 4 * 1024 * 1024) {
-    await new Promise((resolve, reject) => {
-      const reader = new FileReader();
-      reader.onload  = () => { sessionStorage.setItem('vip_pending_data', reader.result); resolve(); };
-      reader.onerror = reject;
-      reader.readAsDataURL(file);
-    });
+    try {
+      await new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload  = () => {
+          try {
+            sessionStorage.setItem('vip_pending_data', reader.result);
+            resolve();
+          } catch (err) {
+            reject(err);
+          }
+        };
+        reader.onerror = reject;
+        reader.readAsDataURL(file);
+      });
+    } catch (err) {
+      console.warn('[VIP] Failed to write to sessionStorage (Layer 3 fallback):', err);
+    }
   }
 
   // Open the app in a new tab (enables window.opener access for Layer 1)

--- a/public/app/handoff-bridge.js
+++ b/public/app/handoff-bridge.js
@@ -85,9 +85,8 @@ export async function decodeAndLoadAudio(arrayBuffer, name = 'audio') {
     if (ctx.state === 'suspended') await ctx.resume();
 
     // decodeAudioData handles MP3, WAV, FLAC, OGG, M4A natively.
-    // Pass arrayBuffer.slice(0) — decodeAudioData detaches (neuters) its input,
-    // so the copy preserves the original for raw waveform rendering if needed.
-    const audioBuffer = await ctx.decodeAudioData(arrayBuffer.slice(0));
+    // Pass arrayBuffer directly since we do not need to preserve the original buffer in this handoff flow.
+    const audioBuffer = await ctx.decodeAudioData(arrayBuffer);
 
     updateStatus(
       `Loaded: ${name} (${audioBuffer.duration.toFixed(2)}s \u2022 ${audioBuffer.sampleRate}Hz \u2022 ${audioBuffer.numberOfChannels}ch)`,


### PR DESCRIPTION
## Summary

Adds `public/app/handoff-bridge.js` — the file transport layer that receives an audio file from the landing page and feeds it into the 32-stage DSP pipeline.

## The Problem

`File` objects can't survive a page navigation. This module implements a 3-layer fallback system to guarantee file delivery across all browser entry flows.

## Architecture

| Priority | Layer | Mechanism | Limit |
|---|---|---|---|
| 1st | **Layer 2** | `?blob=` URL param via `URL.createObjectURL()` | Revoked on tab close |
| 2nd | **Layer 1** | `window.opener.VIP_PENDING_FILE` direct File reference | Memory only |
| 3rd | **Layer 3** | `sessionStorage` base64 DataURL fallback | ~4MB practical limit |

## Key Implementation Details

- **`URL.revokeObjectURL()` immediately after `fetch()`** — prevents memory leaks in long sessions
- **`arrayBuffer.slice(0)` before `decodeAudioData()`** — preserves original buffer since `decodeAudioData` detaches its input
- **`AudioContext` at 48kHz** — matches Demucs v4.1 / BSRNN model input expectations; browser auto-resamples lower-rate sources
- **4MB guard on sessionStorage encode** — base64 inflates ~33%, keeping encoded size under the 5MB quota
- **`ctx.resume()` guard** — handles suspended AudioContext on Chrome/Safari
- **Graceful degradation** — all failure paths fall back to the drop zone UI

## Files Changed

- `public/app/handoff-bridge.js` — new file (replaces inline snippet in `app.js`)

## Integration

In `app.js`, import and call:
```js
import { decodeAndLoadAudio } from './handoff-bridge.js';
```

On the landing page, use the exported `sendFileToApp(file)` helper which populates all 3 layers simultaneously before opening the app tab.

## Testing Checklist

- [ ] File arrives via `?blob=` URL (new tab flow)
- [ ] File arrives via `window.opener` (popup flow) 
- [ ] File arrives via sessionStorage (same-tab navigation)
- [ ] Files >4MB skip sessionStorage encode without error
- [ ] Unsupported format shows user-friendly error + drop zone
- [ ] Memory is freed after blob consumption (`revokeObjectURL`)
- [ ] `AudioContext` initializes at 48kHz

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add 3-layer audio file handoff bridge to auto-ingest files on app load
> - Adds [handoff-bridge.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/637/files#diff-676808e86941109e32280590be0df40cb92c271073df2462e674bf6fc41981a9), which resolves an audio file on `DOMContentLoaded` via three fallback layers: blob URL (from URL param), `window.opener.VIP_PENDING_FILE` (cross-tab File reference), and `sessionStorage` DataURL.
> - Decodes the resolved file using a singleton 48kHz `AudioContext` and passes the resulting `AudioBuffer` to `initDSPPipeline`.
> - Includes `sendFileToApp` for landing pages to initiate the handoff: creates a blob URL, stashes the File on `window`, and optionally stores a base64 DataURL in `sessionStorage` for files under 4MB.
> - Shows a drop zone with an inline error message when no file is resolved or decoding fails.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 04af232.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a more flexible file handoff experience from the landing page to the app.
  * Audio files can now be opened through multiple fallback methods, improving reliability across tabs and navigation flows.
  * Added clearer status updates and error handling when a file can’t be loaded, with a fallback drop zone shown to help users recover.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->