### PR TITLE
fix(visuals): restore wiped files, repair visual aids, add click-to-isolate

### DIFF
--- a/public/app/index.html
+++ b/public/app/index.html
@@ -1,0 +1,488 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>VoiceIsolate Pro v24.0 – Engineer Mode</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <!-- onnxruntime-web is loaded locally from /lib/ort.min.js — never from CDN -->
+  <script type="importmap">{ "imports": { "three": "/lib/three.module.min.js" } }</script>
+  <script type="module">
+    import('three').then((m) => { globalThis.THREE = m; }).catch(() => {});
+  </script>
+  <link rel="stylesheet" href="ds-tokens.css" />
+  <link rel="stylesheet" href="style.css" />
+  <link rel="stylesheet" href="slider-theme.css" />
+  <!-- ✅ WIRED: slider-ticks.css — tick marks, snap targets, value callout bubbles -->
+  <link rel="stylesheet" href="slider-ticks.css" />
+  <link rel="stylesheet" href="style-diag-log.css" />
+  <link rel="stylesheet" href="ds-overrides.css" />
+  <!-- // LOAD ORDER VERIFIED: dsp-core.js is available before any downstream spectral stage/module code runs. -->
+  <!-- DSP math (STFT/iSTFT, filters, Wiener NR) on window.DSPCore. Loaded as a
+       classic blocking script so the binding is live before any module imports
+       evaluate — app.js captures DSP = globalThis.DSPCore at module init. -->
+  <script src="./dsp-core.js"></script>
+  <script type="module" src="./whisper-hunter.js"></script>
+  <!-- // LOAD ORDER VERIFIED: ring-buffer.js is available before pipeline-orchestrator.js can allocate SAB rings or load the canonical worklet. -->
+  <script src="./ring-buffer.js"></script>
+  <script src="./visuals.js"></script>
+  <script src="./premium-visuals.js"></script>
+  <script src="./neon-pulse-visualizer.js"></script>
+  <!-- // LOAD ORDER VERIFIED: visuals-bootstrap.js follows visuals.js + premium-visuals.js so VIP_INFERNO_LUT and premium init helpers are already defined when the driver wires its tab listener. -->
+  <script src="./visuals-bootstrap.js"></script>
+  <script src="./visual-click-isolation.js"></script>
+  <link rel="stylesheet" href="model-status-ui.css" />
+  <link id="vip-overlay-css" rel="stylesheet" href="processing-overlay.css" />
+  <link rel="stylesheet" href="mobile.css" />
+  <link id="vip-enh-css" rel="stylesheet" href="vip-enhancements.css" />
+  <link rel="stylesheet" href="debug-menu.css" />
+
+  <!-- Module-error guard: surfaces broken imports as a red banner instead of blank page -->
+  <style>
+    #vip-boot-error {
+      display: none;
+      position: fixed;
+      top: 0; left: 0; right: 0;
+      z-index: 99999;
+      background: #1a0a0a;
+      border-bottom: 2px solid #ff3b3b;
+      color: #ff9090;
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 12px;
+      padding: 10px 16px;
+      white-space: pre-wrap;
+      max-height: 40vh;
+      overflow: auto;
+    }
+    #vip-boot-error b { color: #ff3b3b; }
+    .tp-ab-no-output { animation: vip-ab-flash 0.6s ease; }
+    @keyframes vip-ab-flash {
+      0%,100% { opacity:1; }
+      50%      { opacity:0.25; color:#ff3b3b; }
+    }
+  </style>
+  <script data-vip-guard="true">
+    window._vipModuleErrors = [];
+    window._vipReportError = function(src, err) {
+      window._vipModuleErrors.push({ src: src, err: err });
+      var banner = document.getElementById('vip-boot-error');
+      if (!banner) return;
+      banner.style.display = 'block';
+      banner.innerHTML = '<b>\u26a0 VoiceIsolate Pro \u2014 Module Load Error</b>\n' +
+        window._vipModuleErrors.map(function(e) {
+          return '  [' + e.src + ']  ' + (e.err && e.err.message ? e.err.message : String(e.err));
+        }).join('\n') +
+        '\n\n<small>Open DevTools \u2192 Console for full stack trace.</small>';
+    };
+    window.addEventListener('error', function(e) {
+      if (e.filename) window._vipReportError(e.filename.split('/').pop(), e.error || e.message);
+    });
+    window.addEventListener('unhandledrejection', function(e) {
+      window._vipReportError('unhandledRejection', e.reason);
+    });
+  </script>
+</head>
+<body>
+  <div id="vip-boot-error"></div>
+
+  <div id="status-message" class="status-bar" style="position:fixed;top:-9999px;left:-9999px;width:1px;height:1px;overflow:hidden;opacity:0;" aria-live="polite" aria-atomic="true"></div>
+
+  <script>
+    window._vipDismissBootSplash = function () {
+      var s = document.getElementById('bootSplash');
+      if (!s || s.dataset.dismissed === '1') return;
+      s.dataset.dismissed = '1';
+      s.classList.add('is-complete');
+      s.style.pointerEvents = 'none';
+      s.style.opacity = '0';
+      s.style.display = 'none';
+      s.setAttribute('aria-hidden', 'true');
+    };
+    setTimeout(window._vipDismissBootSplash, 8000);
+  </script>
+
+  <div id="bootSplash" class="boot-splash" aria-hidden="false" role="status" aria-live="polite">
+    <div class="boot-splash-card">
+      <div class="boot-mark" aria-hidden="true">VIP</div>
+      <div class="boot-kicker">ENGINEER MODE · v24 · LOCAL DSP STACK</div>
+      <h2 class="boot-title">Neural Audio Processor — Initializing</h2>
+      <p id="bootSplashText" class="boot-text">Priming AudioWorklet, ONNX model cache, 32-stage Deca-Pass pipeline, and spectral controls…</p>
+      <div class="boot-progress" aria-hidden="true"><div id="bootSplashProgress" class="boot-progress-fill"></div></div>
+      <div class="boot-bars" aria-hidden="true">
+        <span class="boot-bar"></span>
+        <span class="boot-bar"></span>
+        <span class="boot-bar"></span>
+        <span class="boot-bar"></span>
+        <span class="boot-bar"></span>
+        <span class="boot-bar"></span>
+        <span class="boot-bar"></span>
+      </div>
+    </div>
+  </div>
+
+  <div id="vip-startup-banner" class="startup-banner" style="display:none" role="alert">
+    <div id="vip-startup-msg"></div>
+    <button id="vip-startup-close" class="btn btn-outline" type="button" aria-label="Dismiss startup warning">Dismiss</button>
+  </div>
+
+  <header class="hdr">
+    <div class="hdr-left">
+      <div class="hdr-icon"><svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round" aria-hidden="true"><path d="M12 1v22M8 5v14M4 9v6M16 5v14M20 9v6"/></svg></div>
+      <div style="display:flex;flex-direction:column;gap:2px;">
+        <h1 class="hdr-title" style="margin:0;">VoiceIsolate</h1>
+        <span class="hdr-ver">PRO</span>
+      </div>
+      <div style="width:1px;height:22px;background:var(--border-strong);margin:0 2px;flex:none;"></div>
+      <span class="hdr-title" style="font-size:11px;font-weight:500;color:var(--text-dim);letter-spacing:0;">Engineer Mode</span>
+      <span class="hdr-badge">LOCAL DSP</span>
+      <span class="hdr-badge diag-badge" style="display:none;">32-Stage Deca-Pass</span>
+    </div>
+    <div class="hdr-scale" role="group" aria-label="UI scale">
+      <button id="uiScaleDn" type="button" class="btn-xs" title="Decrease UI scale" aria-label="Decrease UI scale">&minus;</button>
+      <span id="uiScaleVal" aria-live="polite">100%</span>
+      <button id="uiScaleUp" type="button" class="btn-xs" title="Increase UI scale" aria-label="Increase UI scale">+</button>
+      <button id="uiScaleSave" type="button" class="btn-xs" title="Save UI scale" aria-label="Save UI scale">Save</button>
+    </div>
+    <div class="hdr-actions">
+      <a class="btn btn-outline hdr-link" href="how-it-works.html">How It Works</a>
+    </div>
+    <button id="statsToggle" class="hdr-stats-toggle" aria-label="Toggle stats" title="Toggle stats" aria-expanded="false">&#9660;</button>
+    <div class="hdr-stats" id="hdrStats">
+      <div class="hdr-stat"><span class="hs-val" id="hSNR">-- dB</span><span class="hs-lbl">SNR Gain</span></div>
+      <div class="hdr-stat"><span class="hs-val" id="hDur">--</span><span class="hs-lbl">Duration</span></div>
+      <div class="hdr-stat"><span class="hs-val" id="hSR">--</span><span class="hs-lbl">Sample Rate</span></div>
+      <div class="hdr-stat"><span class="hs-val" id="hCh">--</span><span class="hs-lbl">Channels</span></div>
+      <div class="hdr-stat"><span class="hs-val" id="hRMS">--</span><span class="hs-lbl">RMS</span></div>
+      <div class="hdr-stat"><span class="hs-val" id="hPeak">--</span><span class="hs-lbl">Peak</span></div>
+      <div class="hdr-stat"><span class="hs-val" id="hLUFS">--</span><span class="hs-lbl">LUFS</span></div>
+      <div class="hdr-stat"><span class="hs-val" id="hVoices">--</span><span class="hs-lbl">Voices</span></div>
+      <div class="hdr-stat"><span class="hs-val" id="hFile">--</span><span class="hs-lbl">File</span></div>
+      <div class="hdr-stat"><span class="hs-val" id="hStatus">IDLE</span><span class="hs-lbl">Pipeline</span></div>
+    </div>
+  </header>
+
+  <section class="engine-cockpit">
+    <div class="card cockpit-card">
+      <div class="cockpit-row">
+        <div class="cockpit-copy">
+          <span class="cockpit-label">Launch Diagnostics</span>
+          <strong class="cockpit-title">Strictly local processing · WebGPU/WASM inference · one-pass spectral chain</strong>
+        </div>
+        <div class="engine-pills" role="status" aria-label="Engine status">
+          <span class="engine-pill" id="engCtxPill" data-state="pending">CTX</span>
+          <span class="engine-pill" id="engWorkletPill" data-state="pending">WORKLET</span>
+          <span class="engine-pill" id="engSabPill" data-state="pending">SAB</span>
+          <span class="engine-pill" id="engMlPill" data-state="pending">ML</span>
+          <span class="engine-pill" id="engNetPill" data-state="pending">NET</span>
+        </div>
+      </div>
+      <div class="cockpit-row cockpit-row--stack">
+        <div class="cockpit-models">
+          <span class="cockpit-label">Model Cache &amp; Providers</span>
+          <div id="modelStatusPills" class="engine-pills"></div>
+        </div>
+        <div id="cdnHealthPanel" class="cockpit-health"></div>
+      </div>
+    </div>
+  </section>
+
+  <main class="main-grid">
+    <section class="col-left">
+      <div class="card upload-card">
+        <input type="file" id="fileInput" accept="audio/mpeg,audio/mp3,audio/wav,audio/x-wav,audio/ogg,audio/flac,audio/x-flac,audio/aac,audio/x-m4a,audio/m4a,audio/mp4,video/mp4,video/webm,video/quicktime,audio/*,video/*" style="position:fixed;left:-9999px;top:-9999px;width:1px;height:1px;opacity:0;" tabindex="-1" aria-hidden="true" />
+        <div id="dropZone">
+          <div id="uploadZone" class="upload-zone" role="button" tabindex="0" aria-label="Drop Audio or Video file, or press Enter to browse">
+            <svg class="upload-svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
+            <p class="upload-title">Drop Audio or Video</p>
+            <p class="upload-sub">MP3 · WAV · FLAC · OGG · M4A · AAC · MP4 · MOV · WEBM · MKV · AVI</p>
+            <button id="fileBtn" class="btn btn-outline" type="button">Browse Files</button>
+          </div>
+        </div>
+        <div class="upload-row">
+          <span id="fileInfo" class="file-info">No file loaded</span>
+          <span id="fileLoadIndicator" class="file-load-indicator" role="status" aria-live="polite" hidden>
+            <span class="vip-helix-spinner" aria-hidden="true"><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i></span>
+            <span class="file-load-text">Loading…</span>
+          </span>
+          <button id="clearFile" class="btn btn-outline" type="button">Clear</button>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="presets-wrap">
+          <div class="presets-head">
+            <label for="presetSel" class="presets-label">Presets</label>
+            <select id="presetSel" class="btn btn-outline preset-select" aria-label="Preset dropdown">
+              <option>Voice Clarity</option>
+              <option>Podcast Clean</option>
+              <option>Forensic Extract</option>
+              <option>Music Vocal</option>
+              <option>Whisper Boost</option>
+              <option>Phone/Radio</option>
+              <option>Live Performance</option>
+              <option>Surveillance</option>
+              <option>Whisper in a Club</option>
+              <option>Heavy Rain Call</option>
+              <option>Helicopter Rescue</option>
+              <option>Stadium Crowd</option>
+              <option>Phone Wiretap</option>
+              <option>Whisper Room</option>
+            </select>
+            <button id="openPresetModalBtn" class="btn btn-outline" type="button">Save Custom</button>
+          </div>
+          <div class="presets-grid" role="group" aria-label="Example presets">
+            <button class="btn btn-preset" type="button" data-preset="Voice Clarity">Voice Clarity</button>
+            <button class="btn btn-preset" type="button" data-preset="Podcast Clean">Podcast Clean</button>
+            <button class="btn btn-preset" type="button" data-preset="Forensic Extract">Forensic Extract</button>
+            <button class="btn btn-preset" type="button" data-preset="Music Vocal">Music Vocal</button>
+            <button class="btn btn-preset" type="button" data-preset="Whisper Boost">Whisper Boost</button>
+            <button class="btn btn-preset" type="button" data-preset="Phone/Radio">Phone/Radio</button>
+            <button class="btn btn-preset" type="button" data-preset="Live Performance">Live Performance</button>
+            <button class="btn btn-preset" type="button" data-preset="Surveillance">Surveillance</button>
+            <button class="btn btn-preset" type="button" data-preset="Whisper in a Club">Whisper in a Club</button>
+            <button class="btn btn-preset" type="button" data-preset="Heavy Rain Call">Heavy Rain Call</button>
+            <button class="btn btn-preset" type="button" data-preset="Helicopter Rescue">Helicopter Rescue</button>
+            <button class="btn btn-preset" type="button" data-preset="Stadium Crowd">Stadium Crowd</button>
+            <button class="btn btn-preset" type="button" data-preset="Phone Wiretap">Phone Wiretap</button>
+            <button class="btn btn-preset" type="button" data-preset="Whisper Room">Whisper Room</button>
+          </div>
+        </div>
+        <button id="btn-whisper-hunter" type="button">🎙️ WhisperHunter AI</button>
+        <div class="control-search-row">
+          <input type="text" id="sliderSearch" class="btn btn-outline" placeholder="Search controls…" aria-label="Search controls" style="width:100%;" />
+          <button id="resetSlidersBtn" class="btn btn-outline" type="button">Reset Controls</button>
+        </div>
+        <div id="preset-desc-panel" class="preset-desc-panel" style="display:none;" aria-live="polite"></div>
+
+        <div class="slider-group active">
+          <button id="btn-noise-reduction" class="slider-group-header" type="button" aria-expanded="true" aria-controls="group-noise-reduction"><span>Noise Reduction</span><span class="chevron" aria-hidden="true">▾</span></button>
+          <div id="group-noise-reduction" class="slider-group-content" role="region" aria-labelledby="btn-noise-reduction">
+            <p class="group-desc">Removes unwanted background sound. The <strong>gate</strong> silences the gaps between words, while <strong>spectral NR</strong> learns the steady noise (hiss, hum, fans) and subtracts it. <em>Example:</em> clean up a phone interview recorded next to an air conditioner — set NR Amount ~70% and a Gate Threshold around −40 dB.</p>
+            <div id="tab-gate" class="slider-panel"></div>
+            <div id="tab-nr" class="slider-panel"></div>
+          </div>
+        </div>
+        <div class="slider-group"><button class="slider-group-header" type="button" aria-expanded="false" aria-controls="group-eq"><span>EQ (10 bands)</span><span class="chevron" aria-hidden="true">▾</span></button><div id="group-eq" class="slider-group-content"><p class="group-desc">Ten tone controls from deep bass to bright "air". Boost a band to bring it forward, cut it to push it back. <em>Example:</em> for a thin laptop-mic voice, add ~+2 dB Body and +1.5 dB Presence; for a boomy close mic, cut ~−4 dB Bass.</p><div id="tab-eq" class="slider-panel"></div></div></div>
+        <div class="slider-group"><button class="slider-group-header" type="button" aria-expanded="false" aria-controls="group-dynamics"><span>Dynamics</span><span class="chevron" aria-hidden="true">▾</span></button><div id="group-dynamics" class="slider-group-content"><p class="group-desc">Evens out volume. The <strong>compressor</strong> brings loud and soft words closer together; the <strong>limiter</strong> sets a hard ceiling so nothing clips. <em>Example:</em> a guest who keeps drifting from the mic — Threshold ~−24 dB, Ratio 4:1, Makeup +3 dB for a steady, broadcast-level voice.</p><div id="tab-dyn" class="slider-panel"></div></div></div>
+        <div class="slider-group"><button class="slider-group-header" type="button" aria-expanded="false" aria-controls="group-spectral"><span>Spectral</span><span class="chevron" aria-hidden="true">▾</span></button><div id="group-spectral" class="slider-group-content"><p class="group-desc">Surgical frequency tools: high-/low-pass filters to trim the extremes, a de-esser to tame harsh "s" sounds, tilt for quick brighter/darker, and formant shift for vocal character. <em>Example:</em> a sharp, sibilant narrator — De-ess Amount ~6 dB at 7 kHz, HP Freq 90 Hz to drop rumble.</p><div id="tab-spec" class="slider-panel"></div></div></div>
+        <div class="slider-group"><button class="slider-group-header" type="button" aria-expanded="false" aria-controls="group-advanced"><span>Advanced</span><span class="chevron" aria-hidden="true">▾</span></button><div id="group-advanced" class="slider-group-content"><p class="group-desc">Restoration and stereo tools: <strong>dereverb</strong> pulls a voice out of an echoey room, <strong>harmonic recovery</strong> rebuilds detail lost to noise reduction, and width/phase shape the stereo image. <em>Example:</em> speech recorded in an empty hall — Dereverb ~50% with Rev Decay raised toward 70% for the long tail.</p><div id="tab-adv" class="slider-panel"></div></div></div>
+        <div class="slider-group"><button class="slider-group-header" type="button" aria-expanded="false" aria-controls="group-output"><span>Output</span><span class="chevron" aria-hidden="true">▾</span></button><div id="group-output" class="slider-group-content"><p class="group-desc">Final mastering: overall volume trim, the dry/wet blend between original and processed, output stereo width, and export dither. <em>Example:</em> if cleanup sounds too aggressive, pull Dry/Wet to ~75% to mix a little of the natural original back in.</p><div id="tab-out" class="slider-panel"></div></div></div>
+        <div class="slider-group"><button class="slider-group-header" type="button" aria-expanded="false" aria-controls="group-separation"><span>Separation</span><span class="chevron" aria-hidden="true">▾</span></button><div id="group-separation" class="slider-group-content"><p class="group-desc">Isolates the voice from everything else. Focus on the speech frequency band and push down whatever sits outside it, plus cancel stereo bleed between two mics. <em>Example:</em> lift a speaker out of background music — Voice Iso ~85% with BG Suppress ~60%.</p><div id="tab-sep" class="slider-panel"></div></div></div>
+        <div class="slider-group" id="tab-extreme-group">
+          <button class="slider-group-header" type="button" aria-expanded="false" aria-controls="group-extreme"><span>EXTREME</span><span class="chevron" aria-hidden="true">▾</span></button>
+          <div id="group-extreme" class="slider-group-content" role="region">
+            <p class="group-desc">Extreme voice isolation for whispers buried under club noise, crowd roar, and music. <em>Example:</em> nightclub recording with a whisper at −55 dBFS — Whisper Mode Forensic, Crowd Null ~88%, Bass Crush ~95%.</p>
+            <div id="tab-extreme" class="slider-panel"></div>
+          </div>
+        </div>
+
+        <div class="actions-row" style="margin-top:8px;">
+          <button id="processBtn" class="btn btn-primary" type="button" disabled>Process</button>
+          <button id="reprocessBtn" class="btn btn-reprocess" type="button" disabled>Reprocess</button>
+          <button id="forensicToggle" class="btn btn-outline" type="button">Forensic</button>
+          <button id="auditLogBtn" class="btn btn-outline" type="button" disabled>Audit Log</button>
+        </div>
+      </div>
+
+      <div class="card pipeline-box">
+        <div id="vip-proc-badge" role="status" aria-live="polite" data-state="idle">
+          <span class="vip-pb-dot" aria-hidden="true"></span>
+          <span class="vip-pb-label">Ready — drop a file or record to begin</span>
+          <span class="vip-sonar-spinner vip-pb-spinner" aria-hidden="true" style="display:none"><i></i><i></i><i></i><b></b></span>
+        </div>
+        <div class="pipe-header"><span class="pipe-stage" id="pipeStage">S00</span><span id="pipePercent">0%</span></div>
+        <div class="pipe-bar" id="pipeBar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" aria-label="Processing progress">
+          <div id="pipeFill" class="pipe-fill"></div>
+        </div>
+        <div id="pipeDetail" class="pipe-detail">Ready</div>
+      </div>
+
+      <div class="card save-row">
+        <button id="saveOrigBtn" class="btn btn-save" disabled>Save Original WAV</button>
+        <button id="saveProcBtn" class="btn btn-save-proc" disabled>Save Processed WAV</button>
+      </div>
+
+      <!-- Mobile sticky action bar -->
+      <div class="mobile-action-bar" id="mobileActionBar">
+        <button id="mobileProcessBtn" class="btn btn-primary" disabled><svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><polygon points="5 3 19 12 5 21"></polygon></svg>Process</button>
+        <button id="mobileReprocessBtn" class="btn btn-reprocess" disabled>Reprocess</button>
+        <button id="mobileStopBtn" class="btn btn-danger" style="display:none">Stop</button>
+      </div>
+    </section>
+
+    <section class="col-right">
+      <div class="card transport-card">
+        <div class="transport-top">
+          <div class="tp-buttons" role="group" aria-label="Playback controls">
+            <button id="tpPlay" class="btn btn-tp btn-tp-play" type="button" aria-label="Play (Space)" title="Play (Space)" disabled><span aria-hidden="true">&#9654;</span></button>
+            <button id="tpPause" class="btn btn-tp" type="button" aria-label="Pause (Space)" title="Pause (Space)" disabled><span aria-hidden="true">&#9208;</span></button>
+            <button id="tpStop" class="btn btn-tp" type="button" aria-label="Stop" title="Stop" disabled><span aria-hidden="true">&#9209;</span></button>
+            <button id="tpRew" class="btn btn-tp" type="button" aria-label="Rewind" title="Rewind" disabled><span aria-hidden="true">&#9664;&#9664;</span></button>
+            <button id="tpFwd" class="btn btn-tp" type="button" aria-label="Fast Forward" title="Fast Forward" disabled><span aria-hidden="true">&#9654;&#9654;</span></button>
+          </div>
+          <div class="tp-time-wrap">
+            <span class="tp-time" id="tpCur">0:00</span>
+            <span class="tp-time-sep">/</span>
+            <span class="tp-time" id="tpDur">0:00</span>
+          </div>
+          <div class="tp-meta">
+            <div class="tp-speed">
+              <label for="tpSpeed">Speed</label>
+              <button id="tpSpeedDown" class="btn btn-tp btn-speed" type="button" aria-label="Slow Down Playback" title="Slow Down (−)"><span aria-hidden="true">−</span></button>
+              <select id="tpSpeed" aria-label="Playback speed">
+                <option value="0.25">0.25x</option>
+                <option value="0.5">0.5x</option>
+                <option value="0.75">0.75x</option>
+                <option value="1" selected>1x</option>
+                <option value="1.25">1.25x</option>
+                <option value="1.5">1.5x</option>
+                <option value="1.75">1.75x</option>
+                <option value="2">2x</option>
+              </select>
+              <button id="tpSpeedUp" class="btn btn-tp btn-speed" type="button" aria-label="Speed Up Playback" title="Speed Up (+)"><span aria-hidden="true">+</span></button>
+            </div>
+            <div class="tp-ab">
+              <button id="tpAB" class="btn btn-ab" type="button"
+                aria-label="Toggle A/B Comparison"
+                aria-describedby="tpABLabel"
+                title="Toggle A/B — X key shortcut"
+                disabled>A/B</button>
+              <span id="tpABLabel" class="tp-ab-label" data-version="A" aria-live="polite">
+                <span class="tp-ab-tag">A</span>
+                <span class="tp-ab-name">Original</span>
+              </span>
+            </div>
+          </div>
+        </div>
+        <div class="transport-seek">
+          <input type="range" id="tpSeek" class="tp-seek" min="0" max="1000" value="0" aria-label="Playback position" />
+        </div>
+      </div>
+
+      <div class="card viz-card">
+        <div class="viz-hdr"><span>Visualizations</span><button id="fullscreenSpectroBtn" class="btn btn-xs" type="button" aria-label="Toggle Fullscreen" title="Toggle Fullscreen"><span aria-hidden="true">⛶</span></button></div>
+        <div id="neon-pulse-slot" class="neon-pulse-slot"></div>
+        <div id="tabBar" class="tabs" role="tablist" aria-label="Visualization tabs">
+          <button id="btn-spectrogram" class="tab-btn active" type="button" role="tab" aria-controls="tab-spectrogram" data-tab="spectrogram" aria-selected="true" tabindex="0">Spectrogram</button>
+          <button id="btn-waveform" class="tab-btn" type="button" role="tab" aria-controls="tab-waveform" data-tab="waveform" aria-selected="false" tabindex="-1">Waveform</button>
+          <button id="btn-abcompare" class="tab-btn" type="button" role="tab" aria-controls="tab-abcompare" data-tab="abcompare" aria-selected="false" tabindex="-1">A/B</button>
+          <button id="btn-lufs" class="tab-btn" type="button" role="tab" aria-controls="tab-lufs" data-tab="lufs" aria-selected="false" tabindex="-1">LUFS</button>
+          <button id="btn-clusters" class="tab-btn" type="button" role="tab" aria-controls="tab-clusters" data-tab="clusters" aria-selected="false" tabindex="-1">Clusters</button>
+          <button id="btn-aura" class="tab-btn" type="button" role="tab" aria-controls="tab-aura" data-tab="aura" aria-selected="false" tabindex="-1">Aura</button>
+          <button id="btn-topo" class="tab-btn" type="button" role="tab" aria-controls="tab-topo" data-tab="topo" aria-selected="false" tabindex="-1">3D Topo</button>
+          <button id="btn-swarm" class="tab-btn" type="button" role="tab" aria-controls="tab-swarm" data-tab="swarm" aria-selected="false" tabindex="-1">Swarm</button>
+          <button id="btn-liquid" class="tab-btn" type="button" role="tab" aria-controls="tab-liquid" data-tab="liquid" aria-selected="false" tabindex="-1">Liquid</button>
+        </div>
+          <div id="tab-spectrogram" role="tabpanel" aria-labelledby="btn-spectrogram" class="panel active" tabindex="0">
+            <div class="viz-legend">Live spectrum rail · scrolling spectrogram · local-only render</div>
+            <div id="spectro3d-container" class="spectro3d-container"><div class="viz-iso-badge hidden" id="iso-badge-spec"></div><canvas id="spectroCanvas" class="viz-canvas"></canvas></div>
+            <canvas id="spectro2DCanvas" class="viz-canvas spectro2d"></canvas>
+            <canvas id="freqCanvas" class="viz-canvas freq-cv"></canvas>
+          </div>
+          <div id="tab-waveform" role="tabpanel" aria-labelledby="btn-waveform" class="panel"><div class="viz-legend">Static inspection before playback · live playhead during transport</div><canvas id="waveCanvas" class="viz-canvas wave-cv"></canvas></div>
+          <div id="tab-abcompare" role="tabpanel" aria-labelledby="btn-abcompare" class="panel"><div class="viz-legend">Original vs processed waveform overlay for transport A/B</div><div class="wave-row"><canvas id="waveOrigCanvas" class="viz-canvas wave-cv"></canvas><canvas id="waveProcCanvas" class="viz-canvas wave-cv"></canvas></div></div>
+          <div id="tab-lufs" role="tabpanel" aria-labelledby="btn-lufs" class="panel"><div class="lufs-readouts"><div class="lufs-rd"><span class="lufs-val" id="lufsI">-23.0</span><span class="lufs-lbl">Integrated</span></div><div class="lufs-rd"><span class="lufs-val" id="lufsS">-20.0</span><span class="lufs-lbl">Short</span></div></div></div>
+          <div id="tab-saliency" role="tabpanel" aria-labelledby="btn-saliency" class="panel"><canvas id="fsCanvas" class="viz-canvas diag-saliency-cv"></canvas></div>
+          <div id="tab-clusters" role="tabpanel" aria-labelledby="btn-clusters" class="panel">
+            <canvas id="diarCanvas" class="viz-canvas"></canvas>
+            <div id="panel-vu-meters" class="vu-meter-container">
+              <div class="vu-meter" style="--vu-level:42%"><div class="vu-meter-fill"></div><div class="vu-meter-peak" style="--peak-top:58%"></div><span class="vu-meter-label">IN</span></div>
+              <div class="vu-meter" style="--vu-level:36%"><div class="vu-meter-fill"></div><div class="vu-meter-peak" style="--peak-top:64%"></div><span class="vu-meter-label">OUT</span></div>
+            </div>
+            <div class="lufs-readouts"><span class="vu-val">Input -12.4 dB</span><span class="vu-val">Output -10.9 dB</span></div>
+          </div>
+          <div id="tab-aura" role="tabpanel" aria-labelledby="btn-aura" class="panel"><div class="viz-iso-badge hidden" id="iso-badge-aura"></div><canvas id="auraCanvas" class="viz-canvas"></canvas></div>
+          <div id="tab-topo" role="tabpanel" aria-labelledby="btn-topo" class="panel"><div class="viz-iso-badge hidden" id="iso-badge-topo"></div><div id="topoContainer" class="spectro3d-container"></div></div>
+          <div id="tab-swarm" role="tabpanel" aria-labelledby="btn-swarm" class="panel"><div class="viz-iso-badge hidden" id="iso-badge-swarm"></div><div id="swarmContainer" class="spectro3d-container"></div></div>
+          <div id="tab-liquid" role="tabpanel" aria-labelledby="btn-liquid" class="panel"><div class="viz-iso-badge hidden" id="iso-badge-liquid"></div><canvas id="liquidCanvas" class="viz-canvas"></canvas></div>
+      </div>
+
+      <div id="videoCard" class="card video-card" style="display:none">
+        <div class="video-hdr"><span>Video preview</span><span class="video-tag">picture + processed audio</span></div>
+        <video id="videoPlayer" class="video-el" playsinline muted></video>
+        <p class="video-note">The video plays muted in sync with the transport above — what you hear is the processed (or A/B original) audio, not the file's own track.</p>
+      </div>
+    </section>
+  </main>
+
+  <div id="customPresetModal" class="modal" role="dialog" aria-modal="true" aria-labelledby="customPresetTitle" aria-hidden="true">
+    <div class="modal-content">
+      <h3 id="customPresetTitle">Save Custom Preset</h3>
+      <input type="text" id="customPresetName" placeholder="Preset Name" aria-label="Preset Name" />
+      <button id="saveCustomPresetBtn" class="btn btn-primary" type="button">Save</button>
+      <button id="closePresetModal" class="btn btn-outline" type="button">Cancel</button>
+    </div>
+  </div>
+
+  <div id="toastRegion" aria-live="polite"></div>
+
+  <script type="module">
+    // LOAD ORDER VERIFIED: slider-map.js resolves as an app.js dependency before app.js evaluates.
+    // pipeline-orchestrator.js was removed with the live real-time pipeline
+    // (Stem-Split & Live-Mix architecture — see CLAUDE.md). Offline processing
+    // runs through app.js _runFallbackPipeline.
+    const _parallel = [
+      './processing-overlay.js',
+      './session-persist.js',
+    ];
+    await Promise.allSettled(_parallel.map(src =>
+      import(src).catch(err => {
+        console.error('[VIP] Failed to load module:', src, err);
+        if (typeof window._vipReportError === 'function') window._vipReportError(src, err);
+      })
+    ));
+    await import('./app.js').catch(err => {
+      console.error('[VIP] Failed to load module: ./app.js', err);
+      if (typeof window._vipReportError === 'function') window._vipReportError('./app.js', err);
+    });
+    await import('./vip-boot.js').catch(err => {
+      console.error('[VIP] Failed to load module: ./vip-boot.js', err);
+      if (typeof window._vipReportError === 'function') window._vipReportError('./vip-boot.js', err);
+    });
+    import('./vip-enhancements.js').catch(err => {
+      console.error('[VIP] Failed to load module: ./vip-enhancements.js', err);
+      if (typeof window._vipReportError === 'function') window._vipReportError('./vip-enhancements.js', err);
+    });
+    /* vip-fixes.js — transport, A/B, slider search, speed buttons, accordions */
+    import('./vip-fixes.js').catch(err => {
+      console.error('[VIP] Failed to load module: ./vip-fixes.js', err);
+      if (typeof window._vipReportError === 'function') window._vipReportError('./vip-fixes.js', err);
+    });
+    /* ✅ WIRED: slider-ticks.js — tick marks, value callout bubbles, snap-to-default.
+       Loads AFTER app.js + vip-boot.js so all slider panels are in the DOM before
+       initSliderTicks() scans for [data-ticks] attributes. */
+    import('./slider-ticks.js').catch(err => {
+      console.warn('[VIP] slider-ticks.js not loaded (non-fatal):', err);
+    });
+    /* debug-menu.js — live system debug panel (` key to toggle) */
+    import('./debug-menu.js').catch(err => {
+      console.warn('[VIP] debug-menu.js not loaded:', err);
+    });
+  </script>
+
+  <!--
+    REMOVED: _vipSafetyNet <script> block (was here until this commit).
+
+    ROOT CAUSE of processBtn disappearing after file load:
+      The safety-net listened on DOMContentLoaded and called new VoiceIsolatePro()
+      if window._vipApp was falsy. Because ES module evaluation is async, the
+      safety-net's DOMContentLoaded callback often fired AFTER the module bootstrap
+      set window._vipApp — but in the critical race window it fired BEFORE, creating
+      a second VoiceIsolatePro() instance. That second constructor re-ran cacheDom()
+      and bindEvents(), which left processBtn.disabled = true (its HTML default),
+      overwriting the enabled state set by onAudioLoaded() on the first instance.
+
+    The module bootstrap chain (app.js → vip-boot.js) already has:
+      if (window._vipApp) return;
+    The safety-net was fully redundant. Do not re-add it.
+  -->
+
+  <!-- Mobile upload fix: iOS Safari decodeAudioData, AudioContext gesture lock,
+       touch-action bleed, MIME accept scope. Loads after all modules are bootstrapped. -->
+  <script src="./mobile-upload-fix.js"></script>
+
+
+</body>
+</html>

--- a/public/app/style.css
+++ b/public/app/style.css
@@ -1558,6 +1558,30 @@ body::after {
   .spectro3d-container { transition: none !important; }
 }
 
+/* Click-isolation overlay styles */
+.viz-canvas { cursor: crosshair; user-select: none; }
+#waveCanvas { cursor: col-resize; }
+.viz-iso-badge {
+  position: absolute; top: 6px; right: 8px;
+  background: rgba(0,255,231,0.15); border: 1px solid rgba(0,255,231,0.4);
+  color: #00ffe7; font-family: 'JetBrains Mono', monospace; font-size: 10px;
+  padding: 2px 6px; border-radius: 3px; pointer-events: none;
+  letter-spacing: 0.08em; text-transform: uppercase; z-index: 4;
+}
+.viz-iso-badge.hidden { display: none; }
+@keyframes iso-pulse { 0%,100%{opacity:1} 50%{opacity:0.5} }
+.viz-iso-badge.active { animation: iso-pulse 1.8s ease-in-out infinite; }
+#tab-aura, #tab-topo, #tab-swarm, #tab-liquid { position: relative; }
+.viz-iso-tooltip {
+  position: fixed; z-index: 10000; transform: translateX(-50%);
+  background: rgba(3,3,6,0.92); border: 1px solid rgba(0,255,231,0.35);
+  color: #00ffe7; font-family: 'JetBrains Mono', monospace; font-size: 10px;
+  padding: 4px 8px; border-radius: 4px; pointer-events: none; opacity: 0;
+  transition: opacity 0.15s ease;
+}
+.viz-iso-tooltip.visible { opacity: 1; }
+.neon-pulse-slot { width: 100%; margin-bottom: 6px; }
+
 /* [WHISPER UPDATE] EXTREME TAB — deep purple accent */
 #tab-extreme-group { border-color: #7c3aed; }
 #tab-extreme-group.active { border-color: #7c3aed; }

--- a/public/app/vip-fixes.js
+++ b/public/app/vip-fixes.js
@@ -820,9 +820,14 @@
           const s = Math.max(0, Math.floor(sec || 0));
           return Math.floor(s / 60) + ':' + String(s % 60).padStart(2, '0');
         };
