### PR TITLE
fix(transport): layered seek rail for correct playback scrubber visuals

### DIFF
--- a/public/app/app.js
+++ b/public/app/app.js
@@ -956,6 +956,7 @@ class VoiceIsolatePro {
       tpRew:g('tpRew'),
       tpFwd:g('tpFwd'),
       tpSeek:g('tpSeek'),
+      tpSeekFill:g('tpSeekFill'),
       tpRegionBar:g('tpRegionBar'),
       tpLoop:g('tpLoop'),
       tpCropIn:g('tpCropIn'),
@@ -3280,7 +3281,9 @@ class VoiceIsolatePro {
         paintSeekFill(this.dom.tpSeek, clamped, dur);
       } else if (this.dom.tpSeek.style?.setProperty) {
         const pct = Math.max(0, Math.min(100, (clamped / dur) * 100));
-        this.dom.tpSeek.style.setProperty('--seek-pct', `${pct}%`);
+        const pctStr = `${pct}%`;
+        this.dom.tpSeek.style.setProperty('--seek-pct', pctStr);
+        if (this.dom.tpSeekFill) this.dom.tpSeekFill.style.width = pctStr;
       }
     }
   }

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -480,6 +480,7 @@
         </div>
         <div class="transport-seek">
           <div id="tpRegionBar" class="transport-region-bar" hidden aria-hidden="true"></div>
+          <div class="tp-seek-rail" aria-hidden="true"><span id="tpSeekFill" class="tp-seek-fill"></span></div>
           <input type="range" id="tpSeek" class="tp-seek" min="0" max="1000" value="0" aria-label="Playback position" />
         </div>
       </div>

