### PR TITLE
fix: full-length video upload, expanded formats, hide desktop mic

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -114,10 +114,32 @@ function registerIpc() {
 
   ipcMain.handle(IPC.OPEN_FILE, async () => {
     const { canceled, filePaths } = await dialog.showOpenDialog(mainWindow, {
-      title: 'Import Audio',
+      title: 'Import Audio or Video',
       properties: ['openFile'],
       filters: [
-        { name: 'Audio', extensions: ['wav', 'mp3', 'flac', 'ogg', 'm4a', 'aac', 'webm'] },
+        {
+          name: 'Audio & Video',
+          extensions: [
+            'wav', 'wave', 'mp3', 'flac', 'ogg', 'oga', 'opus', 'm4a', 'aac', 'webm', 'weba',
+            'aiff', 'aif', 'caf', 'wma', 'mka', 'm4b', 'm4r', 'amr', 'ac3', 'eac3',
+            'mp4', 'm4v', 'mov', 'mkv', 'avi', 'ogv', '3gp', '3g2', 'wmv', 'mpeg', 'mpg',
+            'ts', 'm2ts', 'mts', 'flv', 'f4v', 'asf',
+          ],
+        },
+        {
+          name: 'Video',
+          extensions: [
+            'mp4', 'm4v', 'mov', 'mkv', 'avi', 'ogv', '3gp', '3g2', 'wmv', 'mpeg', 'mpg',
+            'webm', 'ts', 'm2ts', 'mts', 'flv', 'f4v', 'asf',
+          ],
+        },
+        {
+          name: 'Audio',
+          extensions: [
+            'wav', 'wave', 'mp3', 'flac', 'ogg', 'oga', 'opus', 'm4a', 'aac', 'webm', 'weba',
+            'aiff', 'aif', 'caf', 'wma', 'mka', 'm4b', 'm4r', 'amr', 'ac3', 'eac3',
+          ],
+        },
         { name: 'All Files', extensions: ['*'] },
       ],
     });

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -21,7 +21,8 @@ import { SLIDER_REGISTRY, STAGES } from './slider-map.js';
 import { buildHintPanel, mountInfoPopover, removeAllInfoPopovers } from './slider-hint-ui.js';
 import { decodeBlobToAudioBuffer } from '/src/pipeline/media-decode.js';
 import { resampleToCanonical } from '/src/pipeline/FileIngestion.js';
-import { isDesktopShell, pickAudioFile } from '/src/core/DesktopBridge.js';
+import { isDesktopShell, isMicCaptureEnabled, pickAudioFile } from '/src/core/DesktopBridge.js';
+import { inferMediaKind } from '/src/core/media-types.js';
 import { openFilePicker as triggerFileInput, primeAudioGesture } from '/src/presentation/UploadWiring.js';
 
 /** Hero landing + branded loader — local-only cinematic shell */
@@ -117,22 +118,37 @@ const HeroExperience = (() => {
     }
   }
 
+  function hideMicControls() {
+    for (const id of ['heroCtaRecord', 'micBtn']) {
+      const el = $(id);
+      if (el) {
+        el.hidden = true;
+        el.style.display = 'none';
+        el.setAttribute('aria-hidden', 'true');
+      }
+    }
+  }
+
   function bindHeroCtas(app) {
     $('heroCtaUpload')?.addEventListener('click', (e) => {
       e.preventDefault();
       app.dom.fileBtn?.click();
     });
-    $('heroCtaRecord')?.addEventListener('click', (e) => {
-      e.preventDefault();
-      toggleMicRecord(app);
-    });
+    if (isMicCaptureEnabled()) {
+      $('heroCtaRecord')?.addEventListener('click', (e) => {
+        e.preventDefault();
+        toggleMicRecord(app);
+      });
+      $('micBtn')?.addEventListener('click', (e) => {
+        e.preventDefault();
+        toggleMicRecord(app);
+      });
+    } else {
+      hideMicControls();
+    }
     $('heroCtaProcess')?.addEventListener('click', (e) => {
       e.preventDefault();
       if (!app.dom.processBtn?.disabled) app.runPipeline();
-    });
-    $('micBtn')?.addEventListener('click', (e) => {
-      e.preventDefault();
-      toggleMicRecord(app);
     });
     $('exportBtn')?.addEventListener('click', (e) => {
       e.preventDefault();
@@ -239,7 +255,10 @@ const HeroExperience = (() => {
       patchOverlayRefs();
       setUiState('idle');
       const tierStatus = WorkflowTier.getConfig?.()?.statusIdle;
-      setHeroCopy(tierStatus || 'Ready — upload or record to begin', false);
+      setHeroCopy(
+        tierStatus || (isMicCaptureEnabled() ? 'Ready — upload or record to begin' : 'Ready — upload audio or video to begin'),
+        false,
+      );
       window.addEventListener('vip:fileLoaded', () => {
         setUiState('file-ready');
         setHeroCopy('File loaded — processing pipeline starting', true);
@@ -269,7 +288,10 @@ const HeroExperience = (() => {
     onClear() {
       setUiState('idle');
       const tierStatus = WorkflowTier.getConfig?.()?.statusIdle;
-      setHeroCopy(tierStatus || 'Ready — upload or record to begin', false);
+      setHeroCopy(
+        tierStatus || (isMicCaptureEnabled() ? 'Ready — upload or record to begin' : 'Ready — upload audio or video to begin'),
+        false,
+      );
       syncStatStrip(null, 'Idle');
     },
     mirrorWaveCanvases,
@@ -1923,12 +1945,11 @@ class VoiceIsolatePro {
     }
 
     // Reject clearly non-audio/non-video MIME types. Browsers often report
-    // application/octet-stream for valid audio files — fall back to extension.
-    const AUDIO_EXT = /\.(wav|mp3|m4a|aac|ogg|oga|opus|flac|weba|webm|aiff|aif|wma|caf)$/i;
-    const VIDEO_EXT = /\.(mp4|m4v|mov|webm|mkv|avi|ogv|3gp)$/i;
+    // application/octet-stream for valid media files — fall back to extension.
+    const mediaKind = inferMediaKind(file);
     const mime = (file.type || '').toLowerCase();
-    const hasKnownExt = AUDIO_EXT.test(file.name || '') || VIDEO_EXT.test(file.name || '');
-    const isAudio = !mime || mime.startsWith('audio/') || mime.startsWith('video/') || hasKnownExt;
+    const isAudio = mediaKind === 'audio' || mediaKind === 'video'
+      || !mime || mime.startsWith('audio/') || mime.startsWith('video/');
     if (!isAudio) {
       this._hideFileLoading();
       if (this.dom && this.dom.fileInfo) this.dom.fileInfo.textContent = 'Unsupported file type: ' + (file.type || 'unknown');
@@ -1942,9 +1963,9 @@ class VoiceIsolatePro {
     // from the processed/original AudioBuffer). decodeAudioData demuxes the
     // audio track from most MP4/WEBM/MOV containers directly.
     const mimeLower = (file.type || '').toLowerCase();
-    const isVideoFile = (mimeLower.startsWith('video/')) ||
-      mimeLower === 'audio/mp4' || mimeLower === 'audio/x-m4a' ||
-      /\.(mp4|m4v|m4a|m4b|m4r|mov|webm|mkv|avi|ogv|3gp)$/i.test(file.name || '');
+    const isVideoFile = mediaKind === 'video'
+      || (mimeLower.startsWith('video/') && mediaKind !== 'audio')
+      || (mimeLower === 'audio/mp4' && /\.(mp4|m4v|mov)$/i.test(file.name || ''));
 
     // Release any previously-loaded video source first, so reloading a new clip
     // neither leaks the old object URL nor leaves the old picture on screen.

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -208,9 +208,9 @@
             <option value="custom">Custom</option>
           </select>
         </div>
-        <p id="heroStatus" class="vip-hero-status" role="status" aria-live="polite">Ready — upload or record to begin</p>
+        <p id="heroStatus" class="vip-hero-status" role="status" aria-live="polite">Ready — upload audio or video to begin</p>
         <div class="vip-hero-cta-row" role="group" aria-label="Start actions">
-          <button id="heroCtaUpload" class="btn btn-primary vip-hero-cta" type="button">Upload Audio</button>
+          <button id="heroCtaUpload" class="btn btn-primary vip-hero-cta" type="button">Upload Audio or Video</button>
           <button id="heroCtaRecord" class="btn btn-outline vip-hero-cta btn-mic" type="button">Record Mic</button>
           <button id="heroCtaProcess" class="btn btn-reprocess vip-hero-cta" type="button" disabled>Process Now</button>
         </div>
@@ -293,12 +293,12 @@
   <main class="main-grid">
     <section class="col-left">
       <div class="card upload-card">
-        <input type="file" id="fileInput" accept="audio/mpeg,audio/mp3,audio/wav,audio/x-wav,audio/ogg,audio/flac,audio/x-flac,audio/aac,audio/x-m4a,audio/m4a,audio/mp4,video/mp4,video/webm,video/quicktime,audio/*,video/*" style="position:fixed;left:-9999px;top:-9999px;width:1px;height:1px;opacity:0;" tabindex="-1" aria-hidden="true" />
+        <input type="file" id="fileInput" accept="audio/mpeg,audio/mp3,audio/wav,audio/x-wav,audio/wave,audio/ogg,audio/flac,audio/x-flac,audio/aac,audio/x-m4a,audio/m4a,audio/mp4,audio/webm,audio/amr,audio/aiff,audio/x-aiff,audio/x-caf,audio/x-ms-wma,audio/opus,audio/ac3,audio/eac3,video/mp4,video/webm,video/quicktime,video/x-msvideo,video/x-matroska,video/ogg,video/3gpp,video/3gpp2,video/x-ms-wmv,video/mpeg,video/mp2t,video/x-flv,audio/*,video/*,.wav,.wave,.mp3,.m4a,.aac,.ogg,.oga,.opus,.flac,.webm,.weba,.aiff,.aif,.caf,.wma,.mka,.m4b,.m4r,.amr,.ac3,.eac3,.mp4,.m4v,.mov,.mkv,.avi,.ogv,.3gp,.3g2,.wmv,.mpeg,.mpg,.ts,.m2ts,.mts,.flv,.f4v,.asf" style="position:fixed;left:-9999px;top:-9999px;width:1px;height:1px;opacity:0;" tabindex="-1" aria-hidden="true" />
         <div id="dropZone">
           <div id="uploadZone" class="upload-zone" role="button" tabindex="0" aria-label="Drop Audio or Video file, or press Enter to browse">
             <svg class="upload-svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
             <p class="upload-title">Drop Audio or Video</p>
-            <p class="upload-sub">MP3 · WAV · FLAC · OGG · M4A · AAC · MP4 · MOV · WEBM · MKV · AVI</p>
+            <p class="upload-sub">MP3 · WAV · FLAC · OGG · OPUS · M4A · AAC · AIFF · WMA · MP4 · MOV · MKV · AVI · WEBM · WMV · TS and more</p>
             <button id="fileBtn" class="btn btn-outline" type="button">Browse Files</button>
             <button id="micBtn" class="btn btn-outline btn-mic" type="button" aria-label="Record from microphone">Record Mic</button>
           </div>

--- a/public/app/mobile-upload-fix.js
+++ b/public/app/mobile-upload-fix.js
@@ -110,11 +110,20 @@
    * Explicit MIME list forces the correct native picker on iOS + Android.
    */
   const AUDIO_ACCEPT = [
-    'audio/mpeg', 'audio/mp3', 'audio/wav', 'audio/x-wav',
-    'audio/ogg', 'audio/flac', 'audio/x-flac', 'audio/aac',
-    'audio/x-m4a', 'audio/m4a', 'audio/mp4',
-    'video/mp4', 'video/webm', 'video/quicktime',
-    'audio/*', 'video/*'
+    'audio/mpeg', 'audio/mp3', 'audio/wav', 'audio/x-wav', 'audio/wave',
+    'audio/ogg', 'audio/flac', 'audio/x-flac', 'audio/aac', 'audio/x-aac',
+    'audio/x-m4a', 'audio/m4a', 'audio/mp4', 'audio/webm', 'audio/amr',
+    'audio/aiff', 'audio/x-aiff', 'audio/x-caf', 'audio/x-ms-wma',
+    'audio/opus', 'audio/ac3', 'audio/eac3',
+    'video/mp4', 'video/webm', 'video/quicktime', 'video/x-msvideo',
+    'video/x-matroska', 'video/ogg', 'video/3gpp', 'video/3gpp2',
+    'video/x-ms-wmv', 'video/mpeg', 'video/mp2t', 'video/x-flv',
+    'audio/*', 'video/*',
+    '.wav', '.wave', '.mp3', '.m4a', '.aac', '.ogg', '.oga', '.opus',
+    '.flac', '.webm', '.weba', '.aiff', '.aif', '.caf', '.wma', '.mka',
+    '.m4b', '.m4r', '.amr', '.ac3', '.eac3',
+    '.mp4', '.m4v', '.mov', '.mkv', '.avi', '.ogv', '.3gp', '.3g2',
+    '.wmv', '.mpeg', '.mpg', '.ts', '.m2ts', '.mts', '.flv', '.f4v', '.asf',
   ].join(',');
 
   function patchFileInput() {

--- a/public/index.html
+++ b/public/index.html
@@ -43,9 +43,9 @@
       <div id="uploadZone" class="upload-zone" role="button" tabindex="0" aria-label="Drop audio or video here, or press Enter to browse">
         <svg class="upload-svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
         <p class="upload-title">Drop audio or video here</p>
-        <p class="upload-sub">WAV · MP3 · M4A · FLAC · OGG · MP4 · MOV and more</p>
+        <p class="upload-sub">WAV · MP3 · M4A · FLAC · OGG · OPUS · AAC · AIFF · WMA · MP4 · MOV · MKV · AVI · WEBM · WMV · TS and more</p>
         <button id="browseBtn" class="btn" type="button">Browse Files</button>
-        <input type="file" id="fileInput" class="visually-hidden-file" accept="audio/*,video/*,.wav,.mp3,.m4a,.aac,.ogg,.opus,.flac,.webm,.aiff,.aif,.caf,.mp4,.m4v,.mov,.mkv,.avi,.wmv" aria-label="Choose audio or video file">
+        <input type="file" id="fileInput" class="visually-hidden-file" accept="audio/mpeg,audio/mp3,audio/wav,audio/x-wav,audio/wave,audio/ogg,audio/flac,audio/x-flac,audio/aac,audio/x-m4a,audio/m4a,audio/mp4,audio/webm,audio/amr,audio/aiff,audio/x-aiff,audio/x-caf,audio/x-ms-wma,audio/opus,audio/ac3,audio/eac3,video/mp4,video/webm,video/quicktime,video/x-msvideo,video/x-matroska,video/ogg,video/3gpp,video/3gpp2,video/x-ms-wmv,video/mpeg,video/mp2t,video/x-flv,audio/*,video/*,.wav,.wave,.mp3,.m4a,.aac,.ogg,.oga,.opus,.flac,.webm,.weba,.aiff,.aif,.caf,.wma,.mka,.m4b,.m4r,.amr,.ac3,.eac3,.mp4,.m4v,.mov,.mkv,.avi,.ogv,.3gp,.3g2,.wmv,.mpeg,.mpg,.ts,.m2ts,.mts,.flv,.f4v,.asf" aria-label="Choose audio or video file">
       </div>
       <div class="upload-row">
         <label for="modelSelect" class="inline-label">Model</label>

--- a/src/core/DesktopBridge.js
+++ b/src/core/DesktopBridge.js
@@ -19,6 +19,16 @@ export function isDesktopShell() {
 }
 
 /**
+ * Live microphone capture is enabled on web and native mobile (Capacitor),
+ * but disabled in the Electron desktop shell.
+ * @returns {boolean}
+ */
+export function isMicCaptureEnabled() {
+  if (isDesktopShell()) return false;
+  return true;
+}
+
+/**
  * @returns {Promise<'win32'|'darwin'|'linux'|null>}
  */
 export async function getDesktopPlatform() {
@@ -96,15 +106,43 @@ function mimeFromFilename(name) {
   const ext = (name.split('.').pop() || '').toLowerCase();
   const map = {
     wav: 'audio/wav',
+    wave: 'audio/wav',
     mp3: 'audio/mpeg',
     flac: 'audio/flac',
     ogg: 'audio/ogg',
+    oga: 'audio/ogg',
+    opus: 'audio/opus',
     m4a: 'audio/mp4',
+    m4b: 'audio/mp4',
+    m4r: 'audio/mp4',
     aac: 'audio/aac',
     webm: 'audio/webm',
+    weba: 'audio/webm',
+    aiff: 'audio/aiff',
+    aif: 'audio/aiff',
+    caf: 'audio/x-caf',
+    wma: 'audio/x-ms-wma',
+    mka: 'audio/x-matroska',
+    amr: 'audio/amr',
+    ac3: 'audio/ac3',
+    eac3: 'audio/eac3',
     mp4: 'video/mp4',
+    m4v: 'video/mp4',
     mov: 'video/quicktime',
     mkv: 'video/x-matroska',
+    avi: 'video/x-msvideo',
+    wmv: 'video/x-ms-wmv',
+    mpeg: 'video/mpeg',
+    mpg: 'video/mpeg',
+    ogv: 'video/ogg',
+    '3gp': 'video/3gpp',
+    '3g2': 'video/3gpp2',
+    ts: 'video/mp2t',
+    m2ts: 'video/mp2t',
+    mts: 'video/mp2t',
+    flv: 'video/x-flv',
+    f4v: 'video/x-flv',
+    asf: 'video/x-ms-asf',
   };
   return map[ext] || '';
 }

--- a/src/core/media-types.js
+++ b/src/core/media-types.js
@@ -1,15 +1,43 @@
 'use strict';
 
-/** Common audio container extensions browsers can demux via decodeAudioData. */
-export const AUDIO_EXTENSIONS = /\.(wav|wave|mp3|m4a|aac|ogg|opus|flac|webm|wma|aiff?|caf|mka)$/i;
+/** Common audio container extensions browsers can demux via decodeAudioData or media element. */
+export const AUDIO_EXTENSIONS = /\.(wav|wave|mp3|m4a|aac|ogg|oga|opus|flac|webm|weba|wma|aiff?|caf|mka|m4b|m4r|amr|3ga|ape|wv|tta|ac3|eac3|dts)$/i;
 
-/** Common video container extensions (audio track extracted via decodeAudioData). */
-export const VIDEO_EXTENSIONS = /\.(mp4|m4v|mov|mkv|avi|ogv|3gp|wmv|mpeg|mpg)$/i;
+/** Common video container extensions (audio track extracted via decode or media element). */
+export const VIDEO_EXTENSIONS = /\.(mp4|m4v|mov|mkv|avi|ogv|3gp|3g2|wmv|mpeg|mpg|webm|ts|m2ts|mts|flv|f4v|asf|divx)$/i;
 
 /** MIDI is never supported by the Web Audio decode path. */
 export const MIDI_EXTENSIONS = /\.(mid|midi)$/i;
 
 const MIDI_MIMES = new Set(['audio/midi', 'audio/x-midi', 'audio/mid']);
+
+/** Explicit MIME list for <input type="file" accept="…"> (iOS/Android pickers). */
+export const FILE_INPUT_ACCEPT = [
+  'audio/mpeg', 'audio/mp3', 'audio/wav', 'audio/x-wav', 'audio/wave',
+  'audio/ogg', 'audio/flac', 'audio/x-flac', 'audio/aac', 'audio/x-aac',
+  'audio/x-m4a', 'audio/m4a', 'audio/mp4', 'audio/webm', 'audio/amr',
+  'audio/aiff', 'audio/x-aiff', 'audio/x-caf', 'audio/x-ms-wma',
+  'audio/opus', 'audio/x-opus+ogg', 'audio/ac3', 'audio/eac3',
+  'video/mp4', 'video/webm', 'video/quicktime', 'video/x-msvideo',
+  'video/x-matroska', 'video/ogg', 'video/3gpp', 'video/3gpp2',
+  'video/x-ms-wmv', 'video/mpeg', 'video/mp2t', 'video/x-flv',
+  'audio/*', 'video/*',
+  '.wav', '.wave', '.mp3', '.m4a', '.aac', '.ogg', '.oga', '.opus',
+  '.flac', '.webm', '.weba', '.aiff', '.aif', '.caf', '.wma', '.mka',
+  '.m4b', '.m4r', '.amr', '.3ga', '.ape', '.wv', '.ac3', '.eac3',
+  '.mp4', '.m4v', '.mov', '.mkv', '.avi', '.ogv', '.3gp', '.3g2',
+  '.wmv', '.mpeg', '.mpg', '.ts', '.m2ts', '.mts', '.flv', '.f4v', '.asf',
+].join(',');
+
+/** Native open-dialog extension lists (Electron). */
+export const AUDIO_OPEN_EXTENSIONS = [
+  'wav', 'wave', 'mp3', 'flac', 'ogg', 'oga', 'opus', 'm4a', 'aac', 'webm', 'weba',
+  'aiff', 'aif', 'caf', 'wma', 'mka', 'm4b', 'm4r', 'amr', '3ga', 'ape', 'wv', 'ac3', 'eac3',
+];
+export const VIDEO_OPEN_EXTENSIONS = [
+  'mp4', 'm4v', 'mov', 'mkv', 'avi', 'ogv', '3gp', '3g2', 'wmv', 'mpeg', 'mpg', 'webm',
+  'ts', 'm2ts', 'mts', 'flv', 'f4v', 'asf',
+];
 
 /**
  * Infer whether a blob is ingestible audio/video from its MIME type and/or
@@ -40,4 +68,12 @@ export function isIngestibleMedia(blob) {
   return inferMediaKind(blob) === 'audio' || inferMediaKind(blob) === 'video';
 }
 
-export default { inferMediaKind, isIngestibleMedia, AUDIO_EXTENSIONS, VIDEO_EXTENSIONS };
+export default {
+  inferMediaKind,
+  isIngestibleMedia,
+  AUDIO_EXTENSIONS,
+  VIDEO_EXTENSIONS,
+  FILE_INPUT_ACCEPT,
+  AUDIO_OPEN_EXTENSIONS,
+  VIDEO_OPEN_EXTENSIONS,
+};

--- a/src/pipeline/FileIngestion.js
+++ b/src/pipeline/FileIngestion.js
@@ -34,8 +34,8 @@ export { isDesktopShell, pickAudioFile } from '../core/DesktopBridge.js';
 /** Accepted MIME prefixes. Container formats vary; the decoder is the judge. */
 const ACCEPTED_TYPES = ['audio/', 'video/'];
 
-/** Refuse absurd inputs before burning memory (2 GB). */
-const MAX_FILE_BYTES = 2 * 1024 * 1024 * 1024;
+/** No practical upload size cap — whole files are decoded on-device. */
+const MAX_FILE_BYTES = Number.MAX_SAFE_INTEGER;
 
 /**
  * Map isolation mode to model IDs array for MLWorker.
@@ -101,7 +101,7 @@ export function assertIngestible(blob) {
     throw new RangeError('[VIP][FileIngestion] File is empty.');
   }
   if (blob.size > MAX_FILE_BYTES) {
-    throw new RangeError('[VIP][FileIngestion] File exceeds the 2 GB limit.');
+    throw new RangeError('[VIP][FileIngestion] File exceeds the maximum supported size.');
   }
   const kind = inferMediaKind(blob);
   if (kind === 'midi') {

--- a/src/pipeline/media-decode.js
+++ b/src/pipeline/media-decode.js
@@ -3,7 +3,8 @@
 import { SAMPLE_RATE } from '../core/audio-config.js';
 import { inferMediaKind } from '../core/media-types.js';
 
-const MEDIA_DECODE_TIMEOUT_MS = 60_000;
+/** Minimum capture timeout — long files scale beyond this. */
+const MEDIA_DECODE_MIN_TIMEOUT_MS = 120_000;
 // ScriptProcessorNode block size — must be a power-of-two 256–16384.
 const SPN_BLOCK_SIZE = 4096;
 
@@ -11,19 +12,23 @@ const SPN_BLOCK_SIZE = 4096;
  * Decode any supported blob to an AudioBuffer.
  *
  * Strategy:
- *  1. Fast path  — ctx.decodeAudioData()  (PCM/WAV/MP3/OGG/FLAC)
- *  2. Fallback   — live AudioContext + createMediaElementSource +
- *                  ScriptProcessorNode ring-buffer capture.
- *                  (M4A / AAC / MP4 / WebM containers the browser can
- *                  demux natively but decodeAudioData cannot handle.)
- *
- * ⚠️  OfflineAudioContext.createMediaElementSource() does NOT exist in
- *     any browser. The source MUST come from a live AudioContext.
+ *   Video containers always use the media-element capture path so the browser
+ *   demuxes the full timeline (decodeAudioData can truncate some MP4/MOV).
+ *   Audio:
+ *     1. Fast path  — ctx.decodeAudioData()  (PCM/WAV/MP3/OGG/FLAC)
+ *     2. Fallback   — live AudioContext + createMediaElementSource +
+ *                     ScriptProcessorNode ring-buffer capture until 'ended'.
  *
  * @param {Blob|File} blob
  * @returns {Promise<AudioBuffer>}
  */
 export async function decodeBlobToAudioBuffer(blob) {
+  const kind = inferMediaKind(blob) || 'audio';
+
+  if (kind === 'video') {
+    return _decodeViaMediaElement(blob, kind);
+  }
+
   let primaryErr = null;
   try {
     return await _decodeWithAudioData(blob);
@@ -31,7 +36,6 @@ export async function decodeBlobToAudioBuffer(blob) {
     primaryErr = err;
   }
 
-  const kind = inferMediaKind(blob) || 'audio';
   try {
     return await _decodeViaMediaElement(blob, kind);
   } catch (fallbackErr) {
@@ -60,10 +64,6 @@ async function _decodeWithAudioData(blob) {
 
 // ---------------------------------------------------------------------------
 // Fallback — live AudioContext + createMediaElementSource + ring-buffer
-//
-// OfflineAudioContext does NOT have createMediaElementSource() — it is a
-// live-AudioContext-only API. We capture the output of the live graph with a
-// ScriptProcessorNode and assemble PCM frames into an AudioBuffer ourselves.
 // ---------------------------------------------------------------------------
 async function _decodeViaMediaElement(blob, kind) {
   const doc = globalThis.document;
@@ -77,98 +77,114 @@ async function _decodeViaMediaElement(blob, kind) {
   const tag = kind === 'video' ? 'video' : 'audio';
   const media = doc.createElement(tag);
   media.preload = 'auto';
-  media.muted = true;          // lets browser play without a user gesture
+  media.muted = true;
   media.setAttribute('playsinline', '');
   media.style.cssText = 'position:fixed;left:-9999px;width:1px;height:1px;opacity:0;pointer-events:none';
   doc.body.appendChild(media);
   media.src = url;
 
   let ctx = null;
+  let timeoutHandle = null;
   try {
-    // 1. Wait until metadata (duration / channels) is available.
     await _waitForMetadata(media);
 
-    const duration = media.duration;
+    let duration = media.duration;
     if (!Number.isFinite(duration) || duration <= 0) {
       throw new Error('Media has no decodable audio duration.');
     }
 
-    // 2. Build the live audio graph.
     ctx = new Ctx({ sampleRate: SAMPLE_RATE });
-    const source = ctx.createMediaElementSource(media); // ✅ valid on live ctx
+    const source = ctx.createMediaElementSource(media);
 
-    // 3. Ring-buffer via ScriptProcessorNode.
-    //    SPN is deprecated but universally supported and gives synchronous
-    //    PCM access — the only option for a MediaElementSource on a live ctx.
     const numChannels = 2;
-    const estimatedFrames = Math.ceil(duration * SAMPLE_RATE) + SPN_BLOCK_SIZE * 4;
-    const chunks = [];   // Array<Array<Float32Array>>  [block][ch]
-    let capturedFrames = 0;
-    let resolveDone, rejectDone;
-    const donePromise = new Promise((res, rej) => { resolveDone = res; rejectDone = rej; });
+    const chunks = [];
+    let captureDone = false;
 
     const spn = ctx.createScriptProcessor(SPN_BLOCK_SIZE, numChannels, numChannels);
     source.connect(spn);
-    spn.connect(ctx.destination); // must be connected to run
+    spn.connect(ctx.destination);
 
     spn.onaudioprocess = (e) => {
+      if (captureDone) return;
       const block = [];
       for (let ch = 0; ch < numChannels; ch++) {
-        block.push(new Float32Array(e.inputBuffer.getChannelData(ch))); // copy!
+        block.push(new Float32Array(e.inputBuffer.getChannelData(ch)));
       }
       chunks.push(block);
-      capturedFrames += SPN_BLOCK_SIZE;
-      if (capturedFrames >= estimatedFrames) {
-        spn.onaudioprocess = null;
-        resolveDone();
-      }
     };
 
-    // 4. Timeout guard.
-    const timeoutHandle = setTimeout(() => {
-      spn.onaudioprocess = null;
-      rejectDone(new Error(`Media element capture timed out after ${MEDIA_DECODE_TIMEOUT_MS / 1000}s`));
-    }, MEDIA_DECODE_TIMEOUT_MS);
+    const flushTailMs = Math.ceil((SPN_BLOCK_SIZE / SAMPLE_RATE) * 1000) + 100;
 
-    // 5. Start playback — required to drive the ScriptProcessorNode.
-    await media.play();
+    const resetCaptureTimeout = () => {
+      if (timeoutHandle) clearTimeout(timeoutHandle);
+      const captureTimeoutMs = Math.max(
+        MEDIA_DECODE_MIN_TIMEOUT_MS,
+        Math.ceil(duration * 1000 * 2) + 60_000,
+      );
+      timeoutHandle = setTimeout(() => {
+        captureDone = true;
+        spn.onaudioprocess = null;
+        media.pause();
+      }, captureTimeoutMs);
+    };
 
-    // 6. Also resolve when element fires 'ended' (handles short files
-    //    that finish before estimatedFrames is reached).
-    const endedPromise = new Promise((res) => {
-      media.addEventListener('ended', () => {
-        // One extra SPN quantum to flush the tail.
-        setTimeout(() => {
-          spn.onaudioprocess = null;
-          res();
-        }, Math.ceil((SPN_BLOCK_SIZE / SAMPLE_RATE) * 1000) + 50);
+    const endedPromise = new Promise((resolve, reject) => {
+      const finish = () => {
+        if (captureDone) return;
+        captureDone = true;
+        spn.onaudioprocess = null;
+        setTimeout(resolve, flushTailMs);
+      };
+      media.addEventListener('ended', finish, { once: true });
+      media.addEventListener('error', () => {
+        reject(new Error(media.error?.message || 'Media playback failed'));
       }, { once: true });
+      media.addEventListener('durationchange', () => {
+        if (Number.isFinite(media.duration) && media.duration > duration) {
+          duration = media.duration;
+          resetCaptureTimeout();
+        }
+      });
     });
 
-    await Promise.race([donePromise, endedPromise]);
-    clearTimeout(timeoutHandle);
+    resetCaptureTimeout();
+
+    await media.play();
+    await endedPromise;
+    if (timeoutHandle) clearTimeout(timeoutHandle);
     spn.onaudioprocess = null;
 
-    // 7. Assemble captured chunks into a single AudioBuffer.
-    const totalFrames = chunks.length * SPN_BLOCK_SIZE;
+    if (!chunks.length) {
+      throw new Error('Media element produced an empty audio buffer.');
+    }
+
+    const reportedDuration = Number.isFinite(media.duration) && media.duration > 0
+      ? media.duration
+      : duration;
+    const targetFrames = Math.max(1, Math.ceil(reportedDuration * SAMPLE_RATE));
+    const capturedFrames = chunks.length * SPN_BLOCK_SIZE;
+    const outFrames = Math.min(capturedFrames, targetFrames);
+
     const result = new AudioBuffer({
       numberOfChannels: numChannels,
-      length: totalFrames,
+      length: outFrames,
       sampleRate: SAMPLE_RATE,
     });
     for (let ch = 0; ch < numChannels; ch++) {
       const dest = result.getChannelData(ch);
       let offset = 0;
       for (const block of chunks) {
-        dest.set(block[ch], offset);
-        offset += SPN_BLOCK_SIZE;
+        const remain = outFrames - offset;
+        if (remain <= 0) break;
+        const copyLen = Math.min(SPN_BLOCK_SIZE, remain);
+        dest.set(block[ch].subarray(0, copyLen), offset);
+        offset += copyLen;
       }
     }
 
-    if (!result.length) throw new Error('Media element produced an empty audio buffer.');
     return result;
-
   } finally {
+    if (timeoutHandle) clearTimeout(timeoutHandle);
     try { media.pause(); } catch { /* ignore */ }
     try { media.removeAttribute('src'); media.load(); media.remove(); } catch { /* ignore */ }
     URL.revokeObjectURL(url);
@@ -184,7 +200,7 @@ function _waitForMetadata(media) {
     const HAVE_METADATA = globalThis.HTMLMediaElement?.HAVE_METADATA ?? 1;
     const timer = setTimeout(
       () => reject(new Error('Media metadata load timeout')),
-      MEDIA_DECODE_TIMEOUT_MS
+      MEDIA_DECODE_MIN_TIMEOUT_MS,
     );
     const done = () => { clearTimeout(timer); resolve(); };
     const fail = () => {
@@ -195,7 +211,7 @@ function _waitForMetadata(media) {
     };
     if (media.readyState >= HAVE_METADATA) { done(); return; }
     media.addEventListener('loadedmetadata', done, { once: true });
-    media.addEventListener('error',          fail, { once: true });
+    media.addEventListener('error', fail, { once: true });
   });
 }
 

--- a/tests/engineer-upload-decode.test.js
+++ b/tests/engineer-upload-decode.test.js
@@ -36,4 +36,9 @@ describe('Engineer upload decode wiring', () => {
     expect(appJs).toContain('openFilePicker as triggerFileInput');
     expect(appJs).toContain('triggerFileInput(this.dom.fileInput)');
   });
+
+  test('app.js disables live mic capture on desktop shell', () => {
+    expect(appJs).toContain('isMicCaptureEnabled');
+    expect(appJs).toContain('hideMicControls');
+  });
 });

--- a/tests/helpers/get-app-code.js
+++ b/tests/helpers/get-app-code.js
@@ -88,6 +88,12 @@ function stripRelativeImports(src) {
   );
 }
 
+function buildMediaTypesShim() {
+  return fs.readFileSync(path.join(__dirname, '../../src/core/media-types.js'), 'utf8')
+    .replace(/^export default\s*\{[\s\S]*$/m, '')
+    .replace(/^export\s+/gm, '');
+}
+
 function buildMediaDecodeShim() {
   return `
 async function decodeBlobToAudioBuffer(file) {
@@ -101,6 +107,9 @@ async function decodeBlobToAudioBuffer(file) {
 async function resampleToCanonical(buffer) {
   return buffer;
 }
+function isDesktopShell() { return false; }
+function isMicCaptureEnabled() { return true; }
+async function pickAudioFile() { return null; }
 `;
 }
 
@@ -115,8 +124,9 @@ function getAppCode() {
       'const decoded = await decodeBlobToAudioBuffer.call(this, file);'
     );
   }
+  const mediaTypesShim = buildMediaTypesShim();
   const mediaDecodeShim = buildMediaDecodeShim();
-  return preamble + '\n' + inlined + '\n' + mediaDecodeShim + '\n' + appJsCode;
+  return preamble + '\n' + inlined + '\n' + mediaTypesShim + '\n' + mediaDecodeShim + '\n' + appJsCode;
 }
 
 module.exports = getAppCode;

--- a/tests/m4a-decode-fallback.test.js
+++ b/tests/m4a-decode-fallback.test.js
@@ -50,6 +50,17 @@ describe('M4A decode fallback — media-decode.js', () => {
   test('fallback creates audio/video element by inferred kind', () => {
     expect(mdjs).toContain("const tag = kind === 'video' ? 'video' : 'audio'");
   });
+
+  test('video containers always use media-element capture (full timeline)', () => {
+    expect(mdjs).toContain("if (kind === 'video')");
+    expect(mdjs).toContain('return _decodeViaMediaElement(blob, kind)');
+  });
+
+  test('capture timeout scales with media duration', () => {
+    expect(mdjs).toContain('resetCaptureTimeout');
+    expect(mdjs).toContain('duration * 1000 * 2');
+    expect(mdjs).not.toContain('capturedFrames >= estimatedFrames');
+  });
 });
 
 describe('M4A decode fallback — media-types.js', () => {


### PR DESCRIPTION
## Summary
- Decode entire video files by routing video containers through media-element capture until playback ends, with duration-scaled timeouts (fixes ~15s cutoff on long uploads)
- Expand audio/video upload accept lists across Landing, Engineer Mode, mobile patch, and Electron open dialog
- Remove live microphone capture from the Electron desktop shell; keep mic on web and mobile

## Test plan
- [x] Local Jest: handle_file_validation, m4a-decode-fallback, file-ingestion, engineer-upload-decode, mobile-upload-fix (50 tests)
- [ ] Upload a long MP4/MOV on Landing and Engineer Mode — full duration decodes
- [ ] Desktop/Electron: mic buttons hidden; web still shows Record Mic


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix full-length video upload by removing 2 GB file size cap and improving media decode
> - Removes the 2 GB file size limit in [`FileIngestion.js`](https://github.com/Joker5514/VoiceIsolate-Pro/pull/670/files#diff-6b4ecfacbea3f8d0de17798f712a889b7df7740fc164def3269e7ce650e3b552) by setting `MAX_FILE_BYTES` to `Number.MAX_SAFE_INTEGER`
> - Rewrites `_decodeViaMediaElement` in [`media-decode.js`](https://github.com/Joker5514/VoiceIsolate-Pro/pull/670/files#diff-55e5ad8acd800e02c653d814a59f6ca794f9a3f6823bcb1f88b9fd16698230bf) to collect audio until playback ends, scale timeout with media duration, and trim output to expected length; video containers now always bypass `decodeAudioData`
> - Expands accepted audio/video formats across the desktop file picker, mobile file inputs, and MIME inference in [`media-types.js`](https://github.com/Joker5514/VoiceIsolate-Pro/pull/670/files#diff-88886fad6bda135fb33af6b2ca0b425b6addd710760be4a991fb945cdce64cd6) and [`DesktopBridge.js`](https://github.com/Joker5514/VoiceIsolate-Pro/pull/670/files#diff-f4d0ae9864546156bdd15febc8ea11606fb0363f0ac1b4cedb1b2ef90de52476)
> - Hides microphone controls on the desktop Electron shell by checking `isMicCaptureEnabled()` in [`app.js`](https://github.com/Joker5514/VoiceIsolate-Pro/pull/670/files#diff-8a8b7ea624d7fccc12a516d122dcb07bd67c6a8f796c80e33b898ee6a7557650)
> - Behavioral Change: files previously rejected above 2 GB will now proceed through the full pipeline
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c3d0bd8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Upload and import now support both audio and video files.
  * The app hides microphone recording controls when live mic capture isn’t available.

* **Bug Fixes**
  * Improved file type detection for uploads so more media formats are recognized correctly.
  * Expanded support for larger media files during ingestion.

* **Style**
  * Updated upload messaging and button labels to match the broader media support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->