### PR TITLE
feat(ui): slider hint visual aids and mobile layout

### DIFF
--- a/public/app/app.js
+++ b/public/app/app.js
@@ -18,6 +18,7 @@
  */
 
 import { SLIDER_REGISTRY, STAGES } from './slider-map.js';
+import { buildHintPanel, mountInfoPopover, removeAllInfoPopovers } from './slider-hint-ui.js';
 
 // Registry lookup for examples + calibrated transforms
 const SLIDER_REG_BY_ID = Object.freeze(
@@ -865,6 +866,9 @@ class VoiceIsolatePro {
       row.appendChild(valEl);
 
       const regEntry = SLIDER_REG_BY_ID[s.id];
+      const examples = (regEntry && regEntry.examples && regEntry.examples.length)
+        ? regEntry.examples
+        : this._defaultSliderExamples(s);
       const hintText = (regEntry && regEntry.hint) ? regEntry.hint : (s.desc || '');
       let hintPanel = null;
       if (hintText) {
@@ -890,17 +894,23 @@ class VoiceIsolatePro {
           }
         });
 
-        hintPanel = document.createElement('div');
-        hintPanel.className = 'slider-hint';
-        hintPanel.id = 'hint_' + s.id;
-        hintPanel.textContent = hintText;
+        hintPanel = buildHintPanel({
+          id: 'hint_' + s.id,
+          text: hintText,
+          min: s.min,
+          max: s.max,
+          value: initVal,
+          unit: s.unit || '',
+          examples,
+          onApplyExample: (val) => {
+            inputEl.value = val;
+            inputEl.dispatchEvent(new Event('input', { bubbles: true }));
+          },
+        });
         inputEl.setAttribute('aria-describedby', hintPanel.id);
 
         row.appendChild(hintBtn);
       }
-      const examples = (regEntry && regEntry.examples && regEntry.examples.length)
-        ? regEntry.examples
-        : this._defaultSliderExamples(s);
       const infoBtn = document.createElement('button');
       infoBtn.type = 'button';
       infoBtn.className = 'info-btn';
@@ -965,7 +975,7 @@ class VoiceIsolatePro {
   _bindInfoPopoverDismiss() {
     if (this._infoDismissBound) return;
     this._infoDismissBound = true;
-    const closeAll = () => document.querySelectorAll('.info-popover').forEach((p) => p.remove());
+    const closeAll = () => removeAllInfoPopovers();
     document.addEventListener('click', (e) => {
       if (!e.target.closest('.info-btn') && !e.target.closest('.info-popover')) closeAll();
     });
@@ -977,11 +987,17 @@ class VoiceIsolatePro {
   _toggleInfoPopover(row, sliderId, inputEl, examples) {
     const existing = row.querySelector('.info-popover');
     if (existing) { existing.remove(); return; }
-    document.querySelectorAll('.info-popover').forEach((p) => p.remove());
+    removeAllInfoPopovers();
 
     const pop = document.createElement('div');
     pop.className = 'info-popover';
     pop.setAttribute('role', 'dialog');
+    pop.setAttribute('aria-label', `Examples for ${sliderId}`);
+
+    const title = document.createElement('div');
+    title.className = 'info-popover-title';
+    title.textContent = 'Quick presets';
+    pop.appendChild(title);
 
     examples.forEach((ex) => {
       const line = document.createElement('div');
@@ -994,13 +1010,13 @@ class VoiceIsolatePro {
         ev.stopPropagation();
         inputEl.value = ex.value;
         inputEl.dispatchEvent(new Event('input', { bubbles: true }));
-        pop.remove();
+        removeAllInfoPopovers();
       });
       line.appendChild(apply);
       pop.appendChild(line);
     });
 
-    row.appendChild(pop);
+    mountInfoPopover(pop, row);
   }
 
   // [WHISPER UPDATE] Send calibrated DSP value to worklet (Part 3)
@@ -1085,9 +1101,13 @@ class VoiceIsolatePro {
         const open = row.classList.toggle('hint-open');
         hintBtn.setAttribute('aria-expanded', String(open));
       });
-      const hintPanel = document.createElement('div');
-      hintPanel.className = 'slider-hint';
-      hintPanel.textContent = wmReg.hint;
+      const hintPanel = buildHintPanel({
+        text: wmReg.hint,
+        min: wmReg.min,
+        max: wmReg.max,
+        value: initMode,
+        unit: '',
+      });
       row.appendChild(hintBtn);
       row.appendChild(hintPanel);
     }

