### PR TITLE
Loop/crop transport and sleek playback sliders

### DIFF
--- a/public/app/app.js
+++ b/public/app/app.js
@@ -21,8 +21,10 @@ import { SLIDER_REGISTRY, STAGES } from './slider-map.js';
 import { buildHintPanel, mountInfoPopover, removeAllInfoPopovers } from './slider-hint-ui.js';
 import { decodeBlobToAudioBuffer } from '/src/pipeline/media-decode.js';
 import { resampleToCanonical } from '/src/pipeline/FileIngestion.js';
+import { sliceAudioBuffer } from '/src/core/audio-slice.js';
 import { clearStemCache } from '/src/pipeline/MLStemCache.js';
 import { resetTimings, stageEnd, stageStart } from '/src/pipeline/PipelineTiming.js';
+import { paintSeekFill, wireTransportRegion } from '/src/presentation/TransportRegionControls.js';
 import { isDesktopShell, isMicCaptureEnabled, pickAudioFile } from '/src/core/DesktopBridge.js';
 import { inferMediaKind } from '/src/core/media-types.js';
 import { openFilePicker as triggerFileInput, primeAudioGesture } from '/src/presentation/UploadWiring.js';
@@ -825,6 +827,8 @@ class VoiceIsolatePro {
     this.whisperMode = 0;
     this._mlIsolationSucceeded = false;
     this._autoPipelineRun = false;
+    this._transportRegionWired = false;
+    this._syncTransportRegion = null;
     this._forceSinglePass = false;
     this._extremeFrameIdx = 0;
     this._extremeCircularMag = null;
@@ -930,6 +934,11 @@ class VoiceIsolatePro {
       tpRew:g('tpRew'),
       tpFwd:g('tpFwd'),
       tpSeek:g('tpSeek'),
+      tpRegionBar:g('tpRegionBar'),
+      tpLoop:g('tpLoop'),
+      tpCropIn:g('tpCropIn'),
+      tpCropOut:g('tpCropOut'),
+      tpCropClear:g('tpCropClear'),
       tpAB:g('tpAB'),
       tpABLabel:g('tpABLabel'),
       tpSpeed:g('tpSpeed'),
@@ -1599,8 +1608,16 @@ class VoiceIsolatePro {
     bind('saveOrigBtn', d.saveOrigBtn, 'click', () => {
       if (this.origBuffer || this.inputBuffer) downloadWav(this.origBuffer || this.inputBuffer, 'original-' + Date.now() + '.wav');
     });
-    bind('saveProcBtn', d.saveProcBtn, 'click', () => {
-      if (this.procBuffer || this.outputBuffer) downloadWav(this.procBuffer || this.outputBuffer, 'processed-' + Date.now() + '.wav');
+    bind('saveProcBtn', d.saveProcBtn, 'click', async () => {
+      let buf = this.procBuffer || this.outputBuffer;
+      if (!buf) return;
+      await this.ensureCtx();
+      const transport = this._getTransportMixer();
+      if (transport?.hasCrop?.()) {
+        const { in: cropIn, out: cropOut } = transport.getCropRegion();
+        buf = sliceAudioBuffer(this.ctx, buf, cropIn, cropOut);
+      }
+      downloadWav(buf, 'processed-' + Date.now() + '.wav');
     });
     bind('auditLogBtn', d.auditLogBtn, 'click', () => this.downloadAuditLog());
 
@@ -1807,6 +1824,24 @@ class VoiceIsolatePro {
     }
     if (e.key === 'ArrowLeft') { this.seekDelta(-5); return; }
     if (e.key === 'ArrowRight') { this.seekDelta(5); return; }
+    if (e.key === 'l' || e.key === 'L') {
+      const mixer = this._getTransportMixer();
+      if (mixer) {
+        mixer.setLoop(!mixer.isLoopEnabled());
+        this._syncTransportRegion?.();
+      }
+      return;
+    }
+    if (e.key === '[') {
+      this._getTransportMixer()?.markCropIn(this.playOffset || this._bridge?.currentTime?.() || 0);
+      this._syncTransportRegion?.();
+      return;
+    }
+    if (e.key === ']') {
+      this._getTransportMixer()?.markCropOut(this.playOffset || this._bridge?.currentTime?.() || 0);
+      this._syncTransportRegion?.();
+      return;
+    }
   }
 
   // ── Preset application ────────────────────────────────────────────────────
@@ -2097,6 +2132,8 @@ class VoiceIsolatePro {
   _clearFile() {
     clearStemCache();
     this._sourceName = '';
+    this._transportRegionWired = false;
+    this._syncTransportRegion = null;
     HeroExperience.onClear();
     this.stop();
     this.inputBuffer = null;
@@ -3079,10 +3116,12 @@ class VoiceIsolatePro {
         if (this._bridgeBuf !== buf) {
           bridge.loadBuffer(buf);
           this._bridgeBuf = buf;
+          this._transportRegionWired = false;
           // Seed the graph from the current slider positions.
           const params = window.VIP_PARAMS || {};
           if (typeof bridge.applyParams === 'function') bridge.applyParams(params);
         }
+        this._ensureTransportRegionWiring();
         // Honour the current scrub position, then start.
         Promise.resolve(bridge.seek(this.playOffset || 0))
           .then(() => bridge.play())
@@ -3331,14 +3370,25 @@ class VoiceIsolatePro {
       const cur = b.currentTime();
       const dur = b.duration() || 0;
       if (this.dom && this.dom.tpCur) this.dom.tpCur.textContent = this.fmtDur(cur);
-      if (this.dom && this.dom.tpSeek && dur > 0) this.dom.tpSeek.value = (cur / dur) * 1000;
-      const ended = dur > 0 && !b.isPlaying() && cur >= dur - 0.05;
+      if (this.dom && this.dom.tpSeek && dur > 0) {
+        this.dom.tpSeek.value = (cur / dur) * 1000;
+        paintSeekFill(this.dom.tpSeek, cur, dur);
+      }
+      const region = b.getCropRegion?.() || { in: 0, out: dur };
+      const looping = b.isLoopEnabled?.();
+      const ended = dur > 0 && !b.isPlaying() && !looping && cur >= region.out - 0.05;
       if (ended) {
         this.isPlaying = false;
-        this.playOffset = 0;
-        if (this.dom && this.dom.tpSeek) this.dom.tpSeek.value = 0;
-        if (this.dom && this.dom.tpCur) this.dom.tpCur.textContent = this.fmtDur(0);
+        this.playOffset = region.in || 0;
+        if (this.dom && this.dom.tpSeek && dur > 0) this.dom.tpSeek.value = (this.playOffset / dur) * 1000;
+        if (this.dom && this.dom.tpCur) this.dom.tpCur.textContent = this.fmtDur(this.playOffset);
         if (typeof this._updateTransportUI === 'function') this._updateTransportUI();
+        return;
+      }
+      if (looping && !b.isPlaying()) {
+        this._tickRaf = (typeof requestAnimationFrame === 'function')
+          ? requestAnimationFrame(loop)
+          : setTimeout(loop, 50);
         return;
       }
       this._tickRaf = (typeof requestAnimationFrame === 'function')
@@ -3443,15 +3493,37 @@ class VoiceIsolatePro {
     if (this.dom.mobileProcessBtn) this.dom.mobileProcessBtn.disabled = !canProcess;
   }
 
+  _getTransportMixer() {
+    return this._bridge?.mixer || null;
+  }
+
+  _ensureTransportRegionWiring() {
+    const mixer = this._getTransportMixer();
+    if (!mixer || this._transportRegionWired) return;
+    this._transportRegionWired = true;
+    this._syncTransportRegion = wireTransportRegion({
+      mixer,
+      loopBtn: this.dom.tpLoop,
+      cropInBtn: this.dom.tpCropIn,
+      cropOutBtn: this.dom.tpCropOut,
+      cropClearBtn: this.dom.tpCropClear,
+      seekEl: this.dom.tpSeek,
+      regionBar: this.dom.tpRegionBar,
+    });
+  }
+
   _updateTransportUI() {
     const buf = this.inputBuffer || this.origBuffer;
     const dur = buf ? buf.duration : 0;
     if (this.dom.tpDur) this.dom.tpDur.textContent = fmtTime(dur);
     const enabled = Boolean(buf);
     [this.dom.tpPlay, this.dom.tpPause, this.dom.tpStop, this.dom.tpRew,
-     this.dom.tpFwd, this.dom.tpSeek, this.dom.tpAB].forEach(b => {
+     this.dom.tpFwd, this.dom.tpSeek, this.dom.tpAB,
+     this.dom.tpLoop, this.dom.tpCropIn, this.dom.tpCropOut, this.dom.tpCropClear].forEach(b => {
       if (b) b.disabled = !enabled;
     });
+    if (enabled) this._ensureTransportRegionWiring();
+    this._syncTransportRegion?.();
   }
 
   // ── Pure utility methods (also used as instance methods) ──────────────────

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -39,6 +39,7 @@
   <link rel="stylesheet" href="mobile.css" />
   <link id="vip-enh-css" rel="stylesheet" href="vip-enhancements.css" />
   <link rel="stylesheet" href="debug-menu.css" />
+  <link rel="stylesheet" href="../transport-polish.css" />
 
   <!-- Module-error guard: surfaces broken imports as a red banner instead of blank page -->
   <style>
@@ -456,6 +457,12 @@
               </select>
               <button id="tpSpeedUp" class="btn btn-tp btn-speed" type="button" aria-label="Speed Up Playback" title="Speed Up (+)"><span aria-hidden="true">+</span></button>
             </div>
+            <div class="tp-region-group">
+              <button id="tpLoop" class="btn btn-tp btn-tp-region btn-tp-loop" type="button" disabled aria-pressed="false" title="Loop playback (L)">Loop</button>
+              <button id="tpCropIn" class="btn btn-tp btn-tp-region" type="button" disabled title="Crop in-point at playhead ([)">In</button>
+              <button id="tpCropOut" class="btn btn-tp btn-tp-region" type="button" disabled title="Crop out-point at playhead (])">Out</button>
+              <button id="tpCropClear" class="btn btn-tp btn-tp-region" type="button" disabled title="Clear crop">Clr</button>
+            </div>
             <div class="tp-ab">
               <button id="tpAB" class="btn btn-ab" type="button"
                 aria-label="Toggle A/B Comparison"
@@ -472,6 +479,7 @@
           </div>
         </div>
         <div class="transport-seek">
+          <div id="tpRegionBar" class="transport-region-bar" hidden aria-hidden="true"></div>
           <input type="range" id="tpSeek" class="tp-seek" min="0" max="1000" value="0" aria-label="Playback position" />
         </div>
       </div>

--- a/public/app/slider-theme.css
+++ b/public/app/slider-theme.css
@@ -41,12 +41,12 @@
 
   /* Track geometry */
   --vip-track-empty:    rgba(255, 255, 255, 0.08);
-  --vip-track-h:        4px;
-  --vip-track-h-hov:    6px;
+  --vip-track-h:        3px;
+  --vip-track-h-hov:    5px;
 
   /* Thumb geometry */
-  --vip-thumb-size:     18px;
-  --vip-thumb-size-hov: 21px;
+  --vip-thumb-size:     14px;
+  --vip-thumb-size-hov: 17px;
 
   /* Typography / layout */
   --vip-text:           #e9e9f3;

--- a/public/app/style.css
+++ b/public/app/style.css
@@ -361,25 +361,8 @@ input[type="range"].realtime::-webkit-slider-thumb{background:var(--cyan);box-sh
 .tp-time{font-family:var(--fm);font-size:0.68rem;color:var(--text2);white-space:nowrap}
 .tp-time-sep{color:var(--dim);opacity:0.6}
 .tp-meta{display:flex;align-items:center;gap:8px;margin-left:auto;flex-wrap:wrap}
+/* Transport seek — polished in /transport-polish.css */
 .transport-seek{width:100%}
-.tp-seek{
-  -webkit-appearance:none;appearance:none;width:100%;height:6px;border-radius:3px;outline:none;cursor:pointer;
-  background:linear-gradient(90deg,var(--red) 0%,var(--red2) var(--seek-pct,0%),var(--s4) var(--seek-pct,0%),var(--s4) 100%);
-  box-shadow:inset 0 1px 2px rgba(0,0,0,0.35);
-}
-.tp-seek:hover:not(:disabled){box-shadow:inset 0 1px 2px rgba(0,0,0,0.35),0 0 8px var(--red-glow)}
-.tp-seek:disabled{opacity:0.35;cursor:not-allowed}
-.tp-seek::-webkit-slider-thumb{
-  -webkit-appearance:none;width:14px;height:14px;border-radius:50%;
-  background:linear-gradient(135deg,var(--red2),var(--red3));
-  border:2px solid rgba(255,255,255,0.15);cursor:pointer;box-shadow:0 0 8px var(--red-glow);
-}
-.tp-seek::-moz-range-thumb{
-  width:14px;height:14px;border-radius:50%;
-  background:linear-gradient(135deg,var(--red2),var(--red3));
-  border:2px solid rgba(255,255,255,0.15);cursor:pointer;box-shadow:0 0 8px var(--red-glow);
-}
-.tp-seek::-moz-range-track{height:6px;border-radius:3px;background:transparent}
 .tp-speed{display:flex;align-items:center;gap:4px}
 .tp-speed label{font-size:0.6rem;color:var(--dim)}
 .tp-speed select{background:var(--s3);color:var(--text2);border:1px solid var(--border);border-radius:4px;font-family:var(--fm);font-size:0.65rem;padding:2px 4px}

--- a/public/index.html
+++ b/public/index.html
@@ -11,6 +11,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/landing.css">
+  <link rel="stylesheet" href="/transport-polish.css">
   <!--
     ARCHITECTURE NOTE (CLAUDE.md): this page contains NO inline scripts so it
     runs under the strict CSP (script-src 'self'). It is the reference
@@ -112,10 +113,20 @@
           <option value="original">Original (bypass)</option>
         </select>
         <span id="timeReadout" class="time-readout">0:00 / 0:00</span>
+        <span class="landing-transport-extras">
+          <button id="loopBtn" class="btn-tp-region btn-tp-loop" type="button" disabled aria-pressed="false" title="Loop playback">Loop</button>
+          <button id="cropInBtn" class="btn-tp-region" type="button" disabled title="Set crop in-point at playhead">In</button>
+          <button id="cropOutBtn" class="btn-tp-region" type="button" disabled title="Set crop out-point at playhead">Out</button>
+          <button id="cropClearBtn" class="btn-tp-region" type="button" disabled title="Clear crop region">Clear</button>
+        </span>
+      </div>
+      <div class="transport-seek">
+        <div id="landingRegionBar" class="transport-region-bar" hidden aria-hidden="true"></div>
+        <input type="range" id="seekSlider" class="landing-seek-input" min="0" max="1000" value="0" disabled aria-label="Playback position">
       </div>
 
       <div class="vis-block">
-        <div class="vis-label">Stem waveforms <span class="vis-hint">— voice in red, removed noise in gray · click to seek</span></div>
+        <div class="vis-label">Stem waveforms <span class="vis-hint">— click to seek · In/Out to crop · Loop toggles repeat</span></div>
         <canvas id="waveCanvas" class="vis-canvas" height="110" aria-label="Stem waveform overview"></canvas>
         <div class="vis-label">Live output spectrum <span class="vis-hint">— reacts to every slider in real time</span></div>
         <canvas id="specCanvas" class="vis-canvas" height="110" aria-label="Live output spectrum"></canvas>

--- a/public/landing.css
+++ b/public/landing.css
@@ -861,27 +861,32 @@ input[type="range"]:disabled { opacity: 0.34; cursor: not-allowed; }
 .vip-slider__input {
   -webkit-appearance: none;
   appearance: none;
-  height: 4px;
-  border-radius: 2px;
+  height: 3px;
+  border-radius: 99px;
   background: linear-gradient(
     to right,
     var(--red-600) 0,
-    var(--red-600) var(--pct, 0%),
-    var(--surface-3) var(--pct, 0%),
-    var(--surface-3) 100%
+    var(--red-500) var(--pct, 0%),
+    rgba(255, 255, 255, 0.08) var(--pct, 0%),
+    rgba(255, 255, 255, 0.08) 100%
   );
   cursor: pointer;
+  transition: height 0.15s ease, box-shadow 0.15s ease;
+}
+.vip-slider__input:hover:not(:disabled) {
+  height: 4px;
+  box-shadow: 0 0 8px rgba(239, 68, 68, 0.2);
 }
 .vip-slider__input::-webkit-slider-thumb {
   -webkit-appearance: none;
-  width: 13px; height: 13px; border-radius: 50%;
-  background: var(--red-500);
-  border: 2px solid var(--bg);
-  box-shadow: var(--shadow-sm);
+  width: 11px; height: 11px; border-radius: 50%;
+  background: #fff;
+  border: 2px solid var(--red-500);
+  box-shadow: 0 0 8px rgba(239, 68, 68, 0.35);
 }
 .vip-slider__input::-moz-range-thumb {
-  width: 13px; height: 13px; border: 2px solid var(--bg); border-radius: 50%;
-  background: var(--red-500);
+  width: 11px; height: 11px; border: 2px solid var(--red-500); border-radius: 50%;
+  background: #fff;
 }
 .vip-slider__input:disabled { opacity: 0.4; cursor: not-allowed; }
 

--- a/public/landing.js
+++ b/public/landing.js
@@ -25,6 +25,7 @@ import { DEFAULT_ML_MODEL_IDS } from '/src/core/ml-defaults.js';
 import { createMLWorker, initMLWorker } from '/src/pipeline/MLWorkerHost.js';
 import { clearStemCache, getCachedStems, setCachedStems, stemCacheKey } from '/src/pipeline/MLStemCache.js';
 import { resetTimings, stageEnd, stageStart } from '/src/pipeline/PipelineTiming.js';
+import { paintSeekFill, wireTransportRegion } from '/src/presentation/TransportRegionControls.js';
 import { SLIDER_HINTS } from '/app/slider-map.js';
 import { buildHintPanel } from '/app/slider-hint-ui.js';
 
@@ -98,6 +99,12 @@ const ui = {
   // Realtime processing indicator — DS ProcessLoader component mounts here.
   procLoaderMount: $('procLoaderMount'),
   timeReadout: $('timeReadout'),
+  seekSlider: $('seekSlider'),
+  loopBtn: $('loopBtn'),
+  cropInBtn: $('cropInBtn'),
+  cropOutBtn: $('cropOutBtn'),
+  cropClearBtn: $('cropClearBtn'),
+  regionBar: $('landingRegionBar'),
   presetSelect: $('presetSelect'),
   waveCanvas: $('waveCanvas'),
   specCanvas: $('specCanvas'),
@@ -116,6 +123,7 @@ let sliderUI = null;
 let speakerControls = null;
 let visualizer = null;
 let worker = null;
+let _syncTransportRegion = null;
 
 let ingested = null;
 let requestSeq = 0;
@@ -823,9 +831,20 @@ function onStems({ requestId, clean, noise, sampleRate, passthrough, _cacheKey }
 
   for (const el of [ui.playBtn, ui.pauseBtn, ui.stopBtn,
     ui.muteVoiceBtn, ui.muteNoiseBtn, ui.presetSelect,
+    ui.seekSlider, ui.loopBtn, ui.cropInBtn, ui.cropOutBtn, ui.cropClearBtn,
     ...ui.mixSliders]) {
     if (el) el.disabled = false;
   }
+  _syncTransportRegion = wireTransportRegion({
+    mixer,
+    loopBtn: ui.loopBtn,
+    cropInBtn: ui.cropInBtn,
+    cropOutBtn: ui.cropOutBtn,
+    cropClearBtn: ui.cropClearBtn,
+    seekEl: ui.seekSlider,
+    regionBar: ui.regionBar,
+    onChange: () => visualizer?.invalidate?.(),
+  });
   const cal = autoCalibrateMix(clean, sampleRate);
   const calLabel = ` · calibrated: ${cal.preset} (${cal.level})`;
   setStatus(`Stems ready — press Play and mix in real time${calLabel}.`, 'active');
@@ -932,11 +951,28 @@ function wireTransport() {
   ui.pauseBtn.addEventListener('click', () => { if (mixer) { mixer.pause(); syncVideo(); } });
   ui.stopBtn.addEventListener('click', () => { if (mixer) { mixer.stop(); syncVideo(); } });
 
+  ui.seekSlider?.addEventListener('input', async (e) => {
+    if (!mixer) return;
+    const frac = Number(e.target.value) / 1000;
+    try {
+      await mixer.seek(frac * mixer.duration());
+      syncVideo();
+    } catch (err) {
+      console.warn('[VIP][landing] seek failed:', err);
+    }
+  });
+
   // One ticker drives the time readout and keeps the muted video aligned with
   // the mixer clock (covers waveform click-to-seek and natural end-of-stream).
   setInterval(() => {
     if (!mixer) return;
-    ui.timeReadout.textContent = `${fmtTime(mixer.currentTime())} / ${fmtTime(mixer.duration())}`;
+    const cur = mixer.currentTime();
+    const dur = mixer.duration();
+    ui.timeReadout.textContent = `${fmtTime(cur)} / ${fmtTime(dur)}`;
+    if (ui.seekSlider && dur > 0) {
+      ui.seekSlider.value = String(Math.round((cur / dur) * 1000));
+      paintSeekFill(ui.seekSlider, cur, dur);
+    }
     syncVideo();
   }, 200);
 }

--- a/public/transport-polish.css
+++ b/public/transport-polish.css
@@ -1,0 +1,152 @@
+/* Shared loop/crop + sleek transport scrubber (landing + engineer) */
+
+.transport-seek {
+  position: relative;
+  width: 100%;
+  padding: 10px 2px 6px;
+}
+
+.transport-region-bar {
+  position: absolute;
+  left: 2px;
+  right: 2px;
+  top: 50%;
+  height: 4px;
+  transform: translateY(-50%);
+  border-radius: 99px;
+  pointer-events: none;
+  background: rgba(255, 255, 255, 0.06);
+  overflow: hidden;
+}
+
+.transport-region-bar::before {
+  content: '';
+  position: absolute;
+  left: var(--crop-in-pct, 0%);
+  right: calc(100% - var(--crop-out-pct, 100%));
+  top: 0;
+  bottom: 0;
+  background: linear-gradient(90deg, rgba(52, 211, 153, 0.35), rgba(52, 211, 153, 0.12));
+  border-left: 2px solid rgba(52, 211, 153, 0.85);
+  border-right: 2px solid rgba(52, 211, 153, 0.85);
+}
+
+.tp-seek,
+.landing-seek-input {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 100%;
+  height: 4px;
+  border-radius: 99px;
+  outline: none;
+  cursor: pointer;
+  position: relative;
+  z-index: 1;
+  background: linear-gradient(
+    90deg,
+    var(--red, #dc2626) 0%,
+    var(--red2, #ef4444) var(--seek-pct, 0%),
+    rgba(255, 255, 255, 0.07) var(--seek-pct, 0%),
+    rgba(255, 255, 255, 0.07) 100%
+  );
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.35);
+  transition: height 0.15s ease, box-shadow 0.15s ease;
+}
+
+.tp-seek:hover:not(:disabled),
+.landing-seek-input:hover:not(:disabled) {
+  height: 5px;
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.35), 0 0 10px rgba(239, 68, 68, 0.25);
+}
+
+.tp-seek:disabled,
+.landing-seek-input:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+.tp-seek::-webkit-slider-thumb,
+.landing-seek-input::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+  background: #fff;
+  border: 2px solid var(--red2, #ef4444);
+  cursor: pointer;
+  box-shadow: 0 0 10px rgba(239, 68, 68, 0.45), 0 2px 5px rgba(0, 0, 0, 0.35);
+  transition: transform 0.12s ease, box-shadow 0.12s ease;
+}
+
+.tp-seek::-webkit-slider-thumb:hover,
+.landing-seek-input::-webkit-slider-thumb:hover {
+  transform: scale(1.15);
+  box-shadow: 0 0 14px rgba(239, 68, 68, 0.55), 0 2px 6px rgba(0, 0, 0, 0.4);
+}
+
+.tp-seek::-moz-range-thumb,
+.landing-seek-input::-moz-range-thumb {
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+  background: #fff;
+  border: 2px solid var(--red2, #ef4444);
+  cursor: pointer;
+  box-shadow: 0 0 10px rgba(239, 68, 68, 0.45);
+}
+
+.tp-seek::-moz-range-track,
+.landing-seek-input::-moz-range-track {
+  height: 4px;
+  border-radius: 99px;
+  background: transparent;
+  border: none;
+}
+
+.btn-tp-region {
+  font-family: var(--fm, 'JetBrains Mono', monospace);
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  padding: 4px 8px;
+  min-width: 2.2rem;
+  border-radius: 6px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text2, #a1a1aa);
+  cursor: pointer;
+  transition: border-color 0.15s, color 0.15s, background 0.15s, box-shadow 0.15s;
+}
+
+.btn-tp-region:hover:not(:disabled) {
+  border-color: rgba(52, 211, 153, 0.45);
+  color: #6ee7b7;
+  background: rgba(52, 211, 153, 0.08);
+}
+
+.btn-tp-region.is-active,
+.btn-tp-loop.is-active {
+  border-color: rgba(239, 68, 68, 0.55);
+  color: #fca5a5;
+  background: rgba(239, 68, 68, 0.12);
+  box-shadow: 0 0 10px rgba(239, 68, 68, 0.2) inset;
+}
+
+.btn-tp-loop.is-active {
+  border-color: rgba(52, 211, 153, 0.55);
+  color: #6ee7b7;
+  background: rgba(52, 211, 153, 0.12);
+  box-shadow: 0 0 10px rgba(52, 211, 153, 0.2) inset;
+}
+
+.tp-region-group {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.landing-transport-extras {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}

--- a/src/core/audio-slice.js
+++ b/src/core/audio-slice.js
@@ -1,0 +1,18 @@
+'use strict';
+
+/** Copy a time slice from an AudioBuffer into a new buffer. */
+export function sliceAudioBuffer(ctx, buf, startSec, endSec) {
+  if (!buf || !ctx) return buf;
+  const sr = buf.sampleRate;
+  const start = Math.max(0, Math.floor(startSec * sr));
+  const end = Math.min(buf.length, Math.floor(endSec * sr));
+  const len = Math.max(1, end - start);
+  const out = ctx.createBuffer(buf.numberOfChannels, len, sr);
+  for (let ch = 0; ch < buf.numberOfChannels; ch++) {
+    const slice = buf.getChannelData(ch).subarray(start, end);
+    const dest = new Float32Array(len);
+    dest.set(slice);
+    out.copyToChannel(dest, ch);
+  }
+  return out;
+}

--- a/src/pipeline/EngineerModeBridge.js
+++ b/src/pipeline/EngineerModeBridge.js
@@ -159,6 +159,14 @@ export class EngineerModeBridge {
   currentTime() { return this.mixer ? this.mixer.currentTime() : 0; }
   duration() { return this.mixer ? this.mixer.duration() : 0; }
   getAnalyser() { return this.mixer ? this.mixer.getAnalyser() : null; }
+  setLoop(on) { return this.mixer ? this.mixer.setLoop(on) : undefined; }
+  isLoopEnabled() { return this.mixer ? this.mixer.isLoopEnabled() : false; }
+  setCropRegion(inSec, outSec) { return this.mixer ? this.mixer.setCropRegion(inSec, outSec) : undefined; }
+  getCropRegion() { return this.mixer ? this.mixer.getCropRegion() : { in: 0, out: 0 }; }
+  hasCrop() { return this.mixer ? this.mixer.hasCrop() : false; }
+  clearCrop() { return this.mixer ? this.mixer.clearCrop() : undefined; }
+  markCropIn(at) { return this.mixer ? this.mixer.markCropIn(at) : undefined; }
+  markCropOut(at) { return this.mixer ? this.mixer.markCropOut(at) : undefined; }
 
   /** Release the underlying mixer and its AudioContext. Idempotent. */
   async dispose() {

--- a/src/pipeline/PlaybackMixer.js
+++ b/src/pipeline/PlaybackMixer.js
@@ -300,6 +300,10 @@ export class PlaybackMixer {
     this._isPlaying = false;
     this._startedAt = 0;    // ctx.currentTime when playback began
     this._offset = 0;       // seconds into the stems
+    this._loopEnabled = false;
+    this._cropIn = 0;
+    /** @type {number|null} null = end of file */
+    this._cropOut = null;
 
     // ── Mute + per-speaker state ─────────────────────────────────────────
     this._voiceMuted = false;
@@ -433,6 +437,7 @@ export class PlaybackMixer {
     this.cleanBuffer = this._toAudioBuffer(cleanChannels, sampleRate);
     this.noiseBuffer = this._toAudioBuffer(noiseChannels, sampleRate);
     this._offset = 0;
+    this.clearCrop();
     // New stems invalidate any previous diarization.
     this.loadSpeakerSegments([]);
   }
@@ -445,6 +450,72 @@ export class PlaybackMixer {
 
   // ─── Transport ─────────────────────────────────────────────────────────
 
+  _regionStart() {
+    return clamp(this._cropIn, 0, this.duration());
+  }
+
+  _regionEnd() {
+    const dur = this.duration();
+    const end = this._cropOut == null ? dur : clamp(this._cropOut, 0, dur);
+    return Math.max(this._regionStart(), end);
+  }
+
+  _normalizeCrop() {
+    const dur = this.duration();
+    this._cropIn = clamp(this._cropIn, 0, dur);
+    if (this._cropOut != null) {
+      this._cropOut = clamp(this._cropOut, 0, dur);
+      if (this._cropOut < this._cropIn) {
+        const t = this._cropIn;
+        this._cropIn = this._cropOut;
+        this._cropOut = t;
+      }
+    }
+  }
+
+  setLoop(enabled) {
+    this._loopEnabled = Boolean(enabled);
+  }
+
+  isLoopEnabled() { return this._loopEnabled; }
+
+  setCropRegion(inSec, outSec) {
+    this._cropIn = Number(inSec) || 0;
+    this._cropOut = outSec == null ? null : Number(outSec);
+    this._normalizeCrop();
+  }
+
+  getCropRegion() {
+    return { in: this._regionStart(), out: this._regionEnd() };
+  }
+
+  hasCrop() {
+    const dur = this.duration();
+    if (!dur) return false;
+    return this._cropIn > 0.01 || (this._cropOut != null && this._cropOut < dur - 0.01);
+  }
+
+  clearCrop() {
+    this._cropIn = 0;
+    this._cropOut = null;
+  }
+
+  markCropIn(atSec = this.currentTime()) {
+    this._cropIn = atSec;
+    if (this._cropOut != null && this._cropOut <= this._cropIn) {
+      this._cropOut = this.duration();
+    }
+    this._normalizeCrop();
+  }
+
+  markCropOut(atSec = this.currentTime()) {
+    this._cropOut = atSec;
+    if (this._cropOut <= this._cropIn) {
+      this._cropIn = 0;
+    }
+    this._normalizeCrop();
+  }
+
   /** Begin (or resume) playback of both stems, sample-locked. */
   async play() {
     if (!this.cleanBuffer || !this.noiseBuffer) {
@@ -452,6 +523,12 @@ export class PlaybackMixer {
     }
     if (this._isPlaying) return;
     if (this.ctx.state === 'suspended') await this.ctx.resume();
+
+    const regionStart = this._regionStart();
+    const regionEnd = this._regionEnd();
+    if (this._offset < regionStart || this._offset >= regionEnd - 0.001) {
+      this._offset = regionStart;
+    }
 
     this._teardownSources();
     this._cleanSource = this.ctx.createBufferSource();
@@ -462,20 +539,29 @@ export class PlaybackMixer {
     this._noiseSource.buffer = this.noiseBuffer;
     this._noiseSource.connect(this.noiseGain);
 
-    // Single shared start time keeps the stems phase-aligned.
     const when = this.ctx.currentTime + 0.01;
-    this._cleanSource.start(when, this._offset);
-    this._noiseSource.start(when, this._offset);
-    this._startedAt = when - this._offset;
+    const startAt = this._offset;
+    const segmentLen = Math.max(0.001, regionEnd - startAt);
+    this._cleanSource.start(when, startAt, segmentLen);
+    this._noiseSource.start(when, startAt, segmentLen);
+    this._startedAt = when - startAt;
     this._isPlaying = true;
     this._scheduleSpeakerAutomation();
 
-    this._cleanSource.onended = () => {
-      if (this._isPlaying && this.currentTime() >= this.duration()) {
-        this._isPlaying = false;
-        this._offset = 0;
+    const onSegmentEnd = () => {
+      if (!this._isPlaying) return;
+      this._isPlaying = false;
+      this._teardownSources();
+      if (this._loopEnabled) {
+        this._offset = regionStart;
+        this.play().catch(() => {});
+        return;
       }
+      this._offset = regionStart;
+      this._scheduleSpeakerAutomation();
     };
+    this._cleanSource.onended = onSegmentEnd;
+    this._noiseSource.onended = null;
   }
 
   /** Pause, retaining position. */
@@ -487,11 +573,11 @@ export class PlaybackMixer {
     this._scheduleSpeakerAutomation(); // clear stale ramps from the old timeline
   }
 
-  /** Stop and rewind. */
+  /** Stop and rewind to region start (or file start). */
   stop() {
     this._teardownSources();
     this._isPlaying = false;
-    this._offset = 0;
+    this._offset = this._regionStart();
     this._scheduleSpeakerAutomation();
   }
 

--- a/src/presentation/LandingVisualizer.js
+++ b/src/presentation/LandingVisualizer.js
@@ -17,6 +17,9 @@ const ACCENT = '#ef4444';
 const NOISE_COLOR = 'rgba(154, 154, 164, 0.55)';
 const GRID = 'rgba(80, 80, 90, 0.5)';
 const PLAYHEAD = '#34d399';
+const CROP_FILL = 'rgba(52, 211, 153, 0.14)';
+const CROP_EDGE = 'rgba(52, 211, 153, 0.75)';
+const LOOP_COLOR = 'rgba(239, 68, 68, 0.35)';
 
 export class LandingVisualizer {
   /**
@@ -80,6 +83,10 @@ export class LandingVisualizer {
    * @param {Float32Array[]} noiseChannels
    * @param {number} duration seconds
    */
+  invalidate() {
+    this._drawWave();
+  }
+
   loadStems(cleanChannels, noiseChannels, duration) {
     const columns = Math.max(200, this.waveCanvas.clientWidth || 600);
     this._envelope = {
@@ -144,8 +151,29 @@ export class LandingVisualizer {
       ctx.fillRect(c * colW, y0, Math.max(1, colW), Math.max(1, y1 - y0));
     }
 
-    // Playhead
     if (this._duration > 0) {
+      const region = this.mixer.getCropRegion?.() || { in: 0, out: this._duration };
+      if (this.mixer.hasCrop?.()) {
+        const x0 = (region.in / this._duration) * W;
+        const x1 = (region.out / this._duration) * W;
+        ctx.fillStyle = CROP_FILL;
+        ctx.fillRect(x0, 0, Math.max(1, x1 - x0), H);
+        ctx.strokeStyle = CROP_EDGE;
+        ctx.lineWidth = 1;
+        ctx.beginPath();
+        ctx.moveTo(x0, 0); ctx.lineTo(x0, H);
+        ctx.moveTo(x1, 0); ctx.lineTo(x1, H);
+        ctx.stroke();
+      }
+      if (this.mixer.isLoopEnabled?.()) {
+        const lx0 = (region.in / this._duration) * W;
+        const lx1 = (region.out / this._duration) * W;
+        ctx.strokeStyle = LOOP_COLOR;
+        ctx.lineWidth = 2;
+        ctx.setLineDash([4, 4]);
+        ctx.strokeRect(lx0, 2, Math.max(1, lx1 - lx0), H - 4);
+        ctx.setLineDash([]);
+      }
       const x = (this.mixer.currentTime() / this._duration) * W;
       ctx.strokeStyle = PLAYHEAD;
       ctx.lineWidth = 2;

--- a/src/presentation/TransportRegionControls.js
+++ b/src/presentation/TransportRegionControls.js
@@ -1,0 +1,71 @@
+/**
+ * Loop + crop transport controls shared by landing and engineer surfaces.
+ */
+'use strict';
+
+/**
+ * @param {object} opts
+ * @param {{ setLoop: Function, isLoopEnabled: Function, markCropIn: Function, markCropOut: Function, clearCrop: Function, getCropRegion: Function, hasCrop: Function, duration: Function }} opts.mixer
+ * @param {HTMLElement} [opts.loopBtn]
+ * @param {HTMLElement} [opts.cropInBtn]
+ * @param {HTMLElement} [opts.cropOutBtn]
+ * @param {HTMLElement} [opts.cropClearBtn]
+ * @param {HTMLElement} [opts.seekEl] range input for --seek-pct / crop markers
+ * @param {HTMLElement} [opts.regionBar] overlay bar for crop shading
+ * @param {(region: {in:number,out:number}) => void} [opts.onChange]
+ */
+export function wireTransportRegion(opts) {
+  const mixer = opts.mixer;
+  if (!mixer) return () => {};
+
+  const syncUi = () => {
+    const dur = mixer.duration() || 0;
+    const region = mixer.getCropRegion();
+    if (opts.loopBtn) {
+      const on = mixer.isLoopEnabled();
+      opts.loopBtn.classList.toggle('is-active', on);
+      opts.loopBtn.setAttribute('aria-pressed', String(on));
+    }
+    if (dur > 0 && opts.seekEl) {
+      const inPct = (region.in / dur) * 100;
+      const outPct = (region.out / dur) * 100;
+      opts.seekEl.style.setProperty('--crop-in-pct', `${inPct}%`);
+      opts.seekEl.style.setProperty('--crop-out-pct', `${outPct}%`);
+    }
+    if (opts.regionBar && dur > 0) {
+      const inPct = (region.in / dur) * 100;
+      const outPct = (region.out / dur) * 100;
+      opts.regionBar.style.setProperty('--crop-in-pct', `${inPct}%`);
+      opts.regionBar.style.setProperty('--crop-out-pct', `${outPct}%`);
+      opts.regionBar.hidden = !mixer.hasCrop();
+    }
+    opts.onChange?.(region);
+  };
+
+  opts.loopBtn?.addEventListener('click', () => {
+    mixer.setLoop(!mixer.isLoopEnabled());
+    syncUi();
+  });
+  opts.cropInBtn?.addEventListener('click', () => {
+    mixer.markCropIn();
+    syncUi();
+  });
+  opts.cropOutBtn?.addEventListener('click', () => {
+    mixer.markCropOut();
+    syncUi();
+  });
+  opts.cropClearBtn?.addEventListener('click', () => {
+    mixer.clearCrop();
+    syncUi();
+  });
+
+  syncUi();
+  return syncUi;
+}
+
+/** Paint --seek-pct on a transport range input from current/duration. */
+export function paintSeekFill(seekEl, current, duration) {
+  if (!seekEl || !duration) return;
+  const pct = Math.max(0, Math.min(100, (current / duration) * 100));
+  seekEl.style.setProperty('--seek-pct', `${pct}%`);
+}

--- a/tests/playback-region.test.js
+++ b/tests/playback-region.test.js
@@ -1,0 +1,82 @@
+'use strict';
+
+let PlaybackMixer;
+
+beforeAll(async () => {
+  const mod = await import('../src/pipeline/PlaybackMixer.js');
+  PlaybackMixer = mod.PlaybackMixer;
+});
+
+function mockCtx() {
+  const nodes = [];
+  const makeNode = (extra = {}) => {
+    const p = new Map();
+    const n = {
+      connect() {},
+      disconnect() {},
+      parameters: { get: (k) => ({ value: 0, setTargetAtTime() {} }) },
+      gain: { value: 1, setTargetAtTime() {}, cancelScheduledValues() {} },
+      ...extra,
+    };
+    nodes.push(n);
+    return n;
+  };
+  return {
+    state: 'running',
+    currentTime: 0,
+    sampleRate: 48000,
+    destination: makeNode(),
+    createGain: () => makeNode(),
+    createBiquadFilter: () => makeNode({ frequency: { value: 0 }, Q: { value: 1 }, gain: { value: 0 }, type: '' }),
+    createDynamicsCompressor: () => makeNode({
+      threshold: { value: 0 },
+      knee: { value: 0 },
+      ratio: { value: 1 },
+      attack: { value: 0 },
+      release: { value: 0 },
+    }),
+    createAnalyser: () => makeNode({ fftSize: 2048, frequencyBinCount: 1024 }),
+    createChannelSplitter: () => makeNode(),
+    createChannelMerger: () => makeNode(),
+    createBuffer: (ch, len, sr) => ({
+      numberOfChannels: ch,
+      length: len,
+      duration: len / sr,
+      sampleRate: sr,
+      getChannelData: () => new Float32Array(len),
+      copyToChannel() {},
+    }),
+    createBufferSource: () => makeNode({ buffer: null, start() {}, stop() {}, onended: null }),
+    resume: async () => {},
+    close: async () => {},
+  };
+}
+
+describe('PlaybackMixer loop + crop', () => {
+  test('setCropRegion and hasCrop detect active window', () => {
+    const mixer = new PlaybackMixer({ context: mockCtx() });
+    mixer.loadStems([new Float32Array(48000 * 3)], [new Float32Array(48000 * 3)], 48000);
+    expect(mixer.hasCrop()).toBe(false);
+    mixer.setCropRegion(1, 2);
+    expect(mixer.hasCrop()).toBe(true);
+    expect(mixer.getCropRegion()).toEqual({ in: 1, out: 2 });
+    mixer.clearCrop();
+    expect(mixer.hasCrop()).toBe(false);
+  });
+
+  test('setLoop toggles loop flag', () => {
+    const mixer = new PlaybackMixer({ context: mockCtx() });
+    expect(mixer.isLoopEnabled()).toBe(false);
+    mixer.setLoop(true);
+    expect(mixer.isLoopEnabled()).toBe(true);
+  });
+
+  test('stop rewinds to crop in-point', () => {
+    const mixer = new PlaybackMixer({ context: mockCtx() });
+    mixer.loadStems([new Float32Array(48000 * 5)], [new Float32Array(48000 * 5)], 48000);
+    mixer.setCropRegion(0.5, 1.5);
+    mixer._offset = 1.0;
+    mixer.stop();
+    expect(mixer.currentTime()).toBeCloseTo(0.5, 3);
+  });
+});


### PR DESCRIPTION
## Features

### Loop + crop (landing + engineer)
- **Loop** — repeats playback within the crop region (or full file)
- **In / Out** — set crop markers at the current playhead
- **Clear** — reset crop to full file
- Waveform shows green crop window + dashed loop boundary
- Landing gets a playback scrubber (was time readout only)
- Engineer export saves cropped selection when crop is active

### Sleek sliders
- New \	ransport-polish.css\ — slim 4px track, white glass thumb, soft glow
- Engineer \#tpSeek\ uses the polished scrubber (replaces chunky 14px red orb)
- Engineer param sliders slimmed (14px thumb, 3px track) in slider-theme.css
- Landing mix sliders match the same minimal glass-thumb style

### Shortcuts (engineer)
- **L** — toggle loop
- **[** — crop in
- **]** — crop out

## Test plan
- [x] jest tests/playback-region.test.js
- [x] jest tests/transport.test.js

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add loop/crop transport controls and seek fill to landing and Engineer pages
> - Adds loop and crop-region support to `PlaybackMixer`: playback is constrained to the crop in/out points, looping restarts from the crop in-point, and `stop()` rewinds to the crop in-point instead of 0.
> - Adds loop/crop buttons and a region overlay bar to both the landing page and Engineer app transports, wired via a new `wireTransportRegion` helper in [`TransportRegionControls.js`](https://github.com/Joker5514/VoiceIsolate-Pro/pull/675/files#diff-4d680a156313c63bd2fd957d3c86d31bedd5971e5975ba58c64424bab95dded6).
> - Keyboard shortcuts `L`, `[`, and `]` toggle loop and set crop in/out markers in the Engineer app.
> - The 'Save Processed' action in the Engineer app exports only the cropped segment when a crop region is active, using the new `sliceAudioBuffer` utility.
> - Seek bars now visually fill to reflect playback progress via `paintSeekFill`; slider thumb and track sizes are reduced in [`slider-theme.css`](https://github.com/Joker5514/VoiceIsolate-Pro/pull/675/files#diff-b620efcd953a2a3ca64395268e2ed6988df35c3f6ea26f6cb2cca3c02d664318) and [`landing.css`](https://github.com/Joker5514/VoiceIsolate-Pro/pull/675/files#diff-0cfc64852aad421bc53736616a19dec3e5b249ad2f2509175077db2f108dbd66).
> - Behavioral Change: `PlaybackMixer.stop()` now rewinds to the crop in-point rather than position 0 when a crop region is set.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8dc7ad9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added crop-in, crop-out, loop, and clear controls to the transport UI.
  * Introduced a visible region bar and updated waveform/seek feedback to show active playback ranges.
  * Processed audio export now respects the selected crop region when enabled.

* **Bug Fixes**
  * Playback now stays in sync with crop regions during seeking, looping, and restart behavior.
  * Clearing or loading new content resets region-related state more reliably.

* **Style**
  * Refined slider and transport control styling for a cleaner, more compact look.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->