--- a/public/app/style.css
+++ b/public/app/style.css
@@ -324,13 +324,15 @@ input[type='range']{
 
 .rt-badge{display:inline-block;font-size:0.44rem;padding:1px 4px;border-radius:3px;background:rgba(255, 42, 42,0.12);color:var(--cyan);font-weight:700;vertical-align:middle;margin-left:2px;letter-spacing:0.06em;border:1px solid rgba(255, 42, 42,0.2)}
 
-/* Global range fallback — transport scrubber, volume control */
-input[type="range"]{-webkit-appearance:none;appearance:none;width:100%;height:3px;border-radius:2px;background:var(--s4);outline:none}
-input[type="range"]::-webkit-slider-thumb{-webkit-appearance:none;width:12px;height:12px;border-radius:50%;background:var(--red);cursor:pointer;box-shadow:0 0 6px var(--red-glow);transition:transform 0.1s}
-input[type="range"]::-webkit-slider-thumb:hover{transform:scale(1.3);box-shadow:0 0 10px rgba(220,38,38,0.5)}
-input[type="range"]::-moz-range-thumb{width:12px;height:12px;border-radius:50%;background:var(--red);border:none;cursor:pointer}
-input[type="range"].realtime{background:linear-gradient(90deg,rgba(220,38,38,0.15),var(--s4))}
-input[type="range"].realtime::-webkit-slider-thumb{background:var(--cyan);box-shadow:0 0 6px rgba(255, 42, 42,0.4)}
+/* Global range fallback — volume and misc controls (not transport scrubbers) */
+input[type="range"]:not(.tp-seek):not(.landing-seek-input):not(.dsp-slider){
+  -webkit-appearance:none;appearance:none;width:100%;height:3px;border-radius:2px;background:var(--s4);outline:none}
+input[type="range"]:not(.tp-seek):not(.landing-seek-input):not(.dsp-slider)::-webkit-slider-thumb{
+  -webkit-appearance:none;width:12px;height:12px;border-radius:50%;background:var(--red);cursor:pointer;box-shadow:0 0 6px var(--red-glow);transition:transform 0.1s}
+input[type="range"]:not(.tp-seek):not(.landing-seek-input):not(.dsp-slider)::-webkit-slider-thumb:hover{transform:scale(1.3);box-shadow:0 0 10px rgba(220,38,38,0.5)}
+input[type="range"]:not(.tp-seek):not(.landing-seek-input):not(.dsp-slider)::-moz-range-thumb{width:12px;height:12px;border-radius:50%;background:var(--red);border:none;cursor:pointer}
+input[type="range"].realtime:not(.tp-seek):not(.landing-seek-input){background:linear-gradient(90deg,rgba(220,38,38,0.15),var(--s4))}
+input[type="range"].realtime:not(.tp-seek):not(.landing-seek-input)::-webkit-slider-thumb{background:var(--cyan);box-shadow:0 0 6px rgba(255, 42, 42,0.4)}
 
 /* ---- PRESETS ---- */
 .presets-wrap{margin-bottom:8px}
@@ -667,10 +669,10 @@ input[type="range"]:focus-visible::-moz-range-thumb{
 }
 
 .slider-val,.tp-time,.vu-val,.lufs-val { font-family:'JetBrains Mono',monospace; }
-input[type="range"].realtime {
+input[type="range"].realtime:not(.tp-seek):not(.landing-seek-input):not(.dsp-slider) {
   background: linear-gradient(to right, var(--cyan) 0%, var(--cyan) var(--pct,50%), #2a2a3a var(--pct,50%), #2a2a3a 100%);
 }
-input[type="range"]:not(.realtime) {
+input[type="range"]:not(.realtime):not(.tp-seek):not(.landing-seek-input):not(.dsp-slider) {
   background: linear-gradient(to right, var(--red) 0%, var(--red) var(--pct,50%), #2a2a3a var(--pct,50%), #2a2a3a 100%);
 }
 .slider-group{border:1px solid var(--border);border-radius:var(--rs);margin-bottom:6px;overflow:hidden;transition:border-color 0.15s}

--- a/public/app/vip-fixes.js
+++ b/public/app/vip-fixes.js
@@ -433,6 +433,9 @@
           : (_duration || 0);
         _pauseOffset = (parseFloat(seek.value) / 1000) * dur;
         app.playOffset = _pauseOffset;
+        if (typeof app._paintTransport === 'function') {
+          app._paintTransport(_pauseOffset, dur, { skipSeekValue: true });
+        }
         if (!_isPlaying) _syncVideo(_pauseOffset, false);
       });
       seek.addEventListener('change', () => {

--- a/public/index.html
+++ b/public/index.html
@@ -122,6 +122,7 @@
       </div>
       <div class="transport-seek">
         <div id="landingRegionBar" class="transport-region-bar" hidden aria-hidden="true"></div>
+        <div class="tp-seek-rail" aria-hidden="true"><span class="tp-seek-fill" id="landingSeekFill"></span></div>
         <input type="range" id="seekSlider" class="landing-seek-input" min="0" max="1000" value="0" disabled aria-label="Playback position">
       </div>
 

--- a/public/transport-polish.css
+++ b/public/transport-polish.css
@@ -3,10 +3,12 @@
 .transport-seek {
   position: relative;
   width: 100%;
-  padding: 10px 2px 6px;
+  padding: 14px 2px 10px;
+  min-height: 28px;
 }
 
-.transport-region-bar {
+.transport-region-bar,
+.tp-seek-rail {
   position: absolute;
   left: 2px;
   right: 2px;
@@ -15,6 +17,10 @@
   transform: translateY(-50%);
   border-radius: 99px;
   pointer-events: none;
+}
+
+.transport-region-bar {
+  z-index: 0;
   background: rgba(255, 255, 255, 0.06);
   overflow: hidden;
 }
@@ -31,32 +37,43 @@
   border-right: 2px solid rgba(52, 211, 153, 0.85);
 }
 
+.tp-seek-rail {
+  z-index: 1;
+  background: rgba(255, 255, 255, 0.07);
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.35);
+  overflow: hidden;
+}
+
+.tp-seek-fill {
+  display: block;
+  height: 100%;
+  width: var(--seek-pct, 0%);
+  border-radius: 99px;
+  background: linear-gradient(90deg, var(--red, #dc2626) 0%, var(--red2, #ef4444) 100%);
+  box-shadow: 0 0 8px rgba(239, 68, 68, 0.35);
+  transition: width 0.04s linear;
+  pointer-events: none;
+}
+
 .tp-seek,
 .landing-seek-input {
   -webkit-appearance: none;
   appearance: none;
   width: 100%;
-  height: 4px;
+  height: 18px;
+  margin: 0;
   border-radius: 99px;
   outline: none;
   cursor: pointer;
   position: relative;
-  z-index: 1;
-  background: linear-gradient(
-    90deg,
-    var(--red, #dc2626) 0%,
-    var(--red2, #ef4444) var(--seek-pct, 0%),
-    rgba(255, 255, 255, 0.07) var(--seek-pct, 0%),
-    rgba(255, 255, 255, 0.07) 100%
-  );
-  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.35);
-  transition: height 0.15s ease, box-shadow 0.15s ease;
+  z-index: 2;
+  background: transparent;
+  box-shadow: none;
 }
 
 .tp-seek:hover:not(:disabled),
 .landing-seek-input:hover:not(:disabled) {
-  height: 5px;
-  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.35), 0 0 10px rgba(239, 68, 68, 0.25);
+  cursor: pointer;
 }
 
 .tp-seek:disabled,
@@ -65,11 +82,29 @@
   cursor: not-allowed;
 }
 
+.transport-seek:hover .tp-seek-rail {
+  height: 5px;
+}
+
+.transport-seek:hover .tp-seek-fill {
+  box-shadow: 0 0 12px rgba(239, 68, 68, 0.45);
+}
+
+.tp-seek::-webkit-slider-runnable-track,
+.landing-seek-input::-webkit-slider-runnable-track {
+  -webkit-appearance: none;
+  height: 4px;
+  border-radius: 99px;
+  background: transparent;
+  border: none;
+}
+
 .tp-seek::-webkit-slider-thumb,
 .landing-seek-input::-webkit-slider-thumb {
   -webkit-appearance: none;
-  width: 11px;
-  height: 11px;
+  width: 13px;
+  height: 13px;
+  margin-top: -4.5px;
   border-radius: 50%;
   background: #fff;
   border: 2px solid var(--red2, #ef4444);
@@ -80,19 +115,8 @@
 
 .tp-seek::-webkit-slider-thumb:hover,
 .landing-seek-input::-webkit-slider-thumb:hover {
-  transform: scale(1.15);
+  transform: scale(1.12);
   box-shadow: 0 0 14px rgba(239, 68, 68, 0.55), 0 2px 6px rgba(0, 0, 0, 0.4);
-}
-
-.tp-seek::-moz-range-thumb,
-.landing-seek-input::-moz-range-thumb {
-  width: 11px;
-  height: 11px;
-  border-radius: 50%;
-  background: #fff;
-  border: 2px solid var(--red2, #ef4444);
-  cursor: pointer;
-  box-shadow: 0 0 10px rgba(239, 68, 68, 0.45);
 }
 
 .tp-seek::-moz-range-track,
@@ -101,6 +125,24 @@
   border-radius: 99px;
   background: transparent;
   border: none;
+}
+
+.tp-seek::-moz-range-progress,
+.landing-seek-input::-moz-range-progress {
+  height: 4px;
+  border-radius: 99px;
+  background: transparent;
+}
+
+.tp-seek::-moz-range-thumb,
+.landing-seek-input::-moz-range-thumb {
+  width: 13px;
+  height: 13px;
+  border-radius: 50%;
+  background: #fff;
+  border: 2px solid var(--red2, #ef4444);
+  cursor: pointer;
+  box-shadow: 0 0 10px rgba(239, 68, 68, 0.45);
 }
 
 .btn-tp-region {

--- a/src/presentation/TransportRegionControls.js
+++ b/src/presentation/TransportRegionControls.js
@@ -63,9 +63,13 @@ export function wireTransportRegion(opts) {
   return syncUi;
 }
 
-/** Paint --seek-pct on a transport range input from current/duration. */
+/** Paint playback position on the transport seek rail (current/duration in seconds). */
 export function paintSeekFill(seekEl, current, duration) {
   if (!seekEl || !duration) return;
   const pct = Math.max(0, Math.min(100, (current / duration) * 100));
-  seekEl.style.setProperty('--seek-pct', `${pct}%`);
+  const pctStr = `${pct}%`;
+  seekEl.style.setProperty('--seek-pct', pctStr);
+  const wrap = seekEl.closest('.transport-seek');
+  const fill = wrap?.querySelector('.tp-seek-fill');
+  if (fill) fill.style.width = pctStr;
 }


### PR DESCRIPTION
## Problem
The playback seek slider looked wrong because global input[type=range] gradient rules in style.css overrode transport scrubber styling. CSS gradient fills on range inputs are unreliable across WebKit/Firefox (thumb vs fill misalignment, transparent moz track).

## Solution
- Add a layered seek bar: dedicated .tp-seek-rail + .tp-seek-fill behind a transparent range input
- Scope global range fallback styles to exclude .tp-seek, .landing-seek-input, and .dsp-slider
- Update paintSeekFill() to set fill width on the rail element
- Paint fill during manual scrubbing via vip-fixes.js -> app._paintTransport(..., { skipSeekValue: true })
- Cache tpSeekFill in cacheDom()

## Verification
- tests/transport.test.js — 27/27 pass
- Manual check on engineer page: red fill tracks playhead, thumb aligns with rail

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add layered seek rail with animated fill to transport playback scrubber
> - Adds a `.tp-seek-rail` + `.tp-seek-fill` span element above the range input in both the engineer page ([index.html](https://github.com/Joker5514/VoiceIsolate-Pro/pull/680/files#diff-4400aa5aa5292d143f7e2f1308aa82756255552567d5558874c994833e907ce4)) and landing page ([index.html](https://github.com/Joker5514/VoiceIsolate-Pro/pull/680/files#diff-c2cc24bc9001b11b6add48a4cd8f893d5d6c6e4d1bd254158bd14ab997f552cd)) to render a separate visual progress bar.
> - Updates `TransportRegionControls.paintSeekFill` and `VoiceIsolatePro._paintTransport` to set the fill element's width to match playback position, in addition to the existing `--seek-pct` CSS variable.
> - Calls `_paintTransport` with `skipSeekValue: true` during scrubbing in [vip-fixes.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/680/files#diff-e1b2a993f0bf64b447304c6c2d82a496fd3b394e13cc5cda2d6568a7f7a92e9d) so the fill updates in real time without feeding back into the range input value.
> - Scopes generic range input fallback styles in [style.css](https://github.com/Joker5514/VoiceIsolate-Pro/pull/680/files#diff-35b8006cad11f725a0bc3cee37866f6a39b941ae71d953d622c215dbd1a8d389) to exclude `.tp-seek`, `.landing-seek-input`, and `.dsp-slider`, delegating visual control to the new rail styles in [transport-polish.css](https://github.com/Joker5514/VoiceIsolate-Pro/pull/680/files#diff-1c5682ce45baa8fca25bc3ca837360d107be6d01d3e071760b439ab000a93bda).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dfd0918.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a visible progress fill to the transport seek bar, making playback position easier to see at a glance.
  * Refined the seek slider’s appearance and hover behavior for a smoother, more polished control.

* **Bug Fixes**
  * Improved seek interaction so the transport display updates immediately while dragging, reducing lag and visual jumps.
  * Adjusted range control styling to avoid affecting unrelated sliders elsewhere in the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->