### PR TITLE
fix: restore file upload on Landing and Engineer pages

### DIFF
--- a/public/app/app.js
+++ b/public/app/app.js
@@ -22,6 +22,7 @@ import { buildHintPanel, mountInfoPopover, removeAllInfoPopovers } from './slide
 import { decodeBlobToAudioBuffer } from '/src/pipeline/media-decode.js';
 import { resampleToCanonical } from '/src/pipeline/FileIngestion.js';
 import { isDesktopShell, pickAudioFile } from '/src/core/DesktopBridge.js';
+import { openFilePicker as triggerFileInput, primeAudioGesture } from '/src/presentation/UploadWiring.js';
 
 // Registry lookup for examples + calibrated transforms
 const SLIDER_REG_BY_ID = Object.freeze(
@@ -586,6 +587,8 @@ class VoiceIsolatePro {
       this._renderSliders();
       this.bindEvents();
       this._updateProcessButtonsState();
+      // Upload controls are live — do not leave the splash intercepting clicks.
+      this._dismissBootSplash();
     } catch (initErr) {
       this._dismissBootSplash();
       structuredLog('error', '[VIP] init failed after splash', { err: initErr.message });
@@ -1227,8 +1230,8 @@ class VoiceIsolatePro {
         }
         return;
       }
-      const fi = this.dom.fileInput;
-      if (fi) fi.click();
+      try { await primeAudioGesture(); } catch { /* best-effort */ }
+      triggerFileInput(this.dom.fileInput);
     };
     // File input — always read this.dom.fileInput so late patches cannot orphan handlers
     bind('fileBtn', d.fileBtn, 'click', (e) => { e.preventDefault(); openFilePicker(); });

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -101,7 +101,8 @@
       s.style.display = 'none';
       s.setAttribute('aria-hidden', 'true');
     };
-    setTimeout(window._vipDismissBootSplash, 8000);
+    // Safety net only — app.init() dismisses once bindEvents() completes.
+    setTimeout(window._vipDismissBootSplash, 3000);
   </script>
 
   <div id="bootSplash" class="boot-splash" aria-hidden="false" role="status" aria-live="polite">

--- a/public/app/mobile-upload-fix.js
+++ b/public/app/mobile-upload-fix.js
@@ -123,51 +123,75 @@
     });
   }
 
-  /* ─── 5. Re-wire upload zone click to ensure AudioContext is in gesture ───
+  /* ─── 5. Re-wire upload controls WITHOUT cloning DOM nodes ───────────────
+   * Cloning #dropZone / #uploadZone orphaned app.js handlers and could fire
+   * fileInput.click() twice (zone + nested zone).  Instead, refresh live DOM
+   * refs on _vipApp and bind idempotent listeners once the app boots.
    */
