### PR TITLE
feat(ui): collapse slider hints behind i toggle

### DIFF
--- a/public/app/app.js
+++ b/public/app/app.js
@@ -814,14 +814,6 @@ class VoiceIsolatePro {
         labelEl.appendChild(badge);
       }
 
-      const infoEl = document.createElement('span');
-      infoEl.className = 'sr-info';
-      infoEl.textContent = 'i';
-      infoEl.setAttribute('aria-hidden', 'true');
-      labelEl.appendChild(infoEl);
-      // Full hover/tap tooltip with a concrete example for every control.
-      infoEl.title = (s.desc || '') + (s.example ? ' — Example: ' + s.example : '');
-
       const inputEl = document.createElement('input');
       inputEl.type = 'range';
       inputEl.id = 'sl_' + s.id;
@@ -868,47 +860,43 @@ class VoiceIsolatePro {
         this._applySliderToWorklet(s.id, v);
       });
 
-      // Per-control explanation (what it does + a concrete example). Collapsed
-      // by default; tapping the "i" reveals it. Linked via aria-describedby so
-      // screen readers announce it when the slider is focused.
-      const descEl = document.createElement('div');
-      descEl.className = 'sr-desc';
-      descEl.id = 'desc_' + s.id;
-      const descWhat = document.createElement('span');
-      descWhat.className = 'sr-desc-what';
-      descWhat.textContent = s.desc || '';
-      descEl.appendChild(descWhat);
-      if (s.example) {
-        const exEl = document.createElement('span');
-        exEl.className = 'sr-desc-ex';
-        exEl.innerHTML = '';
-        const exLabel = document.createElement('strong');
-        exLabel.textContent = 'Example: ';
-        exEl.appendChild(exLabel);
-        exEl.appendChild(document.createTextNode(s.example));
-        descEl.appendChild(exEl);
-      }
-      inputEl.setAttribute('aria-describedby', 'desc_' + s.id);
-
-      infoEl.setAttribute('aria-expanded', 'false');
-      const toggleDesc = (e) => {
-        if (e) { e.preventDefault(); e.stopPropagation(); }
-        const open = row.classList.toggle('info-open');
-        infoEl.setAttribute('aria-expanded', String(open));
-      };
-      infoEl.addEventListener('click', toggleDesc);
-
       row.appendChild(labelEl);
       row.appendChild(inputEl);
       row.appendChild(valEl);
 
       const regEntry = SLIDER_REG_BY_ID[s.id];
-      const hintText = (regEntry && regEntry.hint) ? regEntry.hint : '';
+      const hintText = (regEntry && regEntry.hint) ? regEntry.hint : (s.desc || '');
+      let hintPanel = null;
       if (hintText) {
-        const hintEl = document.createElement('span');
-        hintEl.className = 'slider-hint';
-        hintEl.textContent = hintText;
-        row.appendChild(hintEl);
+        const hintBtn = document.createElement('button');
+        hintBtn.type = 'button';
+        hintBtn.className = 'slider-hint-btn';
+        hintBtn.textContent = 'i';
+        hintBtn.setAttribute('aria-label', `Explain ${s.label}`);
+        hintBtn.setAttribute('aria-expanded', 'false');
+        hintBtn.addEventListener('click', (e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          const wasOpen = row.classList.contains('hint-open');
+          document.querySelectorAll('.slider-row.hint-open').forEach((r) => {
+            r.classList.remove('hint-open');
+            const b = r.querySelector('.slider-hint-btn');
+            if (b) b.setAttribute('aria-expanded', 'false');
+          });
+          const open = !wasOpen;
+          if (open) {
+            row.classList.add('hint-open');
+            hintBtn.setAttribute('aria-expanded', 'true');
+          }
+        });
+
+        hintPanel = document.createElement('div');
+        hintPanel.className = 'slider-hint';
+        hintPanel.id = 'hint_' + s.id;
+        hintPanel.textContent = hintText;
+        inputEl.setAttribute('aria-describedby', hintPanel.id);
+
+        row.appendChild(hintBtn);
       }
       const examples = (regEntry && regEntry.examples && regEntry.examples.length)
         ? regEntry.examples