-        if (seek) seek.value = String(ratio * 1000);
-        if (cur) cur.textContent = fmtSec(off);
-        app.playOffset = off;
+        if (seek) {
+          seek.value = String(ratio * 1000);
+          seek.dispatchEvent(new Event('input', { bubbles: true }));
+          seek.dispatchEvent(new Event('change', { bubbles: true }));
+        } else {
+          if (cur) cur.textContent = fmtSec(off);
+          app.playOffset = off;
+        }
       }
     });
 

--- a/public/app/vip-fixes.js
+++ b/public/app/vip-fixes.js
@@ -751,6 +751,85 @@
   window.VIP_DEBUG_REPORT = buildReport;
 
   /* ═══════════════════════════════════════════════════════════════
+   * 8. VISUAL CLICK-ISOLATION → DSP pipeline
+   * ═══════════════════════════════════════════════════════════════ */
+  function patchClickIsolation() {
+    if (window._vipClickIsoPatched) return;
+    window._vipClickIsoPatched = true;
+
+    function _syncVoiceFocusSliders(lo, hi) {
+      document.querySelectorAll('.sr-row[data-slider-id="voiceFocusLo"] input[type="range"]').forEach((sl) => {
+        sl.value = String(lo);
+        sl.dispatchEvent(new Event('input', { bubbles: true }));
+      });
+      document.querySelectorAll('.sr-row[data-slider-id="voiceFocusHi"] input[type="range"]').forEach((sl) => {
+        sl.value = String(hi);
+        sl.dispatchEvent(new Event('input', { bubbles: true }));
+      });
+    }
+
+    window.addEventListener('vip:isolationBandSet', (e) => {
+      const { freqLow, freqHigh } = e.detail || {};
+      const app = window._vipApp;
+      if (!app) return;
+      app.dspParams = app.dspParams || {};
+      app.dspParams.isolationFreqLow = freqLow;
+      app.dspParams.isolationFreqHigh = freqHigh;
+      app.dspParams.isolationActive = true;
+      window.VIP_PARAMS = window.VIP_PARAMS || {};
+      const lo = Math.max(80, Math.round(freqLow || 120));
+      const hi = Math.min(8000, Math.round(freqHigh || 3400));
+      window.VIP_PARAMS.voiceFocusLo = lo;
+      window.VIP_PARAMS.voiceFocusHi = Math.max(lo + 10, hi);
+      _syncVoiceFocusSliders(lo, window.VIP_PARAMS.voiceFocusHi);
+      if (typeof app.runPipeline === 'function') app.runPipeline();
+      else if (typeof app.reprocess === 'function') app.reprocess();
+    });
+
+    window.addEventListener('vip:isolationBandClear', () => {
+      const app = window._vipApp;
+      if (!app || !app.dspParams) return;
+      app.dspParams.isolationActive = false;
+    });
+
+    window.addEventListener('vip:stemToggle', (e) => {
+      const stem = (e.detail && e.detail.stem) || 'all';
+      const app = window._vipApp;
+      if (app && typeof app.setStemSolo === 'function') {
+        app.setStemSolo(stem);
+      } else {
+        window.dispatchEvent(new CustomEvent('vip:stemSoloChanged', { detail: { stem } }));
+      }
+    });
+
+    window.addEventListener('vip:seekRequest', (e) => {
+      const ratio = (e.detail && e.detail.ratio) || 0;
+      const app = window._vipApp;
+      if (!app) return;
+      const buf = app.inputBuffer || app.outputBuffer || app.origBuffer;
+      const dur = buf?.duration || 0;
+      if (typeof app.seekTo === 'function') {
+        app.seekTo(Math.max(0, Math.min(1, ratio)));
+      } else if (typeof app.seek === 'function') {
+        app.seek(ratio * dur);
+      } else {
+        const seek = $('tpSeek');
+        const cur = $('tpCur');
+        const off = ratio * dur;
+        const fmtSec = (sec) => {
+          const s = Math.max(0, Math.floor(sec || 0));
+          return Math.floor(s / 60) + ':' + String(s % 60).padStart(2, '0');
+        };
+        if (seek) seek.value = String(ratio * 1000);
+        if (cur) cur.textContent = fmtSec(off);
+        app.playOffset = off;
+      }
+    });
+
+    log('Click-isolation DSP patch OK');
+  }
+
+  /* ═══════════════════════════════════════════════════════════════
    * INIT
    * ═══════════════════════════════════════════════════════════════ */
   function applyAll(app) {
@@ -760,10 +839,12 @@
     patchSliderSearch();
     patchPresetSelect(app);
     patchAccordions();
+    patchClickIsolation();
     console.info('[VIP-FIX] All patches applied. Call VIP_DEBUG_REPORT() in DevTools for a full snapshot.');
   }
 
   function init() {
+    patchClickIsolation();
     if (window._vipApp) { applyAll(window._vipApp); return; }
     let tries = 0;
     const poll = setInterval(() => {

--- a/public/app/visual-click-isolation.js
+++ b/public/app/visual-click-isolation.js
@@ -282,7 +282,6 @@
       global.dispatchEvent(new CustomEvent('vip:isolationBandSet', {
         detail: { freqLow, freqHigh, source: source },
       }));
-      global.VIP_ISOLATION_BUS.emit('vip:isolationBandSet', { freqLow, freqHigh, source: source });
     }
 
     canvas.addEventListener('mousedown', onDown);

--- a/public/app/visual-click-isolation.js
+++ b/public/app/visual-click-isolation.js
@@ -124,14 +124,24 @@
     return Math.max(0, Math.min(canvas.width || rect.width, (clientX - rect.left) * scale));
   }
 
-  function logBinFromX(x, canvasWidth, logScale) {
+  function pointerCanvasY(canvas, e) {
+    const rect = canvas.getBoundingClientRect();
+    const clientY = (e.touches && e.touches.length) ? e.touches[0].clientY : e.clientY;
+    const scale = (canvas.height || rect.height) / Math.max(1, rect.height);
+    return Math.max(0, Math.min(canvas.height || rect.height, (clientY - rect.top) * scale));
+  }
+
+  function logBinFromY(y, canvasHeight) {
     const an = getAnalyser();
     const binCount = an ? an.frequencyBinCount : 1024;
-    const t = Math.max(0, Math.min(1, x / Math.max(1, canvasWidth)));
-    if (logScale) {
-      return Math.floor(Math.pow(t, 2.0) * binCount);
-    }
-    return Math.floor(t * binCount);
+    const h = Math.max(1, canvasHeight);
+    const t = 1 - (y / h);
+    return Math.floor(Math.pow(Math.max(0, Math.min(1, t)), 2.0) * binCount);
+  }
+
+  function binToCanvasY(bin, canvasHeight, binCount) {
+    const t = Math.sqrt(Math.max(0, bin) / Math.max(1, binCount));
+    return (1 - t) * canvasHeight;
   }
 
   function linearBarFromX(x, canvasWidth) {
@@ -162,6 +172,29 @@
     }
   }
 
+  function drawHorizontalBandOverlay(overlay, y1, y2, label, color) {
+    if (!overlay) return;
+    const ctx = overlay.getContext('2d');
+    if (!ctx) return;
+    const w = overlay.width;
+    const h = overlay.height;
+    ctx.clearRect(0, 0, w, h);
+    const top = Math.min(y1, y2);
+    const height = Math.max(2, Math.abs(y2 - y1));
+    const fill = color || 'rgba(0,255,231,0.18)';
+    const stroke = color ? 'rgba(105,255,71,0.75)' : 'rgba(0,255,231,0.65)';
+    ctx.fillStyle = fill;
+    ctx.fillRect(0, top, w, height);
+    ctx.strokeStyle = stroke;
+    ctx.lineWidth = 1;
+    ctx.strokeRect(0.5, top + 0.5, w - 1, Math.max(0, height - 1));
+    if (label) {
+      ctx.font = '10px "JetBrains Mono", monospace';
+      ctx.fillStyle = color ? '#69ff47' : '#00ffe7';
+      ctx.fillText(label, 6, Math.max(14, top + 14));
+    }
+  }
+
   function updateSpecBadge(freqLow, freqHigh, active) {
     const badge = $('iso-badge-spec');
     if (!badge) return;
@@ -180,26 +213,24 @@
     if (!canvas) return;
     const overlay = ensureOverlay(canvas);
     let dragging = false;
-    let startX = 0;
-    let curX = 0;
+    let startY = 0;
     let lastDown = 0;
     let selLow = 0;
     let selHigh = 0;
 
-    function redraw() {
-      if (!dragging && selLow === selHigh && selLow === 0) {
-        clearOverlay(overlay);
-        return;
-      }
+    function drawSpectroSelection() {
       syncOverlaySize(canvas, overlay);
+      const h = canvas.height || overlay.height;
       const an = getAnalyser();
       const binCount = an ? an.frequencyBinCount : 1024;
       const lo = Math.min(selLow, selHigh);
       const hi = Math.max(selLow, selHigh);
       const freqLow = binToHz(lo, binCount);
       const freqHigh = binToHz(Math.max(lo + 1, hi), binCount);
-      const label = 'ISO: ' + fmtHz(freqLow) + ' – ' + fmtHz(freqHigh);
-      drawBandOverlay(overlay, lo / binCount * canvas.width, hi / binCount * canvas.width, label);
+      const yTop = binToCanvasY(hi, h, binCount);
+      const yBot = binToCanvasY(lo, h, binCount);
+      drawHorizontalBandOverlay(overlay, yTop, yBot,
+        'ISO: ' + fmtHz(freqLow) + ' – ' + fmtHz(freqHigh));
     }
 
     function onDown(e) {
@@ -219,34 +250,24 @@
       }
       lastDown = now;
       dragging = true;
-      const w = canvas.width || canvas.getBoundingClientRect().width;
-      startX = pointerCanvasX(canvas, e);
-      curX = startX;
-      const bin = logBinFromX(startX, w, true);
+      const h = canvas.height || canvas.getBoundingClientRect().height;
+      startY = pointerCanvasY(canvas, e);
+      const bin = logBinFromY(startY, h);
       selLow = bin;
       selHigh = bin;
-      syncOverlaySize(canvas, overlay);
-      drawBandOverlay(overlay, startX, startX, null);
+      drawSpectroSelection();
       if (e.type === 'touchstart') e.preventDefault();
     }
 
     function onMove(e) {
       if (!dragging) return;
-      curX = pointerCanvasX(canvas, e);
-      const w = canvas.width || canvas.getBoundingClientRect().width;
-      const b1 = logBinFromX(startX, w, true);
-      const b2 = logBinFromX(curX, w, true);
+      const h = canvas.height || canvas.getBoundingClientRect().height;
+      const y = pointerCanvasY(canvas, e);
+      const b1 = logBinFromY(startY, h);
+      const b2 = logBinFromY(y, h);
       selLow = Math.min(b1, b2);
       selHigh = Math.max(b1, b2);
-      syncOverlaySize(canvas, overlay);
-      const an = getAnalyser();
-      const binCount = an ? an.frequencyBinCount : 1024;
-      const freqLow = binToHz(selLow, binCount);
-      const freqHigh = binToHz(Math.max(selLow + 1, selHigh), binCount);
-      drawBandOverlay(overlay,
-        (selLow / binCount) * w,
-        (selHigh / binCount) * w,
-        'ISO: ' + fmtHz(freqLow) + ' – ' + fmtHz(freqHigh));
+      drawSpectroSelection();
       if (e.type === 'touchmove') e.preventDefault();
     }
 
@@ -287,7 +308,6 @@
     let startX = 0;
     let barLo = 0;
     let barHi = 0;
-    let lastDown = 0;
     const nyquist = () => getSampleRate() / 2;
 
     function barsToHz(lo, hi) {
@@ -380,7 +400,6 @@
     if (!canvas) return;
     const overlay = ensureOverlay(canvas);
     let dragging = false;
-    let startX = 0;
     let loopStart = null;
     let loopEnd = null;
 
@@ -410,7 +429,6 @@
       }
 
       dragging = true;
-      startX = ratio;
       loopStart = ratio;
       loopEnd = ratio;
       drawLoop();
@@ -481,11 +499,9 @@
       setStemBadge(badge, stem === 'all' ? null : stem);
       global.dispatchEvent(new CustomEvent('vip:stemToggle', { detail: { stem } }));
       global.VIP_ISOLATION_BUS.emit('vip:stemToggle', { stem });
-      if (e.type === 'touchstart') e.preventDefault();
     }
 
     target.addEventListener('click', onClick);
-    target.addEventListener('touchstart', onClick, { passive: false });
   }
 
   function init() {

--- a/public/app/visual-click-isolation.js
+++ b/public/app/visual-click-isolation.js
@@ -1,0 +1,510 @@
+/**
+ * visual-click-isolation.js
+ * VoiceIsolate Pro — click-to-isolate on visual canvases
+ *
+ * 100% local. Reads frequency data from window._vipPlayAnalyser only.
+ * Routes isolation changes via CustomEvents → vip-fixes.js / VIP_ISOLATION_BUS.
+ */
+(function visualClickIsolation(global) {
+  'use strict';
+
+  const NUM_BARS = 64;
+  const STEM_CYCLE = ['vocals', 'accompaniment', 'drums', 'all'];
+  const STEM_LABELS = {
+    vocals: 'VOCALS SOLO',
+    accompaniment: 'INSTRUMENTS SOLO',
+    drums: 'DRUMS SOLO',
+    all: 'ALL STEMS',
+  };
+
+  const _stemIdxByTarget = new WeakMap();
+  let _tooltipEl = null;
+  let _tooltipTimer = 0;
+
+  if (!global.VIP_ISOLATION_BUS) {
+    global.VIP_ISOLATION_BUS = {
+      emit(type, detail) {
+        try { global.dispatchEvent(new CustomEvent(type, { detail: detail || {} })); } catch (_) {}
+      },
+    };
+  }
+
+  function $(id) { return document.getElementById(id); }
+
+  function getAnalyser() {
+    return global._vipPlayAnalyser || null;
+  }
+
+  function getSampleRate() {
+    const ctx = global._vipApp?.ctx || global._vipOrch?.ctx || global.audioCtx;
+    return ctx?.sampleRate || 44100;
+  }
+
+  function hasAudioLoaded() {
+    const app = global._vipApp;
+    return !!(app && (app.inputBuffer || app.outputBuffer || app.origBuffer || app.procBuffer));
+  }
+
+  function canInteract() {
+    return hasAudioLoaded() || !!getAnalyser();
+  }
+
+  function fmtHz(hz) {
+    if (hz >= 1000) return (hz / 1000).toFixed(hz >= 10000 ? 0 : 1) + 'kHz';
+    return Math.round(hz) + 'Hz';
+  }
+
+  function binToHz(bin, binCount) {
+    const nyquist = getSampleRate() / 2;
+    return (bin / Math.max(1, binCount)) * nyquist;
+  }
+
+  function showTooltip(target, message) {
+    if (!_tooltipEl) {
+      _tooltipEl = document.createElement('div');
+      _tooltipEl.className = 'viz-iso-tooltip';
+      _tooltipEl.setAttribute('role', 'status');
+      document.body.appendChild(_tooltipEl);
+    }
+    const rect = target.getBoundingClientRect();
+    _tooltipEl.textContent = message;
+    _tooltipEl.style.left = (rect.left + rect.width / 2) + 'px';
+    _tooltipEl.style.top = (rect.top + 8) + 'px';
+    _tooltipEl.classList.add('visible');
+    clearTimeout(_tooltipTimer);
+    _tooltipTimer = setTimeout(() => { _tooltipEl.classList.remove('visible'); }, 1800);
+  }
+
+  function ensureRelativeParent(el) {
+    if (!el) return;
+    const pos = getComputedStyle(el).position;
+    if (pos === 'static' || !pos) el.style.position = 'relative';
+  }
+
+  function ensureOverlay(canvas) {
+    if (!canvas || !canvas.id) return null;
+    const parent = canvas.parentElement;
+    if (!parent) return null;
+    ensureRelativeParent(parent);
+    const sel = '.viz-iso-overlay[data-for="' + canvas.id + '"]';
+    let ov = parent.querySelector(sel);
+    if (!ov) {
+      ov = document.createElement('canvas');
+      ov.className = 'viz-iso-overlay';
+      ov.dataset.for = canvas.id;
+      ov.setAttribute('aria-hidden', 'true');
+      ov.style.cssText = 'position:absolute;left:0;top:0;width:100%;height:100%;pointer-events:none;z-index:3';
+      parent.appendChild(ov);
+    }
+    return ov;
+  }
+
+  function syncOverlaySize(canvas, overlay) {
+    if (!canvas || !overlay) return;
+    const rect = canvas.getBoundingClientRect();
+    const dpr = global.devicePixelRatio || 1;
+    const w = Math.max(1, Math.floor((canvas.width || rect.width * dpr)));
+    const h = Math.max(1, Math.floor((canvas.height || rect.height * dpr)));
+    overlay.width = w;
+    overlay.height = h;
+    overlay.style.width = rect.width + 'px';
+    overlay.style.height = rect.height + 'px';
+  }
+
+  function clearOverlay(overlay) {
+    if (!overlay) return;
+    const ctx = overlay.getContext('2d');
+    if (ctx) ctx.clearRect(0, 0, overlay.width, overlay.height);
+  }
+
+  function pointerCanvasX(canvas, e) {
+    const rect = canvas.getBoundingClientRect();
+    const clientX = (e.touches && e.touches.length) ? e.touches[0].clientX : e.clientX;
+    const scale = (canvas.width || rect.width) / Math.max(1, rect.width);
+    return Math.max(0, Math.min(canvas.width || rect.width, (clientX - rect.left) * scale));
+  }
+
+  function logBinFromX(x, canvasWidth, logScale) {
+    const an = getAnalyser();
+    const binCount = an ? an.frequencyBinCount : 1024;
+    const t = Math.max(0, Math.min(1, x / Math.max(1, canvasWidth)));
+    if (logScale) {
+      return Math.floor(Math.pow(t, 2.0) * binCount);
+    }
+    return Math.floor(t * binCount);
+  }
+
+  function linearBarFromX(x, canvasWidth) {
+    const t = Math.max(0, Math.min(1, x / Math.max(1, canvasWidth)));
+    return Math.floor(t * NUM_BARS);
+  }
+
+  function drawBandOverlay(overlay, x1, x2, label, color) {
+    if (!overlay) return;
+    const ctx = overlay.getContext('2d');
+    if (!ctx) return;
+    const w = overlay.width;
+    const h = overlay.height;
+    ctx.clearRect(0, 0, w, h);
+    const left = Math.min(x1, x2);
+    const width = Math.max(2, Math.abs(x2 - x1));
+    const fill = color || 'rgba(0,255,231,0.18)';
+    const stroke = color ? 'rgba(105,255,71,0.75)' : 'rgba(0,255,231,0.65)';
+    ctx.fillStyle = fill;
+    ctx.fillRect(left, 0, width, h);
+    ctx.strokeStyle = stroke;
+    ctx.lineWidth = 1;
+    ctx.strokeRect(left + 0.5, 0.5, Math.max(0, width - 1), h - 1);
+    if (label) {
+      ctx.font = '10px "JetBrains Mono", monospace';
+      ctx.fillStyle = color ? '#69ff47' : '#00ffe7';
+      ctx.fillText(label, left + 4, 14);
+    }
+  }
+
+  function updateSpecBadge(freqLow, freqHigh, active) {
+    const badge = $('iso-badge-spec');
+    if (!badge) return;
+    if (!active) {
+      badge.textContent = '';
+      badge.classList.add('hidden');
+      badge.classList.remove('active');
+      return;
+    }
+    badge.textContent = 'ISO: ' + fmtHz(freqLow) + ' – ' + fmtHz(freqHigh);
+    badge.classList.remove('hidden');
+    badge.classList.add('active');
+  }
+
+  function bindSpectrogramCanvas(canvas, source) {
+    if (!canvas) return;
+    const overlay = ensureOverlay(canvas);
+    let dragging = false;
+    let startX = 0;
+    let curX = 0;
+    let lastDown = 0;
+    let selLow = 0;
+    let selHigh = 0;
+
+    function redraw() {
+      if (!dragging && selLow === selHigh && selLow === 0) {
+        clearOverlay(overlay);
+        return;
+      }
+      syncOverlaySize(canvas, overlay);
+      const an = getAnalyser();
+      const binCount = an ? an.frequencyBinCount : 1024;
+      const lo = Math.min(selLow, selHigh);
+      const hi = Math.max(selLow, selHigh);
+      const freqLow = binToHz(lo, binCount);
+      const freqHigh = binToHz(Math.max(lo + 1, hi), binCount);
+      const label = 'ISO: ' + fmtHz(freqLow) + ' – ' + fmtHz(freqHigh);
+      drawBandOverlay(overlay, lo / binCount * canvas.width, hi / binCount * canvas.width, label);
+    }
+
+    function onDown(e) {
+      if (!canInteract()) {
+        showTooltip(canvas, 'Load audio first');
+        return;
+      }
+      const now = Date.now();
+      if (now - lastDown < 320) {
+        selLow = 0;
+        selHigh = 0;
+        clearOverlay(overlay);
+        updateSpecBadge(0, 0, false);
+        global.dispatchEvent(new CustomEvent('vip:isolationBandClear'));
+        lastDown = 0;
+        return;
+      }
+      lastDown = now;
+      dragging = true;
+      const w = canvas.width || canvas.getBoundingClientRect().width;
+      startX = pointerCanvasX(canvas, e);
+      curX = startX;
+      const bin = logBinFromX(startX, w, true);
+      selLow = bin;
+      selHigh = bin;
+      syncOverlaySize(canvas, overlay);
+      drawBandOverlay(overlay, startX, startX, null);
+      if (e.type === 'touchstart') e.preventDefault();
+    }
+
+    function onMove(e) {
+      if (!dragging) return;
+      curX = pointerCanvasX(canvas, e);
+      const w = canvas.width || canvas.getBoundingClientRect().width;
+      const b1 = logBinFromX(startX, w, true);
+      const b2 = logBinFromX(curX, w, true);
+      selLow = Math.min(b1, b2);
+      selHigh = Math.max(b1, b2);
+      syncOverlaySize(canvas, overlay);
+      const an = getAnalyser();
+      const binCount = an ? an.frequencyBinCount : 1024;
+      const freqLow = binToHz(selLow, binCount);
+      const freqHigh = binToHz(Math.max(selLow + 1, selHigh), binCount);
+      drawBandOverlay(overlay,
+        (selLow / binCount) * w,
+        (selHigh / binCount) * w,
+        'ISO: ' + fmtHz(freqLow) + ' – ' + fmtHz(freqHigh));
+      if (e.type === 'touchmove') e.preventDefault();
+    }
+
+    function onUp() {
+      if (!dragging) return;
+      dragging = false;
+      const an = getAnalyser();
+      const binCount = an ? an.frequencyBinCount : 1024;
+      const freqLow = binToHz(selLow, binCount);
+      const freqHigh = binToHz(Math.max(selLow + 1, selHigh), binCount);
+      updateSpecBadge(freqLow, freqHigh, true);
+      global.dispatchEvent(new CustomEvent('vip:isolationBandSet', {
+        detail: { freqLow, freqHigh, source: source },
+      }));
+      global.VIP_ISOLATION_BUS.emit('vip:isolationBandSet', { freqLow, freqHigh, source: source });
+    }
+
+    canvas.addEventListener('mousedown', onDown);
+    canvas.addEventListener('mousemove', onMove);
+    canvas.addEventListener('mouseup', onUp);
+    canvas.addEventListener('mouseleave', () => { if (dragging) onUp(); });
+    canvas.addEventListener('touchstart', onDown, { passive: false });
+    canvas.addEventListener('touchmove', onMove, { passive: false });
+    canvas.addEventListener('touchend', onUp, { passive: true });
+    canvas.addEventListener('dblclick', () => {
+      selLow = 0;
+      selHigh = 0;
+      clearOverlay(overlay);
+      updateSpecBadge(0, 0, false);
+      global.dispatchEvent(new CustomEvent('vip:isolationBandClear'));
+    });
+  }
+
+  function bindFreqCanvas(canvas) {
+    if (!canvas) return;
+    const overlay = ensureOverlay(canvas);
+    let dragging = false;
+    let startX = 0;
+    let barLo = 0;
+    let barHi = 0;
+    let lastDown = 0;
+    const nyquist = () => getSampleRate() / 2;
+
+    function barsToHz(lo, hi) {
+      const n = nyquist();
+      return {
+        freqLow: (lo / NUM_BARS) * n,
+        freqHigh: (Math.max(lo + 1, hi) / NUM_BARS) * n,
+      };
+    }
+
+    function drawFreqSelection() {
+      syncOverlaySize(canvas, overlay);
+      const w = canvas.width || overlay.width;
+      const barW = w / NUM_BARS;
+      const ctx = overlay.getContext('2d');
+      if (!ctx) return;
+      ctx.clearRect(0, 0, overlay.width, overlay.height);
+      const lo = Math.min(barLo, barHi);
+      const hi = Math.max(barLo, barHi);
+      for (let b = lo; b <= hi; b++) {
+        const x = b * barW;
+        const grad = ctx.createLinearGradient(x, overlay.height, x, 0);
+        grad.addColorStop(0, 'rgba(255,255,255,0.05)');
+        grad.addColorStop(1, 'rgba(255,255,255,0.55)');
+        ctx.fillStyle = grad;
+        ctx.fillRect(x + 1, 0, Math.max(1, barW - 2), overlay.height);
+        ctx.fillStyle = 'rgba(255,255,255,0.9)';
+        ctx.fillRect(x + 1, 0, Math.max(1, barW - 2), 3);
+      }
+      const hz = barsToHz(lo, hi);
+      ctx.font = '10px "JetBrains Mono", monospace';
+      ctx.fillStyle = '#00ffe7';
+      ctx.fillText('ISO: ' + fmtHz(hz.freqLow) + ' – ' + fmtHz(hz.freqHigh), lo * barW + 4, 14);
+    }
+
+    function onDown(e) {
+      if (!canInteract()) {
+        showTooltip(canvas, 'Load audio first');
+        return;
+      }
+      dragging = true;
+      startX = pointerCanvasX(canvas, e);
+      const w = canvas.width || canvas.getBoundingClientRect().width;
+      const b = linearBarFromX(startX, w);
+      barLo = b;
+      barHi = b;
+      drawFreqSelection();
+      if (e.type === 'touchstart') e.preventDefault();
+    }
+
+    function onMove(e) {
+      if (!dragging) return;
+      const w = canvas.width || canvas.getBoundingClientRect().width;
+      const x = pointerCanvasX(canvas, e);
+      const b1 = linearBarFromX(startX, w);
+      const b2 = linearBarFromX(x, w);
+      barLo = Math.min(b1, b2);
+      barHi = Math.max(b1, b2);
+      drawFreqSelection();
+      if (e.type === 'touchmove') e.preventDefault();
+    }
+
+    function onUp() {
+      if (!dragging) return;
+      dragging = false;
+      const hz = barsToHz(barLo, barHi);
+      updateSpecBadge(hz.freqLow, hz.freqHigh, true);
+      global.dispatchEvent(new CustomEvent('vip:isolationBandSet', {
+        detail: { freqLow: hz.freqLow, freqHigh: hz.freqHigh, source: 'freq-bars' },
+      }));
+    }
+
+    canvas.addEventListener('mousedown', onDown);
+    canvas.addEventListener('mousemove', onMove);
+    canvas.addEventListener('mouseup', onUp);
+    canvas.addEventListener('mouseleave', () => { if (dragging) onUp(); });
+    canvas.addEventListener('touchstart', onDown, { passive: false });
+    canvas.addEventListener('touchmove', onMove, { passive: false });
+    canvas.addEventListener('touchend', onUp, { passive: true });
+    canvas.addEventListener('dblclick', () => {
+      barLo = 0;
+      barHi = 0;
+      clearOverlay(overlay);
+      updateSpecBadge(0, 0, false);
+      global.dispatchEvent(new CustomEvent('vip:isolationBandClear'));
+    });
+  }
+
+  function bindWaveCanvas(canvas) {
+    if (!canvas) return;
+    const overlay = ensureOverlay(canvas);
+    let dragging = false;
+    let startX = 0;
+    let loopStart = null;
+    let loopEnd = null;
+
+    function drawLoop() {
+      syncOverlaySize(canvas, overlay);
+      if (loopStart == null || loopEnd == null) {
+        clearOverlay(overlay);
+        return;
+      }
+      const w = canvas.width || overlay.width;
+      const x1 = Math.min(loopStart, loopEnd) * w;
+      const x2 = Math.max(loopStart, loopEnd) * w;
+      drawBandOverlay(overlay, x1, x2, null, 'rgba(105,255,71,0.22)');
+    }
+
+    function onDown(e) {
+      if (!canInteract()) {
+        showTooltip(canvas, 'Load audio first');
+        return;
+      }
+      const w = canvas.width || canvas.getBoundingClientRect().width;
+      const x = pointerCanvasX(canvas, e);
+      const ratio = x / Math.max(1, w);
+
+      if (!dragging && !(e.shiftKey || e.altKey)) {
+        global.dispatchEvent(new CustomEvent('vip:seekRequest', { detail: { ratio } }));
+      }
+
+      dragging = true;
+      startX = ratio;
+      loopStart = ratio;
+      loopEnd = ratio;
+      drawLoop();
+      if (e.type === 'touchstart') e.preventDefault();
+    }
+
+    function onMove(e) {
+      if (!dragging) return;
+      const w = canvas.width || canvas.getBoundingClientRect().width;
+      loopEnd = pointerCanvasX(canvas, e) / Math.max(1, w);
+      drawLoop();
+      if (e.type === 'touchmove') e.preventDefault();
+    }
+
+    function onUp() {
+      if (!dragging) return;
+      dragging = false;
+      if (loopStart != null && loopEnd != null && Math.abs(loopEnd - loopStart) > 0.01) {
+        const startRatio = Math.min(loopStart, loopEnd);
+        const endRatio = Math.max(loopStart, loopEnd);
+        global.dispatchEvent(new CustomEvent('vip:loopRegionSet', {
+          detail: { startRatio, endRatio },
+        }));
+      }
+    }
+
+    canvas.addEventListener('mousedown', onDown);
+    canvas.addEventListener('mousemove', onMove);
+    canvas.addEventListener('mouseup', onUp);
+    canvas.addEventListener('mouseleave', () => { if (dragging) onUp(); });
+    canvas.addEventListener('touchstart', onDown, { passive: false });
+    canvas.addEventListener('touchmove', onMove, { passive: false });
+    canvas.addEventListener('touchend', onUp, { passive: true });
+    canvas.addEventListener('dblclick', () => {
+      loopStart = null;
+      loopEnd = null;
+      clearOverlay(overlay);
+      global.dispatchEvent(new CustomEvent('vip:loopRegionClear', { detail: {} }));
+    });
+  }
+
+  function setStemBadge(badge, stem) {
+    if (!badge) return;
+    if (!stem || stem === 'all') {
+      badge.textContent = '';
+      badge.classList.add('hidden');
+      badge.classList.remove('active');
+      return;
+    }
+    badge.textContent = STEM_LABELS[stem] || (stem.toUpperCase() + ' SOLO');
+    badge.classList.remove('hidden');
+    badge.classList.add('active');
+  }
+
+  function bindStemClick(target, badge) {
+    if (!target) return;
+    ensureRelativeParent(target);
+
+    function onClick(e) {
+      if (!canInteract()) {
+        showTooltip(target, 'Load audio first');
+        return;
+      }
+      let idx = _stemIdxByTarget.get(target) || 0;
+      idx = (idx + 1) % STEM_CYCLE.length;
+      _stemIdxByTarget.set(target, idx);
+      const stem = STEM_CYCLE[idx];
+      setStemBadge(badge, stem === 'all' ? null : stem);
+      global.dispatchEvent(new CustomEvent('vip:stemToggle', { detail: { stem } }));
+      global.VIP_ISOLATION_BUS.emit('vip:stemToggle', { stem });
+      if (e.type === 'touchstart') e.preventDefault();
+    }
+
+    target.addEventListener('click', onClick);
+    target.addEventListener('touchstart', onClick, { passive: false });
+  }
+
+  function init() {
+    bindSpectrogramCanvas($('spectro2DCanvas'), 'spectrogram');
+    bindSpectrogramCanvas($('spectroCanvas'), 'spectrogram-3d');
+    bindFreqCanvas($('freqCanvas'));
+    bindWaveCanvas($('waveCanvas'));
+
+    bindStemClick($('auraCanvas'), $('iso-badge-aura'));
+    bindStemClick($('liquidCanvas'), $('iso-badge-liquid'));
+    bindStemClick($('topoContainer'), $('iso-badge-topo'));
+    bindStemClick($('swarmContainer'), $('iso-badge-swarm'));
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init, { once: true });
+  } else {
+    init();
+  }
+
+  global.VIP_CLICK_ISOLATION = { init, STEM_CYCLE, NUM_BARS };
+})(typeof window !== 'undefined' ? window : this);

