### PR TITLE
feat(worklets): complete cross-platform AudioWorklet packaging

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,6 +153,12 @@ Rules:
     `scripts/validate.js`; any other `audioWorklet.addModule` target (or a
     dynamic one) and `getUserMedia` remain forbidden. Do not delete them or
     re-tighten the allowlist as a "live-pipeline" regression.
+  - `public/app/dsp-processor.js` (`registerProcessor('dsp-processor')`) is
+    **legacy-shipped** on web, Android, and desktop for Engineer Mode
+    compatibility and offline precache, but it is **not** `addModule`-loaded
+    (the live SharedArrayBuffer worklet path was removed). Packaging is governed
+    by `scripts/worklet-manifest.json`, `scripts/verify-worklets.js`, and
+    `docs/WORKLETS.md`. After any worklet edit run `pnpm worklets:hash`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ pnpm dev              # http://localhost:3000  (auto-syncs src/ → public/src/)
 pnpm test             # Jest — 2100+ tests
 pnpm lint             # ESLint
 pnpm validate         # Structural integrity checks (CI gate)
+pnpm worklets:verify  # AudioWorklet packaging (web + Android + desktop paths)
 pnpm build            # Production static build (cross-platform via scripts/build.mjs)
 pnpm build:mobile     # Capacitor sync for Android
 pnpm electron:dev     # Desktop shell (requires pnpm dev in another terminal)
@@ -138,7 +139,7 @@ Both surfaces share the canonical `src/pipeline/StemSeparation.js` path for offl
 |-------|------------|
 | Frontend | Vanilla JS (ES modules), Canvas 2D, Three.js (Engineer premium tabs) |
 | ML | ONNX Runtime Web 1.25, WebGPU + WASM (up to 8 threads) |
-| Audio | Web Audio API, AudioWorklets (gate + de-esser on playback stems) |
+| Audio | Web Audio API, 3 AudioWorklets (gate + de-esser active; dsp-processor legacy-shipped) |
 | Server | Express 5 (dev), Vercel serverless (prod, pnpm via `scripts/vercel-install.sh`) |
 | Payments | Stripe (optional, server-side only) |
 | Mobile | Capacitor 8 (Android / iOS) |
@@ -149,7 +150,7 @@ Both surfaces share the canonical `src/pipeline/StemSeparation.js` path for offl
 ```
 src/                       Canonical 4-layer architecture
 ├── core/                  Pure primitives, ModelManifest, BufferPool
-├── workers/               MLWorker (offline), Diarization, SpectralCleanup, Encoders
+├── workers/               MLWorker, GateProcessor, DeEsserProcessor, Diarization, Encoders
 ├── pipeline/              FileIngestion, PlaybackMixer, StemSeparation, Orchestrators
 └── presentation/          SliderUI, LandingVisualizer, ExportControls
 
@@ -161,7 +162,22 @@ public/
 server/                    Express + securityHeaders.js
 api-routes/                Stripe monetization, licensing, sync
 tests/                     80+ Jest suites
-scripts/                   Build, validation, model tooling, Vercel install
+scripts/                   Build, validation, model + worklet tooling, Vercel install
+```
+
+### AudioWorklets (all platforms)
+
+Three worklet files ship in every web, Android, and desktop build. See [`docs/WORKLETS.md`](docs/WORKLETS.md).
+
+| Worklet | Path | Runtime |
+|---------|------|---------|
+| Gate | `/src/workers/GateProcessor.js` | Active — playback noise gate |
+| De-esser | `/src/workers/DeEsserProcessor.js` | Active — playback de-esser |
+| DSP (legacy) | `/app/dsp-processor.js` | Shipped + precached; not loaded (live SAB path removed) |
+
+```bash
+pnpm worklets:hash           # after editing any *Processor.js
+pnpm worklets:verify:build   # confirm build/ copies before cap sync / electron pack
 ```
 
 See [`CLAUDE.md`](CLAUDE.md) for the full contributor contract and [`CONTRIBUTING.md`](CONTRIBUTING.md) for the development workflow.

--- a/docs/MODEL_DELIVERY.md
+++ b/docs/MODEL_DELIVERY.md
@@ -47,6 +47,14 @@ Model files are hosted on Vercel Blob Storage and mirrored on Cloudflare R2.
 The `models-manifest.json` file at `public/app/models-manifest.json` lists all
 models, their sizes, checksums, and provider URLs.
 
+## AudioWorklet delivery
+
+Processor scripts (gate, de-esser, legacy dsp-processor) follow the same
+same-origin packaging path as ONNX models but are committed to the repo and
+pinned by SHA-256 in `models-manifest.json` → `worklets`. See
+[`docs/WORKLETS.md`](WORKLETS.md) for the full cross-platform matrix and CI
+checks.
+
 ## Adding a new model
 
 1. Upload the `.onnx` file to Vercel Blob (`vercel blob upload`).

