### PR TITLE
Preserve user sliders on process, lock toggles, fix RT badges

### DIFF
--- a/public/app/app.js
+++ b/public/app/app.js
@@ -314,6 +314,17 @@ function _formatSliderUnit(unit) {
   return ` ${unit}`;
 }
 
+/** Live-mix bridge sliders — only these affect playback in real time (EngineerModeBridge.PARAM_MAP). */
+const BRIDGE_RT_SLIDER_IDS = new Set([
+  'gateThresh', 'gateRange', 'gateAttack', 'gateRelease', 'gateHold',
+  'eqSub', 'eqBass', 'eqWarmth', 'eqBody', 'eqLowMid', 'eqMid', 'eqPresence', 'eqClarity', 'eqAir', 'eqBrill',
+  'compThresh', 'compRatio', 'compAttack', 'compRelease', 'compKnee', 'compMakeup',
+  'limThresh', 'limRelease',
+  'hpFreq', 'hpQ', 'lpFreq', 'lpQ',
+  'deEssFreq', 'deEssAmt',
+  'specTilt', 'outGain', 'dryWet', 'outWidth', 'stereoWidth',
+]);
+
 /** Calibrated render contract — min/max/step/default from SLIDER_REGISTRY. */
 const RENDER_SLIDERS = SLIDER_REGISTRY.map((s) => ({
   id: s.id,
@@ -323,7 +334,7 @@ const RENDER_SLIDERS = SLIDER_REGISTRY.map((s) => ({
   val: s.default,
   step: s.step,
   unit: _formatSliderUnit(s.unit),
-  rt: Boolean(s.rt),
+  rt: BRIDGE_RT_SLIDER_IDS.has(s.id),
   desc: s.hint || s.tip || '',
   group: s.group,
 }));
@@ -838,6 +849,12 @@ class VoiceIsolatePro {
     this._extremeFrameIdx = 0;
     this._extremeCircularMag = null;
     this._extremeNoiseProfile = null;
+    /** Sliders the user dragged — preserved across auto-calibrate on process. */
+    this._userTouchedSliders = new Set();
+    /** Sliders locked — never overwritten by preset or auto-calibrate. */
+    this._sliderLocks = new Set();
+    this._programmaticSliderUpdate = false;
+    this._loadSliderLocks();
 
     // SAB param lane
     this.sharedParams = null;
@@ -1122,6 +1139,50 @@ class VoiceIsolatePro {
     }
   }
 
+  _loadSliderLocks() {
+    if (typeof sessionStorage === 'undefined') return;
+    try {
+      const raw = sessionStorage.getItem('vip-slider-locks');
+      if (!raw) return;
+      const ids = JSON.parse(raw);
+      if (Array.isArray(ids)) this._sliderLocks = new Set(ids);
+    } catch (_) { /* ignore corrupt storage */ }
+  }
+
+  _persistSliderLocks() {
+    if (typeof sessionStorage === 'undefined') return;
+    try {
+      sessionStorage.setItem('vip-slider-locks', JSON.stringify([...this._sliderLocks]));
+    } catch (_) { /* ignore quota */ }
+  }
+
+  _isSliderLocked(id) {
+    return this._sliderLocks.has(id);
+  }
+
+  _shouldPreserveSlider(id) {
+    return this._isSliderLocked(id) || this._userTouchedSliders.has(id);
+  }
+
+  _syncSliderLockUi(id) {
+    const row = document.querySelector(`.slider-row[data-slider-id="${id}"]`);
+    const btn = row?.querySelector('.slider-lock-btn');
+    if (!row || !btn) return;
+    const locked = this._isSliderLocked(id);
+    row.classList.toggle('slider-locked', locked);
+    btn.classList.toggle('is-locked', locked);
+    btn.setAttribute('aria-pressed', String(locked));
+    btn.title = locked ? 'Unlock slider (allow preset changes)' : 'Lock slider (ignore preset changes)';
+    btn.textContent = locked ? '\u{1F512}' : '\u{1F513}';
+  }
+
+  _toggleSliderLock(id) {
+    if (this._sliderLocks.has(id)) this._sliderLocks.delete(id);
+    else this._sliderLocks.add(id);
+    this._persistSliderLocks();
+    this._syncSliderLockUi(id);
+  }
+
   // ── Slider rendering ─────────────────────────────────────────────────────
   _renderSliders() {
     for (const s of RENDER_SLIDERS) {
@@ -1174,6 +1235,7 @@ class VoiceIsolatePro {
 
       // PATCHED BY vip-fixes.js — consider merging
       inputEl.addEventListener('input', () => {
+        if (!this._programmaticSliderUpdate) this._userTouchedSliders.add(s.id);
         const el = inputEl;
         const v = parseFloat(el.value);
         const min = parseFloat(el.min);
@@ -1194,9 +1256,23 @@ class VoiceIsolatePro {
         this._applySliderToWorklet(s.id, v);
       });
 
+      const lockBtn = document.createElement('button');
+      lockBtn.type = 'button';
+      lockBtn.className = 'slider-lock-btn';
+      lockBtn.setAttribute('aria-label', `Lock ${s.label}`);
+      lockBtn.setAttribute('aria-pressed', 'false');
+      lockBtn.title = 'Lock slider (ignore preset changes)';
+      lockBtn.textContent = '\u{1F513}';
+      lockBtn.addEventListener('click', (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        this._toggleSliderLock(s.id);
+      });
+
       row.appendChild(labelEl);
       row.appendChild(inputEl);
       row.appendChild(valEl);
+      row.appendChild(lockBtn);
 
       const regEntry = SLIDER_REG_BY_ID[s.id];
       const examples = (regEntry && regEntry.examples && regEntry.examples.length)
@@ -1260,6 +1336,7 @@ class VoiceIsolatePro {
       if (hintPanel) row.appendChild(hintPanel);
 
       container.appendChild(row);
+      if (this._isSliderLocked(s.id)) this._syncSliderLockUi(s.id);
 
       window.VIP_PARAMS = window.VIP_PARAMS || {};
       window.VIP_PARAMS[s.id] = initVal;
@@ -1881,6 +1958,15 @@ class VoiceIsolatePro {
 
   /** Push a calibrated slider value through VIP_PARAMS, DOM, bridge, and worklet. */
   _setSliderUi(id, rawValue, { notify = true } = {}) {
+    this._programmaticSliderUpdate = true;
+    try {
+      this._setSliderUiInner(id, rawValue, { notify });
+    } finally {
+      this._programmaticSliderUpdate = false;
+    }
+  }
+
+  _setSliderUiInner(id, rawValue, { notify = true } = {}) {
     if (id === 'whisperMode') {
       this._setWhisperMode(rawValue);
       return;
@@ -1924,6 +2010,7 @@ class VoiceIsolatePro {
     Object.entries(preset).forEach(([key, rawValue]) => {
       if (preserveWhisperMode && key === 'whisperMode') return;
       if (key === 'description') return;
+      if (this._isSliderLocked(key)) return;
       this._setSliderUi(key, rawValue, { notify: false });
     });
     if (preserveWhisperMode && savedWhisper != null) {
@@ -1943,11 +2030,25 @@ class VoiceIsolatePro {
    * Applies the best-matching named preset, then merges AIIntelligence hints
    * for whisper/quiet content when the module is loaded.
    */
+  _applyPresetValues(presetName, options = {}) {
+    const { preserveWhisperMode = false, respectUserTouched = false } = options;
+    const preset = PRESETS[presetName];
+    if (!preset) return;
+    Object.entries(preset).forEach(([key, rawValue]) => {
+      if (preserveWhisperMode && key === 'whisperMode') return;
+      if (key === 'description') return;
+      if (this._isSliderLocked(key)) return;
+      if (respectUserTouched && this._userTouchedSliders.has(key)) return;
+      this._setSliderUi(key, rawValue, { notify: false });
+    });
+  }
+
   _autoCalibratePreset(buffer) {
     if (!buffer || typeof buffer.getChannelData !== 'function') return null;
     if (WorkflowTier.shouldSkipAutoCalibrate()) {
       const preset = WorkflowTier.getDefaultPreset();
-      this.applyPreset(preset);
+      this._applyPresetValues(preset, { respectUserTouched: true });
+      this._syncBridgeParams();
       return { preset, level: 'creator', rmsDb: 0 };
     }
     const channels = [];
@@ -1955,10 +2056,11 @@ class VoiceIsolatePro {
       channels.push(buffer.getChannelData(ch));
     }
     const { preset, level, rmsDb, overrides = {} } = recommendEngineerPreset(channels);
-    this.applyPreset(preset, { preserveWhisperMode: true });
+    this._applyPresetValues(preset, { preserveWhisperMode: true, respectUserTouched: true });
 
     for (const [key, val] of Object.entries(overrides)) {
       if (!(SLIDER_REG_BY_ID[key] || SLIDER_BY_ID[key]) || !Number.isFinite(val)) continue;
+      if (this._shouldPreserveSlider(key)) continue;
       this._setSliderUi(key, val);
     }
 
@@ -1968,6 +2070,7 @@ class VoiceIsolatePro {
       const tune = AI.autoTuneParams(mono, buffer.sampleRate, this.params);
       for (const [key, val] of Object.entries(tune.suggestions || {})) {
         if (!(SLIDER_REG_BY_ID[key] || SLIDER_BY_ID[key]) || !Number.isFinite(val)) continue;
+        if (this._shouldPreserveSlider(key)) continue;
         this._setSliderUi(key, val);
       }
     }
@@ -4046,6 +4149,7 @@ const WHISPER_HUNTER = {
 if (typeof window !== 'undefined') {
   window.numFromInput = numFromInput;
   window.clampToSlider = clampToSlider;
+  window.BRIDGE_RT_SLIDER_IDS = BRIDGE_RT_SLIDER_IDS;
 }
 
 // ---------------------------------------------------------------------------

--- a/public/app/slider-map.js
+++ b/public/app/slider-map.js
@@ -186,7 +186,7 @@ const RAW_SLIDER_REGISTRY = [
   {
     id: 'nrAmount', key: 'nrAmount', label: 'NR Amount',
     min: 0, max: 100, step: 5, default: 78, unit: '%',
-    transform: v => v / 100, target: 'both', rt: true, group: 'tab-nr',
+    transform: v => v / 100, target: 'both', rt: false, group: 'tab-nr',
     tip: 'Strength of spectral noise reduction. 0 = off, 100 = maximum suppression. Start at 70–80% for hiss/fan noise.'
   },
   {
@@ -336,7 +336,7 @@ const RAW_SLIDER_REGISTRY = [
   {
     id: 'hpQ', key: 'hpQ', label: 'HP Q',
     min: 0.5, max: 10, step: 0.5, default: 0.707, unit: '',
-    transform: v => v, target: 'worklet', rt: false, group: 'tab-spec',
+    transform: v => v, target: 'worklet', rt: true, group: 'tab-spec',
     tip: 'High-pass filter resonance (Q). 0.707 = Butterworth (flat); higher = ringing peak at cutoff.'
   },
   {
@@ -348,19 +348,19 @@ const RAW_SLIDER_REGISTRY = [
   {
     id: 'lpQ', key: 'lpQ', label: 'LP Q',
     min: 0.5, max: 10, step: 0.5, default: 0.707, unit: '',
-    transform: v => v, target: 'worklet', rt: false, group: 'tab-spec',
+    transform: v => v, target: 'worklet', rt: true, group: 'tab-spec',
     tip: 'Low-pass filter resonance (Q). 0.707 = flat Butterworth response.'
   },
   {
     id: 'deEssFreq', key: 'deEssFreq', label: 'De-ess Freq',
     min: 2000, max: 16000, step: 500, default: 7000, unit: 'Hz',
-    transform: v => v, target: 'worker', rt: false, group: 'tab-spec',
+    transform: v => v, target: 'worklet', rt: true, group: 'tab-spec',
     tip: 'Center frequency for de-esser detection. Set to the harshest sibilant peak (typically 6–8 kHz).'
   },
   {
     id: 'deEssAmt', key: 'deEssAmt', label: 'De-ess Amount',
     min: 0, max: 24, step: 1, default: 6, unit: 'dB',
-    transform: v => v, target: 'worker', rt: false, group: 'tab-spec',
+    transform: v => v, target: 'worklet', rt: true, group: 'tab-spec',
     tip: 'Maximum attenuation applied to sibilant peaks. 6 dB is subtle; 12+ dB is heavy correction.'
   },
   {
@@ -404,7 +404,7 @@ const RAW_SLIDER_REGISTRY = [
   {
     id: 'stereoWidth', key: 'stereoWidth', label: 'Stereo Width',
     min: 0, max: 200, step: 10, default: 100, unit: '%',
-    transform: v => v, target: 'worklet', rt: false, group: 'tab-adv',
+    transform: v => v, target: 'worklet', rt: true, group: 'tab-adv',
     tip: '0% = mono, 100% = natural stereo, 200% = extra-wide. Affects M/S balance post-processing.'
   },
   {
@@ -468,7 +468,7 @@ const RAW_SLIDER_REGISTRY = [
   {
     id: 'outWidth', key: 'outWidth', label: 'Output Width',
     min: 0, max: 200, step: 10, default: 100, unit: '%',
-    transform: v => v, target: 'worklet', rt: false, group: 'tab-out',
+    transform: v => v, target: 'worklet', rt: true, group: 'tab-out',
     tip: 'Final stereo width on the output bus. 100% = unchanged, 0% = mono sum, 200% = widened.'
   },
 
@@ -476,7 +476,7 @@ const RAW_SLIDER_REGISTRY = [
   {
     id: 'whisperLift', key: 'whisperLift', label: 'Whisper Lift Gain',
     min: 0, max: 40, step: 1, default: 18, unit: 'dB',
-    transform: v => v, target: 'both', rt: true, group: 'tab-extreme',
+    transform: v => v, target: 'both', rt: false, group: 'tab-extreme',
     tip: 'Post-mask amplification on bins where voice confidence exceeds 0.55.'
   },
   {
@@ -488,7 +488,7 @@ const RAW_SLIDER_REGISTRY = [
   {
     id: 'bassCrush', key: 'bassCrush', label: 'Bass Crush (Sub/Kick)',
     min: 0, max: 100, step: 1, default: 90, unit: '%',
-    transform: v => v, target: 'both', rt: true, group: 'tab-extreme',
+    transform: v => v, target: 'both', rt: false, group: 'tab-extreme',
     tip: 'Attenuates kick drum and sub bass that mask whisper formants.'
   },
   {
@@ -500,7 +500,7 @@ const RAW_SLIDER_REGISTRY = [
   {
     id: 'voiceTunnel', key: 'voiceTunnel', label: 'Voice Tunnel (Formant)',
     min: 0, max: 100, step: 1, default: 65, unit: '%',
-    transform: v => v, target: 'both', rt: true, group: 'tab-extreme',
+    transform: v => v, target: 'both', rt: false, group: 'tab-extreme',
     tip: 'Narrow-band formant emphasis for whisper intelligibility.'
   },
   {
@@ -526,25 +526,25 @@ const RAW_SLIDER_REGISTRY = [
   {
     id: 'whisperClarity', key: 'whisperClarity', label: 'Whisper Clarity',
     min: 0, max: 100, step: 1, default: 65, unit: '%',
-    transform: v => v, target: 'both', rt: true, group: 'tab-extreme',
+    transform: v => v, target: 'both', rt: false, group: 'tab-extreme',
     tip: 'Sigmoid-mapped clarity floor for WhisperHunter gain (p_clarity).'
   },
   {
     id: 'whisperSensitivity', key: 'whisperSensitivity', label: 'Whisper Sensitivity',
     min: 0, max: 100, step: 1, default: 55, unit: '%',
-    transform: v => v, target: 'both', rt: true, group: 'tab-extreme',
+    transform: v => v, target: 'both', rt: false, group: 'tab-extreme',
     tip: 'Scales W-VAD energy threshold θ_e — higher catches quieter whispers.'
   },
   {
     id: 'whisperThreshold', key: 'whisperThreshold', label: 'Whisper Threshold',
     min: 0, max: 100, step: 1, default: 50, unit: '%',
-    transform: v => v, target: 'both', rt: true, group: 'tab-extreme',
+    transform: v => v, target: 'both', rt: false, group: 'tab-extreme',
     tip: 'Steepens suppression curve w_str = 1 + 2·p_threshold.'
   },
   {
     id: 'transientShaper', key: 'transientShaper', label: 'Transient Shaper',
     min: -100, max: 100, step: 5, default: 0, unit: '',
-    transform: v => v, target: 'both', rt: true, group: 'tab-extreme',
+    transform: v => v, target: 'both', rt: false, group: 'tab-extreme',
     tip: 'Bipolar transient emphasis: negative softens, positive sharpens consonants.'
   },
   {
@@ -562,7 +562,7 @@ const RAW_SLIDER_REGISTRY = [
   {
     id: 'subHarmonic', key: 'subHarmonic', label: 'Sub Harmonic',
     min: 0, max: 100, step: 1, default: 0, unit: '%',
-    transform: v => v, target: 'both', rt: true, group: 'tab-extreme',
+    transform: v => v, target: 'both', rt: false, group: 'tab-extreme',
     tip: 'Sub-harmonic body reinforcement for thin whisper recordings.'
   },
 ];

--- a/public/app/style.css
+++ b/public/app/style.css
@@ -147,7 +147,19 @@ input[type='range']{
 
 /* ---- SLIDERS ---- */
 .sr{display:grid;grid-template-columns:1fr;gap:0;margin-bottom:2px}
-.sr-row{display:grid;grid-template-columns:130px 1fr 52px 22px 22px;align-items:center;gap:8px;padding:4px 8px 4px 10px;border-radius:5px;position:relative;transition:background 0.1s;border-left:2px solid transparent}
+.sr-row{display:grid;grid-template-columns:130px 1fr 52px 22px 22px 22px;align-items:center;gap:8px;padding:4px 8px 4px 10px;border-radius:5px;position:relative;transition:background 0.1s;border-left:2px solid transparent}
+.slider-lock-btn{
+  flex:0 0 22px;width:22px;height:22px;border-radius:50%;
+  background:rgba(255,255,255,0.05);color:var(--dim);font-size:12px;line-height:22px;
+  text-align:center;cursor:pointer;border:1px solid rgba(255,255,255,0.12);
+  transition:color 0.15s,border-color 0.15s,background 0.15s;padding:0;
+}
+.slider-lock-btn:hover{color:#fcd34d;border-color:rgba(252,211,77,0.45);background:rgba(252,211,77,0.1)}
+.slider-lock-btn.is-locked,.slider-row.slider-locked .slider-lock-btn{
+  color:#fcd34d;border-color:rgba(252,211,77,0.55);background:rgba(252,211,77,0.14);
+}
+.slider-row.slider-locked{border-left-color:rgba(252,211,77,0.45)}
+.slider-row.slider-locked > input[type="range"]{opacity:0.92}
 .slider-hint-btn{
   flex:0 0 22px;width:22px;height:22px;border-radius:50%;
   background:rgba(255,255,255,0.06);color:var(--dim);font-size:11px;font-weight:700;
@@ -210,7 +222,7 @@ input[type='range']{
   outline:2px solid #00f5ff;outline-offset:2px;
 }
 @media (max-width:900px){
-  .sr-row{grid-template-columns:130px 1fr 52px 22px 22px}
+  .sr-row{grid-template-columns:130px 1fr 52px 22px 22px 22px}
 }
 .slider-row{position:relative}
 .info-btn{

--- a/tests/app-utils.test.js
+++ b/tests/app-utils.test.js
@@ -369,12 +369,14 @@ describe('SLIDER_BY_ID (v24 flat slider lookup)', () => {
 
 // ── applyPreset clampToSlider integration (v24 change) ────────────────────────
 describe('applyPreset uses clampToSlider for clamping (source inspection)', () => {
-  test('app.js source calls clampToSlider within applyPreset', () => {
-    expect(appSrc).toContain('clampToSlider(sliderId, rawValue)');
+  test('app.js source calls clampToSlider within slider UI setter', () => {
+    expect(appSrc).toContain('_setSliderUiInner');
+    expect(appSrc).toContain('clampToSlider(id, rawValue)');
   });
 
-  test('app.js source checks SLIDER_BY_ID[sliderId] before clamping', () => {
-    expect(appSrc).toContain('SLIDER_BY_ID[sliderId]');
+  test('app.js applyPreset delegates to _setSliderUi', () => {
+    const methodSrc = appSrc.slice(appSrc.indexOf('applyPreset(name, options = {}) {'));
+    expect(methodSrc.slice(0, 800)).toContain('_setSliderUi(key, rawValue');
   });
 
   test('app.js applyPreset uses rawValue variable (not value)', () => {

--- a/tests/mobile-ui.test.js
+++ b/tests/mobile-ui.test.js
@@ -118,16 +118,15 @@ describe('app.js — --pct CSS variable wiring', () => {
     expect(appJs).toContain('parseFloat(el.max)');
   });
 
-  test('applyPreset dispatches slider input/change events for each slider element', () => {
+  test('applyPreset delegates slider updates through _setSliderUi', () => {
     const presetBlock = appJs.match(/applyPreset\(name[\s\S]*?\)[\s\S]*?if \(this\.liveChainBuilt\)/)?.[0] || '';
-    expect(presetBlock).toContain("dispatchEvent(new Event('input'");
-    expect(presetBlock).toContain("dispatchEvent(new Event('change'");
+    expect(presetBlock).toContain('_setSliderUi(key, rawValue');
   });
 
-  test('applyPreset still updates slider value and aria metadata before dispatch', () => {
-    const presetBlock = appJs.match(/applyPreset\(name[\s\S]*?\)[\s\S]*?if \(this\.liveChainBuilt\)/)?.[0] || '';
-    expect(presetBlock).toContain('sliderDom.el.value = value');
-    expect(presetBlock).toContain("sliderDom.el.setAttribute('aria-valuenow', value)");
+  test('_setSliderUi updates slider value and aria metadata', () => {
+    const setterBlock = appJs.match(/_setSliderUiInner\(id, rawValue[\s\S]*?if \(notify\)/)?.[0] || '';
+    expect(setterBlock).toContain('el.value = value');
+    expect(setterBlock).toContain("el.setAttribute('aria-valuenow', value)");
   });
 });
 

--- a/tests/presets.test.js
+++ b/tests/presets.test.js
@@ -81,9 +81,10 @@ describe('Presets', () => {
     expect(appJs).toContain("dispatchEvent(new Event('change', { bubbles: true }))");
   });
 
-  test('Preset application stores non-slider values in VIP params', () => {
+  test('Preset application stores slider values in VIP params via _setSliderUi', () => {
     expect(appJs).toContain('window.VIP_PARAMS = window.VIP_PARAMS || {}');
-    expect(appJs).toContain('window.VIP_PARAMS[key] = value');
+    expect(appJs).toContain('window.VIP_PARAMS[id] = value');
+    expect(appJs).toContain('_setSliderUi(key, rawValue');
   });
 
   test('Forensic Extract uses maximum voice isolation', () => {

--- a/tests/slider-preserve.test.js
+++ b/tests/slider-preserve.test.js
@@ -1,0 +1,67 @@
+const getAppCode = require('./helpers/get-app-code');
+
+const appJs = getAppCode();
+let VoiceIsolatePro;
+try {
+  const safeCode = appJs.replace(/document\.addEventListener\('DOMContentLoaded'[\s\S]*?\}\);/, '');
+  VoiceIsolatePro = new Function('window', 'document', safeCode + '; return VoiceIsolatePro;')({}, {});
+} catch (e) {
+  throw new Error('Failed to load VoiceIsolatePro: ' + e.message);
+}
+
+describe('Slider preserve + lock', () => {
+  let ctx;
+
+  beforeEach(() => {
+    ctx = Object.create(VoiceIsolatePro.prototype);
+    ctx._userTouchedSliders = new Set();
+    ctx._sliderLocks = new Set();
+    ctx.params = { gateThresh: -42, outGain: 0 };
+    ctx._sliderIndexById = new Map();
+    ctx.onSlider = jest.fn();
+    ctx._applySliderToWorklet = jest.fn();
+    ctx._setWhisperMode = jest.fn();
+  });
+
+  test('_shouldPreserveSlider respects lock and user touch', () => {
+    ctx._sliderLocks.add('gateThresh');
+    expect(VoiceIsolatePro.prototype._shouldPreserveSlider.call(ctx, 'gateThresh')).toBe(true);
+    ctx._sliderLocks.delete('gateThresh');
+    ctx._userTouchedSliders.add('outGain');
+    expect(VoiceIsolatePro.prototype._shouldPreserveSlider.call(ctx, 'outGain')).toBe(true);
+    expect(VoiceIsolatePro.prototype._shouldPreserveSlider.call(ctx, 'eqMid')).toBe(false);
+  });
+
+  test('applyPreset skips locked sliders only', () => {
+    ctx._sliderLocks.add('gateThresh');
+    ctx._setSliderUi = jest.fn();
+    ctx._syncBridgeParams = jest.fn();
+    ctx.showNotification = jest.fn();
+    VoiceIsolatePro.prototype.applyPreset.call(ctx, 'Voice Clarity');
+    const touchedIds = ctx._setSliderUi.mock.calls.map((c) => c[0]);
+    expect(touchedIds).not.toContain('gateThresh');
+    expect(touchedIds.length).toBeGreaterThan(0);
+  });
+
+  test('_applyPresetValues respects user-touched sliders during auto-calibrate', () => {
+    ctx._userTouchedSliders.add('outGain');
+    ctx._setSliderUi = jest.fn();
+    VoiceIsolatePro.prototype._applyPresetValues.call(ctx, 'Voice Clarity', { respectUserTouched: true });
+    const touchedIds = ctx._setSliderUi.mock.calls.map((c) => c[0]);
+    expect(touchedIds).not.toContain('outGain');
+    expect(touchedIds).toContain('gateThresh');
+  });
+});
+
+describe('BRIDGE_RT_SLIDER_IDS', () => {
+  test('matches EngineerModeBridge PARAM_MAP count (34 live controls)', () => {
+    const safeCode = appJs.replace(/document\.addEventListener\('DOMContentLoaded'[\s\S]*?\}\);/, '');
+    const fn = new Function('window', 'document', safeCode + '; return BRIDGE_RT_SLIDER_IDS;');
+    const ids = fn({ BRIDGE_RT_SLIDER_IDS: undefined }, {});
+    expect(ids.size).toBe(34);
+    expect(ids.has('hpQ')).toBe(true);
+    expect(ids.has('deEssFreq')).toBe(true);
+    expect(ids.has('nrAmount')).toBe(false);
+    expect(ids.has('whisperLift')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes sliders resetting to auto-calibrated preset values after processing, adds per-slider lock/unlock, and aligns RT badges with live-mix bridge controls.

## Changes

### Slider preservation
- Track user-touched sliders; auto-calibrate after process skips locked + user-adjusted values
- Manual preset apply still updates unlocked sliders; locked sliders always ignored
- \_applyPresetValues()\ replaces full \pplyPreset()\ call inside auto-calibrate

### Lock toggle
- Each slider row gets a lock button (🔓/🔒) persisted in \sessionStorage\
- Locked sliders ignore preset and auto-calibrate changes

### RT badge correction (34 bridge controls)
- \BRIDGE_RT_SLIDER_IDS\ drives RT badge + realtime styling
- Fixed registry: hpQ, lpQ, deEssFreq, deEssAmt, stereoWidth, outWidth → rt:true
- Removed misleading RT from nrAmount + extreme whisper sliders (reprocess-only)

## Testing
- \	ests/slider-preserve.test.js\ — lock/preserve + 34 bridge RT ids
- Full Jest: 2222/2222 pass

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve user-touched sliders on preset apply and add per-slider lock toggles
> - Adds a lock button to each slider row; locked sliders are skipped when applying presets or auto-calibrating, and lock state persists in `sessionStorage` across the session.
> - Tracks user-touched sliders separately from programmatic updates so `_autoCalibratePreset` can avoid overwriting values the user has manually set.
> - Introduces `BRIDGE_RT_SLIDER_IDS`, a fixed set of 34 slider IDs that defines which sliders are treated as real-time bridge controls, replacing the registry's `rt` field as the source of truth.
> - Centralizes slider value writes in `_setSliderUiInner`, which clamps values, updates `VIP_PARAMS`, and handles `whisperMode`; wraps programmatic calls with a flag to prevent user-touched marking.
> - Behavioral Change: `applyPreset` no longer updates locked sliders, and auto-calibrate now skips both locked and user-touched sliders.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4e4fa19.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-slider lock controls so selected sliders can be preserved during preset changes and auto-calibration.
  * Improved live/real-time slider handling and exposed the live slider list for external use.

* **Bug Fixes**
  * Prevented locked or manually adjusted sliders from being overwritten.
  * Kept slider UI state in sync when values are updated programmatically.

* **Style**
  * Updated slider row layout and visuals to support the new lock control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->