### PR TITLE
Debug isolation pipeline and speed up BS-RNN inference

### DIFF
--- a/public/app/app.js
+++ b/public/app/app.js
@@ -780,6 +780,8 @@ class VoiceIsolatePro {
 
     // Abort flag for runPipeline cancellation
     this.abortFlag = false;
+    /** Monotonic file generation — stale pipeline results are discarded. */
+    this._fileSeq = 0;
 
     // Live chain state
     this.liveChainBuilt = false;
@@ -1963,9 +1965,12 @@ class VoiceIsolatePro {
   // ── File handling ─────────────────────────────────────────────────────────
   async handleFile(file) {
     if (!file) return;
+    if (typeof this._fileSeq !== 'number' || !Number.isFinite(this._fileSeq)) this._fileSeq = 0;
+    const fileSeq = ++this._fileSeq;
     clearStemCache();
     this._sourceName = file.name || '';
     this.stop();
+    if (this.isProcessing) this.abortFlag = true;
     this.setStatus('LOADING');
     HeroExperience.onDecodeStart();
     this._showFileLoading(file.name ? `Loading ${file.name}…` : 'Loading…');
@@ -1997,6 +2002,7 @@ class VoiceIsolatePro {
       this.setStatus('ERROR');
       return;
     }
+    if (fileSeq !== this._fileSeq) return;
 
     // Detect video by MIME type or container extension. The <video> element is
     // then shown and kept in sync with the Web Audio transport so the picture
@@ -2050,6 +2056,7 @@ class VoiceIsolatePro {
       this.setStatus('ERROR');
       return;
     }
+    if (fileSeq !== this._fileSeq) return;
 
     // Show & wire the <video> element for video files (covers the common path
     // where decodeAudioData succeeded). The transport plays the processed audio
@@ -2079,7 +2086,8 @@ class VoiceIsolatePro {
     this.inputBuffer = buffer;
     this.origBuffer = buffer;
     this._hideFileLoading();
-    this.onAudioLoaded(file.name);
+    if (fileSeq !== this._fileSeq) return;
+    this.onAudioLoaded(file.name, fileSeq);
   }
 
   /** @deprecated Use decodeBlobToAudioBuffer — kept for legacy patch scripts. */
@@ -2088,9 +2096,10 @@ class VoiceIsolatePro {
     return resampleToCanonical(decoded);
   }
 
-  onAudioLoaded(name) {
+  onAudioLoaded(name, fileSeq = this._fileSeq) {
     const buf = this.inputBuffer || this.origBuffer;
     if (!buf) return;
+    if (fileSeq !== this._fileSeq) return;
 
     this.setStatus('READY');
 
@@ -2120,9 +2129,10 @@ class VoiceIsolatePro {
 
     // Auto-start pipeline — models warmed during decode (matches Landing latency UX).
     _yieldToUI(() => {
+      if (fileSeq !== this._fileSeq) return;
       if (!this.isProcessing && (this.inputBuffer || this.origBuffer)) {
         this._autoPipelineRun = true;
-        this.runPipeline().catch((err) => {
+        this.runPipeline(fileSeq).catch((err) => {
           structuredLog('error', '[VIP] Auto-process failed', { err: err.message });
         });
       }
@@ -2227,9 +2237,10 @@ class VoiceIsolatePro {
   }
 
   // ── Main pipeline (32-stage Deca-Pass) ────────────────────────────────────
-  async runPipeline() {
+  async runPipeline(fileSeq = this._fileSeq) {
     if (!this.origBuffer && !this.inputBuffer) return;
     if (this.isProcessing) return;
+    if (fileSeq !== this._fileSeq) return;
 
     this.isProcessing = true;
     this.abortFlag = false;
@@ -2280,8 +2291,9 @@ class VoiceIsolatePro {
           // ML inference runs exactly once per file (CLAUDE.md §1). Whisper
           // forensic passes are DSP-only refinement on procBuffer.
           stageStart('ml_isolation');
-          const mlOk = await this._runMLIsolationPipeline();
+          const mlOk = await this._runMLIsolationPipeline(fileSeq);
           stageEnd('ml_isolation');
+          if (fileSeq !== this._fileSeq) break;
           this._mlIsolationSucceeded = mlOk;
           if (!mlOk) {
             stageStart('dsp_fallback');
@@ -2302,6 +2314,17 @@ class VoiceIsolatePro {
         }
       }
 
+      if (fileSeq !== this._fileSeq) {
+        stageEnd('pipeline');
+        return;
+      }
+      if (this.abortFlag) {
+        stageEnd('pipeline');
+        this.setStatus('READY');
+        this.updatePipelineProgress(0, 'Cancelled', 0);
+        return;
+      }
+
       // Success — enable reprocess
       this.outputBuffer = this.outputBuffer || this.procBuffer;
       if (this.dom.reprocessBtn) this.dom.reprocessBtn.disabled = false;
@@ -2314,6 +2337,7 @@ class VoiceIsolatePro {
           ? (cb) => requestIdleCallback(cb, { timeout: 2000 })
           : (cb) => setTimeout(cb, 0);
         scheduleIdle(() => {
+          if (fileSeq !== this._fileSeq) return;
           this.renderStaticVisuals(this.outputBuffer);
           this._autoCalibratePreset(this.outputBuffer);
         });
@@ -2351,9 +2375,10 @@ class VoiceIsolatePro {
    * Offline ML isolation — same Demucs → denoise chain as the Landing page.
    * @returns {Promise<boolean>} true when ML produced a non-passthrough result
    */
-  async _runMLIsolationPipeline() {
+  async _runMLIsolationPipeline(fileSeq = this._fileSeq) {
     const buf = this.inputBuffer || this.origBuffer;
     if (!buf) return false;
+    if (fileSeq !== this._fileSeq) return false;
     try {
       await this.ensureCtx();
       const { separateStems, stemsToAudioBuffer } = await import('/src/pipeline/StemSeparation.js');
@@ -2366,6 +2391,7 @@ class VoiceIsolatePro {
         modelIds: DEFAULT_ML_CHAIN,
         sourceName: this._sourceName || '',
         onProgress: (ev) => {
+          if (fileSeq !== this._fileSeq) return;
           if (ev.type === 'stage') {
             const label = ev.label || `ML: ${ev.stage} (${ev.modelId || 'model'})…`;
             const pct = 15 + Math.round((ev.percent || 0) * 0.55);
@@ -2375,6 +2401,7 @@ class VoiceIsolatePro {
           }
         },
       });
+      if (fileSeq !== this._fileSeq) return false;
       if (result.passthrough) return false;
       this.outputBuffer = stemsToAudioBuffer(this.ctx, result.clean, result.sampleRate);
       this.procBuffer = this.outputBuffer;

--- a/public/landing.js
+++ b/public/landing.js
@@ -786,7 +786,7 @@ function onProcess() {
   ingested._stemCacheKey = cacheKey;
 
   // Channel copies are transferred — keep our reference for re-processing.
-  const channelData = ingested.channelData.map((c) => new Float32Array(c));
+  const channelData = ingested.channelData.map((c) => c.slice());
   const msg = { type: 'process', requestId: ++requestSeq, channelData, sampleRate: ingested.sampleRate };
   if (chain) msg.modelIds = chain;
   else msg.modelId = getModel(selection).id;

--- a/public/landing.js
+++ b/public/landing.js
@@ -128,6 +128,8 @@ let _syncTransportRegion = null;
 let ingested = null;
 let requestSeq = 0;
 let ingestSeq = 0;
+let ingestInFlight = false;
+let processingInFlight = false;
 
 let currentJobLabel = 'Separating stems…';
 /** Object URL backing the <video> preview; revoked when a new file loads. */
@@ -374,6 +376,7 @@ function getWorker() {
   initMLWorker(worker);
   worker.addEventListener('message', (event) => {
     const msg = event.data || {};
+    const stale = msg.requestId != null && msg.requestId !== requestSeq;
     switch (msg.type) {
       case 'ready': {
         let debugEnabled = false;
@@ -387,6 +390,7 @@ function getWorker() {
         break;
       }
       case 'stage':
+        if (stale) break;
         if (msg.stage === 'load') {
           if ((msg.percent ?? 0) <= 1) stageStart('model_load');
           setProcStage(
@@ -402,12 +406,16 @@ function getWorker() {
         }
         break;
       case 'progress':
-        setProgress(msg.percent);
+        if (!stale) setProgress(msg.percent);
         break;
       case 'stems':
         onStems(msg);
         break;
       case 'error':
+        if (stale) break;
+        stageEnd('isolate');
+        stageEnd('model_load');
+        processingInFlight = false;
         setStatus(`Processing failed: ${msg.message}`, 'error');
         hideSpinner();
         ui.processBtn.disabled = false;
@@ -621,7 +629,7 @@ function autoCalibrateMix(clean, sampleRate) {
  * same file can be re-selected after a failed decode.
  */
 async function ingestFrom(file) {
-  if (!file || ui.fileInput.disabled) return;
+  if (!file || ingestInFlight || processingInFlight) return;
   try {
     assertIngestible(file);
   } catch (err) {
@@ -629,6 +637,7 @@ async function ingestFrom(file) {
     return;
   }
   const seq = ++ingestSeq;
+  ingestInFlight = true;
   resetTimings();
   clearStemCache();
   ui.processBtn.disabled = true;
@@ -669,10 +678,11 @@ async function ingestFrom(file) {
     ingested = null;
     ui.processBtn.disabled = true;
   } finally {
-    // Re-enable the input unconditionally so the user can always pick again.
-    // Resetting the value lets the browser fire 'change' even if the same
-    // file is re-chosen (e.g. after a failed decode or an external edit).
-    ui.fileInput.disabled = false;
+    ingestInFlight = false;
+    // Keep input locked while ML isolation runs; onStems/error re-enables it.
+    if (!processingInFlight) {
+      ui.fileInput.disabled = false;
+    }
     ui.fileInput.value = '';
   }
 }
@@ -747,6 +757,8 @@ const MODEL_CHAINS = Object.freeze({
 
 function onProcess() {
   if (!ingested) return;
+  processingInFlight = true;
+  ui.fileInput.disabled = true;
   const selection = ui.modelSelect.value;
   const chain = MODEL_CHAINS[selection];
   const modelIds = chain || [getModel(selection).id];
@@ -795,6 +807,7 @@ function onProcess() {
 
 function onStems({ requestId, clean, noise, sampleRate, passthrough, _cacheKey }) {
   if (requestId !== requestSeq) return; // stale response
+  processingInFlight = false;
   stageEnd('isolate');
   stageEnd('model_load');
   setProgress(100);

--- a/scripts/bench-isolation-speed.cjs
+++ b/scripts/bench-isolation-speed.cjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+/**
+ * Isolation-stage benchmark — mono vs stereo, stage timings, ONNX batch estimate.
+ * Usage: node scripts/bench-isolation-speed.cjs [seconds]
+ */
+'use strict';
+
+const { spawn } = require('child_process');
+const fs = require('fs');
+const http = require('http');
+const path = require('path');
+const os = require('os');
+
+const ROOT = path.join(__dirname, '..');
+const SECS = Number(process.argv[2] || 30);
+
+function getFreePort() {
+  return new Promise((resolve, reject) => {
+    const s = http.createServer();
+    s.listen(0, '127.0.0.1', () => {
+      const port = s.address().port;
+      s.close(() => resolve(port));
+    });
+    s.on('error', reject);
+  });
+}
+
+function waitForServer(base, timeoutMs = 20000) {
+  const start = Date.now();
+  return new Promise((resolve, reject) => {
+    const ping = () => {
+      const req = http.get(`${base}/`, (res) => {
+        res.resume();
+        if (res.statusCode && res.statusCode < 500) resolve();
+        else retry();
+      });
+      req.on('error', retry);
+      req.setTimeout(1500, () => { req.destroy(); retry(); });
+    };
+    const retry = () => {
+      if (Date.now() - start > timeoutMs) reject(new Error('server timeout'));
+      else setTimeout(ping, 250);
+    };
+    ping();
+  });
+}
+
+function makeWav(secs, channels = 1) {
+  const sr = 48000;
+  const n = sr * secs;
+  const pcm = new Int16Array(n * channels);
+  for (let i = 0; i < n; i++) {
+    const t = i / sr;
+    const sample = Math.round(Math.sin(2 * Math.PI * 440 * t) * 16000);
+    for (let ch = 0; ch < channels; ch++) {
+      pcm[i * channels + ch] = sample;
+    }
+  }
+  const data = Buffer.from(pcm.buffer);
+  const header = Buffer.alloc(44);
+  const blockAlign = channels * 2;
+  header.write('RIFF', 0);
+  header.writeUInt32LE(36 + data.length, 4);
+  header.write('WAVE', 8);
+  header.write('fmt ', 12);
+  header.writeUInt32LE(16, 16);
+  header.writeUInt16LE(1, 20);
+  header.writeUInt16LE(channels, 22);
+  header.writeUInt32LE(sr, 24);
+  header.writeUInt32LE(sr * blockAlign, 28);
+  header.writeUInt16LE(blockAlign, 32);
+  header.writeUInt16LE(16, 34);
+  header.write('data', 36);
+  header.writeUInt32LE(data.length, 40);
+  const label = channels === 1 ? 'mono' : `stereo`;
+  const file = path.join(os.tmpdir(), `vip-isolate-${secs}s-${label}.wav`);
+  fs.writeFileSync(file, Buffer.concat([header, data]));
+  return file;
+}
+
+async function runCase(browser, BASE, wavPath, label) {
+  const page = await browser.newPage();
+  await page.goto(`${BASE}/`, { waitUntil: 'load' });
+  const start = Date.now();
+  await page.setInputFiles('#fileInput', wavPath);
+  await page.locator('#fileInput').dispatchEvent('change');
+
+  const deadline = start + Math.max(180_000, SECS * 8000);
+  while (Date.now() < deadline) {
+    const snap = await page.evaluate(() => ({
+      status: (document.getElementById('statusText')?.textContent || '').trim(),
+    }));
+    if (snap.status.includes('Stems ready')) {
+      const elapsed = Date.now() - start;
+      const timings = await page.evaluate(() => window.__vipStageTimings || {});
+      await page.close();
+      return { label, elapsed, timings };
+    }
+    if (/failed|error/i.test(snap.status) && !snap.status.includes('Idle')) {
+      await page.close();
+      throw new Error(`${label} failed: ${snap.status}`);
+    }
+    await page.waitForTimeout(500);
+  }
+  await page.close();
+  throw new Error(`${label} deadline exceeded`);
+}
+
+function estimateOnnxRuns(secs, channels, batchFrames = 96) {
+  const samples = secs * 48000;
+  const hop = 1024;
+  const fft = 4096;
+  const frames = Math.max(1, Math.ceil(Math.max(0, samples - fft) / hop) + 1);
+  const runsPerChannel = Math.ceil(frames / batchFrames);
+  return { frames, runsPerChannel, totalRuns: runsPerChannel * channels };
+}
+
+async function main() {
+  const monoPath = makeWav(SECS, 1);
+  const stereoPath = makeWav(SECS, 2);
+  const PORT = await getFreePort();
+  const BASE = `http://127.0.0.1:${PORT}`;
+
+  console.log(`\n[isolate-bench] ${SECS}s BS-RNN isolation @ ${BASE}\n`);
+
+  const server = spawn(process.execPath, ['server.js'], {
+    cwd: ROOT,
+    env: { ...process.env, PORT: String(PORT) },
+    stdio: 'ignore',
+  });
+  const cleanup = () => { try { server.kill('SIGTERM'); } catch { /* noop */ } };
+  process.on('exit', cleanup);
+  await waitForServer(BASE);
+
+  const { chromium } = require('playwright');
+  const browser = await chromium.launch({ args: ['--no-sandbox'] });
+
+  const mono = await runCase(browser, BASE, monoPath, 'mono');
+  const stereo = await runCase(browser, BASE, stereoPath, 'stereo');
+
+  await browser.close();
+  cleanup();
+
+  const est = estimateOnnxRuns(SECS, 1);
+  const estStereo = estimateOnnxRuns(SECS, 2);
+
+  console.log('── Results ─────────────────────────────────────');
+  for (const r of [mono, stereo]) {
+    console.log(`  ${r.label}: ${(r.elapsed / 1000).toFixed(2)}s total`);
+    console.log(`    timings: ${JSON.stringify(r.timings)}`);
+  }
+  console.log('\n── ONNX run estimate (batch=96) ────────────────');
+  console.log(`  mono:   ${est.totalRuns} runs (${est.frames} STFT frames)`);
+  console.log(`  stereo: ${estStereo.totalRuns} runs`);
+  if (mono.timings.isolate && stereo.timings.isolate) {
+    const ratio = (stereo.timings.isolate / mono.timings.isolate).toFixed(2);
+    console.log(`\n  stereo/mono isolate ratio: ${ratio}x`);
+  }
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/src/pipeline/MLStemCache.js
+++ b/src/pipeline/MLStemCache.js
@@ -13,7 +13,7 @@ const _cache = new Map();
  * @param {string} [sourceName]
  */
 export function stemCacheKey(channelData, sampleRate, modelIds, sourceName = '') {
-  const models = [...modelIds].sort().join('+');
+  const models = modelIds.join('→');
   const ch0 = channelData[0];
   if (!ch0?.length) return `${models}|${sampleRate}|0|${sourceName}`;
   const len = ch0.length;

--- a/src/pipeline/StemSeparation.js
+++ b/src/pipeline/StemSeparation.js
@@ -85,7 +85,8 @@ export async function separateStems(channelData, sampleRate, options = {}) {
   const w = getWorker();
   const requestId = ++_seq;
   const { onProgress } = options;
-  const copies = channelData.map((c) => new Float32Array(c));
+  // Transferable copies — originals stay intact for cache keys / reprocess.
+  const copies = channelData.map((c) => c.slice());
   const msg = { type: 'process', requestId, channelData: copies, sampleRate, modelIds };
 
   return new Promise((resolve, reject) => {

--- a/src/workers/MLWorker.js
+++ b/src/workers/MLWorker.js
@@ -47,6 +47,12 @@ let MANIFEST = Object.create(null);
 /** Map of sessionKey → InferenceSession (lazy, persistent for worker lifetime). */
 const SESSIONS = Object.create(null);
 
+/** In-flight session compiles — dedup concurrent getSession for the same key. */
+const _sessionInflight = Object.create(null);
+
+/** Serialize process requests — overlapping jobs corrupt ACTIVE_REQUEST_ID. */
+let _processChain = Promise.resolve();
+
 /** Per-session ONNX run queue. WASM JSEP allows only one active run worker-wide. */
 const _runQueues = Object.create(null);
 
@@ -246,13 +252,17 @@ async function createSessionFromBytes(entry, bytes) {
 
 async function getSession(entry, sessionKey = entry.id, { quiet = false } = {}) {
   if (SESSIONS[sessionKey]) return SESSIONS[sessionKey];
-  if (!quiet) postStage('load', 0, { modelId: entry.id, label: `Loading ${entry.name || entry.id}…` });
-  const bytes = await fetchModelBytes(entry);
-  if (!quiet) postStage('load', 50, { modelId: entry.id });
-  const session = await createSessionFromBytes(entry, bytes);
-  SESSIONS[sessionKey] = session;
-  if (!quiet) postStage('load', 100, { modelId: entry.id });
-  return session;
+  if (_sessionInflight[sessionKey]) return _sessionInflight[sessionKey];
+  _sessionInflight[sessionKey] = (async () => {
+    if (!quiet) postStage('load', 0, { modelId: entry.id, label: `Loading ${entry.name || entry.id}…` });
+    const bytes = await fetchModelBytes(entry);
+    if (!quiet) postStage('load', 50, { modelId: entry.id });
+    const session = await createSessionFromBytes(entry, bytes);
+    SESSIONS[sessionKey] = session;
+    if (!quiet) postStage('load', 100, { modelId: entry.id });
+    return session;
+  })().finally(() => { delete _sessionInflight[sessionKey]; });
+  return _sessionInflight[sessionKey];
 }
 
 /** Cache bytes + compile ONNX sessions off the hot path (boot / during decode). */
@@ -622,9 +632,12 @@ self.onmessage = async (event) => {
         self.postMessage({ type: 'ready', backend });
         break;
       }
-      case 'process':
-        await processRequest(msg);
+      case 'process': {
+        const run = _processChain.then(() => processRequest(msg));
+        _processChain = run.catch(() => {});
+        await run;
         break;
+      }
       case 'warmup':
         await warmupModels(msg.modelIds);
         break;

--- a/src/workers/MLWorker.js
+++ b/src/workers/MLWorker.js
@@ -65,7 +65,7 @@ async function queuedSessionRun(sessionKey, session, feeds) {
   const prev = _runQueues[key] || Promise.resolve();
   let release;
   _runQueues[key] = new Promise((resolve) => { release = resolve; });
-  await prev;
+  await prev.catch(() => {});
   try {
     return await session.run(feeds);
   } finally {

--- a/src/workers/MLWorker.js
+++ b/src/workers/MLWorker.js
@@ -47,6 +47,26 @@ let MANIFEST = Object.create(null);
 /** Map of sessionKey → InferenceSession (lazy, persistent for worker lifetime). */
 const SESSIONS = Object.create(null);
 
+/** Per-session ONNX run queue. WASM JSEP allows only one active run worker-wide. */
+const _runQueues = Object.create(null);
+
+function inferenceQueueKey(sessionKey) {
+  return BACKEND === 'webgpu' ? sessionKey : '__wasm_global__';
+}
+
+async function queuedSessionRun(sessionKey, session, feeds) {
+  const key = inferenceQueueKey(sessionKey);
+  const prev = _runQueues[key] || Promise.resolve();
+  let release;
+  _runQueues[key] = new Promise((resolve) => { release = resolve; });
+  await prev;
+  try {
+    return await session.run(feeds);
+  } finally {
+    release();
+  }
+}
+
 /** Resolved execution backend, decided once. */
 let BACKEND = null;
 
@@ -108,9 +128,9 @@ function postStage(stage, percent, extra = {}) {
 
 function effectiveBatchFrames(entry) {
   const base = entry.maxBatchFrames || 32;
-  if (BACKEND === 'webgpu') return Math.min(128, base * 2);
+  if (BACKEND === 'webgpu') return Math.min(128, base * 3);
   // Larger WASM batches amortize ONNX session.run overhead on spectral models.
-  return Math.min(64, base * 2);
+  return Math.min(96, base * 3);
 }
 
 // ─── Integrity ───────────────────────────────────────────────────────────────
@@ -333,6 +353,14 @@ function fftInPlace(re, im, inverse) {
  * @param {(p: number) => void} onProgress  0..1
  * @returns {Promise<Float32Array>} masked (clean) channel
  */
+function makeStftBatchBuf(batchMax, bins) {
+  return {
+    batchMags: new Float32Array(batchMax * bins),
+    batchRe: new Float32Array(batchMax * bins),
+    batchIm: new Float32Array(batchMax * bins),
+  };
+}
+
 async function runSpectralMask(entry, session, samples, onProgress) {
   const N = entry.fftSize;
   const hop = entry.hopSize;
@@ -345,17 +373,12 @@ async function runSpectralMask(entry, session, samples, onProgress) {
   const out = new Float32Array(samples.length);
   const norm = new Float32Array(samples.length);
 
-  // Scratch buffers reused across the whole file — no per-frame allocation.
   const re = new Float32Array(N);
   const im = new Float32Array(N);
-  const batchMags = new Float32Array(batchMax * bins);
-  const batchRe = new Float32Array(batchMax * bins);
-  const batchIm = new Float32Array(batchMax * bins);
+  let cur = makeStftBatchBuf(batchMax, bins);
+  let nxt = makeStftBatchBuf(batchMax, bins);
 
-  for (let f0 = 0; f0 < totalFrames; f0 += batchMax) {
-    const count = Math.min(batchMax, totalFrames - f0);
-
-    // ── Forward STFT for this batch ─────────────────────────────────────
+  const forwardStftBatch = (buf, f0, count) => {
     for (let b = 0; b < count; b++) {
       const start = (f0 + b) * hop;
       const avail = Math.max(0, Math.min(N, samples.length - start));
@@ -364,15 +387,35 @@ async function runSpectralMask(entry, session, samples, onProgress) {
       fftInPlace(re, im, false);
       const off = b * bins;
       for (let k = 0; k < bins; k++) {
-        batchRe[off + k] = re[k];
-        batchIm[off + k] = im[k];
-        batchMags[off + k] = Math.hypot(re[k], im[k]);
+        buf.batchRe[off + k] = re[k];
+        buf.batchIm[off + k] = im[k];
+        buf.batchMags[off + k] = Math.hypot(re[k], im[k]);
       }
     }
+  };
 
-    // ── Mask inference (dynamic batch) ──────────────────────────────────
-    const input = new ort.Tensor('float32', batchMags.subarray(0, count * bins), [count, bins]);
-    const results = await session.run({ [entry.io.input]: input });
+  let prefetch = null;
+
+  for (let f0 = 0; f0 < totalFrames; f0 += batchMax) {
+    const count = Math.min(batchMax, totalFrames - f0);
+
+    if (prefetch) {
+      await prefetch;
+      const swap = cur; cur = nxt; nxt = swap;
+    } else {
+      forwardStftBatch(cur, f0, count);
+    }
+
+    const nextF0 = f0 + batchMax;
+    const nextCount = nextF0 < totalFrames ? Math.min(batchMax, totalFrames - nextF0) : 0;
+    prefetch = nextCount > 0
+      ? Promise.resolve().then(() => forwardStftBatch(nxt, nextF0, nextCount))
+      : null;
+
+    // ── Mask inference (prefetch overlaps ONNX on the WASM thread pool) ─
+    const magSlice = cur.batchMags.subarray(0, count * bins);
+    const input = new ort.Tensor('float32', magSlice, [count, bins]);
+    const results = await queuedSessionRun(entry.id, session, { [entry.io.input]: input });
     const mask = results[entry.io.output]?.data;
     if (!mask || mask.length < count * bins) {
       throw new Error(`[VIP][MLWorker] '${entry.id}' returned a malformed output tensor.`);
@@ -381,11 +424,10 @@ async function runSpectralMask(entry, session, samples, onProgress) {
     // ── Masked inverse STFT + overlap-add ───────────────────────────────
     for (let b = 0; b < count; b++) {
       const off = b * bins;
-      // Rebuild the full Hermitian spectrum from the masked half-spectrum.
       for (let k = 0; k < bins; k++) {
         const m = mask[off + k];
-        re[k] = batchRe[off + k] * m;
-        im[k] = batchIm[off + k] * m;
+        re[k] = cur.batchRe[off + k] * m;
+        im[k] = cur.batchIm[off + k] * m;
       }
       for (let k = bins; k < N; k++) {
         re[k] = re[N - k];
@@ -446,7 +488,7 @@ async function runWaveformMask(entry, session, samples, sampleRate, onProgress) 
     chunk.fill(0);
     chunk.set(pcm.subarray(offset, offset + len));
     const input = new ort.Tensor('float32', chunk, [1, 1, segmentLen]);
-    const result = await session.run({ [inName]: input });
+    const result = await queuedSessionRun(entry.id, session, { [inName]: input });
     const maskTensor = result[outName] || result.output;
     if (!maskTensor?.data) {
       throw new Error(`[VIP][MLWorker] '${entry.id}' returned no mask tensor.`);
@@ -519,9 +561,8 @@ async function processRequest({ requestId, modelId, modelIds, channelData, sampl
         ? getSession(MANIFEST[nextId], MANIFEST[nextId].id, { quiet: true }).catch(() => {})
         : null;
       postStage('separate', Math.round((stepBase / totalSteps) * 100), { modelId: id });
+      const session = await getSession(entry, entry.id);
       const next = await Promise.all(current.map(async (samples, ch) => {
-        const sessionKey = current.length > 1 ? `${entry.id}:ch${ch}` : entry.id;
-        const session = await getSession(entry, sessionKey);
         const step = stepBase + ch;
         const progress = (p) => onProgress((step + p) / totalSteps);
         if (entry.strategy === 'spectral-mask') {

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -398,7 +398,7 @@ describe('VoiceIsolatePro class structure', () => {
   });
 
   test('defines runPipeline async method', () => {
-    expect(appSrc).toContain('async runPipeline()');
+    expect(appSrc).toMatch(/async runPipeline\(/);
   });
 
   test('Engineer mode warms ML models and auto-starts pipeline after file load', () => {
@@ -420,7 +420,7 @@ describe('VoiceIsolatePro class structure', () => {
   test('Engineer ML inference runs once per file (whisper passes are DSP-only)', () => {
     expect(appSrc).toContain('pass === 0');
     expect(appSrc).toMatch(/ML inference runs exactly once per file/);
-    expect(appSrc).toMatch(/const mlOk = await this\._runMLIsolationPipeline\(\)/);
+    expect(appSrc).toMatch(/const mlOk = await this\._runMLIsolationPipeline\(/);
   });
 
   test('Engineer default whisper mode is OFF for low-latency first pass', () => {

--- a/tests/audio-upload-fixes.test.js
+++ b/tests/audio-upload-fixes.test.js
@@ -29,16 +29,13 @@ describe('Upload race condition guard', () => {
     expect(js).toContain('ui.fileInput.disabled = true');
   });
 
-  test('ingestFrom() bails early when fileInput is already disabled', () => {
-    // Covers drag-and-drop concurrent calls AND drops during onProcess()
-    // (which also sets fileInput.disabled = true).
-    expect(js).toMatch(/if\s*\(!file\s*\|\|\s*ui\.fileInput\.disabled\)/);
+  test('ingestFrom() bails early when ingest or ML processing is in flight', () => {
+    expect(js).toMatch(/if\s*\(!file\s*\|\|\s*ingestInFlight\s*\|\|\s*processingInFlight\)/);
   });
 
-  test('file input is re-enabled in a finally block (always runs)', () => {
-    // Both success and error paths must restore the input; only a finally
-    // block guarantees this.
-    expect(js).toMatch(/finally\s*\{[^}]*ui\.fileInput\.disabled\s*=\s*false/s);
+  test('file input is re-enabled after decode unless ML isolation is still running', () => {
+    expect(js).toContain('processingInFlight');
+    expect(js).toMatch(/if\s*\(!processingInFlight\)\s*\{[^}]*ui\.fileInput\.disabled\s*=\s*false/s);
   });
 
   test('onFileChosen() delegates to ingestFrom()', () => {
@@ -74,7 +71,7 @@ describe('Same-file re-upload', () => {
   });
 
   test('the reset happens in the finally block (also runs after errors)', () => {
-    expect(js).toMatch(/finally\s*\{[^}]*ui\.fileInput\.value\s*=\s*''/s);
+    expect(js).toMatch(/finally\s*\{[\s\S]*ui\.fileInput\.value\s*=\s*''/);
   });
 });
 

--- a/tests/handle_file_validation.test.js
+++ b/tests/handle_file_validation.test.js
@@ -106,6 +106,8 @@ function makeMockVip() {
       decodeAudioData: jest.fn().mockResolvedValue({ length: 100 }),
     },
     params: {},
+    _fileSeq: 0,
+    isProcessing: false,
   };
 }
 
@@ -271,7 +273,7 @@ describe('handleFile() — file type validation', () => {
     await handleFile.call(mockVip, mockFile);
 
     expect(mockVip.ctx.decodeAudioData).toHaveBeenCalledTimes(1);
-    expect(mockVip.onAudioLoaded).toHaveBeenCalledWith('clip.mp4');
+    expect(mockVip.onAudioLoaded).toHaveBeenCalledWith('clip.mp4', 1);
     expect(mockVip.dom.videoPlayer.src).toBe('blob:test');
     expect(mockVip.dom.fileInfo.textContent).not.toContain('Unsupported');
   });

--- a/tests/helpers/get-app-code.js
+++ b/tests/helpers/get-app-code.js
@@ -94,6 +94,15 @@ function buildMediaTypesShim() {
     .replace(/^export\s+/gm, '');
 }
 
+function buildPipelineShim() {
+  return `
+function clearStemCache() {}
+function resetTimings() {}
+function stageStart() {}
+function stageEnd() {}
+`;
+}
+
 function buildMediaDecodeShim() {
   return `
 async function decodeBlobToAudioBuffer(file) {
@@ -126,7 +135,8 @@ function getAppCode() {
   }
   const mediaTypesShim = buildMediaTypesShim();
   const mediaDecodeShim = buildMediaDecodeShim();
-  return preamble + '\n' + inlined + '\n' + mediaTypesShim + '\n' + mediaDecodeShim + '\n' + appJsCode;
+  const pipelineShim = buildPipelineShim();
+  return preamble + '\n' + inlined + '\n' + mediaTypesShim + '\n' + mediaDecodeShim + '\n' + pipelineShim + '\n' + appJsCode;
 }
 
 module.exports = getAppCode;

--- a/tests/ml-stem-cache.test.js
+++ b/tests/ml-stem-cache.test.js
@@ -32,6 +32,13 @@ describe('MLStemCache', () => {
     expect(a).not.toBe(b);
   });
 
+  test('stemCacheKey preserves model chain order', () => {
+    const ch = [new Float32Array([0.1, 0.2, 0.3, 0.4])];
+    const a = stemCacheKey(ch, 48000, ['demucs', 'rnnoise'], 'clip.wav');
+    const b = stemCacheKey(ch, 48000, ['rnnoise', 'demucs'], 'clip.wav');
+    expect(a).not.toBe(b);
+  });
+
   test('setCachedStems stores and getCachedStems retrieves copies', () => {
     const key = 'test-key';
     const cleanIn = new Float32Array([1, 2]);

--- a/tests/mobile-ui.test.js
+++ b/tests/mobile-ui.test.js
@@ -324,7 +324,7 @@ describe('app.js — mobile button state in onAudioLoaded()', () => {
 
   test('disables mobileReprocessBtn on fresh audio load', () => {
     // After a new file is loaded the reprocess button resets to disabled
-    const onAudioLoadedBlock = appJs.match(/onAudioLoaded\(name\)[\s\S]*?this\.dom\.hDur/)?.[0] || '';
+    const onAudioLoadedBlock = appJs.match(/onAudioLoaded\(name[\s\S]*?\)[\s\S]*?this\.dom\.hDur/)?.[0] || '';
     expect(onAudioLoadedBlock).toContain('this.dom.mobileReprocessBtn.disabled = true');
   });
 
@@ -577,7 +577,7 @@ describe('Regression and boundary cases', () => {
 
   test('app.js: every mobileProcessBtn access in runPipeline is covered by a null guard', () => {
     // Count how many times the null-guard appears vs how many times the button is accessed
-    const runPipelineBlock = appJs.match(/async runPipeline\(\)[\s\S]*?async pip\(/)?.[0] || '';
+    const runPipelineBlock = appJs.match(/async runPipeline\([\s\S]*?async pip\(/)?.[0] || '';
     const guardCount  = (runPipelineBlock.match(/if \(this\.dom\.mobileProcessBtn\)/g) || []).length;
     const accessCount = (runPipelineBlock.match(/this\.dom\.mobileProcessBtn\b/g) || []).length;
     // Each guard covers at least one access so guards must be >= half of total occurrences


### PR DESCRIPTION
## Summary

Debugged the ML isolation hot path and shipped ONNX/DSP optimizations.

## Root causes
- Stereo used per-channel session keys so warmup did not apply
- ORT WASM JSEP allows only one active session.run worker-wide
- STFT and ONNX ran serially per batch
- WASM batch size capped at 64

## Changes
- Shared session per model + global WASM inference queue
- STFT prefetch pipeline overlapping DSP with ONNX
- Larger batches (96 frames)
- scripts/bench-isolation-speed.cjs for mono/stereo timings

## Benchmarks (30s WAV)
| Case | Before | After |
|------|--------|-------|
| Landing mono total | ~6.1s | ~5.1s |
| isolate stage (mono) | ~5149ms | ~4183ms (~19% faster) |
| Stereo isolate | crash risk | ~8.3s (1.58x mono) |

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Debug isolation pipeline and speed up BS-RNN inference in the ML worker
> - Adds a monotonic `_fileSeq` counter to `VoiceIsolatePro` and propagates it through `handleFile`, `onAudioLoaded`, `runPipeline`, and `_runMLIsolationPipeline` to discard stale async results when a new file is selected mid-pipeline.
> - Adds `ingestInFlight` and `processingInFlight` guards in [landing.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/676/files#diff-be23ec2b8a859b1c83e27ce227d9dd0c367c83c7a8f1a4b104128c882bdb30ab) to prevent concurrent ingestion or processing and suppress stale worker messages from updating the UI.
> - Serializes ONNX `session.run` calls per backend in [MLWorker.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/676/files#diff-feb98479b700cf9bcf10c1482f1408a8217b243653a510f90b27c617f61cf8a4) via a per-session promise queue (`queuedSessionRun`), and deduplicates concurrent model compiles via `_sessionInflight`.
> - Overlaps STFT precomputation with ONNX execution in `runSpectralMask` and increases dynamic batch sizes (WebGPU: up to 128, WASM: up to 96) to improve inference throughput.
> - Fixes `stemCacheKey` in [MLStemCache.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/676/files#diff-a167ccc2503f37a0bb64df093e590dc4aeaad6369fdd6f376c4c4792d7f75991) to preserve model chain order, so different orderings produce different cache keys.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6309365.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when switching files mid-decode/pipeline by ignoring stale async results and preventing UI from reflecting outdated work.
  * Fixed ingestion/processing overlap so inputs are enabled/disabled correctly throughout the workflow.
* **Performance**
  * Improved ML worker concurrency and serialized session/pipeline execution to reduce job clobbering and better use backend capacity.
  * Enhanced STFT/masking batching and iSTFT reconstruction efficiency; improved reuse and correctness of cached isolation inputs.
* **New Features**
  * Added a Playwright-based CLI benchmark to measure isolation speed and stage timings.
* **Tests**
  * Updated and expanded unit tests to match the new async sequencing and cache-key behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->