@@ -926,8 +914,8 @@ class VoiceIsolatePro {
         this._toggleInfoPopover(row, s.id, inputEl, examples);
       });
       row.appendChild(infoBtn);
+      if (hintPanel) row.appendChild(hintPanel);
 
-      row.appendChild(descEl);
       container.appendChild(row);
 
       window.VIP_PARAMS = window.VIP_PARAMS || {};
@@ -935,6 +923,25 @@ class VoiceIsolatePro {
     }
     this._renderWhisperModeGroup();
     this._bindInfoPopoverDismiss();
+    this._bindHintDismiss();
+  }
+
+  _bindHintDismiss() {
+    if (this._hintDismissBound) return;
+    this._hintDismissBound = true;
+    const closeAll = () => {
+      document.querySelectorAll('.slider-row.hint-open, .whisper-mode-row.hint-open').forEach((r) => {
+        r.classList.remove('hint-open');
+        const b = r.querySelector('.slider-hint-btn');
+        if (b) b.setAttribute('aria-expanded', 'false');
+      });
+    };
+    document.addEventListener('click', (e) => {
+      if (!e.target.closest('.slider-hint-btn') && !e.target.closest('.slider-hint')) closeAll();
+    });
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape') closeAll();
+    });
   }
 
   /** Fallback usage examples when registry entry has none (legacy sliders). */
