### PR TITLE
🎨 Palette: Add tooltip to speaker mute button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-18 - Missing Focus Styles for Upload Zone and Tab Buttons
 **Learning:** Custom UI interactive elements, specifically the file drop zone (`.upload-zone`) and visualization tabs (`.tab-btn`), are missing explicit `:focus-visible` styles. Because native inputs are hidden or these elements are built using custom `div`/`button` structures, they lose standard browser focus indicators, making keyboard navigation difficult for screen reader and keyboard users despite having standard ARIA roles implemented.
 **Action:** Always provide explicit `:focus-visible` styles for custom interactive elements (e.g., custom tabs, drop zones) to ensure keyboard accessibility.
+
+## 2026-07-03 - Add Tooltips to Icon-Only Action Buttons
+**Learning:** The dynamic `speaker-ui.js` renders icon-only action buttons (like mute). While these correctly used `aria-label` for screen readers, they lacked the standard HTML `title` attribute, which meant sighted mouse users had no tooltip to explain the button's function.
+**Action:** Always ensure that icon-only interactive elements receive both an `aria-label` and a `title` attribute, and that both are dynamically updated together when the button's state changes (e.g., from 'Mute' to 'Unmute').

--- a/public/app/speaker-ui.js
+++ b/public/app/speaker-ui.js
@@ -151,16 +151,16 @@ export class SpeakerUI {
       muteBtn.className = 'speaker-strip__mute';
       muteBtn.style.position = 'relative';
       muteBtn.setAttribute('aria-label', `Mute ${speakerLabel(speakerId, index)}`);
+      muteBtn.setAttribute('title', `Mute ${speakerLabel(speakerId, index)}`);
       muteBtn.innerHTML = `${MIC_SVG}<span class="speaker-strip__mic-strike"></span>`;
 
       muteBtn.addEventListener('click', () => {
         const muted = mixer.toggleMute(speakerId);
         muteBtn.classList.toggle('speaker-strip__mute--muted', muted);
         strip.classList.toggle('speaker-strip--muted', muted);
-        muteBtn.setAttribute(
-          'aria-label',
-          muted ? `Unmute ${speakerLabel(speakerId, index)}` : `Mute ${speakerLabel(speakerId, index)}`,
-        );
+        const label = muted ? `Unmute ${speakerLabel(speakerId, index)}` : `Mute ${speakerLabel(speakerId, index)}`;
+        muteBtn.setAttribute('aria-label', label);
+        muteBtn.setAttribute('title', label);
       });
 
       const gainSlider = document.createElement('input');

--- a/public/app/speaker-ui.js
+++ b/public/app/speaker-ui.js
@@ -151,7 +151,7 @@ export class SpeakerUI {
       muteBtn.className = 'speaker-strip__mute';
       muteBtn.style.position = 'relative';
       muteBtn.setAttribute('aria-label', `Mute ${speakerLabel(speakerId, index)}`);
-      muteBtn.setAttribute('title', `Mute ${speakerLabel(speakerId, index)}`);
+      muteBtn.setAttribute('title', muteBtn.getAttribute('aria-label'));
       muteBtn.innerHTML = `${MIC_SVG}<span class="speaker-strip__mic-strike"></span>`;
 
       muteBtn.addEventListener('click', () => {


### PR DESCRIPTION
💡 **What:** Added a `title` attribute to the dynamically generated `muteBtn` in `public/app/speaker-ui.js` that mirrors its `aria-label` and toggles correctly between "Mute Speaker X" and "Unmute Speaker X".
🎯 **Why:** To provide an explicit, visible tooltip for sighted mouse users interacting with an icon-only button, explaining its function. 
📸 **Before/After:** The button lacked a hover tooltip before. Now it displays "Mute Speaker X" on hover.
♿ **Accessibility:** Enhances usability for sighted users without affecting the pre-existing correct screen reader setup (`aria-label`).

---
*PR created automatically by Jules for task [8900131402422574722](https://jules.google.com/task/8900131402422574722) started by @Joker5514*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add tooltip to the speaker mute button in `SpeakerUI`
> Sets the `title` attribute on the mute button to match its `aria-label` on initial render. The click handler now updates both `aria-label` and `title` together, keeping the tooltip in sync with the muted/unmuted state.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 13406bf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved icon-only action buttons so their visible tooltip text now stays in sync with the button state.
  * Mute controls now update both the accessibility label and the browser `title` text together when switching between states like “Mute” and “Unmute.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->