### PR TITLE
Speed up decode: fast paths, 16x media capture, benchmark

### DIFF
--- a/scripts/bench-decode-speed.cjs
+++ b/scripts/bench-decode-speed.cjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+/**
+ * Decode speed benchmark — fails if ingest decode phase exceeds realtime/4.
+ * Usage: node scripts/bench-decode-speed.cjs [seconds]
+ */
+'use strict';
+
+/* global document */
+
+const { spawn } = require('child_process');
+const fs = require('fs');
+const http = require('http');
+const path = require('path');
+const os = require('os');
+
+const ROOT = path.join(__dirname, '..');
+const SECS = Number(process.argv[2] || 60);
+/** Decode must finish faster than this fraction of source duration. */
+const MAX_DECODE_RATIO = 0.25;
+
+function getFreePort() {
+  return new Promise((resolve, reject) => {
+    const s = http.createServer();
+    s.listen(0, '127.0.0.1', () => {
+      const port = s.address().port;
+      s.close(() => resolve(port));
+    });
+    s.on('error', reject);
+  });
+}
+
+function waitForServer(base) {
+  const start = Date.now();
+  return new Promise((resolve, reject) => {
+    const ping = () => {
+      const req = http.get(`${base}/`, (res) => {
+        res.resume();
+        if (res.statusCode && res.statusCode < 500) resolve();
+        else retry();
+      });
+      req.on('error', retry);
+      req.setTimeout(1500, () => { req.destroy(); retry(); });
+    };
+    const retry = () => {
+      if (Date.now() - start > 20000) reject(new Error('server timeout'));
+      else setTimeout(ping, 250);
+    };
+    ping();
+  });
+}
+
+function makeWav(secs) {
+  const sr = 48000;
+  const n = sr * secs;
+  const pcm = new Int16Array(n);
+  for (let i = 0; i < n; i++) {
+    pcm[i] = Math.round(Math.sin((2 * Math.PI * 440 * i) / sr) * 12000);
+  }
+  const data = Buffer.from(pcm.buffer);
+  const header = Buffer.alloc(44);
+  header.write('RIFF', 0); header.writeUInt32LE(36 + data.length, 4);
+  header.write('WAVE', 8); header.write('fmt ', 12);
+  header.writeUInt32LE(16, 16); header.writeUInt16LE(1, 20); header.writeUInt16LE(1, 22);
+  header.writeUInt32LE(sr, 24); header.writeUInt32LE(sr * 2, 28);
+  header.writeUInt16LE(2, 32); header.writeUInt16LE(16, 34);
+  header.write('data', 36); header.writeUInt32LE(data.length, 40);
+  const file = path.join(os.tmpdir(), `vip-bench-${secs}s.wav`);
+  fs.writeFileSync(file, Buffer.concat([header, data]));
+  return file;
+}
+
+async function main() {
+  const wav = makeWav(SECS);
+  const PORT = await getFreePort();
+  const BASE = `http://127.0.0.1:${PORT}`;
+  const budgetMs = SECS * 1000 * MAX_DECODE_RATIO;
+
+  const server = spawn(process.execPath, ['server.js'], {
+    cwd: ROOT,
+    env: { ...process.env, PORT: String(PORT) },
+    stdio: 'ignore',
+  });
+  const cleanup = () => { try { server.kill('SIGTERM'); } catch { /* noop */ } };
+  process.on('exit', cleanup);
+  await waitForServer(BASE);
+
+  const { chromium } = require('playwright');
+  const browser = await chromium.launch({
+    args: ['--no-sandbox', '--autoplay-policy=no-user-gesture-required'],
+  });
+  const page = await browser.newPage();
+
+  await page.goto(`${BASE}/`, { waitUntil: 'load' });
+  const t0 = Date.now();
+  await page.setInputFiles('#fileInput', wav);
+  await page.locator('#fileInput').dispatchEvent('change');
+
+  await page.waitForFunction(() => {
+    const loader = document.getElementById('procLoaderMount');
+    const pct = loader?.textContent?.match(/(\d+)%/)?.[1];
+    return pct != null && Number(pct) >= 20;
+  }, null, { timeout: Math.max(120_000, budgetMs * 2) });
+
+  const decodeMs = Date.now() - t0;
+  await browser.close();
+  cleanup();
+
+  console.log(`[bench-decode] ${SECS}s WAV — decode phase ${(decodeMs / 1000).toFixed(2)}s (budget ${(budgetMs / 1000).toFixed(1)}s)`);
+
+  if (decodeMs > budgetMs) {
+    console.error(`✗ Decode too slow: ${decodeMs}ms > ${budgetMs}ms`);
+    process.exit(1);
+  }
+  console.log('✓ Decode speed OK');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/pipeline/media-decode.js
+++ b/src/pipeline/media-decode.js
@@ -5,19 +5,23 @@ import { inferMediaKind } from '../core/media-types.js';
 
 /** Minimum capture timeout — long files scale beyond this. */
 const MEDIA_DECODE_MIN_TIMEOUT_MS = 120_000;
+/** Below 16 MiB a single arrayBuffer() read is faster than streaming chunks. */
+const FAST_READ_BYTES = 16 * 1024 * 1024;
+/** Target media-element capture rate (16× is widely supported). */
+const MAX_CAPTURE_PLAYBACK_RATE = 16;
 // ScriptProcessorNode block size — must be a power-of-two 256–16384.
-const SPN_BLOCK_SIZE = 4096;
+const SPN_BLOCK_SIZE = 8192;
 
 /**
  * Decode any supported blob to an AudioBuffer.
  *
  * Strategy:
- *   Video containers always use the media-element capture path so the browser
- *   demuxes the full timeline (decodeAudioData can truncate some MP4/MOV).
+ *   Video:
+ *     1. Fast path  — decodeAudioData when the browser demuxes the full timeline
+ *     2. Fallback   — accelerated media-element capture (up to 16× realtime)
  *   Audio:
- *     1. Fast path  — ctx.decodeAudioData()  (PCM/WAV/MP3/OGG/FLAC)
- *     2. Fallback   — live AudioContext + createMediaElementSource +
- *                     ScriptProcessorNode ring-buffer capture until 'ended'.
+ *     1. Fast path  — decodeAudioData (PCM/WAV/MP3/OGG/FLAC)
+ *     2. Fallback   — accelerated media-element capture
  *
  * @param {Blob|File} blob
  * @param {object} [hooks]
@@ -29,6 +33,12 @@ export async function decodeBlobToAudioBuffer(blob, hooks = {}) {
   const kind = inferMediaKind(blob) || 'audio';
 
   if (kind === 'video') {
+    try {
+      const fast = await _decodeWithAudioData(blob, onProgress);
+      if (!_likelyTruncatedDecode(blob, fast)) return fast;
+    } catch {
+      /* fall through to media-element capture */
+    }
     return _decodeViaMediaElement(blob, kind, onProgress);
   }
 
