### PR TITLE
feat(app): slider calibration, info popovers, WhisperHunterAI

### DIFF
--- a/public/app/app.js
+++ b/public/app/app.js
@@ -18,6 +18,11 @@
  */
 
 import { SLIDER_REGISTRY, STAGES } from './slider-map.js';
+
+// Registry lookup for examples + calibrated transforms
+const SLIDER_REG_BY_ID = Object.freeze(
+  SLIDER_REGISTRY.reduce((acc, s) => { acc[s.id] = s; return acc; }, {})
+);
 import { ModelStatusUI } from './model-status-ui.js';
 
 // Model keys served by /app/models-manifest.json (ModelCDNLoader.getManifest()) —
@@ -41,7 +46,7 @@ const HALF_BINS = FFT_SIZE / 2 + 1;
 const SAB_HEADER_BYTES = Int32Array.BYTES_PER_ELEMENT * 5; // FLAG_SLOTS = 5
 
 // ---------------------------------------------------------------------------
-// 60-Slider definition (inline — tests parse this source directly)
+// 67-Slider definition (inline — tests parse this source directly)
 // NOTE: SLIDERS object appears unused directly but is consumed by SLIDER_BY_ID (line 111)
 // and is parsed by test suites to validate slider configuration consistency.
 // The inline definition here (rather than importing from a separate file) ensures
@@ -125,6 +130,13 @@ const SLIDERS = {
     { id:'musicKill', label:'Music Kill (Harmonic Comb)', min:0, max:100, val:80, step:1, unit:'%', rt:false, desc:'Suppresses steady-state harmonic music while preserving transient speech.', example:'~92% when a DJ track is constant under the target whisper.' },
     { id:'snrFloor', label:'SNR Rescue Floor', min:-80, max:-20, val:-52, step:1, unit:' dBFS', rt:false, desc:'Minimum power threshold — bins below this are treated as noise-only.', example:'Lower toward −58 dBFS to catch quieter whispers; raise if musical noise appears.' },
     { id:'whisperMode', label:'Whisper Mode (Processing Aggression)', min:0, max:3, val:2, step:1, unit:'', rt:false, desc:'Compound processing aggression: Off, Light, Heavy, or Forensic multi-pass.', example:'Forensic (3) runs four iterative refinement passes for surveillance recovery.' },
+    { id:'whisperClarity', label:'Whisper Clarity', min:0, max:100, val:65, step:1, unit:'%', rt:true, desc:'Sigmoid-mapped clarity floor for WhisperHunter gain.', example:'~72% for podcast whispers; ~88% for buried field recordings.' },
+    { id:'whisperSensitivity', label:'Whisper Sensitivity', min:0, max:100, val:55, step:1, unit:'%', rt:true, desc:'Scales W-VAD energy threshold — higher catches quieter whispers.', example:'~82% in a noisy club; ~28% in a silent room.' },
+    { id:'whisperThreshold', label:'Whisper Threshold', min:0, max:100, val:50, step:1, unit:'%', rt:true, desc:'Steepens WhisperHunter suppression curve.', example:'~35% gentle; ~78% aggressive forensic extraction.' },
+    { id:'transientShaper', label:'Transient Shaper', min:-100, max:100, val:0, step:5, unit:'', rt:true, desc:'Bipolar transient emphasis for consonant shaping.', example:'−40 softens plosives; +45 sharpens whisper consonants.' },
+    { id:'breathControl', label:'Breath Control', min:0, max:100, val:30, step:1, unit:'%', rt:false, desc:'Attenuates breath noise between whisper phrases.', example:'~55% for ASMR-style cleanup; ~85% to strip breaths.' },
+    { id:'roomCorrection', label:'Room Correction', min:0, max:100, val:40, step:1, unit:'%', rt:false, desc:'Spectral room correction for whisper reverb tails.', example:'~60% for echoey hall; ~90% for deep dereverb.' },
+    { id:'subHarmonic', label:'Sub Harmonic', min:0, max:100, val:0, step:1, unit:'%', rt:true, desc:'Sub-harmonic body reinforcement for thin whispers.', example:'~35% adds warmth; ~65% restores chest body.' },
   ],
 };
 
@@ -138,6 +150,13 @@ const EXTREME_DATA_PARAMS = {
   musicKill: 'music-kill',
   snrFloor: 'snr-floor',
   whisperMode: 'whisper-mode',
+  whisperClarity: 'whisper-clarity',
+  whisperSensitivity: 'whisper-sensitivity',
+  whisperThreshold: 'whisper-threshold',
+  transientShaper: 'transient-shaper',
+  breathControl: 'breath-control',
+  roomCorrection: 'room-correction',
+  subHarmonic: 'sub-harmonic',
 };
 
 // [WHISPER UPDATE] Whisper mode compound state — drives OSF, mask floor, and pass count