--- a/public/app/visuals-bootstrap.js
+++ b/public/app/visuals-bootstrap.js
@@ -1,0 +1,416 @@
+/**
+ * visuals-bootstrap.js
+ * ─────────────────────────────────────────────────────────────────────────────
+ * Wires the visualization tabs to the playback analyser created in vip-fixes.js.
+ *
+ * What this owns (purely additive — no module imports, no STFT/iSTFT):
+ *   1. Static waveform render to #waveCanvas on `vip:fileLoaded`.
+ *   2. A single RAF loop driving:
+ *        • #spectro2DCanvas — scrolling 2D spectrogram (Inferno LUT from visuals.js)
+ *        • #freqCanvas      — frequency bar rail
+ *        • LUFS readouts (#lufsI / #lufsS) — rolling 400ms short-term, 3s integrated
+ *        • Header peak/RMS (#hPeak / #hRMS)
+ *   3. Lazy init of premium visualizers (aura / topo / swarm / liquid)
+ *      from premium-visuals.js the first time the user activates their tab.
+ *   4. Wave A/B comparison render whenever a processed buffer becomes available.
+ *
+ * Inputs:
+ *   • window._vipPlayAnalyser  → set by vip-fixes.js when play() starts
+ *   • Events:  vip:fileLoaded, vip:playStarted, vip:playStopped, vip:processingDone
+ *
+ * Hard constraints honored:
+ *   • Zero external fetches / zero network.
+ *   • Loaded as a classic <script src> so it works without ESM evaluation order
+ *     gymnastics. Exposes globals on window for testability.
+ *   • One RAF loop total (premium tab visualizers run their own internal loops,
+ *     but only one is active at a time and we stop the previous on tab switch).
+ * ─────────────────────────────────────────────────────────────────────────────
+ */
+(function (global) {
+  'use strict';
+
+  if (global.__VIP_VISUALS_BOOT__) return;
+  global.__VIP_VISUALS_BOOT__ = true;
+
+  const $ = (id) => document.getElementById(id);
+
+  /* ── State ────────────────────────────────────────────────────────────── */
+  let _rafId = 0;
+  let _running = false;
+  let _activeTab = 'spectrogram';
+  let _activePremium = null;   // { stop() } handle for aura/topo/swarm/liquid
+  let _activePremiumTab = null;
+  // Rolling spectrogram scroll position
+  let _specX = 0;
+  // LUFS rolling state
+  let _lufsShortBuf = []; // last ~400 ms of mean-square per RAF tick
+  let _lufsIntBuf   = []; // last ~3 s
+
+  /* ── Static waveform render ───────────────────────────────────────────── */
+  function _drawWaveformOnto(canvas, audioBuf, color) {
+    if (!canvas || !audioBuf || !audioBuf.getChannelData) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    const rect = canvas.getBoundingClientRect();
+    const cssH = parseInt(getComputedStyle(canvas).height, 10) || 0;
+    const bw = rect.width  > 0 ? rect.width  : (canvas.offsetWidth  || 800);
+    const bh = rect.height > 0 ? rect.height : (cssH || canvas.offsetHeight || 70);
+    canvas.width  = Math.floor(bw);
+    canvas.height = Math.floor(bh);
+    const w = canvas.width  || 800;
+    const h = canvas.height || 70;
+    ctx.fillStyle = '#030306';
+    ctx.fillRect(0, 0, w, h);
+
+    const data = audioBuf.getChannelData(0);
+    const step = Math.max(1, Math.floor(data.length / w));
+    const mid  = h / 2;
+
+    ctx.strokeStyle = color || '#22d3ee';
+    ctx.fillStyle   = (color || '#22d3ee') + '33';
+    ctx.lineWidth   = 1;
+    ctx.beginPath();
+    ctx.moveTo(0, mid);
+    for (let x = 0; x < w; x++) {
+      let min = 1.0, max = -1.0;
+      const base = x * step;
+      const end = Math.min(base + step, data.length);
+      for (let i = base; i < end; i++) {
+        const v = data[i];
+        if (v < min) min = v;
+        if (v > max) max = v;
+      }
+      const yMin = mid - max * mid * 0.92;
+      const yMax = mid - min * mid * 0.92;
+      ctx.moveTo(x + 0.5, yMin);
+      ctx.lineTo(x + 0.5, yMax);
+    }
+    ctx.stroke();
+
+    // Zero line
+    ctx.strokeStyle = 'rgba(255,255,255,0.06)';
+    ctx.beginPath();
+    ctx.moveTo(0, mid);
+    ctx.lineTo(w, mid);
+    ctx.stroke();
+  }
+
+  function drawStaticVisuals() {
+    const app = global._vipApp;
+    if (!app) return;
+    const inBuf  = app.inputBuffer || app.origBuffer;
+    const outBuf = app.outputBuffer || app.procBuffer;
+    _drawWaveformOnto($('waveCanvas'), inBuf, '#22d3ee');
+    _drawWaveformOnto($('waveOrigCanvas'), inBuf,  '#22d3ee');
+    _drawWaveformOnto($('waveProcCanvas'), outBuf, '#69ff47');
+  }
+
+  /* ── 2D scrolling spectrogram using Inferno LUT (or fallback ramp) ────── */
+  function _resizeCanvas(canvas, fallbackH) {
+    const dpr = window.devicePixelRatio || 1;
+    const rect = canvas.getBoundingClientRect();
+    const baseW = rect.width  > 0 ? rect.width  : (canvas.offsetWidth  || canvas.clientWidth  || 800);
+    const baseH = rect.height > 0 ? rect.height : (parseInt(getComputedStyle(canvas).height, 10) || canvas.clientHeight || fallbackH || 240);
+    const w = Math.round(baseW * dpr);
+    const h = Math.round(baseH * dpr);
+    if (canvas.width !== w || canvas.height !== h) {
+      canvas.width = w;
+      canvas.height = h;
+    }
+    return { w, h };
+  }
+
+  function _drawSpectro2DColumn(canvas, freqBytes) {
+    if (!canvas) return;
+    // willReadFrequently=true avoids the Canvas2D readback warning since we
+    // call getImageData every RAF tick to scroll the spectrogram left by 1 px.
+    const ctx = canvas.getContext('2d', { willReadFrequently: true });
+    if (!ctx) return;
+    const { w, h } = _resizeCanvas(canvas, 240);
+    // Shift image left by 1 px
+    try {
+      const img = ctx.getImageData(1, 0, w - 1, h);
+      ctx.putImageData(img, 0, 0);
+    } catch (_) { /* tainted canvas — recover by clearing */ ctx.clearRect(0, 0, w, h); }
+    // Draw new column at right edge
+    const colX = w - 1;
+    const N = freqBytes.length;
+    const lut = global.VIP_INFERNO_LUT;
+    for (let y = 0; y < h; y++) {
+      // Top of canvas = high freq, bottom = low. Use log scale.
+      const t = 1 - (y / h);
+      const idx = Math.min(N - 1, Math.floor(Math.pow(t, 2.0) * (N - 1)));
+      const v = freqBytes[idx] / 255;
+      if (lut) {
+        const li = Math.min(255, Math.floor(v * 255)) * 3;
+        ctx.fillStyle = 'rgb(' + lut[li] + ',' + lut[li + 1] + ',' + lut[li + 2] + ')';
+      } else {
+        // Built-in fallback gradient (cyan → magenta → yellow)
+        const r = Math.min(255, Math.floor(v * 320));
+        const g = Math.min(255, Math.floor((1 - Math.abs(v - 0.55)) * 220));
+        const b = Math.min(255, Math.floor((1 - v) * 220));
+        ctx.fillStyle = 'rgb(' + r + ',' + g + ',' + b + ')';
+      }
+      ctx.fillRect(colX, y, 1, 1);
+    }
+    _specX = (_specX + 1) % w;
+  }
+
+  /* ── Frequency bars ───────────────────────────────────────────────────── */
+  function _drawFreqBars(canvas, freqBytes) {
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    const { w, h } = _resizeCanvas(canvas, 80);
+    // Trail for motion blur
+    ctx.fillStyle = 'rgba(3,3,6,0.45)';
+    ctx.fillRect(0, 0, w, h);
+
+    const N = freqBytes.length;
+    const bars = 64;
+    const step = Math.max(1, Math.floor(N / bars));
+    const barW = w / bars;
+    for (let b = 0; b < bars; b++) {
+      let sum = 0;
+      const base = b * step;
+      const end = Math.min(base + step, N);
+      for (let i = base; i < end; i++) sum += freqBytes[i];
+      const avg = sum / (end - base);
+      const v = avg / 255;
+      const barH = v * h * 0.92;
+      // Color: cyan → red as frequency rises
+      const hue = 180 - (b / bars) * 160;
+      ctx.fillStyle = 'hsla(' + hue.toFixed(0) + ',95%,55%,0.9)';
+      ctx.fillRect(b * barW + 1, h - barH, Math.max(1, barW - 2), barH);
+    }
+  }
+
+  /* ── LUFS rolling estimate + header peak/RMS ──────────────────────────── */
+  function _updateLufs(timeBytes, freqBytes) {
+    // K-weighted LUFS is expensive — approximate with un-weighted RMS scaled to
+    // BS.1770 style ~−0.691 LU offset so the readouts feel familiar to ENGs.
+    let sumSq = 0;
+    let peak  = 0;
+    for (let i = 0; i < timeBytes.length; i++) {
+      const s = (timeBytes[i] - 128) / 128;
+      const a = Math.abs(s);
+      if (a > peak) peak = a;
+      sumSq += s * s;
+    }
+    const ms = sumSq / timeBytes.length;
+    _lufsShortBuf.push(ms);
+    _lufsIntBuf.push(ms);
+    if (_lufsShortBuf.length > 24) _lufsShortBuf.shift(); // ~400 ms @ 60 fps
+    if (_lufsIntBuf.length > 180) _lufsIntBuf.shift();    // ~3 s
+
+    const meanShort = _lufsShortBuf.reduce((a, b) => a + b, 0) / Math.max(1, _lufsShortBuf.length);
+    const meanInt   = _lufsIntBuf.reduce((a, b) => a + b, 0) / Math.max(1, _lufsIntBuf.length);
+
+    const lufsShort = meanShort > 1e-12 ? 10 * Math.log10(meanShort) - 0.691 : -70;
+    const lufsInt   = meanInt   > 1e-12 ? 10 * Math.log10(meanInt)   - 0.691 : -70;
+
+    const sEl = $('lufsS'); if (sEl) sEl.textContent = lufsShort.toFixed(1);
+    const iEl = $('lufsI'); if (iEl) iEl.textContent = lufsInt.toFixed(1);
+
+    // Header peak / rms
+    const peakDb = peak > 1e-6 ? 20 * Math.log10(peak) : -60;
+    const rmsDb  = meanShort > 1e-12 ? 10 * Math.log10(meanShort) : -60;
+    const fmt = (v) => (v >= 0 ? '+' : '') + v.toFixed(1) + ' dB';
+    const hPeak = $('hPeak'); if (hPeak) hPeak.textContent = fmt(peakDb);
+    const hRMS  = $('hRMS');  if (hRMS)  hRMS.textContent  = fmt(rmsDb);
+
+    // VU meters defined in static HTML — drive the first two as IN / OUT
+    const meters = document.querySelectorAll('#panel-vu-meters .vu-meter');
+    const toLevel = (db) => Math.max(0, ((db + 60) / 60) * 100).toFixed(1) + '%';
+    if (meters.length >= 1) meters[0].style.setProperty('--vu-level', toLevel(rmsDb));
+    if (meters.length >= 2) meters[1].style.setProperty('--vu-level', toLevel(peakDb));
+  }
+
+  /* ── Main RAF loop ────────────────────────────────────────────────────── */
+  function _loop() {
+    if (!_running) return;
+    _rafId = requestAnimationFrame(_loop);
+    const an = global._vipPlayAnalyser;
+    if (!an) return;
+
+    const bins = an.frequencyBinCount;
+    const freqBytes = new Uint8Array(bins);
+    const timeBytes = new Uint8Array(bins);
+    try {
+      an.getByteFrequencyData(freqBytes);
+      an.getByteTimeDomainData(timeBytes);
+    } catch (_) { return; }
+
+    // Always update LUFS / header — cheap and informative across tabs
+    _updateLufs(timeBytes, freqBytes);
+
+    // Tab-targeted draws — only redraw the active tab to keep RAF light
+    if (_activeTab === 'spectrogram') {
+      const spec2d = $('spectro2DCanvas');
+      if (spec2d) {
+        if (spec2d.style.display === 'none') spec2d.style.display = '';
+        _drawSpectro2DColumn(spec2d, freqBytes);
+      }
+      const freq = $('freqCanvas');
+      if (freq) _drawFreqBars(freq, freqBytes);
+    } else if (_activeTab === 'waveform') {
+      // Live playhead overlay on the static waveform
+      const wave = $('waveCanvas');
+      const app  = global._vipApp;
+      if (wave && app) {
+        const buf = app.inputBuffer || app.origBuffer;
+        if (buf) {
+          const ctx = wave.getContext('2d');
+          // Redraw static then overlay playhead (cheap — buffer is decoded once)
+          _drawWaveformOnto(wave, buf, '#22d3ee');
+          const playOffset = (app._fixPlayState && typeof app._fixPlayState.elapsed === 'function')
+            ? app._fixPlayState.elapsed()
+            : 0;
+          const dur = buf.duration || 1;
+          const px = (playOffset / dur) * wave.width;
+          ctx.strokeStyle = '#ff2a2a';
+          ctx.lineWidth = 1.5;
+          ctx.beginPath();
+          ctx.moveTo(px, 0);
+          ctx.lineTo(px, wave.height);
+          ctx.stroke();
+        }
+      }
+    }
+  }
+
+  function start() {
+    if (_running) return;
+    _running = true;
+    _rafId = requestAnimationFrame(_loop);
+  }
+  function stop() {
+    _running = false;
+    if (_rafId) { cancelAnimationFrame(_rafId); _rafId = 0; }
+  }
+
+  /* ── Premium visualizer lazy init on tab activation ───────────────────── */
+  function _stopPremium() {
+    if (_activePremium && typeof _activePremium.stop === 'function') {
+      try { _activePremium.stop(); } catch (_) {}
+    }
+    _activePremium = null;
+    _activePremiumTab = null;
+  }
+  function _initPremium(tabName) {
+    if (_activePremiumTab === tabName && _activePremium) return; // already running
+    _stopPremium();
+    _activePremiumTab = tabName;
+    const an = global._vipPlayAnalyser;
+    if (!an) return; // analyser will appear when play() starts; we'll re-init then
+    if (tabName === 'aura') {
+      const c = $('auraCanvas');
+      if (c && typeof global.VIP_initPulsingAura === 'function') {
+        const r = c.getBoundingClientRect();
+        if (r.width > 0)  c.width  = Math.floor(r.width);
+        if (r.height > 0) c.height = Math.floor(r.height);
+        _activePremium = global.VIP_initPulsingAura(an, c);
+      }
+    } else if (tabName === 'topo') {
+      const cont = $('topoContainer');
+      if (cont && typeof global.VIP_initTopographic3D === 'function') {
+        _activePremium = global.VIP_initTopographic3D(an, cont);
+      }
+    } else if (tabName === 'swarm') {
+      const cont = $('swarmContainer');
+      if (cont && typeof global.VIP_initParticleSwarm === 'function') {
+        _activePremium = global.VIP_initParticleSwarm(an, cont);
+      }
+    } else if (tabName === 'liquid') {
+      const c = $('liquidCanvas');
+      if (c && typeof global.VIP_initLiquidWaves === 'function') {
+        const r = c.getBoundingClientRect();
+        if (r.width > 0)  c.width  = Math.floor(r.width);
+        if (r.height > 0) c.height = Math.floor(r.height);
+        _activePremium = global.VIP_initLiquidWaves(an, c);
+      }
+    } else if (tabName === 'clusters' || tabName === 'lufs' || tabName === 'abcompare') {
+      // No premium visualizer to spin up — main RAF loop already drives meters/lufs
+    }
+  }
+
+  function _onTabActivated(tab) {
+    _activeTab = tab;
+    if (tab === 'aura' || tab === 'topo' || tab === 'swarm' || tab === 'liquid') {
+      _initPremium(tab);
+    } else if (tab === 'abcompare') {
+      // Refresh the A/B waveform pair lazily — output buffer may have arrived
+      drawStaticVisuals();
+      _stopPremium();
+    } else {
+      _stopPremium();
+    }
+  }
+
+  /* ── Listen for tab clicks via a delegated listener ───────────────────── */
+  function _wireTabListener() {
+    document.addEventListener('click', (e) => {
+      const t = e.target && e.target.closest && e.target.closest('.tab-btn[data-tab]');
+      if (!t) return;
+      const tab = t.dataset.tab;
+      if (!tab) return;
+      _onTabActivated(tab);
+    });
+  }
+
+  /* ── Event wiring ─────────────────────────────────────────────────────── */
+  function _bindEvents() {
+    window.addEventListener('vip:fileLoaded',     drawStaticVisuals);
+    window.addEventListener('vip:processingDone', drawStaticVisuals);
+    window.addEventListener('vip:playStarted', () => {
+      start();
+      if (_activePremiumTab) {
+        _activePremium = null;
+        _initPremium(_activePremiumTab);
+      }
+      const an = global._vipPlayAnalyser;
+      if (an && global.NeonPulseViz && typeof global.NeonPulseViz.init === 'function') {
+        try { global.NeonPulseViz.init(an); } catch (_) {}
+      }
+    });
+    window.addEventListener('vip:playStopped', stop);
+
+    // Synthesize vip:fileLoaded when buffers arrive — vip-fixes already dispatches it
+    // but in case the legacy code path is used, poll briefly for first buffer.
+    let polls = 0;
+    const poll = setInterval(() => {
+      polls++;
+      const app = global._vipApp;
+      if (app && (app.inputBuffer || app.origBuffer)) {
+        clearInterval(poll);
+        try { window.dispatchEvent(new CustomEvent('vip:fileLoaded')); } catch (_) {}
+      } else if (polls > 600) { // ~60s
+        clearInterval(poll);
+      }
+    }, 100);
+  }
+
+  function _init() {
+    _wireTabListener();
+    _bindEvents();
+    if (global.NeonPulseViz && typeof global.NeonPulseViz.mount === 'function') {
+      try { global.NeonPulseViz.mount('#neon-pulse-slot'); } catch (_) {}
+    }
+    // Initial render in case a file is already loaded (re-mount / hot reload)
+    setTimeout(drawStaticVisuals, 400);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', _init, { once: true });
+  } else {
+    _init();
+  }
+
+  /* ── Export for tests / diagnostics ───────────────────────────────────── */
+  global.VIP_VISUALS = {
+    drawStatic: drawStaticVisuals,
+    start, stop,
+    onTabActivated: _onTabActivated,
+    initPremium: _initPremium,
+  };
+})(typeof window !== 'undefined' ? window : this);

