### PR TITLE
fix(electron): unsigned Windows dir builds without symlink privilege

### DIFF
--- a/electron/electron-builder.yml
+++ b/electron/electron-builder.yml
@@ -20,6 +20,8 @@ extraMetadata:
 win:
   target:
     - nsis
+  # Unsigned local builds: winCodeSign cache extraction needs symlink privilege on Windows.
+  signAndEditExecutable: false
   artifactName: VoiceIsolate-Pro-${version}-win-${arch}.${ext}
 
 mac:

--- a/package.json
+++ b/package.json
@@ -69,8 +69,8 @@
     "models:upload:diarization": "node scripts/upload-diarization-blob.mjs",
     "electron:dev": "cross-env VIP_ELECTRON_DEV=1 electron .",
     "electron:start": "electron .",
-    "build:electron": "pnpm run build && electron-builder --config electron/electron-builder.yml",
-    "build:electron:dir": "pnpm run build && electron-builder --dir --config electron/electron-builder.yml"
+    "build:electron": "node scripts/electron-build-win.mjs",
+    "build:electron:dir": "node scripts/electron-build-win.mjs --dir"
   },
   "devDependencies": {
     "@capacitor/android": "^8.3.1",

--- a/scripts/electron-build-win.mjs
+++ b/scripts/electron-build-win.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+/**
+ * Windows Electron unpacked build (unsigned test artifact).
+ * Skips code-sign tooling that requires symlink privileges on Windows.
+ */
+import { spawnSync } from 'child_process';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+const isWin = process.platform === 'win32';
+const dirOnly = process.argv.includes('--dir');
+
+const env = {
+  ...process.env,
+  CSC_IDENTITY_AUTO_DISCOVERY: 'false',
+};
+
+function run(cmd, args) {
+  const result = spawnSync(cmd, args, {
+    cwd: ROOT,
+    stdio: 'inherit',
+    shell: isWin,
+    env,
+  });
+  if (result.status !== 0) process.exit(result.status ?? 1);
+}
+
+run('pnpm', ['run', 'build']);
+
+const builderArgs = [
+  'electron-builder',
+  '--config',
+  'electron/electron-builder.yml',
+];
+if (dirOnly) builderArgs.push('--dir');
+
+run('pnpm', ['exec', ...builderArgs]);
+
+if (dirOnly) {
+  const exe = path.join(ROOT, 'dist', 'electron', 'win-unpacked', 'VoiceIsolate Pro.exe');
+  console.log(`[electron] Unpacked app → ${exe}`);
+}


### PR DESCRIPTION
Fixes Windows electron-builder failure when winCodeSign cache extraction cannot create symlinks. Adds signAndEditExecutable false and electron-build-win.mjs script. Verified pnpm build:electron:dir produces dist/electron/win-unpacked/VoiceIsolate Pro.exe

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix unsigned Windows dir builds by disabling signing and using a build wrapper script
> - Adds [scripts/electron-build-win.mjs](https://github.com/Joker5514/VoiceIsolate-Pro/pull/660/files#diff-5792f9b5deabd97f8010d114fd4fcf6e98d322b6da818a995aefe73fb6f9c68e), a Node script that sets `CSC_IDENTITY_AUTO_DISCOVERY=false`, runs `pnpm run build`, then invokes `electron-builder` — avoiding the need for symlink privileges on Windows.
> - Updates `build:electron` and `build:electron:dir` in [package.json](https://github.com/Joker5514/VoiceIsolate-Pro/pull/660/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) to delegate to this script instead of calling `electron-builder` directly.
> - Adds `signAndEditExecutable: false` to the `win` section of [electron/electron-builder.yml](https://github.com/Joker5514/VoiceIsolate-Pro/pull/660/files#diff-9bac4712524fffd12798dfb60557bcf3f28be46830bf29e7dbba5bf34f2e86b2) so local unsigned builds skip executable editing.
> - Behavioral Change: Windows builds no longer attempt code signing or executable editing by default.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a7ea7fd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->