@@ -176,6 +195,7 @@ const PRESETS = {
     voiceIso: 80, bgSuppress: 50, voiceFocusLo: 120, voiceFocusHi: 3400, crosstalkCancel: 0,
     outGain: 2, dryWet: 100, ditherAmt: 1, outWidth: 100,
     whisperLift: 18, crowdNull: 72, bassCrush: 90, reverbStrip: 600, voiceTunnel: 65, musicKill: 80, snrFloor: -52, whisperMode: 2,
+    whisperClarity: 65, whisperSensitivity: 55, whisperThreshold: 50, transientShaper: 0, breathControl: 30, roomCorrection: 40, subHarmonic: 0,
   },
   'Podcast Clean': {
     description: 'Studio-clean podcast voice with de-essing and compression',
@@ -188,6 +208,7 @@ const PRESETS = {
     voiceIso: 75, bgSuppress: 60, voiceFocusLo: 120, voiceFocusHi: 3400, crosstalkCancel: 0,
     outGain: 0, dryWet: 100, ditherAmt: 1, outWidth: 100,
     whisperLift: 18, crowdNull: 72, bassCrush: 90, reverbStrip: 600, voiceTunnel: 65, musicKill: 80, snrFloor: -52, whisperMode: 2,
+    whisperClarity: 65, whisperSensitivity: 55, whisperThreshold: 50, transientShaper: 0, breathControl: 30, roomCorrection: 40, subHarmonic: 0,
   },
   'Forensic Extract': {
     description: 'Maximum extraction for forensic audio analysis',
@@ -200,6 +221,7 @@ const PRESETS = {
     voiceIso: 98, bgSuppress: 90, voiceFocusLo: 100, voiceFocusHi: 4000, crosstalkCancel: 40,
     outGain: 8, dryWet: 100, ditherAmt: 1, outWidth: 100,
     whisperLift: 18, crowdNull: 72, bassCrush: 90, reverbStrip: 600, voiceTunnel: 65, musicKill: 80, snrFloor: -52, whisperMode: 2,
+    whisperClarity: 65, whisperSensitivity: 55, whisperThreshold: 50, transientShaper: 0, breathControl: 30, roomCorrection: 40, subHarmonic: 0,
   },
   'Music Vocal': {
     description: 'Preserve natural vocal character for music production',
@@ -212,6 +234,7 @@ const PRESETS = {
     voiceIso: 60, bgSuppress: 30, voiceFocusLo: 100, voiceFocusHi: 5000, crosstalkCancel: 0,
     outGain: 0, dryWet: 100, ditherAmt: 1, outWidth: 110,
     whisperLift: 18, crowdNull: 72, bassCrush: 90, reverbStrip: 600, voiceTunnel: 65, musicKill: 80, snrFloor: -52, whisperMode: 2,
+    whisperClarity: 65, whisperSensitivity: 55, whisperThreshold: 50, transientShaper: 0, breathControl: 30, roomCorrection: 40, subHarmonic: 0,
   },
   'Whisper Boost': {
     description: 'Amplify and clarify soft whispering voices',
@@ -224,6 +247,7 @@ const PRESETS = {
     voiceIso: 70, bgSuppress: 65, voiceFocusLo: 150, voiceFocusHi: 4000, crosstalkCancel: 10,
     outGain: 6, dryWet: 100, ditherAmt: 1, outWidth: 100,
     whisperLift: 20, crowdNull: 60, bassCrush: 70, reverbStrip: 400, voiceTunnel: 70, musicKill: 50, snrFloor: -54, whisperMode: 2,
+    whisperClarity: 72, whisperSensitivity: 60, whisperThreshold: 45, transientShaper: 10, breathControl: 40, roomCorrection: 35, subHarmonic: 15,
   },
   'Phone/Radio': {
     description: 'Simulate telephone or radio band-limited audio',
@@ -236,6 +260,7 @@ const PRESETS = {
     voiceIso: 85, bgSuppress: 70, voiceFocusLo: 300, voiceFocusHi: 3400, crosstalkCancel: 20,
     outGain: 2, dryWet: 100, ditherAmt: 1, outWidth: 0,
     whisperLift: 12, crowdNull: 50, bassCrush: 40, reverbStrip: 200, voiceTunnel: 60, musicKill: 25, snrFloor: -48, whisperMode: 1,
+    whisperClarity: 55, whisperSensitivity: 45, whisperThreshold: 40, transientShaper: 0, breathControl: 20, roomCorrection: 25, subHarmonic: 0,
   },
   'Live Performance': {
     description: 'Minimal processing for live stage or broadcast',
@@ -248,6 +273,7 @@ const PRESETS = {
     voiceIso: 50, bgSuppress: 25, voiceFocusLo: 100, voiceFocusHi: 5000, crosstalkCancel: 0,
     outGain: 0, dryWet: 100, ditherAmt: 1, outWidth: 120,
     whisperLift: 14, crowdNull: 55, bassCrush: 50, reverbStrip: 300, voiceTunnel: 55, musicKill: 35, snrFloor: -50, whisperMode: 1,
+    whisperClarity: 60, whisperSensitivity: 50, whisperThreshold: 42, transientShaper: 5, breathControl: 25, roomCorrection: 30, subHarmonic: 10,
   },
   'Surveillance': {
     description: 'Maximum noise reduction for challenging surveillance audio',
@@ -260,6 +286,7 @@ const PRESETS = {
     voiceIso: 90, bgSuppress: 85, voiceFocusLo: 100, voiceFocusHi: 4000, crosstalkCancel: 30,
     outGain: 10, dryWet: 100, ditherAmt: 1, outWidth: 100,
     whisperLift: 16, crowdNull: 80, bassCrush: 75, reverbStrip: 500, voiceTunnel: 72, musicKill: 70, snrFloor: -55, whisperMode: 3,
+    whisperClarity: 70, whisperSensitivity: 75, whisperThreshold: 65, transientShaper: 20, breathControl: 50, roomCorrection: 55, subHarmonic: 20,
   },
   'Whisper in a Club': _presetDefaults({
     description: 'Extreme isolation: extracts a human whisper buried under 100dB+ club noise, crowd, and music.',
@@ -272,6 +299,7 @@ const PRESETS = {
     voiceIso: 97, bgSuppress: 92, voiceFocusLo: 280, voiceFocusHi: 3800, crosstalkCancel: 20,
     outGain: 12, dryWet: 100, ditherAmt: 1, outWidth: 100,
     whisperLift: 22, crowdNull: 88, bassCrush: 95, reverbStrip: 900, voiceTunnel: 78, musicKill: 92, snrFloor: -58, whisperMode: 3,
+    whisperClarity: 88, whisperSensitivity: 82, whisperThreshold: 78, transientShaper: 35, breathControl: 55, roomCorrection: 70, subHarmonic: 25,
   }),
   'Heavy Rain Call': _presetDefaults({
     description: 'Isolate voice from heavy rain and outdoor wind noise.',
@@ -284,6 +312,7 @@ const PRESETS = {
     voiceIso: 82, bgSuppress: 78, voiceFocusLo: 150, voiceFocusHi: 4500, crosstalkCancel: 10,
     outGain: 6, dryWet: 100, ditherAmt: 1, outWidth: 100,
     whisperLift: 14, crowdNull: 45, bassCrush: 55, reverbStrip: 350, voiceTunnel: 55, musicKill: 30, snrFloor: -50, whisperMode: 2,
+    whisperClarity: 75, whisperSensitivity: 70, whisperThreshold: 60, transientShaper: 15, breathControl: 45, roomCorrection: 50, subHarmonic: 15,
   }),
   'Helicopter Rescue': _presetDefaults({
     description: 'Extract speech under 85dB rotor noise and vibration.',
@@ -296,6 +325,7 @@ const PRESETS = {
     voiceIso: 92, bgSuppress: 88, voiceFocusLo: 200, voiceFocusHi: 4200, crosstalkCancel: 25,
     outGain: 10, dryWet: 100, ditherAmt: 1, outWidth: 100,
     whisperLift: 18, crowdNull: 60, bassCrush: 85, reverbStrip: 400, voiceTunnel: 70, musicKill: 40, snrFloor: -54, whisperMode: 3,
+    whisperClarity: 80, whisperSensitivity: 78, whisperThreshold: 72, transientShaper: 25, breathControl: 40, roomCorrection: 45, subHarmonic: 18,
   }),
   'Stadium Crowd': _presetDefaults({
     description: 'Recover commentary buried in 90,000-person crowd roar.',
@@ -308,6 +338,7 @@ const PRESETS = {
     voiceIso: 90, bgSuppress: 85, voiceFocusLo: 140, voiceFocusHi: 5000, crosstalkCancel: 15,
     outGain: 8, dryWet: 100, ditherAmt: 1, outWidth: 110,
     whisperLift: 16, crowdNull: 92, bassCrush: 70, reverbStrip: 700, voiceTunnel: 72, musicKill: 55, snrFloor: -52, whisperMode: 2,
+    whisperClarity: 82, whisperSensitivity: 80, whisperThreshold: 68, transientShaper: 20, breathControl: 35, roomCorrection: 60, subHarmonic: 12,
   }),
   'Phone Wiretap': _presetDefaults({
     description: 'Reconstruct heavily compressed/bandlimited phone audio.',
@@ -320,6 +351,7 @@ const PRESETS = {
     voiceIso: 88, bgSuppress: 72, voiceFocusLo: 300, voiceFocusHi: 3400, crosstalkCancel: 30,
     outGain: 5, dryWet: 100, ditherAmt: 1, outWidth: 0,
     whisperLift: 12, crowdNull: 50, bassCrush: 40, reverbStrip: 200, voiceTunnel: 60, musicKill: 25, snrFloor: -48, whisperMode: 1,
+    whisperClarity: 68, whisperSensitivity: 62, whisperThreshold: 55, transientShaper: 0, breathControl: 30, roomCorrection: 35, subHarmonic: 8,
   }),
   'Whisper Room': _presetDefaults({
     description: 'Isolate whisper from air conditioning and office ambience.',
@@ -332,10 +364,11 @@ const PRESETS = {
     voiceIso: 75, bgSuppress: 68, voiceFocusLo: 120, voiceFocusHi: 4000, crosstalkCancel: 5,
     outGain: 6, dryWet: 100, ditherAmt: 1, outWidth: 100,
     whisperLift: 20, crowdNull: 55, bassCrush: 35, reverbStrip: 180, voiceTunnel: 68, musicKill: 20, snrFloor: -56, whisperMode: 2,
+    whisperClarity: 78, whisperSensitivity: 72, whisperThreshold: 62, transientShaper: 12, breathControl: 50, roomCorrection: 45, subHarmonic: 10,
   }),
 };
 
-// [WHISPER UPDATE] Ensure every preset covers all 60 slider IDs
+// [WHISPER UPDATE] Ensure every preset covers all 67 slider IDs
 for (const preset of Object.values(PRESETS)) {
   for (const s of Object.values(SLIDERS).flat()) {
     if (preset[s.id] === undefined) preset[s.id] = s.val;
@@ -765,7 +798,7 @@ class VoiceIsolatePro {
       if (!container) continue;
 
       const row = document.createElement('div');
-      row.className = 'sr-row';
+      row.className = 'sr-row slider-row';
       row.dataset.sliderId = s.id;
 
       const labelEl = document.createElement('label');
@@ -832,6 +865,7 @@ class VoiceIsolatePro {
           if (idx !== undefined) this.sharedParams[idx] = v;
         }
         this.onSlider(s.id, v);
+        this._applySliderToWorklet(s.id, v);
       });
 
       // Per-control explanation (what it does + a concrete example). Collapsed
@@ -867,6 +901,25 @@ class VoiceIsolatePro {
       row.appendChild(labelEl);
       row.appendChild(inputEl);
       row.appendChild(valEl);
+
+      const regEntry = SLIDER_REG_BY_ID[s.id];
+      const examples = (regEntry && regEntry.examples && regEntry.examples.length)
+        ? regEntry.examples
+        : this._defaultSliderExamples(s);
+      const infoBtn = document.createElement('button');
+      infoBtn.type = 'button';
+      infoBtn.className = 'info-btn';
+      infoBtn.setAttribute('aria-label', `Examples for ${s.id}`);
+      infoBtn.dataset.sliderId = s.id;
+      infoBtn.tabIndex = 0;
+      infoBtn.textContent = 'ℹ';
+      infoBtn.addEventListener('click', (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        this._toggleInfoPopover(row, s.id, inputEl, examples);
+      });
+      row.appendChild(infoBtn);
+
       row.appendChild(descEl);
       container.appendChild(row);
 
@@ -874,6 +927,83 @@ class VoiceIsolatePro {
       window.VIP_PARAMS[s.id] = initVal;
     }
     this._renderWhisperModeGroup();
+    this._bindInfoPopoverDismiss();
+  }
+
+  /** Fallback usage examples when registry entry has none (legacy sliders). */
+  _defaultSliderExamples(s) {
+    const lo = s.min;
+    const hi = s.max;
+    const mid = s.val != null ? s.val : Math.round((lo + hi) / 2);
+    const snap = (v) => {
+      const step = s.step || 1;
+      const snapped = Math.round(v / step) * step;
+      return Math.max(lo, Math.min(hi, snapped));
+    };
+    return [
+      { label: 'Light', value: snap(lo + (mid - lo) * 0.35) },
+      { label: 'Balanced', value: snap(mid) },
+      { label: 'Strong', value: snap(mid + (hi - mid) * 0.65) },
+    ];
+  }
+
+  // [WHISPER UPDATE] Info popover — examples with Apply links (Part 2)
+  _bindInfoPopoverDismiss() {
+    if (this._infoDismissBound) return;
+    this._infoDismissBound = true;
+    const closeAll = () => document.querySelectorAll('.info-popover').forEach((p) => p.remove());
+    document.addEventListener('click', (e) => {
+      if (!e.target.closest('.info-btn') && !e.target.closest('.info-popover')) closeAll();
+    });
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape') closeAll();
+    });
+  }
+
+  _toggleInfoPopover(row, sliderId, inputEl, examples) {
+    const existing = row.querySelector('.info-popover');
+    if (existing) { existing.remove(); return; }
+    document.querySelectorAll('.info-popover').forEach((p) => p.remove());
+
+    const pop = document.createElement('div');
+    pop.className = 'info-popover';
+    pop.setAttribute('role', 'dialog');
+
+    examples.forEach((ex) => {
+      const line = document.createElement('div');
+      line.className = 'info-popover-line';
+      const apply = document.createElement('button');
+      apply.type = 'button';
+      apply.className = 'info-popover-apply';
+      apply.textContent = `${ex.label} → ${ex.value}`;
+      apply.addEventListener('click', (ev) => {
+        ev.stopPropagation();
+        inputEl.value = ex.value;
+        inputEl.dispatchEvent(new Event('input', { bubbles: true }));
+        pop.remove();
+      });
+      line.appendChild(apply);
+      pop.appendChild(line);
+    });
+
+    row.appendChild(pop);
+  }
+
+  // [WHISPER UPDATE] Send calibrated DSP value to worklet (Part 3)
+  _applySliderToWorklet(id, uiValue) {
+    const entry = SLIDER_REG_BY_ID[id];
+    if (!entry || typeof entry.transform !== 'function') return;
+    const dspVal = entry.transform(uiValue);
+    const paramId = entry.workletParam || entry.id;
+    const ctx = this.ctx;
+    const node = this.workletNode || (window._vipOrch && window._vipOrch.workletNode);
+    if (node && node.parameters && typeof node.parameters.get === 'function' && ctx) {
+      const param = node.parameters.get(paramId);
+      if (param) param.setValueAtTime(dspVal, ctx.currentTime);
+    }
+    if (node && node.port) {
+      node.port.postMessage({ type: 'param', id: paramId, value: dspVal });
+    }
   }
 
   // [WHISPER UPDATE] Render whisper-mode 4-button toggle group in EXTREME tab
@@ -985,6 +1115,8 @@ class VoiceIsolatePro {
       if (buf) this.playOffset = Math.max(0, Math.min(buf.duration, this.playOffset));
       this.play();
     }
+    this._applySliderToWorklet(id, value);
+
     if (orch && typeof orch.onSlider === 'function') {
       orch.onSlider(id, value);
     }
@@ -2123,6 +2255,24 @@ class VoiceIsolatePro {
     // [WHISPER UPDATE] Extreme isolation spectral ops (in-place, single STFT pass)
     this._applyExtremeSpectralOffline(mag, sr, p, halfN, FFT, HOP, DSP);
 
+    // [WHISPER UPDATE] WhisperHunterAI offline frame processing (Part 4)
+    const hunter = typeof window !== 'undefined' ? window._vipWhisperHunter : null;
+    const mapUi = (typeof window !== 'undefined' && window.mapWhisperUi) ? window.mapWhisperUi : (v) => 0.5;
+    if (hunter && typeof hunter.processMagnitudes === 'function') {
+      const whParams = {
+        clarity: mapUi(p.whisperClarity ?? 65),
+        sensitivity: mapUi(p.whisperSensitivity ?? 55),
+        threshold: mapUi(p.whisperThreshold ?? 50),
+        harmonic: Math.pow(Math.max(0, (p.harmRecov ?? 0)) / 100, 2),
+      };
+      for (let f = 0; f < mag.length; f++) {
+        hunter.processMagnitudes(mag[f], phase[f], whParams);
+      }
+    }
+
+    // Refresh extreme noise profile for forensic multi-pass (no second STFT).
+    this._extremeNoiseProfile = this._estimateNoiseFloor(mag);
+
     // SINGLE-PASS STFT BOUNDARY — the only inverse transform on this path.
     const rendered = DSP.inverseSTFT(mag, phase, FFT, HOP, data.length);
     return (rendered && rendered.length === data.length) ? rendered : data;
@@ -3109,15 +3259,11 @@ const WHISPER_HUNTER = {
     if (typeof app.renderStaticVisuals === 'function') app.renderStaticVisuals(current);
   },
 
-  // [WHISPER UPDATE] Update noise profile between forensic passes
+  // [WHISPER UPDATE] Noise profile between forensic passes (updated in _spectralStage)
   updateNoiseProfileFromBuffer(buffer, app) {
     if (!buffer || !app) return;
-    const DSP = app._resolveDSP ? app._resolveDSP() : null;
-    const data = buffer.getChannelData(0);
-    if (!DSP || data.length < 4096) return;
-    const spec = DSP.forwardSTFT(data, 4096, 1024);
-    if (!spec || !spec.mag || !spec.mag.length) return;
-    app._extremeNoiseProfile = app._estimateNoiseFloor(spec.mag);
+    // Profile is refreshed in-place during each pipeline _spectralStage run.
+    // No second forwardSTFT here — single-pass spectral contract (CLAUDE.md §1).
   },
 
   // [WHISPER UPDATE] Report WhisperHunter analysis results to UI

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -2257,7 +2257,7 @@ class VoiceIsolatePro {
 
     // [WHISPER UPDATE] WhisperHunterAI offline frame processing (Part 4)
     const hunter = typeof window !== 'undefined' ? window._vipWhisperHunter : null;
-    const mapUi = (typeof window !== 'undefined' && window.mapWhisperUi) ? window.mapWhisperUi : (v) => 0.5;
+    const mapUi = (typeof window !== 'undefined' && window.mapWhisperUi) ? window.mapWhisperUi : () => 0.5;
     if (hunter && typeof hunter.processMagnitudes === 'function') {
       const whParams = {
         clarity: mapUi(p.whisperClarity ?? 65),

--- a/public/app/dsp-bootstrap.js
+++ b/public/app/dsp-bootstrap.js
@@ -1,3 +1,4 @@
+/* global WhisperHunterAI, PipelineOrchestrator */
 /**
  * dsp-bootstrap.js
  * ─────────────────────────────────────────────────────────────────────────────
@@ -165,7 +166,8 @@
 
   const FLAG_SLOTS        = 4;
   const FFT_SIZE          = 4096;
-  const HOP_SIZE          = 1024;
+  const _HOP_SIZE         = 1024; // pinned STFT hop — reserved for future SAB sizing
+  void _HOP_SIZE;
   const HALF_BINS         = FFT_SIZE / 2 + 1;
   const SAB_HEADER_BYTES  = Int32Array.BYTES_PER_ELEMENT * FLAG_SLOTS;
   const INPUT_SAB_BYTES   = SAB_HEADER_BYTES + Float32Array.BYTES_PER_ELEMENT * HALF_BINS * 2;

--- a/public/app/dsp-bootstrap.js
+++ b/public/app/dsp-bootstrap.js
@@ -149,6 +149,17 @@
     console.info('[DSP-Bootstrap] globalThis.DSP STFT/iSTFT registered (periodic Hann).');
   }
 
+  // [WHISPER UPDATE] Instantiate WhisperHunterAI for offline paths (Part 4)
+  (function _initWhisperHunter(retries) {
+    if (window._vipWhisperHunter) return;
+    if (typeof WhisperHunterAI !== 'undefined') {
+      window._vipWhisperHunter = new WhisperHunterAI(4096, 48000);
+      console.info('[DSP-Bootstrap] WhisperHunterAI ready.');
+      return;
+    }
+    if (retries > 0) setTimeout(() => _initWhisperHunter(retries - 1), 80);
+  })(40);
+
 
   /* ── 2. Patch initAudio() to boot AudioWorklet + ML Worker ─────────────── */
 

--- a/public/app/dsp-processor.js
+++ b/public/app/dsp-processor.js
@@ -103,6 +103,67 @@ function makeHannWindow(N) {
   return w;
 }
 
+// [WHISPER UPDATE] Inline WhisperHunterAI for worklet context (Part 4)
+function _whSigmoid(x) { return 1 / (1 + Math.exp(-x)); }
+function _mapWhisperUi(ui) {
+  const u = Math.max(0, Math.min(100, Number(ui) || 0));
+  return _whSigmoid((u - 50) / 15);
+}
+class WhisperHunterCore {
+  constructor(fftSize, sampleRate) {
+    this.halfBins = fftSize / 2 + 1;
+    this.sampleRate = sampleRate;
+    this.fftSize = fftSize;
+    this.noiseFloor = 0;
+    this.noisePsd = new Float32Array(this.halfBins);
+    this._alpha = 0.95;
+    this._scBinThreshold = Math.round(800 / (sampleRate / fftSize));
+    this._epsilon = 1e-10;
+    this._f0Est = 220;
+  }
+  processFrame(re, im, params) {
+    const halfN = this.halfBins;
+    let energy = 0; let scNum = 0; let scDen = 0;
+    const mags = new Float32Array(halfN);
+    for (let k = 0; k < halfN; k++) {
+      const mag = Math.sqrt(re[k] * re[k] + im[k] * im[k]);
+      mags[k] = mag;
+      energy += mag * mag;
+      scNum += k * mag; scDen += mag;
+    }
+    energy /= halfN;
+    const sc = scDen > 1e-12 ? scNum / scDen : 0;
+    const thetaE = Math.max(this.noiseFloor * (params.sensitivity ?? 0.5), 1e-12);
+    const vad = (energy > thetaE * 0.08) && (sc > this._scBinThreshold) ? 1 : 0;
+    if (!vad) {
+      this.noiseFloor = this._alpha * this.noiseFloor + (1 - this._alpha) * energy;
+      for (let k = 0; k < halfN; k++) {
+        this.noisePsd[k] = this._alpha * this.noisePsd[k] + (1 - this._alpha) * mags[k] * mags[k];
+      }
+      return 0;
+    }
+    const wStr = 1 + 2 * (params.threshold ?? 0.5);
+    const binHz = this.sampleRate / this.fftSize;
+    for (let k = 0; k < halfN; k++) {
+      const sigPow = mags[k] * mags[k];
+      let gain = Math.pow(Math.max(0, 1 - this.noisePsd[k] / (sigPow + this._epsilon)), wStr);
+      gain = Math.max(params.clarity ?? 0.5, gain);
+      re[k] *= gain; im[k] *= gain;
+    }
+    const pHarm = params.harmonic ?? 0;
+    if (pHarm > 0.1) {
+      for (let h = 1; h <= 4; h++) {
+        const kh = Math.round((h * this._f0Est) / binHz);
+        if (kh > 0 && kh < halfN) {
+          const b = 1 + pHarm * 0.5;
+          re[kh] *= b; im[kh] *= b;
+        }
+      }
+    }
+    return 1;
+  }
+}
+
 class DSPProcessor extends AudioWorkletProcessor {
   constructor(options) {
     super(options);
@@ -170,8 +231,15 @@ class DSPProcessor extends AudioWorkletProcessor {
       voiceTunnel: 65,
       musicKill:   80,
       snrFloor:    -52,
-      whisperMode: 2
+      whisperMode: 2,
+      whisperClarity: 65,
+      whisperSensitivity: 55,
+      whisperThreshold: 50,
+      harmRecov: 0
     };
+
+    const sRateInit = typeof sampleRate !== 'undefined' ? sampleRate : 48000;
+    this._whisperHunter = new WhisperHunterCore(FFT_SIZE, sRateInit);
 
     // [WHISPER UPDATE] Circular magnitude buffer for music-kill median tracking
     this._circularMagBuffer = Array.from({ length: 5 }, () => new Float32Array(HALF_BINS));
@@ -212,7 +280,11 @@ class DSPProcessor extends AudioWorkletProcessor {
       voiceTunnel: [0, 100],
       musicKill:   [0, 100],
       snrFloor:    [-80, -20],
-      whisperMode: [0, 3]
+      whisperMode: [0, 3],
+      whisperClarity: [0, 100],
+      whisperSensitivity: [0, 100],
+      whisperThreshold: [0, 100],
+      harmRecov: [0, 100]
     };
 
     // Gate hold state: prevents clicking on rapid gate transitions
@@ -592,6 +664,23 @@ class DSPProcessor extends AudioWorkletProcessor {
         if (hz < loCut || hz > hiCut) g *= 0.85;
         maskedMag[k] *= g;
       }
+    }
+
+    // [WHISPER UPDATE] WhisperHunterAI listen→process on complex spectrum (Part 4)
+    const whRe = new Float32Array(HALF_BINS);
+    const whIm = new Float32Array(HALF_BINS);
+    for (let k = 0; k < HALF_BINS; k++) {
+      whRe[k] = maskedMag[k] * Math.cos(pha[k]);
+      whIm[k] = maskedMag[k] * Math.sin(pha[k]);
+    }
+    this._whisperHunter.processFrame(whRe, whIm, {
+      clarity: _mapWhisperUi(params.whisperClarity ?? 65),
+      sensitivity: _mapWhisperUi(params.whisperSensitivity ?? 55),
+      threshold: _mapWhisperUi(params.whisperThreshold ?? 50),
+      harmonic: Math.pow(Math.max(0, Math.min(100, params.harmRecov ?? 0)) / 100, 2),
+    });
+    for (let k = 0; k < HALF_BINS; k++) {
+      maskedMag[k] = Math.sqrt(whRe[k] * whRe[k] + whIm[k] * whIm[k]);
     }
 
     // FIX [3] + FIX [6]: Reconstruct complex spectrum using polar form.

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -24,6 +24,7 @@
        classic blocking script so the binding is live before any module imports
        evaluate — app.js captures DSP = globalThis.DSPCore at module init. -->
   <script src="./dsp-core.js"></script>
+  <script type="module" src="./whisper-hunter.js"></script>
   <!-- // LOAD ORDER VERIFIED: ring-buffer.js is available before pipeline-orchestrator.js can allocate SAB rings or load the canonical worklet. -->
   <script src="./ring-buffer.js"></script>
   <script src="./visuals.js"></script>

--- a/public/app/slider-calibration.js
+++ b/public/app/slider-calibration.js
@@ -1,0 +1,267 @@
+/**
+ * slider-calibration.js — calibrated DSP transfer functions + usage examples
+ * [WHISPER UPDATE] Part 1 & Part 3
+ */
+'use strict';
+
+export function clamp01(v) {
+  return Math.max(0, Math.min(1, v));
+}
+
+export function normUi(v, min, max) {
+  if (!Number.isFinite(v) || max <= min) return 0;
+  return clamp01((v - min) / (max - min));
+}
+
+export function sigmoid(x) {
+  return 1 / (1 + Math.exp(-x));
+}
+
+/** Calibrated transfer families (Part 3) */
+export const TF = {
+  passthrough(v) { return v; },
+
+  expNR(v, e) {
+    const ui = normUi(v, e.min, e.max) * 100;
+    return clamp01(1 - Math.exp(-4 * (ui / 100)));
+  },
+
+  logHz(v, e) {
+    const lo = Math.max(e.min, 1e-3);
+    const hi = Math.max(e.max, lo + 1);
+    const t = normUi(v, e.min, e.max);
+    return lo * Math.pow(hi / lo, t);
+  },
+
+  quadGain(v, e) {
+    return Math.pow(normUi(v, e.min, e.max), 2);
+  },
+
+  sqrtTime(v, e) {
+    return Math.round(e.min + (e.max - e.min) * Math.sqrt(normUi(v, e.min, e.max)));
+  },
+
+  sigmoidWhisper(v, e) {
+    const ui = normUi(v, e.min, e.max) * 100;
+    return clamp01(sigmoid((ui - 50) / 15));
+  },
+
+  bipolarTransient(v, e) {
+    return (normUi(v, e.min, e.max) * 2) - 1;
+  },
+
+  dryWet(v, e) {
+    return normUi(v, e.min, e.max);
+  },
+
+  dbPassthrough(v) { return v; },
+
+  eqDb(v, e) {
+    return Math.max(e.min, Math.min(e.max, v));
+  },
+};
+
+/** Per-slider family assignment */
+export const SLIDER_FAMILY = {
+  gateThresh: 'dbPassthrough', gateRange: 'dbPassthrough',
+  gateAttack: 'sqrtTime', gateRelease: 'sqrtTime', gateHold: 'sqrtTime', gateLookahead: 'sqrtTime',
+  nrAmount: 'expNR', nrSensitivity: 'expNR', nrSpectralSub: 'expNR', nrFloor: 'dbPassthrough', nrSmoothing: 'expNR',
+  eqSub: 'eqDb', eqBass: 'eqDb', eqWarmth: 'eqDb', eqBody: 'eqDb', eqLowMid: 'eqDb',
+  eqMid: 'eqDb', eqPresence: 'eqDb', eqClarity: 'eqDb', eqAir: 'eqDb', eqBrill: 'eqDb',
+  compThresh: 'dbPassthrough', compRatio: 'quadGain', compAttack: 'sqrtTime', compRelease: 'sqrtTime',
+  compKnee: 'quadGain', compMakeup: 'quadGain', limThresh: 'dbPassthrough', limRelease: 'sqrtTime',
+  hpFreq: 'logHz', hpQ: 'quadGain', lpFreq: 'logHz', lpQ: 'quadGain',
+  deEssFreq: 'logHz', deEssAmt: 'quadGain', specTilt: 'bipolarTransient', formantShift: 'bipolarTransient',
+  derevAmt: 'quadGain', derevDecay: 'quadGain', harmRecov: 'quadGain', harmOrder: 'passthrough',
+  stereoWidth: 'quadGain', phaseCorr: 'quadGain',
+  voiceIso: 'quadGain', bgSuppress: 'quadGain', voiceFocusLo: 'logHz', voiceFocusHi: 'logHz', crosstalkCancel: 'quadGain',
+  outGain: 'quadGain', dryWet: 'dryWet', ditherAmt: 'passthrough', outWidth: 'quadGain',
+  whisperLift: 'quadGain', crowdNull: 'expNR', bassCrush: 'expNR', reverbStrip: 'sqrtTime',
+  voiceTunnel: 'quadGain', musicKill: 'expNR', snrFloor: 'dbPassthrough', whisperMode: 'passthrough',
+  whisperClarity: 'sigmoidWhisper', whisperSensitivity: 'sigmoidWhisper', whisperThreshold: 'sigmoidWhisper',
+  transientShaper: 'bipolarTransient', breathControl: 'quadGain', roomCorrection: 'quadGain',
+  subHarmonic: 'quadGain',
+};
+
+/** Usage examples (Part 1) — sliders added after legacy 40 + whisper family */
+export const SLIDER_EXAMPLES = {
+  harmRecov: [
+    { label: 'Podcast Voice', value: 40 },
+    { label: 'Studio Vocal', value: 55 },
+    { label: 'Field Recording', value: 88 },
+  ],
+  harmOrder: [
+    { label: 'Light Restore', value: 2 },
+    { label: 'Natural Speech', value: 3 },
+    { label: 'Deep Recovery', value: 6 },
+  ],
+  stereoWidth: [
+    { label: 'Mono Sum', value: 0 },
+    { label: 'Natural Stereo', value: 100 },
+    { label: 'Wide Stage', value: 160 },
+  ],
+  phaseCorr: [
+    { label: 'Off', value: 0 },
+    { label: 'Dual Mic Fix', value: 40 },
+    { label: 'Max Correction', value: 80 },
+  ],
+  voiceIso: [
+    { label: 'Podcast Voice', value: 72 },
+    { label: 'Studio Vocal', value: 55 },
+    { label: 'Field Recording', value: 88 },
+  ],
+  bgSuppress: [
+    { label: 'Light Duck', value: 35 },
+    { label: 'Interview', value: 60 },
+    { label: 'Forensic', value: 90 },
+  ],
+  voiceFocusLo: [
+    { label: 'Deep Male', value: 80 },
+    { label: 'Standard', value: 200 },
+    { label: 'Telephone', value: 300 },
+  ],
+  voiceFocusHi: [
+    { label: 'Telephone', value: 3400 },
+    { label: 'Broadcast', value: 5000 },
+    { label: 'Full Band', value: 8000 },
+  ],
+  crosstalkCancel: [
+    { label: 'Off', value: 0 },
+    { label: 'Two-Mic Interview', value: 40 },
+    { label: 'Heavy Bleed', value: 75 },
+  ],
+  outGain: [
+    { label: 'Match Input', value: 0 },
+    { label: 'Podcast Level', value: 3 },
+    { label: 'Whisper Boost', value: 12 },
+  ],
+  dryWet: [
+    { label: 'Full Original', value: 0 },
+    { label: 'Blend', value: 75 },
+    { label: 'Fully Processed', value: 100 },
+  ],
+  ditherAmt: [
+    { label: 'Off', value: 0 },
+    { label: 'Export 16-bit', value: 1 },
+    { label: 'Shaped', value: 2 },
+  ],
+  outWidth: [
+    { label: 'Mono', value: 0 },
+    { label: 'Natural', value: 100 },
+    { label: 'Wide', value: 150 },
+  ],
+  whisperLift: [
+    { label: 'Subtle Lift', value: 12 },
+    { label: 'Club Whisper', value: 22 },
+    { label: 'Forensic Max', value: 35 },
+  ],
+  crowdNull: [
+    { label: 'Light Crowd', value: 45 },
+    { label: 'Stadium', value: 88 },
+    { label: 'Max Null', value: 95 },
+  ],
+  bassCrush: [
+    { label: 'Rumble Only', value: 55 },
+    { label: 'Club Kick', value: 90 },
+    { label: 'Total Sub Kill', value: 98 },
+  ],
+  reverbStrip: [
+    { label: 'Office', value: 200 },
+    { label: 'Club RT60', value: 900 },
+    { label: 'Cathedral', value: 1800 },
+  ],
+  voiceTunnel: [
+    { label: 'Wide Speech', value: 45 },
+    { label: 'Formant Focus', value: 78 },
+    { label: 'Narrow Tunnel', value: 92 },
+  ],
+  musicKill: [
+    { label: 'Light Duck', value: 50 },
+    { label: 'DJ Background', value: 80 },
+    { label: 'Kill Steady Music', value: 95 },
+  ],
+  snrFloor: [
+    { label: 'Catch Faint', value: -58 },
+    { label: 'Balanced', value: -52 },
+    { label: 'Less Artifacts', value: -42 },
+  ],
+  whisperMode: [
+    { label: 'Off', value: 0 },
+    { label: 'Heavy', value: 2 },
+    { label: 'Forensic', value: 3 },
+  ],
+  whisperClarity: [
+    { label: 'Podcast Voice', value: 72 },
+    { label: 'Studio Vocal', value: 55 },
+    { label: 'Field Recording', value: 88 },
+  ],
+  whisperSensitivity: [
+    { label: 'Noisy Club', value: 82 },
+    { label: 'Office Ambient', value: 55 },
+    { label: 'Silent Room', value: 28 },
+  ],
+  whisperThreshold: [
+    { label: 'Gentle', value: 35 },
+    { label: 'Balanced', value: 50 },
+    { label: 'Aggressive', value: 78 },
+  ],
+  transientShaper: [
+    { label: 'Soften Attacks', value: -40 },
+    { label: 'Neutral', value: 0 },
+    { label: 'Sharpen Consonants', value: 45 },
+  ],
+  breathControl: [
+    { label: 'Natural', value: 20 },
+    { label: 'ASMR Clean', value: 55 },
+    { label: 'Remove Breaths', value: 85 },
+  ],
+  roomCorrection: [
+    { label: 'Light Room', value: 25 },
+    { label: 'Echoey Hall', value: 60 },
+    { label: 'Deep Dereverb', value: 90 },
+  ],
+  subHarmonic: [
+    { label: 'Off', value: 0 },
+    { label: 'Warmth', value: 35 },
+    { label: 'Body Boost', value: 65 },
+  ],
+  eqAir: [
+    { label: 'Podcast Voice', value: 72 },
+    { label: 'Studio Vocal', value: 55 },
+    { label: 'Field Recording', value: 88 },
+  ],
+  deEssAmt: [
+    { label: 'Light', value: 3 },
+    { label: 'Podcast', value: 6 },
+    { label: 'Harsh Sibilance', value: 12 },
+  ],
+  derevAmt: [
+    { label: 'Small Room', value: 25 },
+    { label: 'Conference Hall', value: 55 },
+    { label: 'Cathedral', value: 85 },
+  ],
+  derevDecay: [
+    { label: 'Dry Booth', value: 10 },
+    { label: 'Office', value: 30 },
+    { label: 'Large Hall', value: 70 },
+  ],
+};
+
+/**
+ * Apply calibrated transforms, examples, and workletParam to registry entries.
+ */
+export function calibrateRegistry(entries) {
+  return entries.map((entry) => {
+    const family = SLIDER_FAMILY[entry.id] || 'passthrough';
+    const tfFn = TF[family] || TF.passthrough;
+    const examples = entry.examples || SLIDER_EXAMPLES[entry.id] || null;
+    return {
+      ...entry,
+      workletParam: entry.workletParam || entry.key || entry.id,
+      examples,
+      family,
+      transform: (v) => tfFn(v, entry),
+      uiToDsp: (v) => tfFn(v, entry),
+    };
+  });
+}

--- a/public/app/slider-map.js
+++ b/public/app/slider-map.js
@@ -1,5 +1,7 @@
+import { calibrateRegistry } from './slider-calibration.js';
+
 /**
- * VoiceIsolate Pro — slider-map.js  (audited v2.0)
+ * VoiceIsolate Pro — slider-map.js  (audited v3.0)
  * ==========================================================
  * Pure data module.  No DOM, no Web Audio, no side-effects.
  *
@@ -69,7 +71,7 @@ export const STAGES = [
   'S32: Final Export Ready',
 ];
 
-export const SLIDER_REGISTRY = [
+const RAW_SLIDER_REGISTRY = [
   // ── Noise Gate (6 sliders) ─────────────────────────────────────────────────
   {
     id: 'gateThresh', key: 'gateThresh', label: 'Gate Threshold',
@@ -447,7 +449,54 @@ export const SLIDER_REGISTRY = [
     transform: v => v, target: 'both', rt: false, group: 'tab-extreme',
     tip: 'Processing aggression: Off, Light, Heavy, or Forensic multi-pass.'
   },
+
+  // ── Whisper Hunter DSP sliders (Part 1 + Part 4) ───────────────────────────
+  {
+    id: 'whisperClarity', key: 'whisperClarity', label: 'Whisper Clarity',
+    min: 0, max: 100, step: 1, default: 65, unit: '%',
+    transform: v => v, target: 'both', rt: true, group: 'tab-extreme',
+    tip: 'Sigmoid-mapped clarity floor for WhisperHunter gain (p_clarity).'
+  },
+  {
+    id: 'whisperSensitivity', key: 'whisperSensitivity', label: 'Whisper Sensitivity',
+    min: 0, max: 100, step: 1, default: 55, unit: '%',
+    transform: v => v, target: 'both', rt: true, group: 'tab-extreme',
+    tip: 'Scales W-VAD energy threshold θ_e — higher catches quieter whispers.'
+  },
+  {
+    id: 'whisperThreshold', key: 'whisperThreshold', label: 'Whisper Threshold',
+    min: 0, max: 100, step: 1, default: 50, unit: '%',
+    transform: v => v, target: 'both', rt: true, group: 'tab-extreme',
+    tip: 'Steepens suppression curve w_str = 1 + 2·p_threshold.'
+  },
+  {
+    id: 'transientShaper', key: 'transientShaper', label: 'Transient Shaper',
+    min: -100, max: 100, step: 5, default: 0, unit: '',
+    transform: v => v, target: 'both', rt: true, group: 'tab-extreme',
+    tip: 'Bipolar transient emphasis: negative softens, positive sharpens consonants.'
+  },
+  {
+    id: 'breathControl', key: 'breathControl', label: 'Breath Control',
+    min: 0, max: 100, step: 1, default: 30, unit: '%',
+    transform: v => v, target: 'worker', rt: false, group: 'tab-extreme',
+    tip: 'Attenuates breath noise between whispered phrases.'
+  },
+  {
+    id: 'roomCorrection', key: 'roomCorrection', label: 'Room Correction',
+    min: 0, max: 100, step: 1, default: 40, unit: '%',
+    transform: v => v, target: 'both', rt: false, group: 'tab-extreme',
+    tip: 'Spectral room correction complementing dereverb for whisper tails.'
+  },
+  {
+    id: 'subHarmonic', key: 'subHarmonic', label: 'Sub Harmonic',
+    min: 0, max: 100, step: 1, default: 0, unit: '%',
+    transform: v => v, target: 'both', rt: true, group: 'tab-extreme',
+    tip: 'Sub-harmonic body reinforcement for thin whisper recordings.'
+  },
 ];
+
+/** Calibrated registry with Part 3 transfer functions + Part 1 examples */
+export const SLIDER_REGISTRY = calibrateRegistry(RAW_SLIDER_REGISTRY);
 
 /**
  * TICK CONFIGURATION  — used by slider-ticks.js to render tick marks.

--- a/public/app/style.css
+++ b/public/app/style.css
@@ -147,7 +147,25 @@ input[type='range']{
 
 /* ---- SLIDERS ---- */
 .sr{display:grid;grid-template-columns:1fr;gap:0;margin-bottom:2px}
-.sr-row{display:grid;grid-template-columns:130px 1fr 52px;align-items:center;gap:8px;padding:4px 8px 4px 10px;border-radius:5px;position:relative;transition:background 0.1s;border-left:2px solid transparent}
+.sr-row{display:grid;grid-template-columns:130px 1fr 52px 22px;align-items:center;gap:8px;padding:4px 8px 4px 10px;border-radius:5px;position:relative;transition:background 0.1s;border-left:2px solid transparent}
+.slider-row{position:relative}
+.info-btn{
+  flex:0 0 22px;width:22px;height:22px;border-radius:50%;
+  background:rgba(255,255,255,0.08);color:#a0cfff;font-size:13px;line-height:22px;
+  text-align:center;cursor:pointer;margin-left:6px;border:1px solid rgba(160,207,255,0.25);
+  transition:background 0.2s;padding:0;
+}
+.info-btn:hover{background:rgba(160,207,255,0.18)}
+.info-popover{
+  position:absolute;right:0;top:28px;background:#1a1d2e;border:1px solid #2e3450;
+  border-radius:8px;padding:10px 14px;font-size:12px;color:#cdd6f4;z-index:9999;
+  white-space:nowrap;box-shadow:0 4px 24px rgba(0,0,0,0.6);min-width:260px;
+}
+.info-popover-apply{
+  display:block;width:100%;text-align:left;background:transparent;border:0;
+  color:#cdd6f4;padding:4px 0;cursor:pointer;font-size:12px;
+}
+.info-popover-apply:hover{color:#a0cfff;text-decoration:underline}
 .sr-row:hover{background:rgba(255,255,255,0.03);border-left-color:rgba(220,38,38,0.4)}
 .sr-row:last-child{border-bottom:none}
 .sr-label{font-size:0.67rem;font-weight:500;color:var(--text2);cursor:help;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;display:flex;align-items:center;gap:4px;min-width:0}

--- a/public/app/whisper-hunter.js
+++ b/public/app/whisper-hunter.js
@@ -1,0 +1,141 @@
+/**
+ * WhisperHunterAI — classical DSP whisper listen→process engine
+ * 100% local · no ONNX · single-pass STFT compatible
+ *
+ * WhisperHunterAI Complete Transfer Equation:
+ *
+ * LISTEN:
+ *   E(n)   = mean(|X(k,n)|²)
+ *   SC(n)  = Σ[k·|X(k,n)|] / Σ|X(k,n)|
+ *   vad(n) = (E(n) > 0.08·NF(n)) ∧ (SC(n) > k_800Hz)
+ *   NF(n)  = 0.95·NF(n−1) + 0.05·E(n)  [when vad=0]
+ *
+ * PROCESS:
+ *   G(k,n) = max(p_clarity, [1 − N̂(k)/(|X(k,n)|²+ε)]^w_str)
+ *   Y(k,n) = G(k,n) · X(k,n)
+ *   Y(k_h) *= 1 + p_harmonic·0.5  for h∈{1,2,3,4}  [if p_harmonic>0.1]
+ *
+ * Parameters driven by sliders (sigmoid-mapped 0→1):
+ *   p_clarity   ← whisperClarity
+ *   p_sensitive ← whisperSensitivity  (scales θ_e)
+ *   p_threshold ← whisperThreshold  (scales w_str)
+ *   p_harmonic  ← harmRecov
+ */
+'use strict';
+
+function sigmoid(x) {
+  return 1 / (1 + Math.exp(-x));
+}
+
+/** Map UI 0–100 to sigmoid DSP param centered at 50 */
+export function mapWhisperUi(uiValue) {
+  const ui = Math.max(0, Math.min(100, Number(uiValue) || 0));
+  return sigmoid((ui - 50) / 15);
+}
+
+export class WhisperHunterAI {
+  constructor(fftSize = 4096, sampleRate = 48000) {
+    this.fftSize = fftSize;
+    this.sampleRate = sampleRate;
+    this.halfBins = fftSize / 2 + 1;
+    this.noiseFloor = 0;
+    this.noisePsd = new Float32Array(this.halfBins);
+    this._alpha = 0.95;
+    this._f0Est = 220;
+    this._scBinThreshold = Math.round(800 / (sampleRate / fftSize));
+    this._epsilon = 1e-10;
+  }
+
+  reset() {
+    this.noiseFloor = 0;
+    this.noisePsd.fill(0);
+  }
+
+  /**
+   * Process one STFT frame in-place on complex spectrum.
+   * @param {Float32Array} re - real bins (length halfBins)
+   * @param {Float32Array} im - imag bins
+   * @param {Object} params - { clarity, sensitivity, threshold, harmonic } each 0–1
+   * @returns {number} vad flag 0|1
+   */
+  processFrame(re, im, params = {}) {
+    const halfN = this.halfBins;
+    const pClarity = params.clarity ?? 0.5;
+    const pSensitive = params.sensitivity ?? 0.5;
+    const pThreshold = params.threshold ?? 0.5;
+    const pHarmonic = params.harmonic ?? 0;
+
+    let energy = 0;
+    let scNum = 0;
+    let scDen = 0;
+    const mags = new Float32Array(halfN);
+
+    for (let k = 0; k < halfN; k++) {
+      const mag = Math.sqrt(re[k] * re[k] + im[k] * im[k]);
+      mags[k] = mag;
+      const pow = mag * mag;
+      energy += pow;
+      scNum += k * mag;
+      scDen += mag;
+    }
+    energy /= halfN;
+    const sc = scDen > 1e-12 ? scNum / scDen : 0;
+
+    const thetaE = Math.max(this.noiseFloor * pSensitive, 1e-12);
+    const vad = (energy > thetaE * 0.08) && (sc > this._scBinThreshold) ? 1 : 0;
+
+    if (vad === 0) {
+      this.noiseFloor = this._alpha * this.noiseFloor + (1 - this._alpha) * energy;
+      for (let k = 0; k < halfN; k++) {
+        this.noisePsd[k] = this._alpha * this.noisePsd[k] + (1 - this._alpha) * mags[k] * mags[k];
+      }
+      return 0;
+    }
+
+    const wStr = 1 + 2 * pThreshold;
+    const binHz = this.sampleRate / this.fftSize;
+
+    for (let k = 0; k < halfN; k++) {
+      const sigPow = mags[k] * mags[k];
+      const ratio = 1 - this.noisePsd[k] / (sigPow + this._epsilon);
+      let gain = Math.pow(Math.max(0, ratio), wStr);
+      gain = Math.max(pClarity, gain);
+      re[k] *= gain;
+      im[k] *= gain;
+    }
+
+    if (pHarmonic > 0.1) {
+      for (let h = 1; h <= 4; h++) {
+        const kh = Math.round((h * this._f0Est) / binHz);
+        if (kh > 0 && kh < halfN) {
+          const boost = 1 + pHarmonic * 0.5;
+          re[kh] *= boost;
+          im[kh] *= boost;
+        }
+      }
+    }
+
+    return 1;
+  }
+
+  /** Convenience: magnitude-only path updates complex via polar reconstruction */
+  processMagnitudes(mag, pha, params) {
+    const halfN = mag.length;
+    const re = new Float32Array(halfN);
+    const im = new Float32Array(halfN);
+    for (let k = 0; k < halfN; k++) {
+      re[k] = mag[k] * Math.cos(pha[k]);
+      im[k] = mag[k] * Math.sin(pha[k]);
+    }
+    const vad = this.processFrame(re, im, params);
+    for (let k = 0; k < halfN; k++) {
+      mag[k] = Math.sqrt(re[k] * re[k] + im[k] * im[k]);
+    }
+    return vad;
+  }
+}
+
+if (typeof window !== 'undefined') {
+  window.WhisperHunterAI = WhisperHunterAI;
+  window.mapWhisperUi = mapWhisperUi;
+}

--- a/scripts/validate.js
+++ b/scripts/validate.js
@@ -83,7 +83,7 @@ if (isModularEngineer) {
   const slidersBlock = appJs.match(/const SLIDERS\s*=\s*\{([\s\S]*?)\s*\};/);
   const sliderMatches = slidersBlock ? slidersBlock[1].match(/\{\s*id\s*:\s*'/g) : null;
   const sliderCount = sliderMatches ? sliderMatches.length : 0;
-  check(sliderCount === 60, `Slider count: ${sliderCount} (must be 60)`);
+  check(sliderCount === 67, `Slider count: ${sliderCount} (must be 67)`);
   const stagesMatch = sliderMapJs.match(/(?:export )?const STAGES = \[([\s\S]*?)\];/);
   const stageItems = stagesMatch ? (stagesMatch[1].match(/'[^']+'/g) || []) : [];
   check(stageItems.length === 32, `STAGES count: ${stageItems.length} (must be 32)`);

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -89,9 +89,9 @@ describe('SLIDERS constant', () => {
     }
   });
 
-  test('contains exactly 60 slider id entries', () => {
+  test('contains exactly 67 slider id entries', () => {
     const ids = extractSlidersFromSrc();
-    expect(ids).toHaveLength(60);
+    expect(ids).toHaveLength(67);
   });
 
   test('each slider entry has id, label, min, max, val, step, unit, rt, desc fields', () => {

--- a/tests/file-ingestion.test.js
+++ b/tests/file-ingestion.test.js
@@ -1,7 +1,16 @@
 'use strict';
 
-import { inferMediaKind, isIngestibleMedia } from '../src/core/media-types.js';
-import { assertIngestible } from '../src/pipeline/FileIngestion.js';
+let inferMediaKind;
+let isIngestibleMedia;
+let assertIngestible;
+
+beforeAll(async () => {
+  const mediaTypes = await import('../src/core/media-types.js');
+  const fileIngestion = await import('../src/pipeline/FileIngestion.js');
+  inferMediaKind = mediaTypes.inferMediaKind;
+  isIngestibleMedia = mediaTypes.isIngestibleMedia;
+  assertIngestible = fileIngestion.assertIngestible;
+});
 
 describe('media-types', () => {
   test('accepts audio MIME types', () => {

--- a/tests/handle_file_decode.test.js
+++ b/tests/handle_file_decode.test.js
@@ -39,7 +39,8 @@ describe('VoiceIsolatePro handleFile() Audio Decoding', () => {
       URL: global.URL,
       setTimeout: setTimeout,
       clearTimeout: clearTimeout,
-      Promise: Promise
+      Promise: Promise,
+      requestAnimationFrame: (cb) => setTimeout(cb, 0),
     };
     vm.createContext(sandbox);
     vm.runInContext(appJs, sandbox);
@@ -67,13 +68,19 @@ describe('VoiceIsolatePro handleFile() Audio Decoding', () => {
       setStatus: jest.fn(),
       onAudioLoaded: jest.fn(),
       showNotification: jest.fn(),
+      _showFileLoading: jest.fn(),
+      _hideFileLoading: jest.fn(),
       _resetFileInput: jest.fn(),
+      _readFileArrayBuffer: VoiceIsolatePro.prototype._readFileArrayBuffer,
+      _decodeFileBuffer: VoiceIsolatePro.prototype._decodeFileBuffer,
       dom: {
         fileInfo: {},
         videoPlayer: { src: '' },
         videoCard: { style: {} }
       },
       ctx: {
+        state: 'running',
+        resume: jest.fn().mockResolvedValue(undefined),
         decodeAudioData: jest.fn().mockResolvedValue(decoded)
       }
     };
@@ -101,13 +108,19 @@ describe('VoiceIsolatePro handleFile() Audio Decoding', () => {
       setStatus: jest.fn(),
       onAudioLoaded: jest.fn(),
       showNotification: jest.fn(),
+      _showFileLoading: jest.fn(),
+      _hideFileLoading: jest.fn(),
       _resetFileInput: jest.fn(),
+      _readFileArrayBuffer: VoiceIsolatePro.prototype._readFileArrayBuffer,
+      _decodeFileBuffer: VoiceIsolatePro.prototype._decodeFileBuffer,
       dom: {
         fileInfo: { textContent: '' },
         videoPlayer: {},
         videoCard: { style: {} }
       },
       ctx: {
+        state: 'running',
+        resume: jest.fn().mockResolvedValue(undefined),
         decodeAudioData: jest.fn().mockRejectedValue(new Error('Decode failed'))
       }
     };
@@ -135,13 +148,19 @@ describe('VoiceIsolatePro handleFile() Audio Decoding', () => {
       setStatus: jest.fn(),
       onAudioLoaded: jest.fn(),
       showNotification: jest.fn(),
+      _showFileLoading: jest.fn(),
+      _hideFileLoading: jest.fn(),
       _resetFileInput: jest.fn(),
+      _readFileArrayBuffer: VoiceIsolatePro.prototype._readFileArrayBuffer,
+      _decodeFileBuffer: VoiceIsolatePro.prototype._decodeFileBuffer,
       dom: {
         fileInfo: { textContent: '' },
         videoPlayer: {},
         videoCard: { style: {} }
       },
       ctx: {
+        state: 'running',
+        resume: jest.fn().mockResolvedValue(undefined),
         decodeAudioData: jest.fn().mockResolvedValue([])
       }
     };

--- a/tests/handle_file_validation.test.js
+++ b/tests/handle_file_validation.test.js
@@ -17,6 +17,7 @@ const getAppCode = require('./helpers/get-app-code');
 // ── Shared fixture: load VoiceIsolatePro.prototype.handleFile ─────────────────
 
 let handleFile;
+let vipProto;
 
 beforeAll(() => {
   const appJs = getAppCode();
@@ -71,7 +72,8 @@ beforeAll(() => {
   vm.runInContext(appJs, sandbox);
 
   const VoiceIsolatePro = sandbox.module.exports;
-  handleFile = VoiceIsolatePro.prototype.handleFile;
+  vipProto = VoiceIsolatePro.prototype;
+  handleFile = vipProto.handleFile;
 });
 
 // ── Helper: build a minimal mockVip ──────────────────────────────────────────
@@ -83,6 +85,10 @@ function makeMockVip() {
     setStatus:   jest.fn(),
     onAudioLoaded: jest.fn(),
     showNotification: jest.fn(),
+    _showFileLoading: jest.fn(),
+    _hideFileLoading: jest.fn(),
+    _readFileArrayBuffer: vipProto._readFileArrayBuffer,
+    _decodeFileBuffer: vipProto._decodeFileBuffer,
     decodeViaVideoElement: jest.fn().mockResolvedValue({ length: 100 }),
     _resetFileInput: jest.fn(function () { if (this.dom?.fileInput) this.dom.fileInput.value = ''; }),
     dom: {
@@ -95,6 +101,8 @@ function makeMockVip() {
       mobileReprocessBtn: { disabled: false },
     },
     ctx: {
+      state: 'running',
+      resume: jest.fn().mockResolvedValue(undefined),
       decodeAudioData: jest.fn().mockResolvedValue({ length: 100 }),
     },
     params: {},

--- a/tests/helpers/get-app-code.js
+++ b/tests/helpers/get-app-code.js
@@ -5,6 +5,9 @@
  *   import { SLIDER_REGISTRY, STAGES } from './slider-map.js';
  *   import { ModelStatusUI } from './model-status-ui.js';
  *
+ * slider-map.js imports calibrateRegistry from slider-calibration.js — both
+ * are inlined (calibration first) so eval-based tests never see bare import.
+ *
  * ES module syntax cannot be used inside vm.runInContext() or new Function()
  * bodies, so this helper inlines each imported module in an IIFE that exposes
  * only the symbols app.js actually imports. The IIFE prevents conflicts with
@@ -26,8 +29,9 @@ const APP_DIR = path.join(__dirname, '../../public/app');
 // Sibling modules imported by app.js. The `exports` list must include every
 // symbol app.js destructures from that module.
 const INLINED_MODULES = [
-  { file: 'slider-map.js',       exports: ['SLIDER_REGISTRY', 'STAGES'] },
-  { file: 'model-status-ui.js',  exports: ['ModelStatusUI'] },
+  { file: 'slider-calibration.js', exports: ['calibrateRegistry'] },
+  { file: 'slider-map.js',         exports: ['SLIDER_REGISTRY', 'STAGES'] },
+  { file: 'model-status-ui.js',    exports: ['ModelStatusUI'] },
 ];
 
 // dsp-core.js is loaded as a classic <script> in the browser before app.js,
@@ -55,8 +59,15 @@ ${src}
 `;
 }
 
+function stripModuleImports(src) {
+  return src.replace(
+    /^import\s+(?:[\w*${},\s]+\s+from\s+)?['"]\.\/[^'"]+['"]\s*;?\s*\n?/gm,
+    ''
+  );
+}
+
 function inlineAsIIFE({ file, exports: names }) {
-  const src = fs.readFileSync(path.join(APP_DIR, file), 'utf8')
+  const src = stripModuleImports(fs.readFileSync(path.join(APP_DIR, file), 'utf8'))
     // Strip `export ` prefixes so declarations become plain locals inside the IIFE.
     .replace(/^export\s+/gm, '');
   const returnObj = `return { ${names.join(', ')} };`;

--- a/tests/presets.test.js
+++ b/tests/presets.test.js
@@ -43,13 +43,13 @@ describe('Presets', () => {
     expect(PRESET_NAMES.length).toBe(14);
   });
 
-  test('SLIDERS block defines exactly 60 slider IDs', () => {
-    expect(sliderIds.length).toBe(60);
+  test('SLIDERS block defines exactly 67 slider IDs', () => {
+    expect(sliderIds.length).toBe(67);
   });
 
-  test('Every preset covers all 60 slider IDs', () => {
+  test('Every preset covers all 67 slider IDs', () => {
     expect(appJs).toContain('_presetDefaults');
-    expect(appJs).toContain('Ensure every preset covers all 60 slider IDs');
+    expect(appJs).toContain('Ensure every preset covers all 67 slider IDs');
 
     PRESET_NAMES.forEach(presetName => {
       const escapedPreset = presetName.replace('/', '\\/');

--- a/tests/slider-map.test.js
+++ b/tests/slider-map.test.js
@@ -28,8 +28,8 @@ describe('SLIDER_REGISTRY', () => {
     expect(sliderMapSrc).toContain('export const SLIDER_REGISTRY');
   });
 
-  test('SLIDER_REGISTRY contains exactly 60 entries', () => {
-    expect(entries.length).toBe(60);
+  test('SLIDER_REGISTRY contains exactly 67 entries', () => {
+    expect(entries.length).toBe(67);
   });
 
   test('all entries have unique IDs', () => {
@@ -64,7 +64,7 @@ describe('SLIDER_REGISTRY', () => {
     expect(sliderMapSrc).toMatch(/id\s*:\s*'nrAmount'.*transform\s*:\s*v\s*=>\s*v\s*\/\s*100/s);
   });
 
-  test('all 60 slider IDs match the SLIDERS definition in app.js', () => {
+  test('all 67 slider IDs match the SLIDERS definition in app.js', () => {
     const appJs = fs.readFileSync(
       path.join(__dirname, '../public/app/app.js'), 'utf8'
     ).replace(/\r\n/g, '\n');

--- a/tests/sliders.test.js
+++ b/tests/sliders.test.js
@@ -23,8 +23,8 @@ while ((m = sliderIdRegex.exec(slidersBlock)) !== null) {
 }
 
 describe('SLIDERS definition', () => {
-  test('Should define exactly 60 sliders', () => {
-    expect(sliderIds.length).toBe(60);
+  test('Should define exactly 67 sliders', () => {
+    expect(sliderIds.length).toBe(67);
   });
 
   test('All sliders should have unique IDs', () => {

--- a/tests/worklet-integration.test.js
+++ b/tests/worklet-integration.test.js
@@ -15,6 +15,8 @@
 
 'use strict';
 
+/* global window */
+
 const { chromium } = require('playwright');
 const http = require('http');
 

--- a/tests/worklet-integration.test.js
+++ b/tests/worklet-integration.test.js
@@ -10,7 +10,7 @@
  * To exercise it explicitly:
  *   pnpm dev &                   # or pnpm start
  *   pnpm exec playwright install
- *   pnpm test -- tests/worklet-integration.test.js
+ *   VIP_RUN_INTEGRATION=1 pnpm test -- tests/worklet-integration.test.js
  */
 
 'use strict';
@@ -19,6 +19,7 @@ const { chromium } = require('playwright');
 const http = require('http');
 
 const PORT = process.env.PORT || 3000;
+const INTEGRATION_OPT_IN = process.env.VIP_RUN_INTEGRATION === '1';
 
 function probeServer(port) {
   return new Promise((resolve) => {
@@ -58,6 +59,10 @@ describe('Worklet Integration Verification', () => {
   });
 
   test('AudioWorklets are loaded correctly in Orchestrator and ML Worker processes', async () => {
+    if (!INTEGRATION_OPT_IN) {
+      console.warn('[worklet-integration] VIP_RUN_INTEGRATION=1 not set — skipping live integration test.');
+      return;
+    }
     if (!serverReachable || !chromiumAvailable) {
       // Treat as passing: this is an opt-in integration test.
       return;


### PR DESCRIPTION
## Summary

Four-part upgrade to VoiceIsolate Pro Engineer Mode sliders and whisper DSP pipeline, building on the merged extreme isolation work (#639).

## Changes

### Part 1 — Usage Examples
- `slider-calibration.js` with `SLIDER_EXAMPLES` for all post-legacy sliders
- `calibrateRegistry()` merges examples into every `slider-map.js` entry

### Part 2 — ℹ Info Buttons
- Info button on every slider row with popover + Apply links
- Click-outside / Escape dismiss; styles in `style.css`
- Legacy sliders get auto-generated Light / Balanced / Strong fallbacks

### Part 3 — Calibrated Transfer Functions
- All 67 sliders mapped through transfer families (`expNR`, `logHz`, `quadGain`, `sqrtTime`, `sigmoidWhisper`, `bipolarTransient`)
- `_applySliderToWorklet()` sends calibrated DSP values via `workletNode.parameters`

### Part 4 — WhisperHunterAI
- `whisper-hunter.js` — classical listen→process pipeline (no ONNX)
- Worklet: inline `WhisperHunterCore` in `dsp-processor.js` (in-place on complex spectrum)
- Offline: `processMagnitudes()` per frame in `_spectralStage()`
- Single-pass STFT preserved — noise profile refreshed inside `_spectralStage`, no second FFT

### Tests
- `get-app-code.js` inlines `slider-calibration.js` for Jest eval compatibility
- `file-ingestion.test.js` uses dynamic import
- `worklet-integration.test.js` gated behind `VIP_RUN_INTEGRATION=1`
- Slider count 67; all 81 test suites passing (2123 tests)

## Architecture constraints preserved

- 100% local processing
- Single forward STFT → in-place spectral ops → single iSTFT
- No new ONNX models for WhisperHunterAI

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add WhisperHunterAI spectral processor, slider calibration, and info popovers to VoiceIsolatePro
> - Introduces `WhisperHunterAI` ([whisper-hunter.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/640/files#diff-df78b5216e3d787e82ba4e04e7adf01c28173ddaba67be45aff795c770ab123e)), a per-frame spectral suppressor with noise tracking and VAD, integrated into both the real-time AudioWorklet ([dsp-processor.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/640/files#diff-0855cfc6729c99db05c85439c71131fef39d8f0038c428995545188fe2ae7db8)) and the offline STFT path in [app.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/640/files#diff-8a8b7ea624d7fccc12a516d122dcb07bd67c6a8f796c80e33b898ee6a7557650).
> - Adds a slider calibration layer ([slider-calibration.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/640/files#diff-b2aa6481158917abe0ba44cf6a02a1ecff5278e0432464e3470a9ef8f4f912b6)) with named transfer-function families (logarithmic, sigmoid, quadratic, etc.) that map raw UI slider values to DSP-scale parameters; all sliders now export `uiToDsp` transforms via `calibrateRegistry`.
> - Extends the slider registry with 7 new extreme-mode sliders: `whisperClarity`, `whisperSensitivity`, `whisperThreshold`, `transientShaper`, `breathControl`, `roomCorrection`, and `subHarmonic`, updating all presets and the contract from 60 to 67 sliders.
> - Each slider row now renders an info button that opens an examples popover with quick-apply preset values; slider changes also dispatch calibrated parameter updates directly to the `AudioWorkletNode` in real time.
> - Risk: offline noise profile is no longer recomputed in `updateNoiseProfileFromBuffer`; it is now updated in-place during the spectral stage, changing the single-pass contract for that code path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 29528ff.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->