--- a/docs/WORKLETS.md
+++ b/docs/WORKLETS.md
@@ -38,7 +38,9 @@ public/app/dsp-processor.js              ──►              ──► build/
 
 ## Integrity
 
-SHA-256 pins live in `public/app/models-manifest.json` under `worklets`. Regenerate after any worklet edit:
+SHA-256 pins live in `public/app/models-manifest.json` under `worklets`. Hashes are
+computed on **LF-normalized** file bytes so Windows CRLF working copies match Linux
+CI and git blobs. Regenerate after any worklet edit:
 
 ```bash
 pnpm worklets:hash      # recompute + update models-manifest.json

--- a/docs/WORKLETS.md
+++ b/docs/WORKLETS.md
@@ -1,0 +1,63 @@
+# AudioWorklet Packaging
+
+VoiceIsolate Pro ships **three** AudioWorklet processor files on every platform (web, Android, desktop). Two are **active** at runtime; one is **legacy-shipped** for compatibility.
+
+## Registry
+
+Canonical list: [`scripts/worklet-manifest.json`](../scripts/worklet-manifest.json)
+
+| ID | File | Processor | Role | Loaded at runtime |
+|----|------|-----------|------|-----------------|
+| `vip-gate` | `src/workers/GateProcessor.js` | `vip-gate` | **Active** | `PlaybackMixer._loadGate()` |
+| `vip-deesser` | `src/workers/DeEsserProcessor.js` | `vip-deesser` | **Active** | `PlaybackMixer._loadDeEsser()` |
+| `dsp-processor` | `public/app/dsp-processor.js` | `dsp-processor` | **Legacy-shipped** | Not `addModule`-loaded (live SAB pipeline removed; see CLAUDE.md §1.1) |
+
+Active worklets run on **playback stems only** — never on a live microphone and never re-running ML.
+
+## Delivery path
+
+```
+src/workers/GateProcessor.js
+src/workers/DeEsserProcessor.js          ──► pnpm build ──► build/src/workers/*.js
+public/app/dsp-processor.js              ──►              ──► build/app/dsp-processor.js
+                                                    │
+                    ┌───────────────────────────────┼───────────────────────────────┐
+                    ▼                               ▼                               ▼
+              Vercel / dev                   Capacitor (Android)              Electron desktop
+         /src/workers/*.js              assets/public/src/workers/         build/** in installer
+         /app/dsp-processor.js          assets/public/app/dsp-processor.js
+```
+
+- **Web:** Express dev server and Vercel serve `public/` + synced `public/src/`. COOP/COEP headers on `/src/workers/*.js` and `/app/dsp-processor.js` (`vercel.json`).
+- **Android:** `capacitor.config.json` sets `webDir: "build"`. Run `pnpm build && npx cap sync android` before APK/AAB builds.
+- **Desktop:** `electron-builder.yml` packs `build/**/*`. Run `pnpm build` before `pnpm build:electron:dir`.
+
+## Offline precache
+
+`public/app/sw.js` `APP_SHELL` precaches all three worklet URLs so the service worker can serve them without a network round-trip after install.
+
+## Integrity
+
+SHA-256 pins live in `public/app/models-manifest.json` under `worklets`. Regenerate after any worklet edit:
+
+```bash
+pnpm worklets:hash      # recompute + update models-manifest.json
+pnpm worklets:verify    # source + manifest + APP_SHELL checks
+pnpm worklets:verify:build   # also requires build/ copies in sync
+```
+
+`pnpm validate` calls `scripts/verify-worklets.js`. `pnpm android:build:win` verifies
+Android assets after `cap sync`. For release CI, add to `release-build.yml` after cap sync:
+
+```bash
+node scripts/verify-worklets.js --require-build --require-android
+```
+
+## Commands
+
+| Command | Purpose |
+|---------|---------|
+| `pnpm worklets:hash` | Recompute SHA-256 and update `models-manifest.json` |
+| `pnpm worklets:verify` | Verify source paths, hashes, SW precache |
+| `pnpm worklets:verify:build` | Above + require synced `build/` copies |
+| `pnpm test -- tests/worklet-packaging.test.js` | Jest packaging assertions |

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
     "lint:fix": "eslint public/app/app.js public/app/dsp-worker.js public/app/dsp-processor.js public/app/ml-worker.js public/app/vip-enhancements.js public/landing.js src server --fix",
     "validate": "node scripts/validate.js",
     "worklets:hash": "node scripts/hash-worklets.js",
+    "worklets:verify": "node scripts/verify-worklets.js",
+    "worklets:verify:build": "node scripts/verify-worklets.js --require-build",
     "test:coverage": "node --experimental-vm-modules node_modules/jest/bin/jest.js --testEnvironment=node --coverage",
     "test:live": "node scripts/live-smoke.cjs",
     "test:landing": "node scripts/landing-smoke.cjs",

--- a/public/app/models-manifest.json
+++ b/public/app/models-manifest.json
@@ -58,7 +58,7 @@
         {
           "provider": "same-origin",
           "url": "/app/dsp-processor.js",
-          "sha256": "069aa57c92823b0140ebbadd3bed439584d38d343c8ce93b2364f344fa036901"
+          "sha256": "5692dac6eeb7b82058f53ecf77ac78d23f2f8a0011797398ffb46e93b97057ee"
         }
       ]
     },
@@ -71,7 +71,7 @@
         {
           "provider": "same-origin",
           "url": "/src/workers/GateProcessor.js",
-          "sha256": "9fdaaabc3a741b903e656599bc7033fc309c7de0f9ba5eee987be947419b7c16"
+          "sha256": "1105c1fe087e55462fcd41f1b67eb27c18c2314f9330dd8c5b8e3aec6e49c60d"
         }
       ]
     },
@@ -84,7 +84,7 @@
         {
           "provider": "same-origin",
           "url": "/src/workers/DeEsserProcessor.js",
-          "sha256": "1af6caac23515aac015ef0c04b8257e0797e2b4ef6f988ebc27e515e66e56eb8"
+          "sha256": "bb66cd422d1f023b802c6de04ad8413fad1eeadb86adccd171720ece119bbb83"
         }
       ]
     }

--- a/public/app/models-manifest.json
+++ b/public/app/models-manifest.json
@@ -7,7 +7,10 @@
       "sizeBytes": 88080384,
       "eager": false,
       "sources": [
-        { "provider": "same-origin", "url": "/app/models/demucs_v4_quantized.onnx" }
+        {
+          "provider": "same-origin",
+          "url": "/app/models/demucs_v4_quantized.onnx"
+        }
       ]
     },
     "bsrnn": {
@@ -15,7 +18,10 @@
       "sizeBytes": 3870554,
       "eager": false,
       "sources": [
-        { "provider": "same-origin", "url": "/app/models/bsrnn_vocals.onnx" }
+        {
+          "provider": "same-origin",
+          "url": "/app/models/bsrnn_vocals.onnx"
+        }
       ]
     },
     "rnnoise": {
@@ -23,7 +29,10 @@
       "sizeBytes": 2027576,
       "eager": true,
       "sources": [
-        { "provider": "same-origin", "url": "/app/models/rnnoise_suppressor.onnx" }
+        {
+          "provider": "same-origin",
+          "url": "/app/models/rnnoise_suppressor.onnx"
+        }
       ]
     },
     "silero_vad": {
@@ -31,19 +40,52 @@
       "sizeBytes": 2327524,
       "eager": true,
       "sources": [
-        { "provider": "same-origin", "url": "/app/models/silero_vad.onnx" }
+        {
+          "provider": "same-origin",
+          "url": "/app/models/silero_vad.onnx"
+        }
       ]
     }
   },
-  "_sha256_note": "SHA256 last updated: 2026-05-20. Regenerate with: node scripts/hash-worklets.js",
+  "_sha256_note": "SHA256 last updated: 2026-07-06. Regenerate with: pnpm worklets:hash",
   "worklets": {
     "dsp_processor": {
       "filename": "dsp-processor.js",
       "processorName": "dsp-processor",
+      "role": "legacy-shipped",
       "contentType": "application/javascript",
       "sources": [
-        { "provider": "same-origin", "url": "/app/dsp-processor.js", "sha256": "e8870cd5c8ee1490a7c1e74d2fceab391f1f6c59d085882157acb3328c2dbba1" },
-        { "provider": "vercel-blob", "url": "https://blob.vercel-storage.com/voiceisolate-pro/worklets/dsp-processor.js", "sha256": "e8870cd5c8ee1490a7c1e74d2fceab391f1f6c59d085882157acb3328c2dbba1" }
+        {
+          "provider": "same-origin",
+          "url": "/app/dsp-processor.js",
+          "sha256": "069aa57c92823b0140ebbadd3bed439584d38d343c8ce93b2364f344fa036901"
+        }
+      ]
+    },
+    "gate_processor": {
+      "filename": "GateProcessor.js",
+      "processorName": "vip-gate",
+      "role": "active",
+      "contentType": "application/javascript",
+      "sources": [
+        {
+          "provider": "same-origin",
+          "url": "/src/workers/GateProcessor.js",
+          "sha256": "9fdaaabc3a741b903e656599bc7033fc309c7de0f9ba5eee987be947419b7c16"
+        }
+      ]
+    },
+    "deesser_processor": {
+      "filename": "DeEsserProcessor.js",
+      "processorName": "vip-deesser",
+      "role": "active",
+      "contentType": "application/javascript",
+      "sources": [
+        {
+          "provider": "same-origin",
+          "url": "/src/workers/DeEsserProcessor.js",
+          "sha256": "1af6caac23515aac015ef0c04b8257e0797e2b4ef6f988ebc27e515e66e56eb8"
+        }
       ]
     }
   }

--- a/public/app/sw.js
+++ b/public/app/sw.js
@@ -35,6 +35,10 @@ const APP_SHELL = [
   '/app/style.css',
   '/app/dsp-core.js',
   '/app/dsp-processor.js',
+  // Playback-only Live-Mix worklets (Gate + De-esser) — loaded by PlaybackMixer
+  '/src/workers/GateProcessor.js',
+  '/src/workers/DeEsserProcessor.js',
+  '/src/pipeline/PlaybackMixer.js',
   '/app/dsp-worker.js',
   '/app/pipeline-state.js',
   '/app/ml-worker.js',

--- a/scripts/android-build-win.mjs
+++ b/scripts/android-build-win.mjs
@@ -61,6 +61,7 @@ if (jdk21) {
 
 run('pnpm', ['run', 'build']);
 run('npx', ['cap', 'sync', 'android']);
+run('node', [path.join(ROOT, 'scripts', 'verify-worklets.js'), '--require-build', '--require-android']);
 run(path.join(ANDROID, 'gradlew.bat'), ['assembleDebug'], ANDROID);
 
 const apk = path.join(ANDROID, 'app', 'build', 'outputs', 'apk', 'debug', 'app-debug.apk');

--- a/scripts/hash-worklets.js
+++ b/scripts/hash-worklets.js
@@ -22,8 +22,10 @@ const MANIFEST_KEYS = {
   'dsp-processor': 'dsp_processor',
 };
 
+/** LF-normalized digest — matches git blobs and Linux CI (avoids CRLF drift on Windows). */
 function sha256(absPath) {
-  return crypto.createHash('sha256').update(fs.readFileSync(absPath)).digest('hex');
+  const normalized = fs.readFileSync(absPath, 'utf8').replace(/\r\n/g, '\n');
+  return crypto.createHash('sha256').update(normalized, 'utf8').digest('hex');
 }
 
 const registry = JSON.parse(fs.readFileSync(REGISTRY, 'utf8'));

--- a/scripts/hash-worklets.js
+++ b/scripts/hash-worklets.js
@@ -1,31 +1,63 @@
 #!/usr/bin/env node
 'use strict';
 
-// Computes and prints the SHA-256 hash of each AudioWorklet file.
-// Run via: node scripts/hash-worklets.js
-// Or:      pnpm run worklets:hash
-//
-// Update the sha256 fields in public/app/models-manifest.json whenever
-// any worklet file changes (e.g. after patching dsp-processor.js).
+/**
+ * Computes SHA-256 hashes for every AudioWorklet in scripts/worklet-manifest.json
+ * and updates public/app/models-manifest.json worklets section.
+ *
+ * Run: pnpm worklets:hash
+ */
 
 const crypto = require('crypto');
 const fs = require('fs');
 const path = require('path');
 
-const WORKLETS = [
-  'public/app/dsp-processor.js',
-];
+const ROOT = path.join(__dirname, '..');
+const REGISTRY = path.join(__dirname, 'worklet-manifest.json');
+const MODELS_MANIFEST = path.join(ROOT, 'public', 'app', 'models-manifest.json');
 
-const root = path.resolve(__dirname, '..');
+const MANIFEST_KEYS = {
+  'vip-gate': 'gate_processor',
+  'vip-deesser': 'deesser_processor',
+  'dsp-processor': 'dsp_processor',
+};
 
-for (const rel of WORKLETS) {
-  const abs = path.join(root, rel);
+function sha256(absPath) {
+  return crypto.createHash('sha256').update(fs.readFileSync(absPath)).digest('hex');
+}
+
+const registry = JSON.parse(fs.readFileSync(REGISTRY, 'utf8'));
+const modelsDoc = JSON.parse(fs.readFileSync(MODELS_MANIFEST, 'utf8'));
+if (!modelsDoc.worklets) modelsDoc.worklets = {};
+
+console.log('🔊 Worklet SHA-256 hashes\n');
+
+for (const entry of registry.worklets) {
+  const abs = path.join(ROOT, entry.source);
   if (!fs.existsSync(abs)) {
-    console.error(`NOT FOUND: ${rel}`);
+    console.error(`NOT FOUND: ${entry.source}`);
     process.exitCode = 1;
     continue;
   }
-  const buf = fs.readFileSync(abs);
-  const hash = crypto.createHash('sha256').update(buf).digest('hex');
-  console.log(`${path.basename(rel)}: ${hash}`);
+  const hash = sha256(abs);
+  const key = MANIFEST_KEYS[entry.id] || entry.id;
+  const filename = path.basename(entry.source);
+
+  console.log(`${entry.name} (${entry.url})`);
+  console.log(`  sha256: ${hash}`);
+  console.log(`  bytes:  ${fs.statSync(abs).size}\n`);
+
+  modelsDoc.worklets[key] = {
+    filename,
+    processorName: entry.processorName,
+    role: entry.role,
+    contentType: 'application/javascript',
+    sources: [
+      { provider: 'same-origin', url: entry.url, sha256: hash },
+    ],
+  };
 }
+
+modelsDoc._sha256_note = `SHA256 last updated: ${new Date().toISOString().slice(0, 10)}. Regenerate with: pnpm worklets:hash`;
+fs.writeFileSync(MODELS_MANIFEST, `${JSON.stringify(modelsDoc, null, 2)}\n`, 'utf8');
+console.log(`Updated ${path.relative(ROOT, MODELS_MANIFEST)}`);

--- a/scripts/validate.js
+++ b/scripts/validate.js
@@ -127,6 +127,14 @@ const awJs = fs.existsSync(path.resolve(__dirname, '..', 'public/app/dsp-process
   ? fs.readFileSync(path.resolve(__dirname, '..', 'public/app/dsp-processor.js'), 'utf8') : '';
 check(awJs.includes("registerProcessor('dsp-processor'"), 'AudioWorklet registerProcessor present');
 check(awJs.includes('process(inputs, outputs'), 'AudioWorklet process() method present');
+const { verifyWorklets } = require('./verify-worklets.js');
+const workletResult = verifyWorklets({ quiet: true });
+if (!workletResult.ok) {
+  workletResult.errors.forEach((e) => console.log(`  ✗ ${e}`));
+  errors += workletResult.errors.length;
+} else {
+  check(true, 'All 3 AudioWorklets present, hashed, and APP_SHELL precached (verify-worklets.js)');
+}
 
 // Phase 4: ONNX Runtime + ML Worker
 console.log('\nONNX Runtime (Phase 4):');

--- a/scripts/verify-worklets.js
+++ b/scripts/verify-worklets.js
@@ -22,8 +22,11 @@ const MANIFEST_PATH = path.join(__dirname, 'worklet-manifest.json');
 const MODELS_MANIFEST = path.join(ROOT, 'public', 'app', 'models-manifest.json');
 const SW_PATH = path.join(ROOT, 'public', 'app', 'sw.js');
 
+/** LF-normalized SHA-256 so Windows CRLF working copies match Linux CI / git blobs. */
 function sha256File(absPath) {
-  return crypto.createHash('sha256').update(fs.readFileSync(absPath)).digest('hex');
+  const raw = fs.readFileSync(absPath, 'utf8');
+  const normalized = raw.replace(/\r\n/g, '\n');
+  return crypto.createHash('sha256').update(normalized, 'utf8').digest('hex');
 }
 
 function loadWorkletManifest() {

--- a/scripts/verify-worklets.js
+++ b/scripts/verify-worklets.js
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * VoiceIsolate Pro — AudioWorklet packaging verifier
+ *
+ * Ensures all registered worklets:
+ *   1. Exist at canonical source paths with registerProcessor()
+ *   2. Are present in build/ after `pnpm build` (when build/ exists)
+ *   3. Match SHA-256 pins in public/app/models-manifest.json (when present)
+ *   4. Are listed in public/app/sw.js APP_SHELL for offline precache
+ *
+ * Used by: pnpm validate, CI release-build, tests/worklet-packaging.test.js
+ */
+
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const MANIFEST_PATH = path.join(__dirname, 'worklet-manifest.json');
+const MODELS_MANIFEST = path.join(ROOT, 'public', 'app', 'models-manifest.json');
+const SW_PATH = path.join(ROOT, 'public', 'app', 'sw.js');
+
+function sha256File(absPath) {
+  return crypto.createHash('sha256').update(fs.readFileSync(absPath)).digest('hex');
+}
+
+function loadWorkletManifest() {
+  return JSON.parse(fs.readFileSync(MANIFEST_PATH, 'utf8'));
+}
+
+function loadModelsManifestWorklets() {
+  if (!fs.existsSync(MODELS_MANIFEST)) return {};
+  const doc = JSON.parse(fs.readFileSync(MODELS_MANIFEST, 'utf8'));
+  return doc.worklets || {};
+}
+
+function extractAppShellUrls(swSrc) {
+  const block = swSrc.match(/const APP_SHELL\s*=\s*\[([\s\S]*?)\];/);
+  if (!block) return [];
+  const urls = [];
+  const re = /['"]([^'"]+)['"]/g;
+  let m;
+  while ((m = re.exec(block[1]))) urls.push(m[1]);
+  return urls;
+}
+
+/**
+ * @param {object} [options]
+ * @param {boolean} [options.requireBuild=false] Fail if build/ copies are missing
+ * @param {boolean} [options.requireAndroid=false] Fail if cap-sync android assets missing
+ * @param {boolean} [options.quiet=false]
+ * @returns {{ ok: boolean, errors: string[], warnings: string[] }}
+ */
+function verifyWorklets(options = {}) {
+  const { requireBuild = false, requireAndroid = false, quiet = false } = options;
+  const errors = [];
+  const warnings = [];
+  const log = (msg) => { if (!quiet) console.log(msg); };
+
+  log('\n🔊 VoiceIsolate Pro — AudioWorklet Verifier\n');
+
+  const registry = loadWorkletManifest();
+  const modelsWorklets = loadModelsManifestWorklets();
+  const swSrc = fs.existsSync(SW_PATH) ? fs.readFileSync(SW_PATH, 'utf8') : '';
+  const appShell = extractAppShellUrls(swSrc);
+
+  for (const entry of registry.worklets) {
+    const srcAbs = path.join(ROOT, entry.source);
+    log(`  ${entry.id} (${entry.role})`);
+
+    if (!fs.existsSync(srcAbs)) {
+      errors.push(`Missing source: ${entry.source}`);
+      continue;
+    }
+
+    const srcBody = fs.readFileSync(srcAbs, 'utf8');
+    if (!srcBody.includes(`registerProcessor('${entry.processorName}'`)) {
+      errors.push(`${entry.source}: missing registerProcessor('${entry.processorName}')`);
+    } else {
+      log(`    ✓ source + registerProcessor`);
+    }
+
+    const hash = sha256File(srcAbs);
+    const manifestKey = entry.id === 'vip-gate' ? 'gate_processor'
+      : entry.id === 'vip-deesser' ? 'deesser_processor'
+      : entry.id;
+    const manifestEntry = modelsWorklets[manifestKey] || modelsWorklets[entry.id.replace(/-/g, '_')];
+    if (manifestEntry) {
+      const pinned = manifestEntry.sources?.[0]?.sha256 || manifestEntry.sha256;
+      if (pinned && pinned !== hash) {
+        errors.push(`${entry.source}: SHA-256 mismatch (manifest ${pinned.slice(0, 12)}… vs actual ${hash.slice(0, 12)}…). Run: pnpm worklets:hash`);
+      } else if (pinned) {
+        log(`    ✓ SHA-256 matches models-manifest.json`);
+      }
+    } else if (entry.role === 'active') {
+      warnings.push(`No models-manifest.json entry for active worklet '${entry.id}'`);
+    }
+
+    if (!appShell.includes(entry.url)) {
+      errors.push(`${entry.url} missing from public/app/sw.js APP_SHELL precache`);
+    } else {
+      log(`    ✓ APP_SHELL precache`);
+    }
+
+    const buildAbs = path.join(ROOT, entry.buildPath);
+    if (fs.existsSync(buildAbs)) {
+      if (sha256File(buildAbs) !== hash) {
+        errors.push(`${entry.buildPath}: out of sync with ${entry.source} — run pnpm build`);
+      } else {
+        log(`    ✓ build/ copy in sync`);
+      }
+    } else if (requireBuild) {
+      errors.push(`Missing build copy: ${entry.buildPath} (run pnpm build)`);
+    } else {
+      log(`    ℹ  build/ copy not checked (${entry.buildPath} absent — run pnpm build locally)`);
+    }
+
+    const androidAbs = path.join(ROOT, entry.androidAssetPath);
+    if (fs.existsSync(androidAbs)) {
+      if (sha256File(androidAbs) !== hash) {
+        errors.push(`${entry.androidAssetPath}: out of sync — run pnpm build && npx cap sync android`);
+      } else {
+        log(`    ✓ Android assets in sync`);
+      }
+    } else if (requireAndroid) {
+      errors.push(`Missing Android asset: ${entry.androidAssetPath} (run pnpm build && npx cap sync android)`);
+    }
+  }
+
+  if (warnings.length) {
+    log('\nWarnings:');
+    warnings.forEach((w) => log(`  ⚠ ${w}`));
+  }
+
+  if (errors.length) {
+    log('\n❌ Worklet verification failed:\n');
+    errors.forEach((e) => log(`  ✗ ${e}`));
+    return { ok: false, errors, warnings };
+  }
+
+  log('\n✅ All worklets verified\n');
+  return { ok: true, errors, warnings };
+}
+
+if (require.main === module) {
+  const requireBuild = process.argv.includes('--require-build');
+  const requireAndroid = process.argv.includes('--require-android');
+  const result = verifyWorklets({ requireBuild, requireAndroid });
+  process.exit(result.ok ? 0 : 1);
+}
+
+module.exports = { verifyWorklets, loadWorkletManifest, sha256File };

--- a/scripts/worklet-manifest.json
+++ b/scripts/worklet-manifest.json
@@ -1,0 +1,41 @@
+{
+  "_note": "Canonical AudioWorklet registry. verify-worklets.js and hash-worklets.js read this file. Run: pnpm worklets:hash && node scripts/verify-worklets.js",
+  "worklets": [
+    {
+      "id": "vip-gate",
+      "name": "GateProcessor",
+      "source": "src/workers/GateProcessor.js",
+      "url": "/src/workers/GateProcessor.js",
+      "buildPath": "build/src/workers/GateProcessor.js",
+      "androidAssetPath": "android/app/src/main/assets/public/src/workers/GateProcessor.js",
+      "processorName": "vip-gate",
+      "role": "active",
+      "loadedBy": "PlaybackMixer._loadGate()",
+      "platforms": ["web", "android", "desktop"]
+    },
+    {
+      "id": "vip-deesser",
+      "name": "DeEsserProcessor",
+      "source": "src/workers/DeEsserProcessor.js",
+      "url": "/src/workers/DeEsserProcessor.js",
+      "buildPath": "build/src/workers/DeEsserProcessor.js",
+      "androidAssetPath": "android/app/src/main/assets/public/src/workers/DeEsserProcessor.js",
+      "processorName": "vip-deesser",
+      "role": "active",
+      "loadedBy": "PlaybackMixer._loadDeEsser()",
+      "platforms": ["web", "android", "desktop"]
+    },
+    {
+      "id": "dsp-processor",
+      "name": "DSPProcessor",
+      "source": "public/app/dsp-processor.js",
+      "url": "/app/dsp-processor.js",
+      "buildPath": "build/app/dsp-processor.js",
+      "androidAssetPath": "android/app/src/main/assets/public/app/dsp-processor.js",
+      "processorName": "dsp-processor",
+      "role": "legacy-shipped",
+      "loadedBy": "Shipped for Engineer Mode compatibility; not addModule-loaded (live SAB pipeline removed per CLAUDE.md §1.1)",
+      "platforms": ["web", "android", "desktop"]
+    }
+  ]
+}

--- a/tests/deployment-config.test.js
+++ b/tests/deployment-config.test.js
@@ -309,7 +309,7 @@ describe('vercel.json — COOP/COEP and model CORP route assertions', () => {
   });
 
   test('worklet script routes explicitly include both COOP and COEP', () => {
-    const workletRoutes = ['/app/dsp-processor.js'];
+    const workletRoutes = ['/app/dsp-processor.js', '/src/workers/(.*\\.js)'];
     for (const route of workletRoutes) {
       const routeHeaders = cfg.headers.find((h) => h.source === route);
       expect(routeHeaders).toBeDefined();

--- a/tests/worklet-packaging.test.js
+++ b/tests/worklet-packaging.test.js
@@ -1,0 +1,88 @@
+/**
+ * AudioWorklet packaging — web, Android (Capacitor), and desktop (Electron).
+ * Ensures all three registered worklets ship on every platform.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { verifyWorklets, loadWorkletManifest, sha256File } = require('../scripts/verify-worklets.js');
+
+const ROOT = path.join(__dirname, '..');
+
+describe('AudioWorklet packaging (all platforms)', () => {
+  const registry = loadWorkletManifest();
+
+  test('worklet-manifest.json lists exactly 3 worklets', () => {
+    expect(registry.worklets).toHaveLength(3);
+    const ids = registry.worklets.map((w) => w.id);
+    expect(ids).toEqual(['vip-gate', 'vip-deesser', 'dsp-processor']);
+  });
+
+  test('verify-worklets.js passes (source + manifest + APP_SHELL)', () => {
+    const result = verifyWorklets({ quiet: true });
+    expect(result.errors).toEqual([]);
+  });
+
+  test('each worklet source defines registerProcessor with the expected name', () => {
+    for (const entry of registry.worklets) {
+      const src = fs.readFileSync(path.join(ROOT, entry.source), 'utf8');
+      expect(src).toContain(`registerProcessor('${entry.processorName}'`);
+    }
+  });
+
+  test('build/ copies exist and match source hashes after pnpm build', () => {
+    const missing = registry.worklets
+      .map((w) => w.buildPath)
+      .filter((p) => !fs.existsSync(path.join(ROOT, p)));
+    if (missing.length) {
+      // build/ is optional in CI validate-only runs; skip with guidance
+      console.warn('[worklet-packaging] build/ absent — run pnpm build to verify desktop/android packaging');
+      return;
+    }
+    for (const entry of registry.worklets) {
+      const srcHash = sha256File(path.join(ROOT, entry.source));
+      const buildHash = sha256File(path.join(ROOT, entry.buildPath));
+      expect(buildHash).toBe(srcHash);
+    }
+  });
+
+  test('models-manifest.json pins SHA-256 for every worklet', () => {
+    const doc = JSON.parse(fs.readFileSync(path.join(ROOT, 'public/app/models-manifest.json'), 'utf8'));
+    expect(doc.worklets.gate_processor).toBeDefined();
+    expect(doc.worklets.deesser_processor).toBeDefined();
+    expect(doc.worklets.dsp_processor).toBeDefined();
+    for (const key of ['gate_processor', 'deesser_processor', 'dsp_processor']) {
+      const sha = doc.worklets[key].sources[0].sha256;
+      expect(sha).toMatch(/^[0-9a-f]{64}$/);
+    }
+  });
+
+  test('public/app/sw.js APP_SHELL precaches all worklet URLs', () => {
+    const sw = fs.readFileSync(path.join(ROOT, 'public/app/sw.js'), 'utf8');
+    for (const entry of registry.worklets) {
+      expect(sw).toContain(entry.url);
+    }
+  });
+
+  test('capacitor.config.json webDir is build (worklets flow through pnpm build)', () => {
+    const cfg = JSON.parse(fs.readFileSync(path.join(ROOT, 'capacitor.config.json'), 'utf8'));
+    expect(cfg.webDir).toBe('build');
+  });
+
+  test('electron-builder.yml packs build/** (includes worklets)', () => {
+    const yml = fs.readFileSync(path.join(ROOT, 'electron/electron-builder.yml'), 'utf8');
+    expect(yml).toContain('build/**/*');
+  });
+
+  test('PlaybackMixer allowlists only Gate + DeEsser for addModule', () => {
+    const src = fs.readFileSync(path.join(ROOT, 'src/pipeline/PlaybackMixer.js'), 'utf8');
+    expect(src).toContain("addModule('/src/workers/GateProcessor.js')");
+    expect(src).toContain("addModule('/src/workers/DeEsserProcessor.js')");
+    const matches = [...src.matchAll(/addModule\s*\(\s*['"]([^'"]+)['"]/g)].map((m) => m[1]);
+    expect(matches).toEqual([
+      '/src/workers/GateProcessor.js',
+      '/src/workers/DeEsserProcessor.js',
+    ]);
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -151,6 +151,27 @@
       ]
     },
     {
+      "source": "/src/workers/(.*\\.js)",
+      "headers": [
+        {
+          "key": "Cross-Origin-Opener-Policy",
+          "value": "same-origin"
+        },
+        {
+          "key": "Cross-Origin-Embedder-Policy",
+          "value": "require-corp"
+        },
+        {
+          "key": "Cross-Origin-Resource-Policy",
+          "value": "same-origin"
+        },
+        {
+          "key": "Content-Type",
+          "value": "text/javascript; charset=utf-8"
+        }
+      ]
+    },
+    {
       "source": "/app/models/(.*\\.onnx)",
       "headers": [
         {


### PR DESCRIPTION
## Summary

Makes all three AudioWorklets packaging-ready on web, Android, and desktop.

| Worklet | Path | Status |
|---------|------|--------|
| Gate | `/src/workers/GateProcessor.js` | Active |
| De-esser | `/src/workers/DeEsserProcessor.js` | Active |
| DSP legacy | `/app/dsp-processor.js` | Shipped + precached |

## Key files

- `scripts/worklet-manifest.json` — canonical registry
- `scripts/verify-worklets.js` — packaging verifier (used by validate + android build)
- `docs/WORKLETS.md` — full cross-platform matrix
- `tests/worklet-packaging.test.js` — 9 Jest assertions

## Verify locally

```
pnpm worklets:verify:build
pnpm test -- tests/worklet-packaging.test.js
pnpm validate
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add cross-platform AudioWorklet packaging registry with verification and service worker precache
> - Adds [scripts/worklet-manifest.json](https://github.com/Joker5514/VoiceIsolate-Pro/pull/662/files#diff-7de22b9f3eb9d2e7f3cc879cc3bc08f9a16741fd496496d1d8e9a2b144fa41e4) as a canonical registry for three worklets: `GateProcessor`, `DeEsserProcessor`, and `dsp-processor` (legacy), with source paths, build paths, Android asset paths, and processor names.
> - Rewrites [scripts/hash-worklets.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/662/files#diff-a7def7a5e99bb3c844f98e402c16652cec88b3e592e4b8f264ae1236d3534b8c) to read the registry and update SHA-256 pins and metadata in [public/app/models-manifest.json](https://github.com/Joker5514/VoiceIsolate-Pro/pull/662/files#diff-b87a8b88754e6cc55eb465c7c97288e4d677e21e92d2554dff69a41c58677150) automatically via `pnpm worklets:hash`.
> - Adds [scripts/verify-worklets.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/662/files#diff-f39646422a902f08ab15714910ec6b9791d57cadb734b0276e56b6678b9b90d0) to check source existence, `registerProcessor` names, hash pins, service worker precache, and optional build/Android copies; integrated into `pnpm validate` and the Android build script.
> - Precaches `GateProcessor.js`, `DeEsserProcessor.js`, and `PlaybackMixer.js` in the service worker `APP_SHELL` for offline availability.
> - Adds COOP/COEP/CORP headers for `/src/workers/*.js` routes in [vercel.json](https://github.com/Joker5514/VoiceIsolate-Pro/pull/662/files#diff-a3265310f552fb66876e8bfe8809737e59e5ba946bdf39138b44d9baf4e21240).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 08571e5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added verification and hashing checks for packaged audio worklets.
  * Expanded offline precaching to include additional audio processing assets.

* **Bug Fixes**
  * Improved deployment rules for worklet scripts so they load correctly across supported platforms.
  * Strengthened integrity checks for shipped audio assets.

* **Documentation**
  * Updated setup and deployment docs with current audio worklet packaging, verification, and build steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->