--- a/public/app/visuals-bootstrap.js
+++ b/public/app/visuals-bootstrap.js
@@ -122,37 +122,36 @@
 
   function _drawSpectro2DColumn(canvas, freqBytes) {
     if (!canvas) return;
-    // willReadFrequently=true avoids the Canvas2D readback warning since we
-    // call getImageData every RAF tick to scroll the spectrogram left by 1 px.
-    const ctx = canvas.getContext('2d', { willReadFrequently: true });
+    const ctx = canvas.getContext('2d');
     if (!ctx) return;
     const { w, h } = _resizeCanvas(canvas, 240);
-    // Shift image left by 1 px
     try {
-      const img = ctx.getImageData(1, 0, w - 1, h);
-      ctx.putImageData(img, 0, 0);
-    } catch (_) { /* tainted canvas — recover by clearing */ ctx.clearRect(0, 0, w, h); }
-    // Draw new column at right edge
+      ctx.drawImage(canvas, 1, 0, w - 1, h, 0, 0, w - 1, h);
+    } catch (_) { ctx.clearRect(0, 0, w, h); }
     const colX = w - 1;
     const N = freqBytes.length;
     const lut = global.VIP_INFERNO_LUT;
+    const colImg = ctx.createImageData(1, h);
     for (let y = 0; y < h; y++) {
-      // Top of canvas = high freq, bottom = low. Use log scale.
       const t = 1 - (y / h);
       const idx = Math.min(N - 1, Math.floor(Math.pow(t, 2.0) * (N - 1)));
       const v = freqBytes[idx] / 255;
+      let r = 0; let g = 0; let b = 0;
       if (lut) {
         const li = Math.min(255, Math.floor(v * 255)) * 3;
-        ctx.fillStyle = 'rgb(' + lut[li] + ',' + lut[li + 1] + ',' + lut[li + 2] + ')';
+        r = lut[li]; g = lut[li + 1]; b = lut[li + 2];
       } else {
-        // Built-in fallback gradient (cyan → magenta → yellow)
-        const r = Math.min(255, Math.floor(v * 320));
-        const g = Math.min(255, Math.floor((1 - Math.abs(v - 0.55)) * 220));
-        const b = Math.min(255, Math.floor((1 - v) * 220));
-        ctx.fillStyle = 'rgb(' + r + ',' + g + ',' + b + ')';
+        r = Math.min(255, Math.floor(v * 320));
+        g = Math.min(255, Math.floor((1 - Math.abs(v - 0.55)) * 220));
+        b = Math.min(255, Math.floor((1 - v) * 220));
       }
-      ctx.fillRect(colX, y, 1, 1);
+      const pixelIdx = y * 4;
+      colImg.data[pixelIdx] = r;
+      colImg.data[pixelIdx + 1] = g;
+      colImg.data[pixelIdx + 2] = b;
+      colImg.data[pixelIdx + 3] = 255;
     }