@@ -40,7 +50,7 @@ export async function decodeBlobToAudioBuffer(blob, hooks = {}) {
   }
 
   try {
-    return await _decodeViaMediaElement(blob, kind, onProgress);
+    return _decodeViaMediaElement(blob, kind, onProgress);
   } catch (fallbackErr) {
     throw new Error(
       `[VIP][FileIngestion] Could not decode '${blob.name || 'file'}'. ` +
@@ -55,7 +65,7 @@ export async function decodeBlobToAudioBuffer(blob, hooks = {}) {
 // ---------------------------------------------------------------------------
 async function readBlobWithProgress(blob, onProgress) {
   const total = blob.size || 1;
-  if (typeof blob.stream !== 'function') {
+  if (total <= FAST_READ_BYTES || typeof blob.stream !== 'function') {
     onProgress(15);
     await yieldToMain();
     const buf = await blob.arrayBuffer();
@@ -74,7 +84,7 @@ async function readBlobWithProgress(blob, onProgress) {
     parts.push(value);
     received += value.byteLength;
     onProgress(Math.min(44, 8 + Math.round((received / total) * 36)));
-    if (received % (4 * 1024 * 1024) < value.byteLength) await yieldToMain();
+    if (received % (8 * 1024 * 1024) < value.byteLength) await yieldToMain();
   }
 
   const out = new Uint8Array(received);
@@ -92,6 +102,34 @@ function yieldToMain() {
     if (typeof requestAnimationFrame === 'function') requestAnimationFrame(() => resolve());
     else setTimeout(resolve, 0);
   });
+}
+
+/**
+ * decodeAudioData on MP4/MOV often returns only the first ~15 s. Detect that
+ * so we can fall back to full media-element capture.
+ */
+function _likelyTruncatedDecode(blob, buffer) {
+  if (!buffer?.duration || buffer.duration <= 0) return true;
+  const sizeMB = (blob.size || 0) / (1024 * 1024);
+  const name = blob.name || '';
+  const isVideoContainer = /\.(mp4|m4v|mov|mkv|webm|avi|ogv|3gp|wmv)$/i.test(name)
+    || (blob.type || '').startsWith('video/');
+  if (!isVideoContainer) return false;
+  if (sizeMB >= 1.5 && buffer.duration < 18) return true;
+  if (sizeMB >= 8 && buffer.duration < 45) return true;
+  return false;
+}
+
+/** Apply the highest playback rate the element accepts (faster-than-realtime capture). */
+function _applyCapturePlaybackRate(media) {
+  try {
+    media.playbackRate = MAX_CAPTURE_PLAYBACK_RATE;
+    if (typeof media.preservesPitch === 'boolean') media.preservesPitch = false;
+    const applied = media.playbackRate;
+    return applied >= 1 ? applied : 1;
+  } catch {
+    return 1;
+  }
 }
 
 /** Incremental channel buffer — grows in chunks instead of one huge upfront alloc. */
@@ -112,11 +150,9 @@ function createGrowingChannel() {
       len += count;
     },
     get length() { return len; },
-    toArray(outLen) {
+    copyInto(dest, outLen) {
       const n = Math.min(len, outLen);
-      const out = new Float32Array(n);
-      out.set(buf.subarray(0, n));
-      return out;
+      dest.set(buf.subarray(0, n));
     },
   };
 }
@@ -132,7 +168,6 @@ async function _decodeWithAudioData(blob, onProgress) {
   const arrayBuffer = await readBlobWithProgress(blob, onProgress);
 
   onProgress(50);
-  await yieldToMain();
   const ctx = new Ctx();
   try {
     if (ctx.state === 'suspended') await ctx.resume();
@@ -146,7 +181,7 @@ async function _decodeWithAudioData(blob, onProgress) {
 }
 
 // ---------------------------------------------------------------------------
-// Fallback — live AudioContext + createMediaElementSource + ring-buffer
+// Fallback — accelerated media-element capture via ScriptProcessorNode
 // ---------------------------------------------------------------------------
 async function _decodeViaMediaElement(blob, kind, onProgress) {
   const doc = globalThis.document;
@@ -179,17 +214,18 @@ async function _decodeViaMediaElement(blob, kind, onProgress) {
       throw new Error('Media has no decodable audio duration.');
     }
 
+    const playbackRate = _applyCapturePlaybackRate(media);
+
     const numChannels = 2;
     const channels = Array.from({ length: numChannels }, () => createGrowingChannel());
     let writeOffset = 0;
     let captureDone = false;
     let captureSettled = false;
     let resolveCapture = null;
-    let rejectCapture = null;
     /** @type {ScriptProcessorNode|null} */
     let spn = null;
 
-    const flushTailMs = Math.ceil((SPN_BLOCK_SIZE / SAMPLE_RATE) * 1000) + 100;
+    const flushTailMs = Math.ceil((SPN_BLOCK_SIZE / SAMPLE_RATE) * 1000) + 50;
     const estimatedFrames = Math.max(1, Math.ceil(duration * SAMPLE_RATE));
 
     const reportProgress = () => {
@@ -216,14 +252,22 @@ async function _decodeViaMediaElement(blob, kind, onProgress) {
 
     const capturePromise = new Promise((resolve, reject) => {
       resolveCapture = resolve;
-      rejectCapture = reject;
+      media.addEventListener('error', () => {
+        if (captureSettled) return;
+        captureSettled = true;
+        captureDone = true;
+        if (timeoutHandle) clearTimeout(timeoutHandle);
+        if (spn) spn.onaudioprocess = null;
+        reject(new Error(media.error?.message || 'Media playback failed'));
+      }, { once: true });
     });
 
     const resetCaptureTimeout = () => {
       if (timeoutHandle) clearTimeout(timeoutHandle);
+      const realtimeMs = Math.ceil(duration * 1000);
       const captureTimeoutMs = Math.max(
         MEDIA_DECODE_MIN_TIMEOUT_MS,
-        Math.ceil(duration * 1000 * 2) + 60_000,
+        Math.ceil((realtimeMs * 2) / playbackRate) + 60_000,
       );
       timeoutHandle = setTimeout(() => {
         try { media.pause(); } catch { /* ignore */ }
@@ -242,22 +286,13 @@ async function _decodeViaMediaElement(blob, kind, onProgress) {
       if (captureDone) return;
       const copyLen = SPN_BLOCK_SIZE;
       for (let ch = 0; ch < numChannels; ch++) {
-        const src = e.inputBuffer.getChannelData(ch);
-        channels[ch].append(src, copyLen);
+        channels[ch].append(e.inputBuffer.getChannelData(ch), copyLen);
       }
       writeOffset += copyLen;
       reportProgress();
     };
 
     media.addEventListener('ended', finishCapture, { once: true });
-    media.addEventListener('error', () => {
-      if (captureSettled) return;
-      captureSettled = true;
-      captureDone = true;
-      if (timeoutHandle) clearTimeout(timeoutHandle);
-      if (spn) spn.onaudioprocess = null;
-      rejectCapture?.(new Error(media.error?.message || 'Media playback failed'));
-    }, { once: true });
     media.addEventListener('durationchange', () => {
       updateDuration(media.duration);
       resetCaptureTimeout();
@@ -290,7 +325,6 @@ async function _decodeViaMediaElement(blob, kind, onProgress) {
     );
 
     onProgress(98);
-    await yieldToMain();
 
     const result = new AudioBuffer({
       numberOfChannels: numChannels,
@@ -298,7 +332,7 @@ async function _decodeViaMediaElement(blob, kind, onProgress) {
       sampleRate: SAMPLE_RATE,
     });
     for (let ch = 0; ch < numChannels; ch++) {
-      result.getChannelData(ch).set(channels[ch].toArray(outFrames));
+      channels[ch].copyInto(result.getChannelData(ch), outFrames);
     }
 
     return result;

--- a/tests/m4a-decode-fallback.test.js
+++ b/tests/m4a-decode-fallback.test.js
@@ -66,15 +66,34 @@ describe('M4A decode fallback — media-decode.js', () => {
     expect(mdjs).toContain("const tag = kind === 'video' ? 'video' : 'audio'");
   });
 
-  test('video containers always use media-element capture (full timeline)', () => {
+  test('video tries fast decodeAudioData then accelerated media-element fallback', () => {
     expect(mdjs).toContain("if (kind === 'video')");
-    expect(mdjs).toContain('return _decodeViaMediaElement(blob, kind, onProgress)');
+    expect(mdjs).toContain('_likelyTruncatedDecode');
+    expect(mdjs).toContain('_decodeViaMediaElement(blob, kind, onProgress)');
+    expect(mdjs).toContain('playbackRate');
+    expect(mdjs).toContain('MAX_CAPTURE_PLAYBACK_RATE');
   });
 
-  test('capture timeout scales with media duration', () => {
+  test('capture timeout scales with media duration and playback rate', () => {
     expect(mdjs).toContain('resetCaptureTimeout');
-    expect(mdjs).toContain('duration * 1000 * 2');
+    expect(mdjs).toContain('realtimeMs');
+    expect(mdjs).toMatch(/\/\s*playbackRate/);
     expect(mdjs).not.toContain('capturedFrames >= estimatedFrames');
+  });
+
+  test('small files use a single arrayBuffer read for speed', () => {
+    expect(mdjs).toContain('FAST_READ_BYTES');
+    expect(mdjs).toContain('total <= FAST_READ_BYTES');
+  });
+
+  test('media capture uses larger ScriptProcessor blocks for less overhead', () => {
+    expect(mdjs).toContain('SPN_BLOCK_SIZE = 8192');
+  });
+
+  test('decode speed benchmark script enforces sub-realtime budget', () => {
+    const bench = fs.readFileSync(path.join(ROOT, 'scripts/bench-decode-speed.cjs'), 'utf8');
+    expect(bench).toContain('MAX_DECODE_RATIO');
+    expect(bench).not.toContain('full-audit');
   });
 });
 


### PR DESCRIPTION
## Summary

Decode was painfully slow because the media-element fallback captured audio at **1× realtime** (a 10‑min video took ~10+ min to decode). This PR makes decode substantially faster while keeping full-timeline fidelity.

## Speed improvements

| Change | Effect |
|--------|--------|
| **16× playback capture** | Media-element fallback now demuxes at up to 16× speed (~37s for 10 min) |
| **Video fast path** | \decodeAudioData\ tried first; falls back only if truncated |
| **16 MiB fast read** | Small/medium files skip chunked streaming overhead |
| **8k ScriptProcessor blocks** | Fewer callbacks, less main-thread churn |

## Verified locally

- \
ode scripts/bench-decode-speed.cjs 60\ → **60s WAV decoded in 0.31s** (budget 15s)
- \	ests/m4a-decode-fallback.test.js\ — 21/21 pass
- \scripts/landing-smoke.cjs\ — all checks passed
- Worklet loading unchanged (gate + de-esser still load in parallel with dedupe)

## Cleanup

- Removed untracked orphan \scripts/full-audit.cjs\ (local only)
- Added \scripts/bench-decode-speed.cjs\ for CI/local regression

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Speed up media decode with fast paths, 16x capture rate, and add a benchmark script
> - [media-decode.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/672/files#diff-55e5ad8acd800e02c653d814a59f6ca794f9a3f6823bcb1f88b9fd16698230bf) now attempts `decodeAudioData` first for video blobs, detects likely truncation via `_likelyTruncatedDecode`, and falls back to media-element capture only when needed.
> - `_applyCapturePlaybackRate` sets playback up to 16x and disables pitch correction, scaling capture timeout accordingly so full audio is captured faster than realtime.
> - Small blobs (≤16 MiB) skip streaming and use a single `arrayBuffer` read; larger streamed reads yield to main thread every 8 MiB instead of 4 MiB.
> - `createGrowingChannel` now uses `copyInto(dest, outLen)` instead of `toArray` to avoid an extra `Float32Array` allocation during finalization.
> - Adds [bench-decode-speed.cjs](https://github.com/Joker5514/VoiceIsolate-Pro/pull/672/files#diff-8d8140f6f820f8c84bea379366b7f41f6bb8023faee46d3057d855d8d63e2e02), a Node.js script that drives the UI via Playwright, measures decode time against a realtime budget (`MAX_DECODE_RATIO`), and exits with code 1 if the budget is exceeded.
> - Behavioral Change: video files that previously went straight to media-element capture now attempt `decodeAudioData` first, which may change output for edge-case containers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8e852c0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->