### PR TITLE
perf: lower time-to-stems latency

### DIFF
--- a/public/landing.js
+++ b/public/landing.js
@@ -341,6 +341,20 @@ function syncVideo() {
 
 // ─── Worker lifecycle ────────────────────────────────────────────────────────
 
+const DEFAULT_WARMUP_CHAIN = ['demucs', 'rnnoise'];
+
+function resolveModelIds(selection) {
+  const chain = MODEL_CHAINS[selection];
+  if (chain) return chain;
+  return [getModel(selection).id];
+}
+
+/** Prefetch model bytes + compile ONNX sessions off the hot path. */
+function warmupWorkerModels(modelIds) {
+  if (!modelIds?.length) return;
+  getWorker().postMessage({ type: 'warmup', modelIds });
+}
+
 function getWorker() {
   if (worker) return worker;
   worker = new Worker('/src/workers/MLWorker.js');
@@ -356,6 +370,7 @@ function getWorker() {
         if (debugEnabled) {
           console.log('[VIP][landing] MLWorker ready (backend: ' + msg.backend + ')');
         }
+        warmupWorkerModels(DEFAULT_WARMUP_CHAIN);
         break;
       }
       case 'stage':
@@ -594,6 +609,7 @@ async function ingestFrom(file) {
   try {
     showSpinner('Decoding…', { indeterminate: true });
     setStatus(`Decoding “${file.name}”…`, 'warn');
+    warmupWorkerModels(resolveModelIds(ui.modelSelect.value));
     const next = await ingestFile(file, {
       onProgress: (stage, percent = 0) => {
         if (seq !== ingestSeq) return;
@@ -606,9 +622,8 @@ async function ingestFrom(file) {
     });
     if (seq !== ingestSeq) return;
     ingested = next;
-    hideSpinner();
-    setStatus(`Ready: ${ingested.sourceName} · ${fmtTime(ingested.duration)} · ${ingested.numberOfChannels} ch`, '');
-    ui.processBtn.disabled = false;
+    // Auto-start separation — models were warming during decode; skip the extra click.
+    onProcess();
   } catch (err) {
     if (seq !== ingestSeq) return;
     hideSpinner();
@@ -733,7 +748,10 @@ function onStems({ requestId, clean, noise, sampleRate, passthrough }) {
   const cal = autoCalibrateMix(clean, sampleRate);
   const calLabel = ` · calibrated: ${cal.preset} (${cal.level})`;
   setStatus(`Stems ready — press Play and mix in real time${calLabel}.`, 'active');
-  detectSpeakers(clean, sampleRate);
+  const scheduleIdle = globalThis.requestIdleCallback
+    ? (cb) => requestIdleCallback(cb, { timeout: 2000 })
+    : (cb) => setTimeout(cb, 0);
+  scheduleIdle(() => detectSpeakers(clean, sampleRate));
 }
 
 // ─── Stem mute toggles ───────────────────────────────────────────────────────

--- a/src/pipeline/FileIngestion.js
+++ b/src/pipeline/FileIngestion.js
@@ -171,7 +171,7 @@ export async function ingestFile(file, hooks = {}) {
   onProgress('decoding', 5);
   // Yield so the presentation layer can paint a loading state before the
   // (potentially heavy) main-thread decode call.
-  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => queueMicrotask(resolve));
   onProgress('decoding', 15);
   const decoded = await decodeBlobToAudioBuffer(file);
   onProgress('decoding', 100);

--- a/src/pipeline/StemSeparation.js
+++ b/src/pipeline/StemSeparation.js
@@ -30,8 +30,11 @@ function ensureReady() {
     }, 30000);
     const onMsg = (ev) => {
       const msg = ev.data || {};
-      if (msg.type === 'ready') { cleanup(); resolve(msg.backend || 'wasm'); }
-      else if (msg.type === 'error') { cleanup(); reject(new Error(msg.message || 'MLWorker init failed')); }
+      if (msg.type === 'ready') {
+        cleanup();
+        w.postMessage({ type: 'warmup', modelIds: ['demucs', 'rnnoise'] });
+        resolve(msg.backend || 'wasm');
+      } else if (msg.type === 'error') { cleanup(); reject(new Error(msg.message || 'MLWorker init failed')); }
     };
     const onErr = (e) => { cleanup(); reject(new Error(e.message || 'MLWorker error')); };
     const cleanup = () => {
@@ -53,6 +56,12 @@ function ensureReady() {
  * @param {{ modelIds?: string[], modelId?: string, onProgress?: (event: object) => void }} options
  * @returns {Promise<{ clean: Float32Array[], noise: Float32Array[], sampleRate: number, passthrough: boolean }>}
  */
+/** Prefetch + compile ONNX sessions while the user decodes a file. */
+export async function warmupModels(modelIds = ['demucs', 'rnnoise']) {
+  await ensureReady();
+  getWorker().postMessage({ type: 'warmup', modelIds });
+}
+
 export async function separateStems(channelData, sampleRate, options = {}) {
   await ensureReady();
   const w = getWorker();
@@ -116,4 +125,4 @@ export function resetStemSeparation() {
   _ready = null;
 }
 
-export default { ensureReady, separateStems, stemsToAudioBuffer, resetStemSeparation };
+export default { ensureReady, warmupModels, separateStems, stemsToAudioBuffer, resetStemSeparation };

--- a/src/workers/MLWorker.js
+++ b/src/workers/MLWorker.js
@@ -24,6 +24,8 @@
  *   ← { type: 'stage', requestId, stage, percent, modelId?, label? }
  *   ← { type: 'stems', requestId, clean: Float32Array[], noise: Float32Array[],
  *       sampleRate, passthrough: boolean }
+ *   → { type: 'warmup', modelIds: string[] }
+ *   ← { type: 'warmed', modelIds: string[] }
  *   ← { type: 'error', requestId?, message }
  *
  * This worker NEVER touches the DOM, never opens a microphone, and never
@@ -171,20 +173,39 @@ async function resolveBackend() {
   return BACKEND;
 }
 
-async function getSession(entry, sessionKey = entry.id) {
-  if (SESSIONS[sessionKey]) return SESSIONS[sessionKey];
-  postStage('load', 0, { modelId: entry.id, label: `Loading ${entry.name || entry.id}…` });
-  const bytes = await fetchModelBytes(entry);
-  postStage('load', 50, { modelId: entry.id });
+async function createSessionFromBytes(entry, bytes) {
   const backend = await resolveBackend();
   const opts = {
     executionProviders: backend === 'webgpu' ? ['webgpu', 'wasm'] : ['wasm'],
     graphOptimizationLevel: 'all',
   };
-  const session = await ort.InferenceSession.create(bytes, opts);
+  return ort.InferenceSession.create(bytes, opts);
+}
+
+async function getSession(entry, sessionKey = entry.id, { quiet = false } = {}) {
+  if (SESSIONS[sessionKey]) return SESSIONS[sessionKey];
+  if (!quiet) postStage('load', 0, { modelId: entry.id, label: `Loading ${entry.name || entry.id}…` });
+  const bytes = await fetchModelBytes(entry);
+  if (!quiet) postStage('load', 50, { modelId: entry.id });
+  const session = await createSessionFromBytes(entry, bytes);
   SESSIONS[sessionKey] = session;
-  postStage('load', 100, { modelId: entry.id });
+  if (!quiet) postStage('load', 100, { modelId: entry.id });
   return session;
+}
+
+/** Cache bytes + compile ONNX sessions off the hot path (boot / during decode). */
+async function warmupModels(modelIds) {
+  const ids = (Array.isArray(modelIds) ? modelIds : [])
+    .filter((id) => typeof id === 'string' && MANIFEST[id]);
+  await Promise.all(ids.map(async (id) => {
+    const entry = MANIFEST[id];
+    try {
+      await getSession(entry, entry.id, { quiet: true });
+    } catch (err) {
+      console.warn(`[VIP][MLWorker] Warmup failed for '${id}':`, err);
+    }
+  }));
+  self.postMessage({ type: 'warmed', modelIds: ids });
 }
 
 // ─── DSP helpers (STFT / mask / iSTFT reconstruction) ────────────────────────
@@ -375,11 +396,12 @@ async function runWaveformMask(entry, session, samples, sampleRate, onProgress) 
   const outName = entry.io?.output || 'output';
   const out = new Float32Array(pcm.length);
   const totalSegs = Math.ceil(pcm.length / segmentLen) || 1;
+  const chunk = new Float32Array(segmentLen);
 
   for (let seg = 0; seg < totalSegs; seg++) {
     const offset = seg * segmentLen;
     const len = Math.min(segmentLen, pcm.length - offset);
-    const chunk = new Float32Array(segmentLen);
+    chunk.fill(0);
     chunk.set(pcm.subarray(offset, offset + len));
     const input = new ort.Tensor('float32', chunk, [1, 1, segmentLen]);
     const result = await session.run({ [inName]: input });
@@ -434,16 +456,26 @@ async function processRequest({ requestId, modelId, modelIds, channelData, sampl
   }
 
   ACTIVE_REQUEST_ID = requestId;
+  let lastProgressSent = -1;
   const onProgress = (p) => {
-    self.postMessage({ type: 'progress', requestId, percent: Math.round(p * 100) });
+    const pct = Math.round(p * 100);
+    if (pct === lastProgressSent) return;
+    if (pct < 100 && lastProgressSent >= 0 && pct - lastProgressSent < 2) return;
+    lastProgressSent = pct;
+    self.postMessage({ type: 'progress', requestId, percent: pct });
   };
 
   const totalSteps = chain.length * channelData.length;
   let stepBase = 0;
   let current = channelData;
   try {
-    for (const id of chain) {
+    for (let ci = 0; ci < chain.length; ci++) {
+      const id = chain[ci];
       const entry = MANIFEST[id];
+      const nextId = chain[ci + 1];
+      const nextWarm = nextId && MANIFEST[nextId]
+        ? getSession(MANIFEST[nextId], MANIFEST[nextId].id, { quiet: true }).catch(() => {})
+        : null;
       postStage('separate', Math.round((stepBase / totalSteps) * 100), { modelId: id });
       const next = await Promise.all(current.map(async (samples, ch) => {
         const sessionKey = current.length > 1 ? `${entry.id}:ch${ch}` : entry.id;
@@ -460,6 +492,7 @@ async function processRequest({ requestId, modelId, modelIds, channelData, sampl
       }));
       current = next;
       stepBase += channelData.length;
+      if (nextWarm) await nextWarm;
     }
   } finally {
     ACTIVE_REQUEST_ID = null;
@@ -494,6 +527,9 @@ self.onmessage = async (event) => {
       }
       case 'process':
         await processRequest(msg);
+        break;
+      case 'warmup':
+        await warmupModels(msg.modelIds);
         break;
       default:
         self.postMessage({ type: 'error', message: `Unknown message type '${msg.type}'` });

--- a/tests/landing-video-spinner.test.js
+++ b/tests/landing-video-spinner.test.js
@@ -72,6 +72,13 @@ describe('Landing page — realtime processing indicator (ProcessLoader)', () =>
     expect(js).not.toContain('ui.progress');
   });
 
+  test('models warm up off the hot path and separation auto-starts after ingest', () => {
+    expect(js).toContain("type: 'warmup'");
+    expect(js).toContain('warmupWorkerModels');
+    expect(js).toContain('onProcess()');
+    expect(js).toContain('requestIdleCallback');
+  });
+
   test('inference progress drives the ProcessLoader component', () => {
     expect(js).toContain('function setProgress(');
     expect(js).toContain("case 'progress'");


### PR DESCRIPTION
## Problem
First separation felt slow: ~149 MB Demucs download + ONNX compile happened on button click, and users had to decode **then** click Separate Stems.

## Changes

### Model warmup (biggest win)
- New \warmup\ worker message caches model bytes in IndexedDB and compiles ONNX sessions off the hot path
- Landing warms the default \demucs → rnnoise\ chain on boot and again while the file decodes
- \StemSeparation\ warms the same chain after worker init (Engineer Mode benefits too)
- During multi-model chains, the **next** model warms in parallel while the current one runs

### Pipeline efficiency
- Throttled \progress\ postMessage (≥2% steps) to cut main-thread churn
- Reused Demucs segment buffer (no per-segment \Float32Array\ alloc)
- \queueMicrotask\ instead of \setTimeout(0)\ before decode

### UX latency
- **Auto-start separation** when ingest finishes — removes the extra click; models are already warm
- Speaker diarization deferred via \equestIdleCallback\ so stems load/play sooner

## Test plan
- [x] \
ode scripts/validate.js\
- [x] \landing-video-spinner\, \ml-worker-dsp\ Jest suites
- [ ] Full \pnpm test:ci\ on merge

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Lower time-to-stems latency by warming models on worker startup and auto-starting separation after ingest
> - On worker ready, `ensureReady` in [StemSeparation.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/655/files#diff-ee2b9dbe14c9d6ef6bccb4d4a853a8f31db7d6d7487b98f2a39ee6a09058151b) and `getWorker` in [landing.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/655/files#diff-be23ec2b8a859b1c83e27ce227d9dd0c367c83c7a8f1a4b104128c882bdb30ab) both post a `warmup` message for `demucs` and `rnnoise`, prefetching and compiling ONNX sessions before the user starts a job.
> - [MLWorker.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/655/files#diff-feb98479b700cf9bcf10c1482f1408a8217b243653a510f90b27c617f61cf8a4) gains a `warmupModels` function that loads sessions in quiet mode (no progress events) and posts a `warmed` acknowledgement; during processing, the next model in a chain is warmed in the background while the current one runs.
> - After ingest completes, separation now starts automatically via `onProcess()` instead of waiting for a manual click.
> - Speaker detection in `onStems` is deferred to idle time via `requestIdleCallback` to reduce main-thread work after stems arrive.
> - Behavioral Change: ingest no longer pauses for user confirmation before separation begins.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 81c314d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Processing now begins automatically after a file is added, reducing extra clicks.
  * Background model preloading helps get separation started sooner.

* **Bug Fixes**
  * Speaker detection is deferred until the browser is idle, improving responsiveness during playback and ingest.
  * Progress updates are smoother and less noisy during processing.

* **Performance**
  * File loading and model setup now yield more efficiently to keep the interface more responsive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->