-  function wireUploadZoneGesture() {
-    const zones = document.querySelectorAll('#dz, #dropZone, #uploadZone, .drop-zone');
+  function ensureUploadWiring() {
+    var app = window._vipApp;
+    var fi = document.getElementById('fileInput');
+    if (!fi) return false;
 
-    zones.forEach(function (zone) {
-      const fresh = zone.cloneNode(true);
-      zone.parentNode && zone.parentNode.replaceChild(fresh, zone);
+    if (app && app.dom) {
+      app.dom.fileInput = fi;
+      var fb = document.getElementById('fileBtn');
+      if (fb) app.dom.fileBtn = fb;
+      var uz = document.getElementById('uploadZone');
+      if (uz) app.dom.uploadZone = uz;
+      var dz = document.getElementById('dropZone');
+      if (dz) app.dom.dropZone = dz;
+    }
 
-      fresh.addEventListener('click', async function (e) {
-        // Zone is cloned after app.js bindEvents(), so Browse must open the
-        // picker here — skipping BUTTON clicks left fileBtn inert.
-        e.preventDefault();
-        try { await window.getAudioContext(); } catch (_) {}
-        const fi = document.getElementById('fileInput') ||
-                   document.getElementById('fi') ||
-                   document.querySelector('input[type="file"]');
-        if (fi) fi.click();
+    // Re-bind change in case a legacy patch cloned/replaced the input node.
+    if (!fi.dataset.vipChangeBound) {
+      fi.dataset.vipChangeBound = '1';
+      fi.addEventListener('change', function (e) {
+        var file = e.target.files && e.target.files[0];
+        if (!file) return;
+        var live = window._vipApp;
+        if (live && typeof live.handleFile === 'function') {
+          live.handleFile(file);
+        }
       });
+    }
 
+    var dropZone = document.getElementById('dropZone');
+    if (dropZone && !dropZone.dataset.vipDropBound) {
+      dropZone.dataset.vipDropBound = '1';
       ['dragenter', 'dragover'].forEach(function (ev) {
-        fresh.addEventListener(ev, function (e) {
+        dropZone.addEventListener(ev, function (e) {
           e.preventDefault();
-          fresh.classList.add('over', 'dragover');
+          dropZone.classList.add('drag-over', 'dragover', 'over');
         });
       });
       ['dragleave', 'dragend'].forEach(function (ev) {
-        fresh.addEventListener(ev, function () {
-          fresh.classList.remove('over', 'dragover');
+        dropZone.addEventListener(ev, function () {
+          dropZone.classList.remove('drag-over', 'dragover', 'over');
         });
       });
-      fresh.addEventListener('drop', async function (e) {
+      dropZone.addEventListener('drop', async function (e) {
         e.preventDefault();
-        fresh.classList.remove('over', 'dragover');
-        const file = e.dataTransfer && e.dataTransfer.files[0];
+        dropZone.classList.remove('drag-over', 'dragover', 'over');
+        var file = e.dataTransfer && e.dataTransfer.files && e.dataTransfer.files[0];
         if (!file) return;
         try { await window.getAudioContext(); } catch (_) {}
-        const app = window._vipApp;
-        if (app && typeof app.handleFile === 'function') {
-          app.handleFile(file);
-        } else if (typeof window.loadFile === 'function') {
-          window.loadFile(file);
+        var live = window._vipApp;
+        if (live && typeof live.handleFile === 'function') {
+          live.handleFile(file);
         }
       });
-    });
+    }
+
+    return true;
+  }
+
+  function waitForUploadWiring() {
+    if (ensureUploadWiring()) return;
+    var tries = 0;
+    var timer = setInterval(function () {
+      if (ensureUploadWiring() || ++tries >= 40) clearInterval(timer);
+    }, 250);
   }
 
   /* ─── 6. Patch loadFile — intercept the decode call with safeDecodeAudioData
@@ -238,7 +262,7 @@
   function init() {
     fixUploadZoneTouchTarget();
     patchFileInput();
-    wireUploadZoneGesture();
+    waitForUploadWiring();
     patchLoadFile();
 
     // MutationObserver: re-apply if DOM is rebuilt by app.js
@@ -246,6 +270,7 @@
       fixUploadZoneTouchTarget();
       patchFileInput();
       patchLoadFile();
+      ensureUploadWiring();
     });
     observer.observe(document.body, { childList: true, subtree: true });
 

--- a/public/landing.js
+++ b/public/landing.js
@@ -12,6 +12,7 @@
 'use strict';
 
 import { ingestFile, isDesktopShell, pickAudioFile } from '/src/pipeline/FileIngestion.js';
+import { openFilePicker, primeAudioGesture, fixUploadTouchTargets } from '/src/presentation/UploadWiring.js';
 import { PlaybackMixer } from '/src/pipeline/PlaybackMixer.js';
 import { SliderUI } from '/src/presentation/SliderUI.js';
 import { LANDING_PRESETS, calibrateFromStems } from '/src/core/MixCalibration.js';
@@ -661,7 +662,8 @@ function wireUploadDropZone() {
       }
       return;
     }
-    if (ui.fileInput) ui.fileInput.click();
+    try { await primeAudioGesture(); } catch { /* best-effort */ }
+    openFilePicker(ui.fileInput);
   };
   zone.addEventListener('click', (event) => {
     if (event.target.closest('#browseBtn')) return;
@@ -904,6 +906,7 @@ function wireDragAndDrop() {
 // ─── Boot ────────────────────────────────────────────────────────────────────
 
 ui.fileInput.addEventListener('change', onFileChosen);
+fixUploadTouchTargets();
 wireUploadDropZone();
 warnIfNotServed();
 window.addEventListener('error', (event) => {

--- a/scripts/engineer-upload-smoke.cjs
+++ b/scripts/engineer-upload-smoke.cjs
@@ -4,7 +4,7 @@
  */
 'use strict';
 
-/* global window, document — used inside Playwright page.evaluate / waitForFunction */
+/* global window, document */
 
 const { spawn } = require('child_process');
 const fs = require('fs');
@@ -87,11 +87,29 @@ function makeWav() {
 
   try {
     await page.goto(`${BASE}/app/`, { waitUntil: 'load' });
-    await page.waitForFunction(() => !!window._vipApp, null, { timeout: 20000 });
+    await page.waitForFunction(
+      () => {
+        const splash = document.getElementById('bootSplash');
+        const splashGone = !splash
+          || splash.dataset.dismissed === '1'
+          || splash.classList.contains('is-complete')
+          || splash.style.display === 'none';
+        return splashGone && !!window._vipApp && !!document.getElementById('fileInput');
+      },
+      null,
+      { timeout: 20000 },
+    );
 
-    await page.click('#fileBtn');
-    await page.setInputFiles('#fileInput', wavPath);
-    await page.locator('#fileInput').dispatchEvent('change');
+    // Browse Files — prefer real filechooser; headless may skip the event.
+    const chooserPromise = page.waitForEvent('filechooser', { timeout: 8000 }).catch(() => null);
+    await page.locator('#fileBtn').click();
+    const fileChooser = await chooserPromise;
+    if (fileChooser) {
+      await fileChooser.setFiles(wavPath);
+    } else {
+      await page.setInputFiles('#fileInput', wavPath);
+      await page.locator('#fileInput').dispatchEvent('change');
+    }
 
     await page.waitForFunction(
       () => window._vipApp?.inputBuffer?.length > 0,

--- a/scripts/landing-smoke.cjs
+++ b/scripts/landing-smoke.cjs
@@ -108,10 +108,15 @@ async function waitForLandingBoot(page) {
 }
 
 async function triggerFileIngest(page, wavPath) {
-  await page.setInputFiles('#fileInput', wavPath);
-  // Playwright usually fires `change`, but dispatch explicitly to avoid races
-  // when the ESM bundle finishes loading right as the file is attached.
-  await page.locator('#fileInput').dispatchEvent('change');
+  const chooserPromise = page.waitForEvent('filechooser', { timeout: 8000 }).catch(() => null);
+  await page.locator('#browseBtn').click();
+  const fileChooser = await chooserPromise;
+  if (fileChooser) {
+    await fileChooser.setFiles(wavPath);
+  } else {
+    await page.setInputFiles('#fileInput', wavPath);
+    await page.locator('#fileInput').dispatchEvent('change');
+  }
 }
 
 async function waitForPipelineStart(page, consoleErrors) {

--- a/src/presentation/UploadWiring.js
+++ b/src/presentation/UploadWiring.js
@@ -1,0 +1,62 @@
+'use strict';
+
+/**
+ * Shared upload helpers for Landing + Engineer Mode.
+ * Opens the native picker inside a user gesture and prefers showPicker()
+ * when the browser supports it (more reliable than off-screen input.click()).
+ */
+
+/**
+ * @param {HTMLInputElement|null|undefined} fileInput
+ * @returns {boolean}
+ */
+export function openFilePicker(fileInput) {
+  if (!fileInput || fileInput.disabled) return false;
+  if (typeof fileInput.showPicker === 'function') {
+    try {
+      fileInput.showPicker();
+      return true;
+    } catch {
+      /* fall through to .click() */
+    }
+  }
+  fileInput.click();
+  return true;
+}
+
+/**
+ * Resume/create a throwaway AudioContext inside the current user gesture.
+ * Mobile Safari requires this before decodeAudioData will run.
+ * @returns {Promise<void>}
+ */
+export async function primeAudioGesture() {
+  const Ctor = globalThis.AudioContext || globalThis.webkitAudioContext;
+  if (!Ctor) return;
+  const ctx = new Ctor();
+  try {
+    if (ctx.state === 'suspended') await ctx.resume();
+  } finally {
+    try { await ctx.close(); } catch { /* ignore */ }
+  }
+}
+
+/**
+ * Apply touch/pointer fixes so upload controls stay tappable under slider CSS.
+ */
+export function fixUploadTouchTargets(root = globalThis.document) {
+  if (!root?.querySelectorAll) return;
+  const selectors = [
+    '#dz', '#dropZone', '.drop-zone', '#uploadZone',
+    '#fileBtn', '#browseBtn', 'input[type="file"]',
+  ];
+  for (const sel of selectors) {
+    root.querySelectorAll(sel).forEach((el) => {
+      el.style.touchAction = 'auto';
+      el.style.pointerEvents = 'auto';
+      el.style.webkitUserSelect = 'auto';
+      el.style.userSelect = 'auto';
+    });
+  }
+}
+
+export default { openFilePicker, primeAudioGesture, fixUploadTouchTargets };

--- a/tests/engineer-upload-decode.test.js
+++ b/tests/engineer-upload-decode.test.js
@@ -27,4 +27,13 @@ describe('Engineer upload decode wiring', () => {
     expect(appJs).toContain('pickAudioFile');
     expect(appJs).toContain('isDesktopShell');
   });
+
+  test('boot splash dismisses once bindEvents completes (upload not blocked)', () => {
+    expect(appJs).toMatch(/bindEvents\(\);[\s\S]*_dismissBootSplash\(\)/);
+  });
+
+  test('openFilePicker import is aliased to avoid infinite recursion', () => {
+    expect(appJs).toContain('openFilePicker as triggerFileInput');
+    expect(appJs).toContain('triggerFileInput(this.dom.fileInput)');
+  });
 });

--- a/tests/mobile-upload-fix.test.js
+++ b/tests/mobile-upload-fix.test.js
@@ -12,15 +12,22 @@ const js = fs.readFileSync(
 );
 
 describe('mobile-upload-fix.js', () => {
-  test('upload zone click opens file picker for BUTTON targets (Browse Files)', () => {
-    expect(js).not.toMatch(
-      /if\s*\(\s*e\.target\.tagName\s*===\s*['"]BUTTON['"]\s*&&\s*e\.target\s*!==\s*fresh\s*\)\s*return/
-    );
-    expect(js).toContain('if (fi) fi.click()');
+  test('does not clone upload zones (avoids orphaning app.js handlers)', () => {
+    expect(js).not.toContain('cloneNode(true)');
+    expect(js).not.toContain('replaceChild(fresh, zone)');
+  });
+
+  test('re-binds file input change to _vipApp.handleFile', () => {
+    expect(js).toContain('ensureUploadWiring');
+    expect(js).toContain('live.handleFile(file)');
+  });
+
+  test('does not add duplicate picker click handlers (app.js owns Browse)', () => {
+    expect(js).not.toContain('vipPickerBound');
   });
 
   test('drop handler routes to Engineer Mode handleFile when available', () => {
     expect(js).toContain('window._vipApp');
-    expect(js).toContain('app.handleFile(file)');
+    expect(js).toContain('live.handleFile(file)');
   });
 });

--- a/tests/upload-wiring.test.js
+++ b/tests/upload-wiring.test.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const uploadJs = fs.readFileSync(
+  path.join(__dirname, '../src/presentation/UploadWiring.js'),
+  'utf8'
+);
+const landingJs = fs.readFileSync(
+  path.join(__dirname, '../public/landing.js'),
+  'utf8'
+);
+const appJs = fs.readFileSync(
+  path.join(__dirname, '../public/app/app.js'),
+  'utf8'
+);
+
+describe('UploadWiring.js', () => {
+  test('exports openFilePicker with showPicker fallback', () => {
+    expect(uploadJs).toContain('export function openFilePicker');
+    expect(uploadJs).toContain('showPicker');
+    expect(uploadJs).toContain('fileInput.click()');
+  });
+
+  test('exports primeAudioGesture for mobile decode unlock', () => {
+    expect(uploadJs).toContain('export async function primeAudioGesture');
+  });
+});
+
+describe('Landing + Engineer import UploadWiring', () => {
+  test('landing.js uses shared openFilePicker + touch fixes', () => {
+    expect(landingJs).toContain("from '/src/presentation/UploadWiring.js'");
+    expect(landingJs).toContain('openFilePicker(ui.fileInput)');
+    expect(landingJs).toContain('fixUploadTouchTargets()');
+  });
+
+  test('app.js uses triggerFileInput alias (avoids openFilePicker recursion)', () => {
+    expect(appJs).toContain("openFilePicker as triggerFileInput");
+    expect(appJs).toContain('triggerFileInput(this.dom.fileInput)');
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #665 — uploads were still broken on both pages due to:

1. **Engineer (/app/)**: openFilePicker local function shadowed the imported helper and called itself (infinite recursion). Boot splash intercepted clicks until timeout. mobile-upload-fix.js cloned drop zones and orphaned app.js handlers.
2. **Landing (/)**: Needed shared showPicker() + gesture priming for reliable mobile/desktop picker.

## Changes

- New src/presentation/UploadWiring.js — shared openFilePicker, primeAudioGesture, fixUploadTouchTargets
- Engineer app.js — import as triggerFileInput; dismiss splash after bindEvents()
- Engineer mobile-upload-fix.js — refresh DOM refs only (no cloning)
- Landing landing.js — use shared upload wiring
- Smoke tests — wait for splash dismiss; browse via browseBtn / filechooser
- Tests — upload-wiring.test.js + updated mobile-upload/decode tests

## Verification

- node scripts/engineer-upload-smoke.cjs PASS
- node scripts/landing-smoke.cjs PASS
- Jest: upload-wiring, mobile-upload-fix, engineer-upload-decode — 13/13 PASS

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore file upload on Landing and Engineer pages by replacing DOM cloning with live element binding
> - Introduces [UploadWiring.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/666/files#diff-21c4b89b447092defb0830c8b6fc7584ab268ef8e8de4c9e4aa2e235e938b406) with `openFilePicker` (prefers `showPicker()`), `primeAudioGesture` (unlocks mobile audio in a user gesture), and `fixUploadTouchTargets` (keeps upload controls tappable under slider CSS).
> - Rewrites [mobile-upload-fix.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/666/files#diff-3ab1eb859dafbe1f44fae5258d4e33ba05f567d2e9efa7b029cbee1ca07983bb) to bind change and drag-and-drop handlers directly to live DOM elements instead of cloning nodes, eliminating orphaned handlers and duplicate picker triggers.
> - Landing and Engineer pages now call `primeAudioGesture()` then `openFilePicker()` instead of `.click()` when opening the file chooser on non-desktop browsers.
> - Boot splash dismissal is moved into `VoiceIsolatePro.init` after `bindEvents()` completes, with the safety-net timeout in [index.html](https://github.com/Joker5514/VoiceIsolate-Pro/pull/666/files#diff-4400aa5aa5292d143f7e2f1308aa82756255552567d5558874c994833e907ce4) reduced from 8000ms to 3000ms.
> - Behavioral Change: upload zones are no longer cloned; any code that held references to the old cloned nodes will no longer receive events.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 38f7973.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved file upload interactions across app and landing pages, including a more reliable file picker experience.
  * Better touch handling for upload controls on mobile devices.

* **Bug Fixes**
  * Reduced the chance of the boot splash blocking interaction during startup.
  * Made upload behavior more reliable by handling file selection and drag-and-drop more consistently.
  * Improved upload responsiveness when audio-related actions are involved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->