### PR TITLE
BS-RNN-only default and ML stem cache for faster reprocess

### DIFF
--- a/public/app/app.js
+++ b/public/app/app.js
@@ -21,6 +21,7 @@ import { SLIDER_REGISTRY, STAGES } from './slider-map.js';
 import { buildHintPanel, mountInfoPopover, removeAllInfoPopovers } from './slider-hint-ui.js';
 import { decodeBlobToAudioBuffer } from '/src/pipeline/media-decode.js';
 import { resampleToCanonical } from '/src/pipeline/FileIngestion.js';
+import { clearStemCache } from '/src/pipeline/MLStemCache.js';
 import { resetTimings, stageEnd, stageStart } from '/src/pipeline/PipelineTiming.js';
 import { isDesktopShell, isMicCaptureEnabled, pickAudioFile } from '/src/core/DesktopBridge.js';
 import { inferMediaKind } from '/src/core/media-types.js';
@@ -334,8 +335,8 @@ import { recommendEngineerPreset } from '/src/core/MixCalibration.js';
 // that parse this file directly to validate model configuration consistency.
 const MODEL_STATUS_KEYS = ['demucs', 'bsrnn', 'rnnoise', 'silero_vad'];
 
-/** Default offline chain — BS-RNN vocals → denoise (fast; Demucs is opt-in on Landing). */
-const DEFAULT_ML_CHAIN = Object.freeze(['bsrnn_vocals', 'rnnoise']);
+/** Default offline chain — BS-RNN vocals only (fast; denoise chain is opt-in). */
+const DEFAULT_ML_CHAIN = Object.freeze(['bsrnn_vocals']);
 
 function _yieldToUI(cb) {
   setTimeout(cb, 0);
@@ -1927,6 +1928,8 @@ class VoiceIsolatePro {
   // ── File handling ─────────────────────────────────────────────────────────
   async handleFile(file) {
     if (!file) return;
+    clearStemCache();
+    this._sourceName = file.name || '';
     this.stop();
     this.setStatus('LOADING');
     HeroExperience.onDecodeStart();
@@ -2092,6 +2095,8 @@ class VoiceIsolatePro {
   }
 
   _clearFile() {
+    clearStemCache();
+    this._sourceName = '';
     HeroExperience.onClear();
     this.stop();
     this.inputBuffer = null;
@@ -2322,6 +2327,7 @@ class VoiceIsolatePro {
       this.updatePipelineProgress(4, 'ML isolation…', 15);
       const result = await separateStems(channelData, buf.sampleRate, {
         modelIds: DEFAULT_ML_CHAIN,
+        sourceName: this._sourceName || '',
         onProgress: (ev) => {
           if (ev.type === 'stage') {
             const label = ev.label || `ML: ${ev.stage} (${ev.modelId || 'model'})…`;
@@ -2335,7 +2341,8 @@ class VoiceIsolatePro {
       if (result.passthrough) return false;
       this.outputBuffer = stemsToAudioBuffer(this.ctx, result.clean, result.sampleRate);
       this.procBuffer = this.outputBuffer;
-      this.updatePipelineProgress(20, 'ML isolation complete', 85);
+      const mlLabel = result.fromCache ? 'ML isolation (cached)' : 'ML isolation complete';
+      this.updatePipelineProgress(20, mlLabel, 85);
       return true;
     } catch (err) {
       structuredLog('warn', '[VIP] ML isolation unavailable, falling back to DSP', { err: err.message });

--- a/public/index.html
+++ b/public/index.html
@@ -50,8 +50,8 @@
       <div class="upload-row">
         <label for="modelSelect" class="inline-label">Model</label>
         <select id="modelSelect" class="vip-select" aria-label="Separation model">
-          <option value="max_isolation" selected>Maximum Isolation — BS-RNN → Denoise (recommended)</option>
-          <option value="bsrnn_vocals">Vocal Isolation — Band-Split RNN (~4 MB, fast)</option>
+          <option value="max_isolation">Maximum Isolation — BS-RNN → Denoise (2-pass)</option>
+          <option value="bsrnn_vocals" selected>Vocal Isolation — Band-Split RNN (~4 MB, fast, recommended)</option>
           <option value="rnnoise">Noise Suppression — BiGRU mask (~2 MB)</option>
           <option value="studio_isolation">Studio Quality — Demucs → Denoise (slow, ~149 MB)</option>
           <option value="demucs">Vocal Isolation — Demucs v4 only (~149 MB)</option>

--- a/public/landing.js
+++ b/public/landing.js
@@ -21,7 +21,9 @@ import { LandingVisualizer } from '/src/presentation/LandingVisualizer.js';
 import { getModel } from '/src/core/ModelManifest.js';
 
 import { detectSpeakers as detectSpeakersPipeline } from '/src/pipeline/SpeakerDetection.js';
+import { DEFAULT_ML_MODEL_IDS } from '/src/core/ml-defaults.js';
 import { createMLWorker, initMLWorker } from '/src/pipeline/MLWorkerHost.js';
+import { clearStemCache, getCachedStems, setCachedStems, stemCacheKey } from '/src/pipeline/MLStemCache.js';
 import { resetTimings, stageEnd, stageStart } from '/src/pipeline/PipelineTiming.js';
 import { SLIDER_HINTS } from '/app/slider-map.js';
 import { buildHintPanel } from '/app/slider-hint-ui.js';
@@ -344,7 +346,7 @@ function syncVideo() {
 
 // ─── Worker lifecycle ────────────────────────────────────────────────────────
 
-const DEFAULT_WARMUP_CHAIN = ['bsrnn_vocals', 'rnnoise'];
+const DEFAULT_WARMUP_CHAIN = DEFAULT_ML_MODEL_IDS;
 
 function resolveModelIds(selection) {
   const chain = MODEL_CHAINS[selection];
@@ -620,6 +622,7 @@ async function ingestFrom(file) {
   }
   const seq = ++ingestSeq;
   resetTimings();
+  clearStemCache();
   ui.processBtn.disabled = true;
   ui.fileInput.disabled = true;
   // Unlock Web Audio inside the user gesture (required on mobile + some desktop builds).
@@ -738,13 +741,41 @@ function onProcess() {
   if (!ingested) return;
   const selection = ui.modelSelect.value;
   const chain = MODEL_CHAINS[selection];
+  const modelIds = chain || [getModel(selection).id];
+  const cacheKey = stemCacheKey(
+    ingested.channelData,
+    ingested.sampleRate,
+    modelIds,
+    ingested.sourceName,
+  );
   ui.processBtn.disabled = true;
   ui.fileInput.disabled = true;
   ui.modelSelect.disabled = true;
   currentJobLabel = chain ? 'Maximum isolation (2 passes)…' : 'Separating stems…';
   setProgress(0, currentJobLabel);
   setStatus(currentJobLabel, 'warn');
+
+  const cached = getCachedStems(cacheKey);
+  if (cached) {
+    currentJobLabel = 'Using cached stems…';
+    setStatus(currentJobLabel, 'warn');
+    stageStart('model_load');
+    stageEnd('model_load');
+    stageStart('isolate');
+    stageEnd('isolate');
+    onStems({
+      requestId: ++requestSeq,
+      clean: cached.clean.map((c) => new Float32Array(c)),
+      noise: cached.noise.map((c) => new Float32Array(c)),
+      sampleRate: cached.sampleRate,
+      passthrough: false,
+      _cacheKey: cacheKey,
+    });
+    return;
+  }
+
   stageStart('model_load');
+  ingested._stemCacheKey = cacheKey;
 
   // Channel copies are transferred — keep our reference for re-processing.
   const channelData = ingested.channelData.map((c) => new Float32Array(c));
@@ -754,12 +785,17 @@ function onProcess() {
   getWorker().postMessage(msg, channelData.map((c) => c.buffer));
 }
 
-function onStems({ requestId, clean, noise, sampleRate, passthrough }) {
+function onStems({ requestId, clean, noise, sampleRate, passthrough, _cacheKey }) {
   if (requestId !== requestSeq) return; // stale response
   stageEnd('isolate');
   stageEnd('model_load');
   setProgress(100);
   hideSpinner();
+
+  const cacheKey = _cacheKey || ingested?._stemCacheKey;
+  if (!passthrough && cacheKey) {
+    setCachedStems(cacheKey, { clean, noise, sampleRate, passthrough: false });
+  }
   ui.processBtn.disabled = false;
   ui.fileInput.disabled = false;
   ui.modelSelect.disabled = false;

--- a/src/core/ml-defaults.js
+++ b/src/core/ml-defaults.js
@@ -1,0 +1,10 @@
+/**
+ * Shared default ML model chains for landing + engineer surfaces.
+ */
+'use strict';
+
+/** Fast default — BS-RNN vocal separation only (~4 MB). */
+export const DEFAULT_ML_MODEL_IDS = Object.freeze(['bsrnn_vocals']);
+
+/** Optional second-pass denoise chain (user-selected "maximum" modes). */
+export const DENOISE_CHAIN_MODEL_IDS = Object.freeze(['bsrnn_vocals', 'rnnoise']);

--- a/src/pipeline/MLStemCache.js
+++ b/src/pipeline/MLStemCache.js
@@ -1,0 +1,49 @@
+/**
+ * In-memory stem cache — skip repeat ONNX runs for the same file + model chain.
+ */
+'use strict';
+
+/** @type {Map<string, { clean: Float32Array[], noise: Float32Array[], sampleRate: number, passthrough: boolean }>} */
+const _cache = new Map();
+
+/**
+ * @param {Float32Array[]} channelData
+ * @param {number} sampleRate
+ * @param {string[]} modelIds
+ * @param {string} [sourceName]
+ */
+export function stemCacheKey(channelData, sampleRate, modelIds, sourceName = '') {
+  const models = [...modelIds].sort().join('+');
+  const ch0 = channelData[0];
+  if (!ch0?.length) return `${models}|${sampleRate}|0|${sourceName}`;
+  const len = ch0.length;
+  const nCh = channelData.length;
+  const mid = ch0[len >> 1] ?? 0;
+  const end = ch0[len - 1] ?? 0;
+  let sum = 0;
+  const step = Math.max(1, Math.floor(len / 64));
+  for (let i = 0; i < len; i += step) sum += Math.abs(ch0[i]);
+  return `${models}|${sampleRate}|${nCh}|${len}|${sum.toFixed(4)}|${ch0[0]}|${mid}|${end}|${sourceName}`;
+}
+
+export function getCachedStems(key) {
+  return _cache.get(key) || null;
+}
+
+export function setCachedStems(key, result) {
+  if (!key || !result || result.passthrough) return;
+  _cache.set(key, {
+    clean: result.clean.map((c) => new Float32Array(c)),
+    noise: result.noise.map((c) => new Float32Array(c)),
+    sampleRate: result.sampleRate,
+    passthrough: false,
+  });
+}
+
+export function clearStemCache() {
+  _cache.clear();
+}
+
+export function getStemCacheSize() {
+  return _cache.size;
+}

--- a/src/pipeline/StemSeparation.js
+++ b/src/pipeline/StemSeparation.js
@@ -6,7 +6,9 @@
  */
 'use strict';
 
+import { DEFAULT_ML_MODEL_IDS } from '../core/ml-defaults.js';
 import { createMLWorker, initMLWorker } from './MLWorkerHost.js';
+import { clearStemCache, getCachedStems, setCachedStems, stemCacheKey } from './MLStemCache.js';
 
 let _worker = null;
 let _ready = null;
@@ -30,7 +32,7 @@ function ensureReady() {
       const msg = ev.data || {};
       if (msg.type === 'ready') {
         cleanup();
-        w.postMessage({ type: 'warmup', modelIds: ['bsrnn_vocals', 'rnnoise'] });
+        w.postMessage({ type: 'warmup', modelIds: [...DEFAULT_ML_MODEL_IDS] });
         resolve(msg.backend || 'wasm');
       } else if (msg.type === 'error') { cleanup(); reject(new Error(msg.message || 'MLWorker init failed')); }
     };
@@ -55,21 +57,36 @@ function ensureReady() {
  * @returns {Promise<{ clean: Float32Array[], noise: Float32Array[], sampleRate: number, passthrough: boolean }>}
  */
 /** Prefetch + compile ONNX sessions while the user decodes a file. */
-export async function warmupModels(modelIds = ['bsrnn_vocals', 'rnnoise']) {
+export async function warmupModels(modelIds = DEFAULT_ML_MODEL_IDS) {
   await ensureReady();
   getWorker().postMessage({ type: 'warmup', modelIds });
 }
 
 export async function separateStems(channelData, sampleRate, options = {}) {
+  const modelIds = options.modelIds?.length
+    ? options.modelIds
+    : options.modelId
+      ? [options.modelId]
+      : [...DEFAULT_ML_MODEL_IDS];
+  const cacheKey = stemCacheKey(channelData, sampleRate, modelIds, options.sourceName);
+  const cached = getCachedStems(cacheKey);
+  if (cached) {
+    options.onProgress?.({ type: 'stage', stage: 'separate', percent: 100, label: 'Using cached stems…' });
+    return {
+      clean: cached.clean.map((c) => new Float32Array(c)),
+      noise: cached.noise.map((c) => new Float32Array(c)),
+      sampleRate: cached.sampleRate,
+      passthrough: cached.passthrough,
+      fromCache: true,
+    };
+  }
+
   await ensureReady();
   const w = getWorker();
   const requestId = ++_seq;
   const { onProgress } = options;
   const copies = channelData.map((c) => new Float32Array(c));
-  const msg = { type: 'process', requestId, channelData: copies, sampleRate };
-  if (options.modelIds?.length) msg.modelIds = options.modelIds;
-  else if (options.modelId) msg.modelId = options.modelId;
-  else msg.modelIds = ['bsrnn_vocals', 'rnnoise'];
+  const msg = { type: 'process', requestId, channelData: copies, sampleRate, modelIds };
 
   return new Promise((resolve, reject) => {
     const timer = setTimeout(() => {
@@ -83,12 +100,14 @@ export async function separateStems(channelData, sampleRate, options = {}) {
         onProgress?.(m);
       } else if (m.type === 'stems') {
         cleanup();
-        resolve({
+        const out = {
           clean: m.clean,
           noise: m.noise,
           sampleRate: m.sampleRate,
           passthrough: Boolean(m.passthrough),
-        });
+        };
+        if (!out.passthrough) setCachedStems(cacheKey, out);
+        resolve(out);
       } else if (m.type === 'error') {
         cleanup();
         reject(new Error(m.message || 'Separation failed'));
@@ -121,6 +140,9 @@ export function resetStemSeparation() {
     _worker = null;
   }
   _ready = null;
+  clearStemCache();
 }
 
-export default { ensureReady, warmupModels, separateStems, stemsToAudioBuffer, resetStemSeparation };
+export { clearStemCache };
+
+export default { ensureReady, warmupModels, separateStems, stemsToAudioBuffer, resetStemSeparation, clearStemCache };

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -408,8 +408,13 @@ describe('VoiceIsolatePro class structure', () => {
     expect(appSrc).toMatch(/_yieldToUI\(\(\)\s*=>\s*\{[\s\S]*runPipeline\(\)/);
   });
 
-  test('Engineer ML chain uses fast BS-RNN default (not Demucs)', () => {
-    expect(appSrc).toMatch(/DEFAULT_ML_CHAIN\s*=\s*Object\.freeze\(\[['"]bsrnn_vocals['"],\s*['"]rnnoise['"]\]\)/);
+  test('Engineer ML chain uses fast BS-RNN-only default (not Demucs)', () => {
+    expect(appSrc).toMatch(/DEFAULT_ML_CHAIN\s*=\s*Object\.freeze\(\[['"]bsrnn_vocals['"]\]\)/);
+  });
+
+  test('Engineer clears stem cache on new file load', () => {
+    expect(appSrc).toContain("import { clearStemCache } from '/src/pipeline/MLStemCache.js'");
+    expect(appSrc).toMatch(/async handleFile\(file\)[\s\S]*clearStemCache\(\)/);
   });
 
   test('Engineer ML inference runs once per file (whisper passes are DSP-only)', () => {

--- a/tests/ml-stem-cache.test.js
+++ b/tests/ml-stem-cache.test.js
@@ -1,0 +1,62 @@
+'use strict';
+
+let clearStemCache;
+let getCachedStems;
+let getStemCacheSize;
+let setCachedStems;
+let stemCacheKey;
+
+beforeAll(async () => {
+  const mod = await import('../src/pipeline/MLStemCache.js');
+  clearStemCache = mod.clearStemCache;
+  getCachedStems = mod.getCachedStems;
+  getStemCacheSize = mod.getStemCacheSize;
+  setCachedStems = mod.setCachedStems;
+  stemCacheKey = mod.stemCacheKey;
+});
+
+describe('MLStemCache', () => {
+  beforeEach(() => clearStemCache());
+
+  test('stemCacheKey is stable for the same audio + models', () => {
+    const ch = [new Float32Array([0.1, 0.2, 0.3, 0.4])];
+    const a = stemCacheKey(ch, 48000, ['bsrnn_vocals'], 'clip.wav');
+    const b = stemCacheKey(ch, 48000, ['bsrnn_vocals'], 'clip.wav');
+    expect(a).toBe(b);
+  });
+
+  test('stemCacheKey differs when model chain changes', () => {
+    const ch = [new Float32Array([0.1, 0.2, 0.3, 0.4])];
+    const a = stemCacheKey(ch, 48000, ['bsrnn_vocals'], 'clip.wav');
+    const b = stemCacheKey(ch, 48000, ['bsrnn_vocals', 'rnnoise'], 'clip.wav');
+    expect(a).not.toBe(b);
+  });
+
+  test('setCachedStems stores and getCachedStems retrieves copies', () => {
+    const key = 'test-key';
+    const cleanIn = new Float32Array([1, 2]);
+    setCachedStems(key, {
+      clean: [cleanIn],
+      noise: [new Float32Array([3, 4])],
+      sampleRate: 48000,
+      passthrough: false,
+    });
+    expect(getStemCacheSize()).toBe(1);
+    const hit = getCachedStems(key);
+    expect(hit.sampleRate).toBe(48000);
+    expect(hit.clean[0][0]).toBe(1);
+    expect(hit.clean[0]).not.toBe(cleanIn);
+  });
+
+  test('clearStemCache empties the store', () => {
+    setCachedStems('k', {
+      clean: [new Float32Array([1])],
+      noise: [new Float32Array([0])],
+      sampleRate: 48000,
+      passthrough: false,
+    });
+    clearStemCache();
+    expect(getStemCacheSize()).toBe(0);
+    expect(getCachedStems('k')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- **Default model chain** is now BS-RNN vocals only (drops RNNoise from the hot path on landing + engineer)
- **ML stem cache** stores separation results keyed by audio fingerprint + model chain — reprocess/re-run is instant
- Landing default select changed to BS-RNN (recommended); Maximum Isolation (2-pass) remains opt-in

## Benchmarks (30s WAV, local)

| Surface | Before (#673) | After |
|---------|---------------|-------|
| Landing | 15.3s | **7.2s** |
| Engineer | 15.5s | **6.2s** |

Reprocess with same file + model: **<100ms** (cache hit).

## Test plan

- [x] jest tests/ml-stem-cache.test.js
- [x] jest tests/app.test.js
- [x] node scripts/debug-full-pipeline.cjs 30
- [x] node scripts/debug-engineer-pipeline.cjs 30

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add in-memory stem cache and default to BS-RNN-only processing
> - Adds [MLStemCache.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/674/files#diff-a167ccc2503f37a0bb64df093e590dc4aeaad6369fdd6f376c4c4792d7f75991) providing a `Map`-based cache keyed by audio characteristics, model chain, and source name; repeat `separateStems` calls for the same file and chain skip the worker entirely and return cached copies with a `fromCache` flag.
> - Changes the default ML chain from `['bsrnn_vocals', 'rnnoise']` to `['bsrnn_vocals']` in both [ml-defaults.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/674/files#diff-1a8f6c57ade55ba83f2426b8d7096ab02b133819945a3fdf8906b1c080ec7e57) and the app/landing configs; the rnnoise denoise pass is now opt-in only.
> - Clears the stem cache on new file ingest and on `resetStemSeparation` to prevent stale results from prior files or model runs.
> - Updates the `index.html` model dropdown to select BS-RNN by default and relabels the two-pass option as "Maximum Isolation — BS-RNN → Denoise (2-pass)".
> - Behavioral Change: users who previously relied on automatic denoising will no longer get it unless they explicitly select the two-pass chain.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 366fea4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->