@@ -1063,13 +1070,28 @@ class VoiceIsolatePro {
 
     row.appendChild(labelEl);
     row.appendChild(group);
+
     const wmReg = SLIDER_REG_BY_ID.whisperMode;
     if (wmReg && wmReg.hint) {
-      const hintEl = document.createElement('span');
-      hintEl.className = 'slider-hint';
-      hintEl.textContent = wmReg.hint;
-      row.appendChild(hintEl);
+      const hintBtn = document.createElement('button');
+      hintBtn.type = 'button';
+      hintBtn.className = 'slider-hint-btn';
+      hintBtn.textContent = 'i';
+      hintBtn.setAttribute('aria-label', 'Explain Whisper Mode');
+      hintBtn.setAttribute('aria-expanded', 'false');
+      hintBtn.addEventListener('click', (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        const open = row.classList.toggle('hint-open');
+        hintBtn.setAttribute('aria-expanded', String(open));
+      });
+      const hintPanel = document.createElement('div');
+      hintPanel.className = 'slider-hint';
+      hintPanel.textContent = wmReg.hint;
+      row.appendChild(hintBtn);
+      row.appendChild(hintPanel);
     }
+
     panel.insertBefore(row, panel.firstChild);
 
     window.VIP_PARAMS = window.VIP_PARAMS || {};

--- a/public/app/style.css
+++ b/public/app/style.css
@@ -147,14 +147,27 @@ input[type='range']{
 
 /* ---- SLIDERS ---- */
 .sr{display:grid;grid-template-columns:1fr;gap:0;margin-bottom:2px}
-.sr-row{display:grid;grid-template-columns:130px 1fr 52px minmax(0,220px) 22px;align-items:center;gap:8px;padding:4px 8px 4px 10px;border-radius:5px;position:relative;transition:background 0.1s;border-left:2px solid transparent}
+.sr-row{display:grid;grid-template-columns:130px 1fr 52px 22px 22px;align-items:center;gap:8px;padding:4px 8px 4px 10px;border-radius:5px;position:relative;transition:background 0.1s;border-left:2px solid transparent}
+.slider-hint-btn{
+  flex:0 0 22px;width:22px;height:22px;border-radius:50%;
+  background:rgba(255,255,255,0.06);color:var(--dim);font-size:11px;font-weight:700;
+  line-height:22px;text-align:center;cursor:pointer;border:1px solid rgba(255,255,255,0.12);
+  transition:color 0.15s,border-color 0.15s,background 0.15s;padding:0;
+}
+.slider-hint-btn:hover{color:#00f5ff;border-color:rgba(0,245,255,0.5);background:rgba(0,245,255,0.08)}
+.sr-row.hint-open .slider-hint-btn,.whisper-mode-row.hint-open .slider-hint-btn{
+  color:#00f5ff;border-color:rgba(0,245,255,0.6);background:rgba(0,245,255,0.12);
+}
 .slider-hint{
+  grid-column:1 / -1;display:none;margin-top:4px;padding:7px 10px;border-radius:6px;
   font-size:11px;color:var(--text-dim,#888);line-height:1.35;
-  max-width:220px;margin-left:10px;align-self:center;flex-shrink:0;
+  background:rgba(0,245,255,0.05);border:1px solid rgba(0,245,255,0.14);
+}
+.sr-row.hint-open .slider-hint,.whisper-mode-row.hint-open .slider-hint{
+  display:block;animation:vip-desc-in 0.18s ease;
 }
 @media (max-width:900px){
-  .sr-row{grid-template-columns:130px 1fr 52px 22px}
-  .slider-hint{grid-column:2 / -1;max-width:none;margin-left:0;margin-top:2px}
+  .sr-row{grid-template-columns:130px 1fr 52px 22px 22px}
 }
 .slider-row{position:relative}
 .info-btn{
@@ -1492,6 +1505,8 @@ body::after {
 #tab-extreme-group .slider-group-header { color: #a78bfa; }
 #tab-extreme-group.active .slider-group-header { border-bottom-color: #7c3aed; color: #c4b5fd; }
 
+.whisper-mode-row{grid-template-columns:130px 1fr 22px}
+.whisper-mode-row .whisper-mode-group{grid-column:2}
 .whisper-mode-group { display: flex; gap: 4px; margin: 8px 0 14px; width: 100%; }
 .wm-btn {
   flex: 1; padding: 7px 4px; font-size: 0.72em; font-weight: 700;

--- a/public/landing.css
+++ b/public/landing.css
@@ -418,7 +418,7 @@ input[type="file"]:focus { border-color: var(--border-focus); }
 
 .slider-row {
   display: grid;
-  grid-template-columns: 148px 1fr 64px;
+  grid-template-columns: 148px 1fr 64px 22px;
   align-items: center;
   gap: 12px;
   padding: 4px 8px;
@@ -427,6 +427,42 @@ input[type="file"]:focus { border-color: var(--border-focus); }
   transition: background var(--dur-fast) var(--ease-out),
               border-color var(--dur-fast) var(--ease-out);
 }
+.slider-hint-btn {
+  flex: 0 0 22px;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text-dim);
+  font: var(--fw-bold) 11px/22px var(--font-ui);
+  text-align: center;
+  cursor: pointer;
+  border: 1px solid var(--border-strong);
+  padding: 0;
+  transition: color var(--dur-fast), border-color var(--dur-fast), background var(--dur-fast);
+}
+.slider-hint-btn:hover {
+  color: var(--red-400);
+  border-color: rgba(220, 38, 38, 0.45);
+  background: rgba(220, 38, 38, 0.08);
+}
+.slider-row.hint-open .slider-hint-btn {
+  color: var(--red-400);
+  border-color: rgba(220, 38, 38, 0.55);
+  background: rgba(220, 38, 38, 0.12);
+}
+.slider-hint {
+  grid-column: 1 / -1;
+  display: none;
+  margin-top: 2px;
+  padding: 8px 10px;
+  border-radius: var(--radius-sm);
+  font: var(--fw-regular) var(--fs-2xs)/1.35 var(--font-ui);
+  color: var(--text-dim);
+  background: rgba(220, 38, 38, 0.06);
+  border: 1px solid rgba(220, 38, 38, 0.18);
+}
+.slider-row.hint-open .slider-hint { display: block; }
 .slider-row:hover {
   background: var(--hover-fill);
   border-left-color: var(--red-600);
@@ -538,7 +574,7 @@ input[type="range"]:disabled { opacity: 0.34; cursor: not-allowed; }
 
 /* ── Responsive ───────────────────────────────────────────────────────── */
 @media (max-width: 560px) {
-  .slider-row { grid-template-columns: 110px 1fr 50px; }
+  .slider-row { grid-template-columns: 110px 1fr 50px 22px; }
   .time-readout { margin-left: 0; }
   .main-area { padding: 14px 12px 48px; }
 }

--- a/public/landing.js
+++ b/public/landing.js
@@ -18,8 +18,41 @@ import { SpeakerControls } from '/src/presentation/SpeakerControls.js';
 import { LandingVisualizer } from '/src/presentation/LandingVisualizer.js';
 import { getModel } from '/src/core/ModelManifest.js';
 import { MODEL_MANIFEST } from '/src/core/ModelManifest.js';
+import { SLIDER_HINTS } from '/app/slider-map.js';
 
 const $ = (id) => document.getElementById(id);
+
+/** Maps landing slider DOM ids → engineer-mode SLIDER_HINTS keys (or _custom). */
+const LANDING_HINT_MAP = Object.freeze({
+  noiseReductionSlider: 'nrAmount',
+  voiceLevelSlider: '_voiceLevel',
+  volumeSlider: 'outGain',
+  eqLowSlider: 'eqBass',
+  eqHighSlider: 'eqAir',
+  eqLowMidSlider: 'eqLowMid',
+  eqMidSlider: 'eqMid',
+  eqHighMidSlider: 'eqPresence',
+  highpassSlider: 'hpFreq',
+  lowpassSlider: 'lpFreq',
+  compThresholdSlider: 'compThresh',
+  compRatioSlider: 'compRatio',
+  compAttackSlider: 'compAttack',
+  compReleaseSlider: 'compRelease',
+  compKneeSlider: 'compKnee',
+  makeupGainSlider: 'compMakeup',
+  stereoWidthSlider: 'stereoWidth',
+  gateThresholdSlider: 'gateThresh',
+  gateRangeSlider: 'gateRange',
+  gateAttackSlider: 'gateAttack',
+  gateReleaseSlider: 'gateRelease',
+  deEsserFreqSlider: 'deEssFreq',
+  deEsserAmountSlider: '_deEsserPct',
+});
+
+const LANDING_CUSTOM_HINTS = Object.freeze({
+  _voiceLevel: 'Sets how loud the isolated voice sits against the removed noise stem. Raise toward 130% when the voice feels buried after separation.',
+  _deEsserPct: 'Limits how much harsh “S” and “T” sounds are pulled down in the live mix. Raise toward 40% for bright podcast mics; keep near 0% for already-smooth sources.',
+});
 
 const ui = {
   fileInput: $('fileInput'),
@@ -404,6 +437,78 @@ function paintSliderFill(slider) {
   slider.style.setProperty('--pct', `${Math.max(0, Math.min(100, pct))}%`);
 }
 
+function resolveLandingHint(sliderId) {
+  const key = LANDING_HINT_MAP[sliderId];
+  if (!key) return '';
+  if (key.startsWith('_')) return LANDING_CUSTOM_HINTS[key] || '';
+  return SLIDER_HINTS[key] || '';
+}
+
+/** Collapsed hint panels — tap “i” after each value readout to expand. */
+function wireSliderHints() {
+  const grid = document.querySelector('.slider-grid');
+  if (!grid) return;
+
+  grid.querySelectorAll('.slider-row').forEach((row) => {
+    if (row.querySelector('.slider-hint-btn')) return;
+    const input = row.querySelector('input[type="range"]');
+    if (!input) return;
+    const hintText = resolveLandingHint(input.id);
+    if (!hintText) return;
+
+    const hintBtn = document.createElement('button');
+    hintBtn.type = 'button';
+    hintBtn.className = 'slider-hint-btn';
+    hintBtn.textContent = 'i';
+    hintBtn.setAttribute('aria-label', `Explain ${row.querySelector('label')?.textContent || input.id}`);
+    hintBtn.setAttribute('aria-expanded', 'false');
+
+    const hintPanel = document.createElement('div');
+    hintPanel.className = 'slider-hint';
+    hintPanel.id = `landing_hint_${input.id}`;
+    hintPanel.textContent = hintText;
+    input.setAttribute('aria-describedby', hintPanel.id);
+
+    hintBtn.addEventListener('click', (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      const wasOpen = row.classList.contains('hint-open');
+      grid.querySelectorAll('.slider-row.hint-open').forEach((r) => {
+        r.classList.remove('hint-open');
+        const b = r.querySelector('.slider-hint-btn');
+        if (b) b.setAttribute('aria-expanded', 'false');
+      });
+      if (!wasOpen) {
+        row.classList.add('hint-open');
+        hintBtn.setAttribute('aria-expanded', 'true');
+      }
+    });
+
+    row.appendChild(hintBtn);
+    row.appendChild(hintPanel);
+  });
+
+  if (!grid.dataset.hintDismissBound) {
+    grid.dataset.hintDismissBound = '1';
+    document.addEventListener('click', (e) => {
+      if (e.target.closest('.slider-hint-btn') || e.target.closest('.slider-hint')) return;
+      grid.querySelectorAll('.slider-row.hint-open').forEach((r) => {
+        r.classList.remove('hint-open');
+        const b = r.querySelector('.slider-hint-btn');
+        if (b) b.setAttribute('aria-expanded', 'false');
+      });
+    });
+    document.addEventListener('keydown', (e) => {
+      if (e.key !== 'Escape') return;
+      grid.querySelectorAll('.slider-row.hint-open').forEach((r) => {
+        r.classList.remove('hint-open');
+        const b = r.querySelector('.slider-hint-btn');
+        if (b) b.setAttribute('aria-expanded', 'false');
+      });
+    });
+  }
+}
+
 function wireReadouts() {
   for (const [sliderId, valId, fmt] of READOUTS) {
     const slider = $(sliderId);
@@ -756,6 +861,7 @@ window.addEventListener('unhandledrejection', (event) => {
 ui.processBtn.addEventListener('click', onProcess);
 ui.presetSelect.addEventListener('change', () => applyPreset(ui.presetSelect.value));
 wireReadouts();
+wireSliderHints();
 wireTransport();
 wireMuteButtons();
 wireDragAndDrop();


### PR DESCRIPTION
## Summary

Collapses inline slider explanations behind an **i** button on both Engineer Mode and the landing page.

## Changes

### Engineer Mode (`public/app/`)
- Hints hidden by default in a `.slider-hint` panel (full-width row expand)
- `.slider-hint-btn` (i) after value readout toggles `.hint-open`
- ℹ examples popover unchanged
- Click-outside + Escape dismiss
- Whisper Mode row gets the same pattern

### Landing page (`public/`)
- `wireSliderHints()` injects i button + collapsed panel on all 22 mix sliders
- Hints sourced from `SLIDER_HINTS` via id map (+ 2 landing-specific custom hints)
- Matching styles in `landing.css`

## Test plan

- [x] `node scripts/validate.js` — passed
- [x] ESLint on `app.js` + `landing.js` — passed

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Collapse slider hints behind an 'i' toggle button across app and landing page
> - Replaces always-visible hint text and inline info icons on slider rows with a circular 'i' button that toggles a hint panel, in both the app ([app.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/642/files#diff-8a8b7ea624d7fccc12a516d122dcb07bd67c6a8f796c80e33b898ee6a7557650)) and landing page ([landing.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/642/files#diff-be23ec2b8a859b1c83e27ce227d9dd0c367c83c7a8f1a4b104128c882bdb30ab)).
> - At most one hint panel is open at a time; clicking outside or pressing Escape closes all open panels.
> - Whisper Mode rows get the same toggle behavior, replacing the previously static hint span.
> - Updates grid layout in [style.css](https://github.com/Joker5514/VoiceIsolate-Pro/pull/642/files#diff-35b8006cad11f725a0bc3cee37866f6a39b941ae71d953d622c215dbd1a8d389) and [landing.css](https://github.com/Joker5514/VoiceIsolate-Pro/pull/642/files#diff-0cfc64852aad421bc53736616a19dec3e5b249ad2f2509175077db2f108dbd66) to reserve a column for the new hint button.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 345c4c6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->