+    ctx.putImageData(colImg, colX, 0);
     _specX = (_specX + 1) % w;
   }
 
@@ -186,7 +185,7 @@
   }
 
   /* ── LUFS rolling estimate + header peak/RMS ──────────────────────────── */
-  function _updateLufs(timeBytes, freqBytes) {
+  function _updateLufs(timeBytes, _freqBytes) {
     // K-weighted LUFS is expensive — approximate with un-weighted RMS scaled to
     // BS.1770 style ~−0.691 LU offset so the readouts feel familiar to ENGs.
     let sumSq = 0;
@@ -363,6 +362,8 @@
     window.addEventListener('vip:fileLoaded',     drawStaticVisuals);
     window.addEventListener('vip:processingDone', drawStaticVisuals);
     window.addEventListener('vip:playStarted', () => {
+      _lufsShortBuf = [];
+      _lufsIntBuf = [];
       start();
       if (_activePremiumTab) {
         _activePremium = null;


### PR DESCRIPTION
## Summary

Fixes broken visual aids after commit \0f83e8\ accidentally wiped \public/app/index.html\ and \public/app/visuals-bootstrap.js\. Restores both from last good commit \865e3c0\ and applies targeted repairs plus click-to-isolate.

## Changes

### Task A — Visual aid fixes
- **PATCH 1**: Canvas height/width fallbacks when \getBoundingClientRect()\ returns 0 (hidden panels)
- **PATCH 2**: Save \_activePremiumTab\ before null-analyser early return in \_initPremium\
- **PATCH 3**: Force premium re-init + \NeonPulseViz.init\ on \ip:playStarted\
- **PATCH 4**: Mount \NeonPulseViz\ on page load
- **PATCH 5**: Show \spectro2DCanvas\, load \
eon-pulse-visualizer.js\

### Task B — Click-to-isolate
- New \isual-click-isolation.js\ — spectrogram/freq/waveform band selection + stem toggle on premium visuals
- DSP routing in \ip-fixes.js\ (\ip:isolationBandSet\, \ip:stemToggle\, \ip:seekRequest\)
- CSS overlay styles + HUD badges in \index.html\

## Constraints
- 100% local processing — no external API calls
- Single-pass STFT — reads AnalyserNode only, no second FFT
- Classic scripts only — zero ESM imports in new file

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore visual aid files and add click-to-isolate interaction on visualization canvases
> - Adds [visual-click-isolation.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/649/files#diff-23f28d0889827ede4c2c8bafe9ceb856a11f426c0ddc03736635cee961280016), which enables drag-to-select frequency bands on spectrogram/frequency canvases, click-to-seek on waveform, and stem cycling on premium visuals; emits `CustomEvent`s for app consumption.
> - Adds [visuals-bootstrap.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/649/files#diff-97305f1278d299699dbd4b6d6074b123eebb509e482ae1a8caa5cbae8693314f), which drives all visualization tabs from a single RAF loop tied to the playback analyser: scrolling spectrogram, animated frequency bars, live LUFS/RMS meters, waveform playhead, and on-demand premium visualizers.
> - Extends [vip-fixes.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/649/files#diff-e1b2a993f0bf64b447304c6c2d82a496fd3b394e13cc5cda2d6568a7f7a92e9d) with `patchClickIsolation()`, which bridges isolation-band, stem-toggle, and seek events from visuals into DSP params, sliders, and playback controls.
> - Restores [index.html](https://github.com/Joker5514/VoiceIsolate-Pro/pull/649/files#diff-4400aa5aa5292d143f7e2f1308aa82756255552567d5558874c994833e907ce4) with the full Engineer Mode shell, wiring all CSS/JS assets, visualization tab markup, and the guarded ESM bootstrap sequence.
> - Adds cursor, iso-badge, and tooltip styles to [style.css](https://github.com/Joker5514/VoiceIsolate-Pro/pull/649/files#diff-35b8006cad11f725a0bc3cee37866f6a39b941ae71d953d622c215dbd1a8d389) to support the new canvas interactions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c0b1e68.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->