--- a/public/app/mobile.css
+++ b/public/app/mobile.css
@@ -155,14 +155,12 @@ html {
     border-radius: 8px;
   }
 
-  /* ── Slider rows: 2-row layout on mobile ──
-     Top row: label + value
-     Bottom row: full-width track              */
+  /* ── Slider rows: label + controls / track / hint panel ── */
   .sr-row {
     display: grid;
-    grid-template-columns: 1fr auto;
-    grid-template-rows: auto auto;
-    gap: 4px 8px;
+    grid-template-columns: minmax(0, 1fr) auto auto auto;
+    grid-template-rows: auto auto auto;
+    gap: 4px 6px;
     padding: 9px 8px;
     border-radius: 8px;
   }
@@ -176,8 +174,8 @@ html {
     overflow: visible;
     text-overflow: unset;
     line-height: 1.3;
+    align-self: center;
   }
-  /* Info icon is a real tap target on mobile — reveals the explanation panel */
   .sr-info {
     display: inline-flex;
     width: 22px;
@@ -186,85 +184,34 @@ html {
     margin-left: 4px;
   }
   .sr-desc { font-size: 0.72rem; padding: 9px 10px; }
-
-  /* ── Slider rows: 2-row layout on mobile ──
-     Top row: label + value
-     Bottom row: full-width track              */
-  .sr-row {
-    display: grid;
-    grid-template-columns: 1fr auto;
-    grid-template-rows: auto auto;
-    gap: 4px 8px;
-    padding: 9px 8px;
-    border-radius: 8px;
-  }
-  .sr-label {
-    grid-column: 1;
-    grid-row: 1;
-    font-size: 0.72rem;
-    font-weight: 600;
-    color: var(--text);
-    white-space: normal;
-    overflow: visible;
-    text-overflow: unset;
-    line-height: 1.3;
-  }
-  /* Info icon is a real tap target on mobile — reveals the explanation panel */
-  .sr-info {
-    display: inline-flex;
-    width: 22px;
-    height: 22px;
-    font-size: 0.62rem;
-    margin-left: 4px;
-  }
-  .sr-desc { font-size: 0.72rem; padding: 9px 10px; }
-
   .sr-val {
     grid-column: 2;
     grid-row: 1;
     font-size: 0.7rem;
     padding: 3px 7px;
     align-self: center;
-    min-width: 52px;
+    min-width: 48px;
     text-align: center;
   }
-  .sr-row > input[type="range"] {
-    grid-column: 1 / -1;
-    grid-row: 2;
-    height: var(--mob-slider-track);
-    border-radius: calc(var(--mob-slider-track) / 2);
-    /* track gradient shape still driven by --pct */
-  }
-  .sr-row > input[type="range"]::-webkit-slider-runnable-track {
-    height: var(--mob-slider-track);
-  }
-  .sr-row > input[type="range"]::-webkit-slider-thumb {
-    width: var(--mob-slider-thumb);
-    height: var(--mob-slider-thumb);
-    margin-top: calc((var(--mob-slider-thumb) / -2) + (var(--mob-slider-track) / 2));
-    border-width: 3px;
-  }
-  .sr-row > input[type="range"]::-moz-range-thumb {
-    width: var(--mob-slider-thumb);
-    height: var(--mob-slider-thumb);
-    border-width: 3px;
-  }
-
-  /* RT badge sizing */
-  .rt-badge { font-size: 0.5rem; padding: 1px 5px; }
-
-  .sr-val {
-    grid-column: 2;
+  .slider-hint-btn {
+    grid-column: 3;
     grid-row: 1;
-    font-size: 0.7rem;
-    padding: 3px 7px;
     align-self: center;
-    min-width: 52px;
-    text-align: center;
+    justify-self: center;
   }
-  .sr-row > input[type="range"] {
+  .info-btn {
+    grid-column: 4;
+    grid-row: 1;
+    align-self: center;
+    justify-self: center;
+    margin-left: 0;
+  }
+  .sr-row > input[type="range"],
+  .sr-row > .slider-tick-wrapper {
     grid-column: 1 / -1;
     grid-row: 2;
+  }
+  .sr-row > input[type="range"] {
     height: var(--mob-slider-track);
     border-radius: calc(var(--mob-slider-track) / 2);
   }
@@ -282,6 +229,23 @@ html {
     height: var(--mob-slider-thumb);
     border-width: 3px;
   }
+  .slider-hint {
+    grid-column: 1 / -1;
+    grid-row: 3;
+    font-size: 0.72rem;
+    padding: 9px 10px;
+  }
+  .hint-aids-row { gap: 6px; }
+  .hint-range-meter { min-width: 0; flex: 1 1 100%; }
+  .hint-body { font-size: 0.72rem; }
+  .hint-chip, .hint-example-pill { font-size: 0.68rem; }
+  .whisper-mode-row {
+    grid-template-columns: minmax(0, 1fr) auto;
+    grid-template-rows: auto auto auto;
+  }
+  .whisper-mode-group { grid-column: 1 / -1; grid-row: 2; }
+  .whisper-mode-row .slider-hint-btn { grid-column: 2; grid-row: 1; }
+  .whisper-mode-row .slider-hint { grid-column: 1 / -1; grid-row: 3; }
 
   /* RT badge sizing */
   .rt-badge { font-size: 0.5rem; padding: 1px 5px; }
@@ -450,9 +414,24 @@ html {
   .btn,
   .tab,
   .btn-tp,
-  .btn-preset {
+  .btn-preset,
+  .slider-hint-btn,
+  .info-btn,
+  .hint-example-pill,
+  .info-popover-apply {
     min-height: var(--mob-touch-min);
     min-width: var(--mob-touch-min);
+  }
+  .slider-hint-btn,
+  .info-btn {
+    width: var(--mob-touch-min);
+    height: var(--mob-touch-min);
+    line-height: var(--mob-touch-min);
+    font-size: 14px;
+  }
+  .hint-example-pill {
+    padding: 8px 12px;
+    font-size: 0.72rem;
   }
 
   /* Slider hit-area — invisible expansion */

--- a/public/app/slider-hint-ui.js
+++ b/public/app/slider-hint-ui.js
@@ -1,0 +1,180 @@
+/**
+ * slider-hint-ui.js — Rich visual hint panels for slider rows
+ * Direction badges, range meter, toward-chips, and example pills.
+ */
+
+const UP_VERBS = new Set(['raise', 'push', 'boost', 'add', 'increase', 'lengthen', 'widen']);
+const DOWN_VERBS = new Set(['lower', 'pull', 'cut', 'decrease', 'shorten', 'narrow', 'ease']);
+
+function escapeHtml(text) {
+  return String(text)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+/** Infer dominant adjustment direction from hint prose. */
+export function inferHintDirection(text) {
+  if (!text) return 'both';
+  const lower = text.toLowerCase();
+  let up = 0;
+  let down = 0;
+  for (const v of UP_VERBS) {
+    if (lower.includes(v)) up += 1;
+  }
+  for (const v of DOWN_VERBS) {
+    if (lower.includes(v)) down += 1;
+  }
+  if (up > down) return 'up';
+  if (down > up) return 'down';
+  return 'both';
+}
+
+/** Pull "verb toward target" chips for quick scanning. */
+export function extractTowardChips(text) {
+  if (!text) return [];
+  const re = /\b(Raise|Lower|Push|Pull|Cut|Boost|Add|Lengthen|Shorten|Widen|Narrow|Ease)\s+toward\s+([^.;]+)/gi;
+  const chips = [];
+  let match;
+  while ((match = re.exec(text)) !== null) {
+    const verb = match[1];
+    const target = match[2].trim();
+    const dir = UP_VERBS.has(verb.toLowerCase()) ? 'up'
+      : DOWN_VERBS.has(verb.toLowerCase()) ? 'down' : 'both';
+    const arrow = dir === 'up' ? '↑' : dir === 'down' ? '↓' : '↕';
+    chips.push({ verb, target, dir, arrow, label: `${verb} toward ${target}` });
+  }
+  return chips.slice(0, 3);
+}
+
+function formatHintText(text) {
+  const safe = escapeHtml(text);
+  return safe.replace(
+    /\b(Raise|Lower|Push|Pull|Cut|Boost|Add|Lengthen|Shorten|Widen|Narrow|Ease)\s+toward\s+([^.;]+)/gi,
+    '<mark class="hint-toward"><strong>$1</strong> toward <em>$2</em></mark>',
+  );
+}
+
+function directionLabel(dir) {
+  if (dir === 'up') return '↑ Raise';
+  if (dir === 'down') return '↓ Lower';
+  return '↕ Adjust';
+}
+
+/**
+ * Build a rich hint panel DOM node.
+ * @param {object} opts
+ * @param {string} opts.id
+ * @param {string} opts.text
+ * @param {number} [opts.min]
+ * @param {number} [opts.max]
+ * @param {number} [opts.value]
+ * @param {string} [opts.unit]
+ * @param {Array<{label:string,value:number}>} [opts.examples]
+ * @param {(value:number)=>void} [opts.onApplyExample]
+ */
+export function buildHintPanel(opts) {
+  const {
+    id, text, min, max, value, unit = '', examples = [], onApplyExample,
+  } = opts;
+
+  const panel = document.createElement('div');
+  panel.className = 'slider-hint';
+  if (id) panel.id = id;
+
+  const aids = document.createElement('div');
+  aids.className = 'hint-aids-row';
+
+  const dir = inferHintDirection(text);
+  const badge = document.createElement('span');
+  badge.className = `hint-dir-badge hint-dir-${dir}`;
+  badge.setAttribute('aria-hidden', 'true');
+  badge.textContent = directionLabel(dir);
+  aids.appendChild(badge);
+
+  if (Number.isFinite(min) && Number.isFinite(max)) {
+    const pct = max > min && Number.isFinite(value)
+      ? Math.max(0, Math.min(100, ((value - min) / (max - min)) * 100))
+      : 50;
+    const meter = document.createElement('div');
+    meter.className = 'hint-range-meter';
+    meter.setAttribute('role', 'img');
+    meter.setAttribute('aria-label', `Range ${min}${unit} to ${max}${unit}, current ${value}${unit}`);
+    meter.innerHTML = [
+      `<span class="hint-range-lo">${min}${unit}</span>`,
+      `<span class="hint-range-track"><i class="hint-range-thumb" style="left:${pct.toFixed(1)}%"></i></span>`,
+      `<span class="hint-range-hi">${max}${unit}</span>`,
+    ].join('');
+    aids.appendChild(meter);
+  }
+
+  panel.appendChild(aids);
+
+  const body = document.createElement('p');
+  body.className = 'hint-body';
+  body.innerHTML = formatHintText(text);
+  panel.appendChild(body);
+
+  const chips = extractTowardChips(text);
+  if (chips.length) {
+    const chipRow = document.createElement('div');
+    chipRow.className = 'hint-chips';
+    chipRow.setAttribute('aria-label', 'Suggested adjustments');
+    chips.forEach((chip) => {
+      const el = document.createElement('span');
+      el.className = `hint-chip hint-chip-${chip.dir}`;
+      el.textContent = `${chip.arrow} ${chip.label}`;
+      chipRow.appendChild(el);
+    });
+    panel.appendChild(chipRow);
+  }
+
+  if (examples.length) {
+    const exRow = document.createElement('div');
+    exRow.className = 'hint-examples';
+    exRow.setAttribute('aria-label', 'Quick presets');
+    examples.forEach((ex) => {
+      const pill = document.createElement('button');
+      pill.type = 'button';
+      pill.className = 'hint-example-pill';
+      pill.textContent = ex.label;
+      pill.title = `Apply ${ex.value}${unit}`;
+      pill.addEventListener('click', (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        if (typeof onApplyExample === 'function') onApplyExample(ex.value);
+      });
+      exRow.appendChild(pill);
+    });
+    panel.appendChild(exRow);
+  }
+
+  return panel;
+}
+
+/** Mobile bottom-sheet popover with backdrop; desktop inline popover. */
+export function mountInfoPopover(pop, anchorRow) {
+  const useSheet = window.matchMedia('(max-width: 768px)').matches;
+  if (!useSheet) {
+    anchorRow.appendChild(pop);
+    return () => pop.remove();
+  }
+
+  pop.classList.add('info-popover--sheet');
+  const backdrop = document.createElement('div');
+  backdrop.className = 'info-popover-backdrop';
+  backdrop.setAttribute('aria-hidden', 'true');
+  document.body.appendChild(backdrop);
+  document.body.appendChild(pop);
+
+  const teardown = () => {
+    pop.remove();
+    backdrop.remove();
+  };
+  backdrop.addEventListener('click', teardown);
+  return teardown;
+}
+
+export function removeAllInfoPopovers() {
+  document.querySelectorAll('.info-popover, .info-popover-backdrop').forEach((el) => el.remove());
+}

--- a/public/app/style.css
+++ b/public/app/style.css
@@ -166,6 +166,49 @@ input[type='range']{
 .sr-row.hint-open .slider-hint,.whisper-mode-row.hint-open .slider-hint{
   display:block;animation:vip-desc-in 0.18s ease;
 }
+.hint-aids-row{display:flex;flex-wrap:wrap;align-items:center;gap:8px;margin-bottom:6px}
+.hint-dir-badge{
+  display:inline-flex;align-items:center;gap:3px;padding:2px 8px;border-radius:99px;
+  font-size:10px;font-weight:700;letter-spacing:0.02em;white-space:nowrap;
+  border:1px solid rgba(255,255,255,0.12);background:rgba(255,255,255,0.05);color:var(--text2);
+}
+.hint-dir-up{color:#6ee7b7;border-color:rgba(52,211,153,0.35);background:rgba(52,211,153,0.1)}
+.hint-dir-down{color:#fca5a5;border-color:rgba(248,113,113,0.35);background:rgba(248,113,113,0.1)}
+.hint-dir-both{color:#a5f3fc;border-color:rgba(0,245,255,0.35);background:rgba(0,245,255,0.08)}
+.hint-range-meter{display:flex;align-items:center;gap:6px;flex:1;min-width:120px}
+.hint-range-lo,.hint-range-hi{font-family:var(--fm);font-size:9px;color:var(--dim);white-space:nowrap}
+.hint-range-track{
+  position:relative;flex:1;height:5px;border-radius:99px;
+  background:linear-gradient(90deg,rgba(248,113,113,0.35),rgba(52,211,153,0.35));
+  box-shadow:inset 0 1px 2px rgba(0,0,0,0.35);
+}
+.hint-range-thumb{
+  position:absolute;top:50%;width:9px;height:9px;border-radius:50%;
+  transform:translate(-50%,-50%);background:#0d0d15;border:2px solid var(--red2);
+  box-shadow:0 0 0 2px rgba(220,38,38,0.2);
+}
+.hint-body{margin:0;font-size:11px;line-height:1.4;color:var(--text2)}
+.hint-toward{background:rgba(0,245,255,0.08);border-radius:3px;padding:0 2px}
+.hint-toward em{color:#00f5ff;font-style:normal;font-weight:600}
+.hint-chips{display:flex;flex-wrap:wrap;gap:5px;margin-top:6px}
+.hint-chip{
+  display:inline-flex;align-items:center;gap:3px;padding:3px 8px;border-radius:6px;
+  font-size:10px;line-height:1.25;color:var(--text2);border:1px solid rgba(255,255,255,0.1);
+  background:rgba(255,255,255,0.04);
+}
+.hint-chip-up{border-color:rgba(52,211,153,0.28);color:#a7f3d0}
+.hint-chip-down{border-color:rgba(248,113,113,0.28);color:#fecaca}
+.hint-chip-both{border-color:rgba(0,245,255,0.22);color:#a5f3fc}
+.hint-examples{display:flex;flex-wrap:wrap;gap:5px;margin-top:7px;padding-top:6px;border-top:1px solid rgba(255,255,255,0.06)}
+.hint-example-pill{
+  padding:4px 9px;border-radius:99px;border:1px solid rgba(160,207,255,0.28);
+  background:rgba(160,207,255,0.08);color:#cdd6f4;font-size:10px;font-weight:600;cursor:pointer;
+  transition:background 0.15s,border-color 0.15s,color 0.15s;
+}
+.hint-example-pill:hover{background:rgba(160,207,255,0.16);border-color:rgba(160,207,255,0.45);color:#fff}
+.slider-hint-btn:focus-visible,.info-btn:focus-visible,.hint-example-pill:focus-visible,.info-popover-apply:focus-visible{
+  outline:2px solid #00f5ff;outline-offset:2px;
+}
 @media (max-width:900px){
   .sr-row{grid-template-columns:130px 1fr 52px 22px 22px}
 }
@@ -180,13 +223,28 @@ input[type='range']{
 .info-popover{
   position:absolute;right:0;top:28px;background:#1a1d2e;border:1px solid #2e3450;
   border-radius:8px;padding:10px 14px;font-size:12px;color:#cdd6f4;z-index:9999;
-  white-space:nowrap;box-shadow:0 4px 24px rgba(0,0,0,0.6);min-width:260px;
+  white-space:normal;box-shadow:0 4px 24px rgba(0,0,0,0.6);min-width:220px;max-width:min(320px,calc(100vw - 24px));
 }
+.info-popover-title{
+  font-size:10px;font-weight:700;letter-spacing:0.08em;text-transform:uppercase;
+  color:var(--dim);margin-bottom:6px;padding-bottom:5px;border-bottom:1px solid rgba(255,255,255,0.08);
+}
+.info-popover-line+.info-popover-line{margin-top:2px}
 .info-popover-apply{
   display:block;width:100%;text-align:left;background:transparent;border:0;
-  color:#cdd6f4;padding:4px 0;cursor:pointer;font-size:12px;
+  color:#cdd6f4;padding:8px 4px;cursor:pointer;font-size:12px;border-radius:6px;
+  min-height:36px;
 }
-.info-popover-apply:hover{color:#a0cfff;text-decoration:underline}
+.info-popover-apply:hover{color:#a0cfff;background:rgba(160,207,255,0.08)}
+.info-popover-backdrop{
+  position:fixed;inset:0;background:rgba(0,0,0,0.55);z-index:9998;
+  backdrop-filter:blur(2px);-webkit-backdrop-filter:blur(2px);
+}
+.info-popover--sheet{
+  position:fixed;left:12px;right:12px;bottom:calc(12px + var(--safe-bottom,0px));top:auto;
+  min-width:0;max-width:none;border-radius:12px;padding:14px 16px;z-index:9999;
+  max-height:min(48vh,420px);overflow-y:auto;-webkit-overflow-scrolling:touch;
+}
 .sr-row:hover{background:rgba(255,255,255,0.03);border-left-color:rgba(220,38,38,0.4)}
 .sr-row:last-child{border-bottom:none}
 .sr-label{font-size:0.67rem;font-weight:500;color:var(--text2);cursor:help;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;display:flex;align-items:center;gap:4px;min-width:0}
@@ -206,6 +264,7 @@ input[type='range']{
 
 /* ---- Capability (slider-group) explanation ---- */
 .group-desc{margin:0 4px 8px;padding:8px 10px;border-radius:7px;background:linear-gradient(160deg,rgba(157,77,255,0.07),rgba(0,245,255,0.04));border:1px solid rgba(157,77,255,0.16);font-size:0.66rem;line-height:1.5;color:var(--text2)}
+.group-desc::before{content:'◆ Group guide';display:block;font-size:9px;font-weight:700;letter-spacing:0.08em;text-transform:uppercase;color:#00f5ff;margin-bottom:4px}
 .group-desc strong{color:var(--text);font-weight:700}
 .group-desc em{color:#00f5ff;font-style:normal;font-weight:700}
 

--- a/public/landing.css
+++ b/public/landing.css
@@ -463,6 +463,49 @@ input[type="file"]:focus { border-color: var(--border-focus); }
   border: 1px solid rgba(220, 38, 38, 0.18);
 }
 .slider-row.hint-open .slider-hint { display: block; }
+.hint-aids-row { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; margin-bottom: 6px; }
+.hint-dir-badge {
+  display: inline-flex; align-items: center; padding: 2px 8px; border-radius: 99px;
+  font: var(--fw-bold) 10px/1 var(--font-ui); border: 1px solid var(--border-strong);
+  background: rgba(255, 255, 255, 0.05); color: var(--text-dim);
+}
+.hint-dir-up { color: #6ee7b7; border-color: rgba(52, 211, 153, 0.35); background: rgba(52, 211, 153, 0.1); }
+.hint-dir-down { color: #fca5a5; border-color: rgba(248, 113, 113, 0.35); background: rgba(248, 113, 113, 0.1); }
+.hint-dir-both { color: var(--red-400); border-color: rgba(220, 38, 38, 0.35); background: rgba(220, 38, 38, 0.08); }
+.hint-range-meter { display: flex; align-items: center; gap: 6px; flex: 1; min-width: 120px; }
+.hint-range-lo, .hint-range-hi { font: var(--fw-regular) 9px/1 var(--font-mono); color: var(--text-ghost); }
+.hint-range-track {
+  position: relative; flex: 1; height: 5px; border-radius: 99px;
+  background: linear-gradient(90deg, rgba(248, 113, 113, 0.35), rgba(52, 211, 153, 0.35));
+}
+.hint-range-thumb {
+  position: absolute; top: 50%; width: 9px; height: 9px; border-radius: 50%;
+  transform: translate(-50%, -50%); background: var(--text-hi); border: 2px solid var(--red-600);
+}
+.hint-body { margin: 0; font: var(--fw-regular) var(--fs-2xs)/1.4 var(--font-ui); color: var(--text-dim); }
+.hint-toward { background: rgba(220, 38, 38, 0.08); border-radius: 3px; padding: 0 2px; }
+.hint-toward em { color: var(--red-400); font-style: normal; font-weight: var(--fw-semibold); }
+.hint-chips { display: flex; flex-wrap: wrap; gap: 5px; margin-top: 6px; }
+.hint-chip {
+  display: inline-flex; padding: 3px 8px; border-radius: 6px; font: var(--fw-medium) 10px/1.25 var(--font-ui);
+  border: 1px solid var(--border-strong); background: rgba(255, 255, 255, 0.04); color: var(--text-dim);
+}
+.hint-chip-up { border-color: rgba(52, 211, 153, 0.28); color: #a7f3d0; }
+.hint-chip-down { border-color: rgba(248, 113, 113, 0.28); color: #fecaca; }
+.hint-chip-both { border-color: rgba(220, 38, 38, 0.22); color: var(--red-400); }
+.hint-examples {
+  display: flex; flex-wrap: wrap; gap: 5px; margin-top: 7px; padding-top: 6px;
+  border-top: 1px solid var(--border);
+}
+.hint-example-pill {
+  padding: 4px 9px; border-radius: 99px; border: 1px solid rgba(220, 38, 38, 0.28);
+  background: rgba(220, 38, 38, 0.08); color: var(--text-2); font: var(--fw-semibold) 10px/1 var(--font-ui);
+  cursor: pointer;
+}
+.hint-example-pill:hover { background: rgba(220, 38, 38, 0.16); color: var(--text-hi); }
+.slider-hint-btn:focus-visible, .hint-example-pill:focus-visible {
+  outline: 2px solid var(--red-400); outline-offset: 2px;
+}
 .slider-row:hover {
   background: var(--hover-fill);
   border-left-color: var(--red-600);
@@ -573,10 +616,37 @@ input[type="range"]:disabled { opacity: 0.34; cursor: not-allowed; }
 .speaker-empty { margin: 0; color: var(--text-dim); }
 
 /* ── Responsive ───────────────────────────────────────────────────────── */
+@media (max-width: 768px) {
+  .slider-row {
+    grid-template-columns: minmax(0, 1fr) auto auto;
+    grid-template-rows: auto auto auto;
+    gap: 6px;
+    padding: 8px 6px;
+  }
+  .slider-row label { grid-column: 1; grid-row: 1; align-self: center; }
+  .slider-val { grid-column: 2; grid-row: 1; align-self: center; min-width: 44px; }
+  .slider-hint-btn { grid-column: 3; grid-row: 1; align-self: center; }
+  .slider-row input[type="range"] { grid-column: 1 / -1; grid-row: 2; }
+  .slider-hint { grid-column: 1 / -1; grid-row: 3; font-size: var(--fs-xs); padding: 10px; }
+  .hint-range-meter { min-width: 0; flex: 1 1 100%; }
+}
 @media (max-width: 560px) {
-  .slider-row { grid-template-columns: 110px 1fr 50px 22px; }
   .time-readout { margin-left: 0; }
   .main-area { padding: 14px 12px 48px; }
+}
+@media (pointer: coarse) {
+  .slider-hint-btn, .hint-example-pill {
+    min-width: 44px;
+    min-height: 44px;
+  }
+  .slider-hint-btn {
+    width: 44px;
+    height: 44px;
+    line-height: 44px;
+    font-size: 14px;
+  }
+  .hint-example-pill { padding: 10px 14px; font-size: var(--fs-xs); }
+  .slider-row input[type="range"] { padding: 12px 0; }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/public/landing.js
+++ b/public/landing.js
@@ -19,6 +19,7 @@ import { LandingVisualizer } from '/src/presentation/LandingVisualizer.js';
 import { getModel } from '/src/core/ModelManifest.js';
 import { MODEL_MANIFEST } from '/src/core/ModelManifest.js';
 import { SLIDER_HINTS } from '/app/slider-map.js';
+import { buildHintPanel } from '/app/slider-hint-ui.js';
 
 const $ = (id) => document.getElementById(id);
 
@@ -463,10 +464,22 @@ function wireSliderHints() {
     hintBtn.setAttribute('aria-label', `Explain ${row.querySelector('label')?.textContent || input.id}`);
     hintBtn.setAttribute('aria-expanded', 'false');
 
-    const hintPanel = document.createElement('div');
-    hintPanel.className = 'slider-hint';
-    hintPanel.id = `landing_hint_${input.id}`;
-    hintPanel.textContent = hintText;
+    const min = Number(input.min) || 0;
+    const max = Number(input.max) || 100;
+    const value = Number(input.value) || min;
+    const hintPanel = buildHintPanel({
+      id: `landing_hint_${input.id}`,
+      text: hintText,
+      min,
+      max,
+      value,
+      unit: '',
+      onApplyExample: (val) => {
+        input.value = val;
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+        paintSliderFill(input);
+      },
+    });
     input.setAttribute('aria-describedby', hintPanel.id);
 
     hintBtn.addEventListener('click', (e) => {


### PR DESCRIPTION
## Summary

Adds rich visual aids to slider hint panels and makes the hint/example UI mobile-friendly across Engineer Mode and the landing page.

### Visual aids (hint panels)
- Direction badges (↑ Raise / ↓ Lower / ↕ Adjust) inferred from hint prose
- Mini range meter showing min → current → max
- Highlighted "toward" phrases in hint body text
- Toward-chips for quick scanning of suggested adjustments
- Example preset pills (tap to apply) inside expanded hint panels
- Group guide label on accordion descriptions

### Mobile-friendly
- Engineer slider rows: 3-row grid (label + value + i/ℹ / track / hint panel)
- 44×44px touch targets for hint, info, and example buttons on coarse pointers
- Info popover becomes a bottom sheet with backdrop on ≤768px viewports
- Landing sliders mirror the same stacked mobile layout

### Files
- `public/app/slider-hint-ui.js` (new shared builder)
- `public/app/app.js`, `public/landing.js`
- `public/app/style.css`, `public/app/mobile.css`, `public/landing.css`

## Test plan
- [x] `node scripts/validate.js`
- [x] ESLint on changed JS
- [x] `npm test -- --testPathPatterns=slider-map|sliders`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add rich slider hint panels with visual aids and mobile bottom-sheet layout
> - Introduces [slider-hint-ui.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/643/files#diff-33d6513bd046fb8a492d99c7b3a59c70673963c17bc58b431b2cebb0215098c2) with utilities to build structured hint panels (direction badge, range meter, toward chips, example pills) and mount/dismiss info popovers.
> - Replaces plain-text hint panels in both the app and landing page with `buildHintPanel`, wiring example pills to apply preset values directly to sliders.
> - On small screens, info popovers now mount as a bottom-sheet with a dismissible backdrop; desktop behavior remains inline anchoring.
> - Mobile CSS reworks slider rows into an explicit grid and enlarges tap targets for hint, info, and example pill controls.
> - Behavioral Change: applying an example preset now closes all active info popovers via `removeAllInfoPopovers` rather than removing only the local element.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 224c918.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->