### PR TITLE
fix(visuals): tab switching, gallery mode, and live rendering

### DIFF
--- a/public/app/app.js
+++ b/public/app/app.js
@@ -1059,6 +1059,9 @@ class VoiceIsolatePro {
 
   // ── Render static visuals (waveform/spectrogram placeholder) ─────────────
   renderStaticVisuals(buffer) {
+    if (window.VIP_VISUALS && typeof window.VIP_VISUALS.drawStatic === 'function') {
+      try { window.VIP_VISUALS.drawStatic(); } catch (_) {}
+    }
     if (typeof window.drawWaveform === 'function') {
       try { window.drawWaveform(buffer); } catch (_) {}
     }
@@ -1761,21 +1764,30 @@ class VoiceIsolatePro {
       });
     });
 
-    // Tab switching
+    // Tab switching — CSS visibility + VIP_VISUALS driver
     const tabs = qsa('.tab-btn[data-tab]');
     tabs.forEach((btn, index) => {
       btn.addEventListener('click', () => {
+        const tab = btn.dataset.tab;
+        if (window.VIP_VISUALS && typeof window.VIP_VISUALS.getViewMode === 'function'
+            && window.VIP_VISUALS.getViewMode() === 'gallery'
+            && typeof window.VIP_VISUALS.setViewMode === 'function') {
+          window.VIP_VISUALS.setViewMode('single');
+        }
         tabs.forEach(b => {
           b.classList.remove('active');
           b.setAttribute('aria-selected', 'false');
           b.setAttribute('tabindex', '-1');
         });
-        qsa('.panel').forEach(p => p.classList.remove('active'));
+        qsa('.viz-card .panel[data-viz-panel]').forEach(p => p.classList.remove('active'));
         btn.classList.add('active');
         btn.setAttribute('aria-selected', 'true');
         btn.setAttribute('tabindex', '0');
-        const panel = document.getElementById('tab-' + btn.dataset.tab);
+        const panel = document.getElementById('tab-' + tab);
         if (panel) panel.classList.add('active');
+        if (window.VIP_VISUALS && typeof window.VIP_VISUALS.onTabActivated === 'function') {
+          window.VIP_VISUALS.onTabActivated(tab);
+        }
       });
 
       btn.addEventListener('keydown', (e) => {

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -956,6 +956,7 @@ class VoiceIsolatePro {
       tpRew:g('tpRew'),
       tpFwd:g('tpFwd'),
       tpSeek:g('tpSeek'),
+      tpSeekFill:g('tpSeekFill'),
       tpRegionBar:g('tpRegionBar'),
       tpLoop:g('tpLoop'),
       tpCropIn:g('tpCropIn'),
@@ -3280,7 +3281,9 @@ class VoiceIsolatePro {
         paintSeekFill(this.dom.tpSeek, clamped, dur);
       } else if (this.dom.tpSeek.style?.setProperty) {
         const pct = Math.max(0, Math.min(100, (clamped / dur) * 100));
-        this.dom.tpSeek.style.setProperty('--seek-pct', `${pct}%`);
+        const pctStr = `${pct}%`;
+        this.dom.tpSeek.style.setProperty('--seek-pct', pctStr);
+        if (this.dom.tpSeekFill) this.dom.tpSeekFill.style.width = pctStr;
       }
     }
   }

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -480,6 +480,7 @@
         </div>
         <div class="transport-seek">
           <div id="tpRegionBar" class="transport-region-bar" hidden aria-hidden="true"></div>
+          <div class="tp-seek-rail" aria-hidden="true"><span id="tpSeekFill" class="tp-seek-fill"></span></div>
           <input type="range" id="tpSeek" class="tp-seek" min="0" max="1000" value="0" aria-label="Playback position" />
         </div>
       </div>

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -486,7 +486,13 @@
       </div>
 
       <div class="card viz-card">
-        <div class="viz-hdr"><span>Visualizations</span><button id="fullscreenSpectroBtn" class="btn btn-xs" type="button" aria-label="Toggle Fullscreen" title="Toggle Fullscreen"><span aria-hidden="true">⛶</span></button></div>
+        <div class="viz-hdr">
+          <span>Visualizations</span>
+          <div class="viz-actions">
+            <button id="btnVizGallery" class="btn btn-xs btn-viz-gallery" type="button" aria-pressed="false" title="Show all visualizations at once">Show All</button>
+            <button id="fullscreenSpectroBtn" class="btn btn-xs" type="button" aria-label="Toggle Fullscreen" title="Toggle Fullscreen"><span aria-hidden="true">⛶</span></button>
+          </div>
+        </div>
         <div id="neon-pulse-slot" class="neon-pulse-slot"></div>
         <div id="tabBar" class="tabs" role="tablist" aria-label="Visualization tabs">
           <button id="btn-spectrogram" class="tab-btn active" type="button" role="tab" aria-controls="tab-spectrogram" data-tab="spectrogram" aria-selected="true" tabindex="0">Spectrogram</button>
@@ -499,17 +505,18 @@
           <button id="btn-swarm" class="tab-btn" type="button" role="tab" aria-controls="tab-swarm" data-tab="swarm" aria-selected="false" tabindex="-1">Swarm</button>
           <button id="btn-liquid" class="tab-btn" type="button" role="tab" aria-controls="tab-liquid" data-tab="liquid" aria-selected="false" tabindex="-1">Liquid</button>
         </div>
-          <div id="tab-spectrogram" role="tabpanel" aria-labelledby="btn-spectrogram" class="panel active" tabindex="0">
+          <div id="tab-spectrogram" role="tabpanel" aria-labelledby="btn-spectrogram" class="panel active" data-viz-panel="spectrogram" tabindex="0">
+            <div class="viz-panel-label">Spectrogram</div>
             <div class="viz-legend">Live spectrum rail · scrolling spectrogram · local-only render</div>
             <div id="spectro3d-container" class="spectro3d-container"><div class="viz-iso-badge hidden" id="iso-badge-spec"></div><canvas id="spectroCanvas" class="viz-canvas"></canvas></div>
             <canvas id="spectro2DCanvas" class="viz-canvas spectro2d"></canvas>
             <canvas id="freqCanvas" class="viz-canvas freq-cv"></canvas>
           </div>
-          <div id="tab-waveform" role="tabpanel" aria-labelledby="btn-waveform" class="panel"><div class="viz-legend">Static inspection before playback · live playhead during transport</div><canvas id="waveCanvas" class="viz-canvas wave-cv"></canvas><canvas id="inputCanvas" class="viz-canvas wave-cv vip-canvas-alias" aria-hidden="true" tabindex="-1"></canvas></div>
-          <div id="tab-abcompare" role="tabpanel" aria-labelledby="btn-abcompare" class="panel"><div class="viz-legend">Original vs processed waveform overlay for transport A/B</div><div class="wave-row"><canvas id="waveOrigCanvas" class="viz-canvas wave-cv"></canvas><canvas id="waveProcCanvas" class="viz-canvas wave-cv"></canvas><canvas id="outputCanvas" class="viz-canvas wave-cv vip-canvas-alias" aria-hidden="true" tabindex="-1"></canvas></div></div>
-          <div id="tab-lufs" role="tabpanel" aria-labelledby="btn-lufs" class="panel"><div class="lufs-readouts"><div class="lufs-rd"><span class="lufs-val" id="lufsI">-23.0</span><span class="lufs-lbl">Integrated</span></div><div class="lufs-rd"><span class="lufs-val" id="lufsS">-20.0</span><span class="lufs-lbl">Short</span></div></div></div>
-          <div id="tab-saliency" role="tabpanel" aria-labelledby="btn-saliency" class="panel"><canvas id="fsCanvas" class="viz-canvas diag-saliency-cv"></canvas></div>
-          <div id="tab-clusters" role="tabpanel" aria-labelledby="btn-clusters" class="panel">
+          <div id="tab-waveform" role="tabpanel" aria-labelledby="btn-waveform" class="panel" data-viz-panel="waveform"><div class="viz-panel-label">Waveform</div><div class="viz-legend">Static inspection before playback · live playhead during transport</div><canvas id="waveCanvas" class="viz-canvas wave-cv"></canvas><canvas id="inputCanvas" class="viz-canvas wave-cv vip-canvas-alias" aria-hidden="true" tabindex="-1"></canvas></div>
+          <div id="tab-abcompare" role="tabpanel" aria-labelledby="btn-abcompare" class="panel" data-viz-panel="abcompare"><div class="viz-panel-label">A/B Compare</div><div class="viz-legend">Original vs processed waveform overlay for transport A/B</div><div class="wave-row"><canvas id="waveOrigCanvas" class="viz-canvas wave-cv"></canvas><canvas id="waveProcCanvas" class="viz-canvas wave-cv"></canvas><canvas id="outputCanvas" class="viz-canvas wave-cv vip-canvas-alias" aria-hidden="true" tabindex="-1"></canvas></div></div>
+          <div id="tab-lufs" role="tabpanel" aria-labelledby="btn-lufs" class="panel" data-viz-panel="lufs"><div class="viz-panel-label">LUFS</div><div class="lufs-readouts"><div class="lufs-rd"><span class="lufs-val" id="lufsI">-23.0</span><span class="lufs-lbl">Integrated</span></div><div class="lufs-rd"><span class="lufs-val" id="lufsS">-20.0</span><span class="lufs-lbl">Short</span></div></div></div>
+          <div id="tab-clusters" role="tabpanel" aria-labelledby="btn-clusters" class="panel" data-viz-panel="clusters">
+            <div class="viz-panel-label">Clusters</div>
             <canvas id="diarCanvas" class="viz-canvas"></canvas>
             <div id="panel-vu-meters" class="vu-meter-container">
               <div class="vu-meter" style="--vu-level:42%"><div class="vu-meter-fill"></div><div class="vu-meter-peak" style="--peak-top:58%"></div><span class="vu-meter-label">IN</span></div>
@@ -517,10 +524,10 @@
             </div>
             <div class="lufs-readouts"><span class="vu-val">Input -12.4 dB</span><span class="vu-val">Output -10.9 dB</span></div>
           </div>
-          <div id="tab-aura" role="tabpanel" aria-labelledby="btn-aura" class="panel"><div class="viz-iso-badge hidden" id="iso-badge-aura"></div><canvas id="auraCanvas" class="viz-canvas"></canvas></div>
-          <div id="tab-topo" role="tabpanel" aria-labelledby="btn-topo" class="panel"><div class="viz-iso-badge hidden" id="iso-badge-topo"></div><div id="topoContainer" class="spectro3d-container"></div></div>
-          <div id="tab-swarm" role="tabpanel" aria-labelledby="btn-swarm" class="panel"><div class="viz-iso-badge hidden" id="iso-badge-swarm"></div><div id="swarmContainer" class="spectro3d-container"></div></div>
-          <div id="tab-liquid" role="tabpanel" aria-labelledby="btn-liquid" class="panel"><div class="viz-iso-badge hidden" id="iso-badge-liquid"></div><canvas id="liquidCanvas" class="viz-canvas"></canvas></div>
+          <div id="tab-aura" role="tabpanel" aria-labelledby="btn-aura" class="panel" data-viz-panel="aura"><div class="viz-panel-label">Aura</div><div class="viz-iso-badge hidden" id="iso-badge-aura"></div><canvas id="auraCanvas" class="viz-canvas"></canvas></div>
+          <div id="tab-topo" role="tabpanel" aria-labelledby="btn-topo" class="panel" data-viz-panel="topo"><div class="viz-panel-label">3D Topo</div><div class="viz-iso-badge hidden" id="iso-badge-topo"></div><div id="topoContainer" class="spectro3d-container"></div></div>
+          <div id="tab-swarm" role="tabpanel" aria-labelledby="btn-swarm" class="panel" data-viz-panel="swarm"><div class="viz-panel-label">Swarm</div><div class="viz-iso-badge hidden" id="iso-badge-swarm"></div><div id="swarmContainer" class="spectro3d-container"></div></div>
+          <div id="tab-liquid" role="tabpanel" aria-labelledby="btn-liquid" class="panel" data-viz-panel="liquid"><div class="viz-panel-label">Liquid</div><div class="viz-iso-badge hidden" id="iso-badge-liquid"></div><canvas id="liquidCanvas" class="viz-canvas"></canvas></div>
       </div>
 
       <div id="videoCard" class="card video-card" style="display:none">

--- a/public/app/mobile.css
+++ b/public/app/mobile.css
@@ -139,12 +139,17 @@ html {
     flex-wrap: nowrap;
     gap: 4px;
     padding-bottom: 2px;
+    touch-action: pan-x;
   }
   .tabs::-webkit-scrollbar { display: none; }
-  .tab {
-    padding: 7px 12px;
+  .tab,
+  .tab-btn {
+    padding: 10px 14px;
     font-size: 0.68rem;
     border-radius: 8px;
+    min-height: var(--mob-touch-min);
+    flex-shrink: 0;
+    touch-action: manipulation;
   }
 
   /* ── Slider panels ── */
@@ -329,11 +334,16 @@ html {
     text-align: right;
     font-size: 0.65rem;
   }
+  .transport-seek {
+    width: 100%;
+    padding: 12px 0 8px;
+    min-height: var(--mob-touch-min);
+    touch-action: manipulation;
+  }
   .tp-seek {
-    grid-row: 2;
-    grid-column: 1 / -1;
     width: 100%;
     padding: 14px 0;
+    min-height: var(--mob-touch-min);
   }
   .tp-speed { display: none; }
   .tp-ab {
@@ -351,7 +361,21 @@ html {
   .freq-cv   { height: 70px; }
   .fs-wrap   { height: 130px; }
   .viz-hdr   { flex-direction: column; align-items: flex-start; gap: 4px; }
-  .viz-actions { flex-wrap: wrap; gap: 4px; }
+  .viz-actions { flex-wrap: wrap; gap: 4px; width: 100%; }
+  .btn-viz-gallery,
+  #fullscreenSpectroBtn {
+    min-height: var(--mob-touch-min);
+    padding: 8px 12px;
+    touch-action: manipulation;
+  }
+  .viz-card.viz-gallery .panel {
+    margin-bottom: 10px;
+    padding: 6px;
+  }
+  .viz-card.viz-gallery .spectro3d-container { height: 120px; }
+  .viz-card.viz-gallery .spectro2d { height: 72px; }
+  .viz-card.viz-gallery .freq-cv { height: 48px; }
+  .viz-card.viz-gallery .wave-cv { height: 48px; }
 
   /* ── Sticky mobile action bar ── */
   .mobile-action-bar {
@@ -550,7 +574,24 @@ html {
   .freq-cv   { height: 70px; }
   .fs-wrap   { height: 130px; }
   .viz-hdr   { flex-direction: column; align-items: flex-start; gap: 4px; }
-  .viz-actions { flex-wrap: wrap; gap: 4px; }
+  .viz-actions { flex-wrap: wrap; gap: 4px; width: 100%; }
+  .tab-btn {
+    min-height: var(--mob-touch-min);
+    padding: 10px 12px;
+    flex-shrink: 0;
+    touch-action: manipulation;
+  }
+  .transport-seek {
+    width: 100%;
+    padding: 12px 0 8px;
+    min-height: var(--mob-touch-min);
+  }
+  .btn-viz-gallery,
+  #fullscreenSpectroBtn {
+    min-height: var(--mob-touch-min);
+    padding: 8px 12px;
+  }
+  .viz-card.viz-gallery .panel { margin-bottom: 10px; }
 }
 
 /* ═══════════════════════════════════════════

--- a/public/app/style.css
+++ b/public/app/style.css
@@ -324,13 +324,15 @@ input[type='range']{
 
 .rt-badge{display:inline-block;font-size:0.44rem;padding:1px 4px;border-radius:3px;background:rgba(255, 42, 42,0.12);color:var(--cyan);font-weight:700;vertical-align:middle;margin-left:2px;letter-spacing:0.06em;border:1px solid rgba(255, 42, 42,0.2)}
 
-/* Global range fallback — transport scrubber, volume control */
-input[type="range"]{-webkit-appearance:none;appearance:none;width:100%;height:3px;border-radius:2px;background:var(--s4);outline:none}
-input[type="range"]::-webkit-slider-thumb{-webkit-appearance:none;width:12px;height:12px;border-radius:50%;background:var(--red);cursor:pointer;box-shadow:0 0 6px var(--red-glow);transition:transform 0.1s}
-input[type="range"]::-webkit-slider-thumb:hover{transform:scale(1.3);box-shadow:0 0 10px rgba(220,38,38,0.5)}
-input[type="range"]::-moz-range-thumb{width:12px;height:12px;border-radius:50%;background:var(--red);border:none;cursor:pointer}
-input[type="range"].realtime{background:linear-gradient(90deg,rgba(220,38,38,0.15),var(--s4))}
-input[type="range"].realtime::-webkit-slider-thumb{background:var(--cyan);box-shadow:0 0 6px rgba(255, 42, 42,0.4)}
+/* Global range fallback — volume and misc controls (not transport scrubbers) */
+input[type="range"]:not(.tp-seek):not(.landing-seek-input):not(.dsp-slider){
+  -webkit-appearance:none;appearance:none;width:100%;height:3px;border-radius:2px;background:var(--s4);outline:none}
+input[type="range"]:not(.tp-seek):not(.landing-seek-input):not(.dsp-slider)::-webkit-slider-thumb{
+  -webkit-appearance:none;width:12px;height:12px;border-radius:50%;background:var(--red);cursor:pointer;box-shadow:0 0 6px var(--red-glow);transition:transform 0.1s}
+input[type="range"]:not(.tp-seek):not(.landing-seek-input):not(.dsp-slider)::-webkit-slider-thumb:hover{transform:scale(1.3);box-shadow:0 0 10px rgba(220,38,38,0.5)}
+input[type="range"]:not(.tp-seek):not(.landing-seek-input):not(.dsp-slider)::-moz-range-thumb{width:12px;height:12px;border-radius:50%;background:var(--red);border:none;cursor:pointer}
+input[type="range"].realtime:not(.tp-seek):not(.landing-seek-input){background:linear-gradient(90deg,rgba(220,38,38,0.15),var(--s4))}
+input[type="range"].realtime:not(.tp-seek):not(.landing-seek-input)::-webkit-slider-thumb{background:var(--cyan);box-shadow:0 0 6px rgba(255, 42, 42,0.4)}
 
 /* ---- PRESETS ---- */
 .presets-wrap{margin-bottom:8px}
@@ -667,10 +669,10 @@ input[type="range"]:focus-visible::-moz-range-thumb{
 }
 
 .slider-val,.tp-time,.vu-val,.lufs-val { font-family:'JetBrains Mono',monospace; }
-input[type="range"].realtime {
+input[type="range"].realtime:not(.tp-seek):not(.landing-seek-input):not(.dsp-slider) {
   background: linear-gradient(to right, var(--cyan) 0%, var(--cyan) var(--pct,50%), #2a2a3a var(--pct,50%), #2a2a3a 100%);
 }
-input[type="range"]:not(.realtime) {
+input[type="range"]:not(.realtime):not(.tp-seek):not(.landing-seek-input):not(.dsp-slider) {
   background: linear-gradient(to right, var(--red) 0%, var(--red) var(--pct,50%), #2a2a3a var(--pct,50%), #2a2a3a 100%);
 }
 .slider-group{border:1px solid var(--border);border-radius:var(--rs);margin-bottom:6px;overflow:hidden;transition:border-color 0.15s}

--- a/public/app/style.css
+++ b/public/app/style.css
@@ -437,6 +437,15 @@ input[type="range"].realtime:not(.tp-seek):not(.landing-seek-input)::-webkit-sli
 .viz-card{margin-bottom:8px}
 .viz-hdr{display:flex;justify-content:space-between;align-items:center;font-size:0.68rem;color:var(--dim);font-weight:600;text-transform:uppercase;letter-spacing:0.04em;margin-bottom:4px}
 .viz-actions{display:flex;align-items:center;gap:6px}
+.btn-viz-gallery.is-active{border-color:rgba(0,255,231,.45);color:var(--cyan);background:rgba(0,255,231,.08)}
+.viz-panel-label{display:none;font-size:0.58rem;font-weight:700;letter-spacing:0.08em;text-transform:uppercase;color:var(--cyan);margin-bottom:4px}
+.viz-card.viz-gallery .viz-panel-label{display:block}
+.viz-card.viz-gallery .panel{display:block!important;border:1px solid var(--border);border-radius:8px;padding:8px;margin-bottom:8px;background:rgba(0,0,0,.18)}
+.viz-card.viz-gallery .panel .spectro3d-container{height:140px}
+.viz-card.viz-gallery .spectro2d{height:80px}
+.viz-card.viz-gallery .freq-cv{height:56px}
+.viz-card.viz-gallery .wave-cv{height:56px}
+.viz-card.viz-gallery .wave-row{grid-template-columns:1fr 1fr}
 .viz-hint{font-size:0.55rem;color:var(--dim);font-weight:400;text-transform:none;letter-spacing:0}
 .viz-canvas{width:100%;display:block;border-radius:4px;background:#030306}
 .spectro2d{height:110px}

--- a/public/app/vip-fixes.js
+++ b/public/app/vip-fixes.js
@@ -433,6 +433,9 @@
           : (_duration || 0);
         _pauseOffset = (parseFloat(seek.value) / 1000) * dur;
         app.playOffset = _pauseOffset;
+        if (typeof app._paintTransport === 'function') {
+          app._paintTransport(_pauseOffset, dur, { skipSeekValue: true });
+        }
         if (!_isPlaying) _syncVideo(_pauseOffset, false);
       });
       seek.addEventListener('change', () => {

--- a/public/app/visuals-bootstrap.js
+++ b/public/app/visuals-bootstrap.js
@@ -572,6 +572,14 @@
       _syncPremiumViz();
     });
     ro.observe(card);
+    const onViewportChange = () => {
+      setTimeout(() => {
+        _resizeVisibleCanvases();
+        _syncPremiumViz();
+      }, 180);
+    };
+    window.addEventListener('orientationchange', onViewportChange);
+    window.addEventListener('resize', onViewportChange);
   }
 
   /* ── Event wiring ─────────────────────────────────────────────────────── */

--- a/public/app/visuals-bootstrap.js
+++ b/public/app/visuals-bootstrap.js
@@ -1,30 +1,7 @@
 /**
  * visuals-bootstrap.js
- * ─────────────────────────────────────────────────────────────────────────────
- * Wires the visualization tabs to the playback analyser created in vip-fixes.js.
- *
- * What this owns (purely additive — no module imports, no STFT/iSTFT):
- *   1. Static waveform render to #waveCanvas on `vip:fileLoaded`.
- *   2. A single RAF loop driving:
- *        • #spectro2DCanvas — scrolling 2D spectrogram (Inferno LUT from visuals.js)
- *        • #freqCanvas      — frequency bar rail
- *        • LUFS readouts (#lufsI / #lufsS) — rolling 400ms short-term, 3s integrated
- *        • Header peak/RMS (#hPeak / #hRMS)
- *   3. Lazy init of premium visualizers (aura / topo / swarm / liquid)
- *      from premium-visuals.js the first time the user activates their tab.
- *   4. Wave A/B comparison render whenever a processed buffer becomes available.
- *
- * Inputs:
- *   • window._vipPlayAnalyser  → set by vip-fixes.js when play() starts
- *   • Events:  vip:fileLoaded, vip:playStarted, vip:playStopped, vip:processingDone
- *
- * Hard constraints honored:
- *   • Zero external fetches / zero network.
- *   • Loaded as a classic <script src> so it works without ESM evaluation order
- *     gymnastics. Exposes globals on window for testability.
- *   • One RAF loop total (premium tab visualizers run their own internal loops,
- *     but only one is active at a time and we stop the previous on tab switch).
- * ─────────────────────────────────────────────────────────────────────────────
+ * Wires visualization tabs to the playback analyser from vip-fixes.js.
+ * Supports single-tab mode and gallery (show-all) mode.
  */
 (function (global) {
   'use strict';
@@ -33,18 +10,45 @@
   global.__VIP_VISUALS_BOOT__ = true;
 
   const $ = (id) => document.getElementById(id);
+  const qsa = (sel, root) => Array.from((root || document).querySelectorAll(sel));
+
+  const PREMIUM_TABS = ['aura', 'topo', 'swarm', 'liquid'];
+  const CLUSTERS_TAB = 'clusters';
 
   /* ── State ────────────────────────────────────────────────────────────── */
   let _rafId = 0;
   let _running = false;
   let _activeTab = 'spectrogram';
-  let _activePremium = null;   // { stop() } handle for aura/topo/swarm/liquid
-  let _activePremiumTab = null;
-  // Rolling spectrogram scroll position
+  let _viewMode = 'single';
+  let _premiumHandles = new Map();
+  let _vizEngine = null;
   let _specX = 0;
-  // LUFS rolling state
-  let _lufsShortBuf = []; // last ~400 ms of mean-square per RAF tick
-  let _lufsIntBuf   = []; // last ~3 s
+  let _lufsShortBuf = [];
+  let _lufsIntBuf = [];
+  let _syntheticDiarHistory = [];
+  let _lastDiarSpeaker = 0;
+  let _lastDiarSegStart = 0;
+  let _lastSpeakerState = null;
+
+  function _getPlayOffset() {
+    const app = global._vipApp;
+    if (app && app._fixPlayState && typeof app._fixPlayState.elapsed === 'function') {
+      return app._fixPlayState.elapsed();
+    }
+    return (app && app.playOffset) || 0;
+  }
+
+  function _isTabDrawTarget(tab) {
+    if (_viewMode === 'gallery') return true;
+    return tab === _activeTab;
+  }
+
+  function _panelVisible(tabName) {
+    const panel = $('tab-' + tabName);
+    if (!panel) return false;
+    if (_viewMode === 'gallery') return true;
+    return panel.classList.contains('active');
+  }
 
   /* ── Static waveform render ───────────────────────────────────────────── */
   function _drawWaveformOnto(canvas, audioBuf, color) {
@@ -53,26 +57,27 @@
     if (!ctx) return;
     const rect = canvas.getBoundingClientRect();
     const cssH = parseInt(getComputedStyle(canvas).height, 10) || 0;
-    const bw = rect.width  > 0 ? rect.width  : (canvas.offsetWidth  || 800);
+    const bw = rect.width > 0 ? rect.width : (canvas.offsetWidth || 800);
     const bh = rect.height > 0 ? rect.height : (cssH || canvas.offsetHeight || 70);
-    canvas.width  = Math.floor(bw);
+    canvas.width = Math.floor(bw);
     canvas.height = Math.floor(bh);
-    const w = canvas.width  || 800;
+    const w = canvas.width || 800;
     const h = canvas.height || 70;
     ctx.fillStyle = '#030306';
     ctx.fillRect(0, 0, w, h);
 
     const data = audioBuf.getChannelData(0);
     const step = Math.max(1, Math.floor(data.length / w));
-    const mid  = h / 2;
+    const mid = h / 2;
 
     ctx.strokeStyle = color || '#22d3ee';
-    ctx.fillStyle   = (color || '#22d3ee') + '33';
-    ctx.lineWidth   = 1;
+    ctx.fillStyle = (color || '#22d3ee') + '33';
+    ctx.lineWidth = 1;
     ctx.beginPath();
     ctx.moveTo(0, mid);
     for (let x = 0; x < w; x++) {
-      let min = 1.0, max = -1.0;
+      let min = 1.0;
+      let max = -1.0;
       const base = x * step;
       const end = Math.min(base + step, data.length);
       for (let i = base; i < end; i++) {
@@ -87,7 +92,6 @@
     }
     ctx.stroke();
 
-    // Zero line
     ctx.strokeStyle = 'rgba(255,255,255,0.06)';
     ctx.beginPath();
     ctx.moveTo(0, mid);
@@ -95,21 +99,36 @@
     ctx.stroke();
   }
 
+  function _drawPlayhead(canvas, buffer, color) {
+    if (!canvas || !buffer) return;
+    _drawWaveformOnto(canvas, buffer, color);
+    const dur = buffer.duration || 1;
+    const px = (_getPlayOffset() / dur) * canvas.width;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    ctx.strokeStyle = '#ff2a2a';
+    ctx.lineWidth = 1.5;
+    ctx.beginPath();
+    ctx.moveTo(px, 0);
+    ctx.lineTo(px, canvas.height);
+    ctx.stroke();
+  }
+
   function drawStaticVisuals() {
     const app = global._vipApp;
     if (!app) return;
-    const inBuf  = app.inputBuffer || app.origBuffer;
+    const inBuf = app.inputBuffer || app.origBuffer;
     const outBuf = app.outputBuffer || app.procBuffer;
     _drawWaveformOnto($('waveCanvas'), inBuf, '#22d3ee');
-    _drawWaveformOnto($('waveOrigCanvas'), inBuf,  '#22d3ee');
+    _drawWaveformOnto($('waveOrigCanvas'), inBuf, '#22d3ee');
     _drawWaveformOnto($('waveProcCanvas'), outBuf, '#69ff47');
   }
 
-  /* ── 2D scrolling spectrogram using Inferno LUT (or fallback ramp) ────── */
+  /* ── Canvas helpers ───────────────────────────────────────────────────── */
   function _resizeCanvas(canvas, fallbackH) {
     const dpr = window.devicePixelRatio || 1;
     const rect = canvas.getBoundingClientRect();
-    const baseW = rect.width  > 0 ? rect.width  : (canvas.offsetWidth  || canvas.clientWidth  || 800);
+    const baseW = rect.width > 0 ? rect.width : (canvas.offsetWidth || canvas.clientWidth || 800);
     const baseH = rect.height > 0 ? rect.height : (parseInt(getComputedStyle(canvas).height, 10) || canvas.clientHeight || fallbackH || 240);
     const w = Math.round(baseW * dpr);
     const h = Math.round(baseH * dpr);
@@ -120,6 +139,40 @@
     return { w, h };
   }
 
+  function _resizeVisibleCanvases() {
+    const targets = [
+      ['spectro2DCanvas', 240],
+      ['spectroCanvas', 200],
+      ['freqCanvas', 80],
+      ['waveCanvas', 70],
+      ['waveOrigCanvas', 70],
+      ['waveProcCanvas', 70],
+      ['diarCanvas', 80],
+      ['auraCanvas', 180],
+      ['liquidCanvas', 180],
+    ];
+    for (const [id, h] of targets) {
+      const c = $(id);
+      if (c && _panelVisible(_canvasTabFor(id))) _resizeCanvas(c, h);
+    }
+  }
+
+  function _canvasTabFor(id) {
+    const map = {
+      spectro2DCanvas: 'spectrogram',
+      spectroCanvas: 'spectrogram',
+      freqCanvas: 'spectrogram',
+      waveCanvas: 'waveform',
+      waveOrigCanvas: 'abcompare',
+      waveProcCanvas: 'abcompare',
+      diarCanvas: CLUSTERS_TAB,
+      auraCanvas: 'aura',
+      liquidCanvas: 'liquid',
+    };
+    return map[id] || _activeTab;
+  }
+
+  /* ── Spectrogram + frequency bars ─────────────────────────────────────── */
   function _drawSpectro2DColumn(canvas, freqBytes) {
     if (!canvas) return;
     const ctx = canvas.getContext('2d');
@@ -127,7 +180,9 @@
     const { w, h } = _resizeCanvas(canvas, 240);
     try {
       ctx.drawImage(canvas, 1, 0, w - 1, h, 0, 0, w - 1, h);
-    } catch (_) { ctx.clearRect(0, 0, w, h); }
+    } catch (_) {
+      ctx.clearRect(0, 0, w, h);
+    }
     const colX = w - 1;
     const N = freqBytes.length;
     const lut = global.VIP_INFERNO_LUT;
@@ -136,10 +191,14 @@
       const t = 1 - (y / h);
       const idx = Math.min(N - 1, Math.floor(Math.pow(t, 2.0) * (N - 1)));
       const v = freqBytes[idx] / 255;
-      let r = 0; let g = 0; let b = 0;
+      let r = 0;
+      let g = 0;
+      let b = 0;
       if (lut) {
         const li = Math.min(255, Math.floor(v * 255)) * 3;
-        r = lut[li]; g = lut[li + 1]; b = lut[li + 2];
+        r = lut[li];
+        g = lut[li + 1];
+        b = lut[li + 2];
       } else {
         r = Math.min(255, Math.floor(v * 320));
         g = Math.min(255, Math.floor((1 - Math.abs(v - 0.55)) * 220));
@@ -155,13 +214,21 @@
     _specX = (_specX + 1) % w;
   }
 
-  /* ── Frequency bars ───────────────────────────────────────────────────── */
+  function _mirrorSpectro3D() {
+    const src = $('spectro2DCanvas');
+    const dst = $('spectroCanvas');
+    if (!src || !dst || !src.width) return;
+    const ctx = dst.getContext('2d');
+    if (!ctx) return;
+    _resizeCanvas(dst, 200);
+    ctx.drawImage(src, 0, 0, dst.width, dst.height);
+  }
+
   function _drawFreqBars(canvas, freqBytes) {
     if (!canvas) return;
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
     const { w, h } = _resizeCanvas(canvas, 80);
-    // Trail for motion blur
     ctx.fillStyle = 'rgba(3,3,6,0.45)';
     ctx.fillRect(0, 0, w, h);
 
@@ -177,19 +244,25 @@
       const avg = sum / (end - base);
       const v = avg / 255;
       const barH = v * h * 0.92;
-      // Color: cyan → red as frequency rises
       const hue = 180 - (b / bars) * 160;
       ctx.fillStyle = 'hsla(' + hue.toFixed(0) + ',95%,55%,0.9)';
       ctx.fillRect(b * barW + 1, h - barH, Math.max(1, barW - 2), barH);
     }
   }
 
-  /* ── LUFS rolling estimate + header peak/RMS ──────────────────────────── */
-  function _updateLufs(timeBytes, _freqBytes) {
-    // K-weighted LUFS is expensive — approximate with un-weighted RMS scaled to
-    // BS.1770 style ~−0.691 LU offset so the readouts feel familiar to ENGs.
+  function _drawABCompareLive() {
+    const app = global._vipApp;
+    if (!app) return;
+    const inBuf = app.inputBuffer || app.origBuffer;
+    const outBuf = app.outputBuffer || app.procBuffer;
+    if (inBuf) _drawPlayhead($('waveOrigCanvas'), inBuf, '#22d3ee');
+    if (outBuf) _drawPlayhead($('waveProcCanvas'), outBuf, '#69ff47');
+  }
+
+  /* ── LUFS + header meters ─────────────────────────────────────────────── */
+  function _updateLufs(timeBytes) {
     let sumSq = 0;
-    let peak  = 0;
+    let peak = 0;
     for (let i = 0; i < timeBytes.length; i++) {
       const s = (timeBytes[i] - 128) / 128;
       const a = Math.abs(s);
@@ -199,30 +272,114 @@
     const ms = sumSq / timeBytes.length;
     _lufsShortBuf.push(ms);
     _lufsIntBuf.push(ms);
-    if (_lufsShortBuf.length > 24) _lufsShortBuf.shift(); // ~400 ms @ 60 fps
-    if (_lufsIntBuf.length > 180) _lufsIntBuf.shift();    // ~3 s
+    if (_lufsShortBuf.length > 24) _lufsShortBuf.shift();
+    if (_lufsIntBuf.length > 180) _lufsIntBuf.shift();
 
     const meanShort = _lufsShortBuf.reduce((a, b) => a + b, 0) / Math.max(1, _lufsShortBuf.length);
-    const meanInt   = _lufsIntBuf.reduce((a, b) => a + b, 0) / Math.max(1, _lufsIntBuf.length);
+    const meanInt = _lufsIntBuf.reduce((a, b) => a + b, 0) / Math.max(1, _lufsIntBuf.length);
 
     const lufsShort = meanShort > 1e-12 ? 10 * Math.log10(meanShort) - 0.691 : -70;
-    const lufsInt   = meanInt   > 1e-12 ? 10 * Math.log10(meanInt)   - 0.691 : -70;
+    const lufsInt = meanInt > 1e-12 ? 10 * Math.log10(meanInt) - 0.691 : -70;
 
-    const sEl = $('lufsS'); if (sEl) sEl.textContent = lufsShort.toFixed(1);
-    const iEl = $('lufsI'); if (iEl) iEl.textContent = lufsInt.toFixed(1);
+    const sEl = $('lufsS');
+    if (sEl) sEl.textContent = lufsShort.toFixed(1);
+    const iEl = $('lufsI');
+    if (iEl) iEl.textContent = lufsInt.toFixed(1);
 
-    // Header peak / rms
     const peakDb = peak > 1e-6 ? 20 * Math.log10(peak) : -60;
-    const rmsDb  = meanShort > 1e-12 ? 10 * Math.log10(meanShort) : -60;
+    const rmsDb = meanShort > 1e-12 ? 10 * Math.log10(meanShort) : -60;
     const fmt = (v) => (v >= 0 ? '+' : '') + v.toFixed(1) + ' dB';
-    const hPeak = $('hPeak'); if (hPeak) hPeak.textContent = fmt(peakDb);
-    const hRMS  = $('hRMS');  if (hRMS)  hRMS.textContent  = fmt(rmsDb);
+    const hPeak = $('hPeak');
+    if (hPeak) hPeak.textContent = fmt(peakDb);
+    const hRMS = $('hRMS');
+    if (hRMS) hRMS.textContent = fmt(rmsDb);
 
-    // VU meters defined in static HTML — drive the first two as IN / OUT
-    const meters = document.querySelectorAll('#panel-vu-meters .vu-meter');
-    const toLevel = (db) => Math.max(0, ((db + 60) / 60) * 100).toFixed(1) + '%';
-    if (meters.length >= 1) meters[0].style.setProperty('--vu-level', toLevel(rmsDb));
-    if (meters.length >= 2) meters[1].style.setProperty('--vu-level', toLevel(peakDb));
+    if (!_isTabDrawTarget(CLUSTERS_TAB)) {
+      const meters = document.querySelectorAll('#panel-vu-meters .vu-meter');
+      const toLevel = (db) => Math.max(0, ((db + 60) / 60) * 100).toFixed(1) + '%';
+      if (meters.length >= 1) meters[0].style.setProperty('--vu-level', toLevel(rmsDb));
+      if (meters.length >= 2) meters[1].style.setProperty('--vu-level', toLevel(peakDb));
+    }
+  }
+
+  /* ── Synthetic diarization for clusters tab ───────────────────────────── */
+  function _getSyntheticSpeakerState(freqBytes) {
+    const numSpeakers = 4;
+    const speakerRMS = new Float32Array(numSpeakers);
+    const chunk = Math.max(1, Math.floor(freqBytes.length / numSpeakers));
+    let activeSpeaker = 0;
+    let maxEnergy = 0;
+    for (let s = 0; s < numSpeakers; s++) {
+      let sum = 0;
+      for (let i = s * chunk; i < (s + 1) * chunk && i < freqBytes.length; i++) sum += freqBytes[i];
+      const rms = (sum / chunk) / 255 * 0.45;
+      speakerRMS[s] = rms;
+      if (rms > maxEnergy) {
+        maxEnergy = rms;
+        activeSpeaker = s;
+      }
+    }
+
+    const now = _getPlayOffset();
+    if (activeSpeaker !== _lastDiarSpeaker || now - _lastDiarSegStart > 1.2) {
+      if (_syntheticDiarHistory.length && _syntheticDiarHistory[_syntheticDiarHistory.length - 1].endTime === now) {
+        _syntheticDiarHistory[_syntheticDiarHistory.length - 1].endTime = now;
+      } else if (_lastDiarSegStart > 0) {
+        _syntheticDiarHistory.push({
+          speaker: _lastDiarSpeaker,
+          confidence: 0.75 + Math.random() * 0.2,
+          startTime: _lastDiarSegStart,
+          endTime: now,
+        });
+      }
+      _lastDiarSpeaker = activeSpeaker;
+      _lastDiarSegStart = now;
+      if (_syntheticDiarHistory.length > 120) _syntheticDiarHistory.shift();
+    } else if (_syntheticDiarHistory.length) {
+      _syntheticDiarHistory[_syntheticDiarHistory.length - 1].endTime = now;
+    } else {
+      _syntheticDiarHistory.push({
+        speaker: activeSpeaker,
+        confidence: 0.85,
+        startTime: Math.max(0, now - 0.5),
+        endTime: now,
+      });
+    }
+
+    return {
+      activeSpeaker,
+      numSpeakers,
+      confidence: 0.85,
+      speakerRMS,
+      currentTime: now,
+      history: _syntheticDiarHistory,
+    };
+  }
+
+  function _ensureVizEngine() {
+    if (_vizEngine || typeof global.VisualizationEngine !== 'function') return;
+    _vizEngine = new global.VisualizationEngine({
+      vuPanel: $('panel-vu-meters'),
+      diarCanvas: $('diarCanvas'),
+      maxSpeakers: 4,
+      getAnalysers: () => {
+        const an = global._vipPlayAnalyser;
+        return { orig: an, proc: an };
+      },
+      getSpeakerState: () => _lastSpeakerState,
+    });
+  }
+
+  function _syncClustersEngine(freqBytes) {
+    if (!_isTabDrawTarget(CLUSTERS_TAB)) {
+      if (_vizEngine) _vizEngine.stop();
+      return;
+    }
+    _ensureVizEngine();
+    if (!_vizEngine) return;
+    _lastSpeakerState = _getSyntheticSpeakerState(freqBytes);
+    if (!_vizEngine._running) _vizEngine.start();
+    if (_vizEngine.diarCanvas) _resizeCanvas(_vizEngine.diarCanvas, 80);
   }
 
   /* ── Main RAF loop ────────────────────────────────────────────────────── */
@@ -238,44 +395,32 @@
     try {
       an.getByteFrequencyData(freqBytes);
       an.getByteTimeDomainData(timeBytes);
-    } catch (_) { return; }
+    } catch (_) {
+      return;
+    }
 
-    // Always update LUFS / header — cheap and informative across tabs
-    _updateLufs(timeBytes, freqBytes);
+    _updateLufs(timeBytes);
 
-    // Tab-targeted draws — only redraw the active tab to keep RAF light
-    if (_activeTab === 'spectrogram') {
+    if (_isTabDrawTarget('spectrogram')) {
       const spec2d = $('spectro2DCanvas');
       if (spec2d) {
         if (spec2d.style.display === 'none') spec2d.style.display = '';
         _drawSpectro2DColumn(spec2d, freqBytes);
+        _mirrorSpectro3D();
       }
       const freq = $('freqCanvas');
       if (freq) _drawFreqBars(freq, freqBytes);
-    } else if (_activeTab === 'waveform') {
-      // Live playhead overlay on the static waveform
-      const wave = $('waveCanvas');
-      const app  = global._vipApp;
-      if (wave && app) {
-        const buf = app.inputBuffer || app.origBuffer;
-        if (buf) {
-          const ctx = wave.getContext('2d');
-          // Redraw static then overlay playhead (cheap — buffer is decoded once)
-          _drawWaveformOnto(wave, buf, '#22d3ee');
-          const playOffset = (app._fixPlayState && typeof app._fixPlayState.elapsed === 'function')
-            ? app._fixPlayState.elapsed()
-            : 0;
-          const dur = buf.duration || 1;
-          const px = (playOffset / dur) * wave.width;
-          ctx.strokeStyle = '#ff2a2a';
-          ctx.lineWidth = 1.5;
-          ctx.beginPath();
-          ctx.moveTo(px, 0);
-          ctx.lineTo(px, wave.height);
-          ctx.stroke();
-        }
-      }
     }
+
+    if (_isTabDrawTarget('waveform')) {
+      const app = global._vipApp;
+      const buf = app && (app.inputBuffer || app.origBuffer);
+      if (buf) _drawPlayhead($('waveCanvas'), buf, '#22d3ee');
+    }
+
+    if (_isTabDrawTarget('abcompare')) _drawABCompareLive();
+
+    _syncClustersEngine(freqBytes);
   }
 
   function start() {
@@ -283,101 +428,174 @@
     _running = true;
     _rafId = requestAnimationFrame(_loop);
   }
+
   function stop() {
     _running = false;
-    if (_rafId) { cancelAnimationFrame(_rafId); _rafId = 0; }
+    if (_rafId) {
+      cancelAnimationFrame(_rafId);
+      _rafId = 0;
+    }
+    if (_vizEngine) _vizEngine.stop();
   }
 
-  /* ── Premium visualizer lazy init on tab activation ───────────────────── */
-  function _stopPremium() {
-    if (_activePremium && typeof _activePremium.stop === 'function') {
-      try { _activePremium.stop(); } catch (_) {}
+  /* ── Premium visualizers ──────────────────────────────────────────────── */
+  function _stopPremiumTab(tabName) {
+    const handle = _premiumHandles.get(tabName);
+    if (handle && typeof handle.stop === 'function') {
+      try { handle.stop(); } catch (_) {}
     }
-    _activePremium = null;
-    _activePremiumTab = null;
+    _premiumHandles.delete(tabName);
   }
-  function _initPremium(tabName) {
-    if (_activePremiumTab === tabName && _activePremium) return; // already running
-    _stopPremium();
-    _activePremiumTab = tabName;
+
+  function _stopAllPremium() {
+    for (const tab of Array.from(_premiumHandles.keys())) _stopPremiumTab(tab);
+  }
+
+  function _initPremiumTab(tabName) {
+    if (_premiumHandles.has(tabName)) return;
+    if (!_panelVisible(tabName)) return;
     const an = global._vipPlayAnalyser;
-    if (!an) return; // analyser will appear when play() starts; we'll re-init then
+    if (!an) return;
+
+    let handle = null;
     if (tabName === 'aura') {
       const c = $('auraCanvas');
       if (c && typeof global.VIP_initPulsingAura === 'function') {
-        const r = c.getBoundingClientRect();
-        if (r.width > 0)  c.width  = Math.floor(r.width);
-        if (r.height > 0) c.height = Math.floor(r.height);
-        _activePremium = global.VIP_initPulsingAura(an, c);
+        _resizeCanvas(c, 180);
+        handle = global.VIP_initPulsingAura(an, c);
       }
     } else if (tabName === 'topo') {
       const cont = $('topoContainer');
       if (cont && typeof global.VIP_initTopographic3D === 'function') {
-        _activePremium = global.VIP_initTopographic3D(an, cont);
+        if (cont.clientWidth < 2) cont.style.minHeight = '180px';
+        handle = global.VIP_initTopographic3D(an, cont);
       }
     } else if (tabName === 'swarm') {
       const cont = $('swarmContainer');
       if (cont && typeof global.VIP_initParticleSwarm === 'function') {
-        _activePremium = global.VIP_initParticleSwarm(an, cont);
+        if (cont.clientWidth < 2) cont.style.minHeight = '180px';
+        handle = global.VIP_initParticleSwarm(an, cont);
       }
     } else if (tabName === 'liquid') {
       const c = $('liquidCanvas');
       if (c && typeof global.VIP_initLiquidWaves === 'function') {
-        const r = c.getBoundingClientRect();
-        if (r.width > 0)  c.width  = Math.floor(r.width);
-        if (r.height > 0) c.height = Math.floor(r.height);
-        _activePremium = global.VIP_initLiquidWaves(an, c);
+        _resizeCanvas(c, 180);
+        handle = global.VIP_initLiquidWaves(an, c);
       }
-    } else if (tabName === 'clusters' || tabName === 'lufs' || tabName === 'abcompare') {
-      // No premium visualizer to spin up — main RAF loop already drives meters/lufs
     }
+    if (handle) _premiumHandles.set(tabName, handle);
+  }
+
+  function _syncPremiumViz() {
+    const tabsToRun = _viewMode === 'gallery'
+      ? PREMIUM_TABS.slice()
+      : (PREMIUM_TABS.includes(_activeTab) ? [_activeTab] : []);
+
+    for (const tab of Array.from(_premiumHandles.keys())) {
+      if (!tabsToRun.includes(tab)) _stopPremiumTab(tab);
+    }
+
+    if (!global._vipPlayAnalyser) return;
+    for (const tab of tabsToRun) {
+      if (!_premiumHandles.has(tab)) {
+        requestAnimationFrame(() => _initPremiumTab(tab));
+      }
+    }
+  }
+
+  /* ── View mode + tab activation ───────────────────────────────────────── */
+  function _applyGalleryDom() {
+    const card = document.querySelector('.viz-card');
+    const btn = $('btnVizGallery');
+    if (card) card.classList.toggle('viz-gallery', _viewMode === 'gallery');
+    if (btn) {
+      btn.classList.toggle('is-active', _viewMode === 'gallery');
+      btn.setAttribute('aria-pressed', String(_viewMode === 'gallery'));
+      btn.textContent = _viewMode === 'gallery' ? 'Single View' : 'Show All';
+    }
+    const panels = qsa('.viz-card .panel[data-viz-panel]');
+    if (_viewMode === 'gallery') {
+      panels.forEach((p) => p.classList.add('active'));
+      qsa('.tab-btn[data-tab]').forEach((b) => {
+        b.classList.remove('active');
+        b.setAttribute('aria-selected', 'false');
+        b.setAttribute('tabindex', '-1');
+      });
+    } else {
+      panels.forEach((p) => p.classList.remove('active'));
+      const panel = $('tab-' + _activeTab);
+      const tabBtn = document.querySelector('.tab-btn[data-tab="' + _activeTab + '"]');
+      if (panel) panel.classList.add('active');
+      if (tabBtn) {
+        tabBtn.classList.add('active');
+        tabBtn.setAttribute('aria-selected', 'true');
+        tabBtn.setAttribute('tabindex', '0');
+      }
+    }
+  }
+
+  function setViewMode(mode) {
+    _viewMode = mode === 'gallery' ? 'gallery' : 'single';
+    _applyGalleryDom();
+    _resizeVisibleCanvases();
+    _syncPremiumViz();
+    try {
+      window.dispatchEvent(new CustomEvent('vip:vizModeChanged', { detail: { mode: _viewMode } }));
+    } catch (_) {}
+  }
+
+  function getViewMode() {
+    return _viewMode;
   }
 
   function _onTabActivated(tab) {
-    _activeTab = tab;
-    if (tab === 'aura' || tab === 'topo' || tab === 'swarm' || tab === 'liquid') {
-      _initPremium(tab);
-    } else if (tab === 'abcompare') {
-      // Refresh the A/B waveform pair lazily — output buffer may have arrived
-      drawStaticVisuals();
-      _stopPremium();
-    } else {
-      _stopPremium();
-    }
+    if (_viewMode === 'gallery') setViewMode('single');
+    _activeTab = tab || 'spectrogram';
+    if (tab === 'abcompare') drawStaticVisuals();
+    _resizeVisibleCanvases();
+    _syncPremiumViz();
   }
 
-  /* ── Listen for tab clicks via a delegated listener ───────────────────── */
-  function _wireTabListener() {
-    document.addEventListener('click', (e) => {
-      const t = e.target && e.target.closest && e.target.closest('.tab-btn[data-tab]');
-      if (!t) return;
-      const tab = t.dataset.tab;
-      if (!tab) return;
-      _onTabActivated(tab);
+  function _wireGalleryToggle() {
+    const btn = $('btnVizGallery');
+    if (!btn) return;
+    btn.addEventListener('click', () => {
+      setViewMode(_viewMode === 'gallery' ? 'single' : 'gallery');
     });
+  }
+
+  function _wireResizeObserver() {
+    const card = document.querySelector('.viz-card');
+    if (!card || typeof ResizeObserver === 'undefined') return;
+    const ro = new ResizeObserver(() => {
+      _resizeVisibleCanvases();
+      _syncPremiumViz();
+    });
+    ro.observe(card);
   }
 
   /* ── Event wiring ─────────────────────────────────────────────────────── */
   function _bindEvents() {
-    window.addEventListener('vip:fileLoaded',     drawStaticVisuals);
+    window.addEventListener('vip:fileLoaded', drawStaticVisuals);
     window.addEventListener('vip:processingDone', drawStaticVisuals);
     window.addEventListener('vip:playStarted', () => {
       _lufsShortBuf = [];
       _lufsIntBuf = [];
+      _syntheticDiarHistory = [];
+      _lastDiarSegStart = _getPlayOffset();
       start();
-      if (_activePremiumTab) {
-        _activePremium = null;
-        _initPremium(_activePremiumTab);
-      }
+      _resizeVisibleCanvases();
+      _syncPremiumViz();
       const an = global._vipPlayAnalyser;
       if (an && global.NeonPulseViz && typeof global.NeonPulseViz.init === 'function') {
         try { global.NeonPulseViz.init(an); } catch (_) {}
       }
     });
-    window.addEventListener('vip:playStopped', stop);
+    window.addEventListener('vip:playStopped', () => {
+      stop();
+      _stopAllPremium();
+    });
 
-    // Synthesize vip:fileLoaded when buffers arrive — vip-fixes already dispatches it
-    // but in case the legacy code path is used, poll briefly for first buffer.
     let polls = 0;
     const poll = setInterval(() => {
       polls++;
@@ -385,19 +603,19 @@
       if (app && (app.inputBuffer || app.origBuffer)) {
         clearInterval(poll);
         try { window.dispatchEvent(new CustomEvent('vip:fileLoaded')); } catch (_) {}
-      } else if (polls > 600) { // ~60s
+      } else if (polls > 600) {
         clearInterval(poll);
       }
     }, 100);
   }
 
   function _init() {
-    _wireTabListener();
+    _wireGalleryToggle();
+    _wireResizeObserver();
     _bindEvents();
     if (global.NeonPulseViz && typeof global.NeonPulseViz.mount === 'function') {
       try { global.NeonPulseViz.mount('#neon-pulse-slot'); } catch (_) {}
     }
-    // Initial render in case a file is already loaded (re-mount / hot reload)
     setTimeout(drawStaticVisuals, 400);
   }
 
@@ -407,11 +625,14 @@
     _init();
   }
 
-  /* ── Export for tests / diagnostics ───────────────────────────────────── */
   global.VIP_VISUALS = {
     drawStatic: drawStaticVisuals,
-    start, stop,
+    start,
+    stop,
     onTabActivated: _onTabActivated,
-    initPremium: _initPremium,
+    initPremium: _initPremiumTab,
+    setViewMode,
+    getViewMode,
+    syncPremium: _syncPremiumViz,
   };
 })(typeof window !== 'undefined' ? window : this);

--- a/public/index.html
+++ b/public/index.html
@@ -122,6 +122,7 @@
       </div>
       <div class="transport-seek">
         <div id="landingRegionBar" class="transport-region-bar" hidden aria-hidden="true"></div>
+        <div class="tp-seek-rail" aria-hidden="true"><span class="tp-seek-fill" id="landingSeekFill"></span></div>
         <input type="range" id="seekSlider" class="landing-seek-input" min="0" max="1000" value="0" disabled aria-label="Playback position">
       </div>
 

--- a/public/landing.css
+++ b/public/landing.css
@@ -635,6 +635,14 @@ input[type="range"]:disabled { opacity: 0.34; cursor: not-allowed; }
   .main-area { padding: 14px 12px 48px; }
 }
 @media (pointer: coarse) {
+  .transport-seek {
+    padding: 14px 0 12px;
+    min-height: 44px;
+    touch-action: manipulation;
+  }
+  .landing-seek-input {
+    height: 28px;
+  }
   .slider-hint-btn, .hint-example-pill {
     min-width: 44px;
     min-height: 44px;

--- a/public/transport-polish.css
+++ b/public/transport-polish.css
@@ -3,10 +3,12 @@
 .transport-seek {
   position: relative;
   width: 100%;
-  padding: 10px 2px 6px;
+  padding: 14px 2px 10px;
+  min-height: 28px;
 }
 
-.transport-region-bar {
+.transport-region-bar,
+.tp-seek-rail {
   position: absolute;
   left: 2px;
   right: 2px;
@@ -15,6 +17,10 @@
   transform: translateY(-50%);
   border-radius: 99px;
   pointer-events: none;
+}
+
+.transport-region-bar {
+  z-index: 0;
   background: rgba(255, 255, 255, 0.06);
   overflow: hidden;
 }
@@ -31,32 +37,43 @@
   border-right: 2px solid rgba(52, 211, 153, 0.85);
 }
 
+.tp-seek-rail {
+  z-index: 1;
+  background: rgba(255, 255, 255, 0.07);
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.35);
+  overflow: hidden;
+}
+
+.tp-seek-fill {
+  display: block;
+  height: 100%;
+  width: var(--seek-pct, 0%);
+  border-radius: 99px;
+  background: linear-gradient(90deg, var(--red, #dc2626) 0%, var(--red2, #ef4444) 100%);
+  box-shadow: 0 0 8px rgba(239, 68, 68, 0.35);
+  transition: width 0.04s linear;
+  pointer-events: none;
+}
+
 .tp-seek,
 .landing-seek-input {
   -webkit-appearance: none;
   appearance: none;
   width: 100%;
-  height: 4px;
+  height: 18px;
+  margin: 0;
   border-radius: 99px;
   outline: none;
   cursor: pointer;
   position: relative;
-  z-index: 1;
-  background: linear-gradient(
-    90deg,
-    var(--red, #dc2626) 0%,
-    var(--red2, #ef4444) var(--seek-pct, 0%),
-    rgba(255, 255, 255, 0.07) var(--seek-pct, 0%),
-    rgba(255, 255, 255, 0.07) 100%
-  );
-  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.35);
-  transition: height 0.15s ease, box-shadow 0.15s ease;
+  z-index: 2;
+  background: transparent;
+  box-shadow: none;
 }
 
 .tp-seek:hover:not(:disabled),
 .landing-seek-input:hover:not(:disabled) {
-  height: 5px;
-  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.35), 0 0 10px rgba(239, 68, 68, 0.25);
+  cursor: pointer;
 }
 
 .tp-seek:disabled,
@@ -65,11 +82,29 @@
   cursor: not-allowed;
 }
 
+.transport-seek:hover .tp-seek-rail {
+  height: 5px;
+}
+
+.transport-seek:hover .tp-seek-fill {
+  box-shadow: 0 0 12px rgba(239, 68, 68, 0.45);
+}
+
+.tp-seek::-webkit-slider-runnable-track,
+.landing-seek-input::-webkit-slider-runnable-track {
+  -webkit-appearance: none;
+  height: 4px;
+  border-radius: 99px;
+  background: transparent;
+  border: none;
+}
+
 .tp-seek::-webkit-slider-thumb,
 .landing-seek-input::-webkit-slider-thumb {
   -webkit-appearance: none;
-  width: 11px;
-  height: 11px;
+  width: 13px;
+  height: 13px;
+  margin-top: -4.5px;
   border-radius: 50%;
   background: #fff;
   border: 2px solid var(--red2, #ef4444);
@@ -80,19 +115,8 @@
 
 .tp-seek::-webkit-slider-thumb:hover,
 .landing-seek-input::-webkit-slider-thumb:hover {
-  transform: scale(1.15);
+  transform: scale(1.12);
   box-shadow: 0 0 14px rgba(239, 68, 68, 0.55), 0 2px 6px rgba(0, 0, 0, 0.4);
-}
-
-.tp-seek::-moz-range-thumb,
-.landing-seek-input::-moz-range-thumb {
-  width: 11px;
-  height: 11px;
-  border-radius: 50%;
-  background: #fff;
-  border: 2px solid var(--red2, #ef4444);
-  cursor: pointer;
-  box-shadow: 0 0 10px rgba(239, 68, 68, 0.45);
 }
 
 .tp-seek::-moz-range-track,
@@ -101,6 +125,24 @@
   border-radius: 99px;
   background: transparent;
   border: none;
+}
+
+.tp-seek::-moz-range-progress,
+.landing-seek-input::-moz-range-progress {
+  height: 4px;
+  border-radius: 99px;
+  background: transparent;
+}
+
+.tp-seek::-moz-range-thumb,
+.landing-seek-input::-moz-range-thumb {
+  width: 13px;
+  height: 13px;
+  border-radius: 50%;
+  background: #fff;
+  border: 2px solid var(--red2, #ef4444);
+  cursor: pointer;
+  box-shadow: 0 0 10px rgba(239, 68, 68, 0.45);
 }
 
 .btn-tp-region {

--- a/public/transport-polish.css
+++ b/public/transport-polish.css
@@ -192,3 +192,36 @@
   align-items: center;
   gap: 4px;
 }
+
+/* Touch / mobile — engineer + landing seek bars (Android, iOS, coarse pointers) */
+@media (pointer: coarse) {
+  .transport-seek {
+    padding: 16px 2px 14px;
+    min-height: 44px;
+    touch-action: manipulation;
+  }
+
+  .tp-seek,
+  .landing-seek-input {
+    height: 28px;
+  }
+
+  .tp-seek::-webkit-slider-thumb,
+  .landing-seek-input::-webkit-slider-thumb {
+    width: 18px;
+    height: 18px;
+    margin-top: -7px;
+  }
+
+  .tp-seek::-moz-range-thumb,
+  .landing-seek-input::-moz-range-thumb {
+    width: 18px;
+    height: 18px;
+  }
+}
+
+@media (hover: none) {
+  .transport-seek:hover .tp-seek-rail {
+    height: 4px;
+  }
+}

--- a/src/presentation/TransportRegionControls.js
+++ b/src/presentation/TransportRegionControls.js
@@ -63,9 +63,13 @@ export function wireTransportRegion(opts) {
   return syncUi;
 }
 
-/** Paint --seek-pct on a transport range input from current/duration. */
+/** Paint playback position on the transport seek rail (current/duration in seconds). */
 export function paintSeekFill(seekEl, current, duration) {
   if (!seekEl || !duration) return;
   const pct = Math.max(0, Math.min(100, (current / duration) * 100));
-  seekEl.style.setProperty('--seek-pct', `${pct}%`);
+  const pctStr = `${pct}%`;
+  seekEl.style.setProperty('--seek-pct', pctStr);
+  const wrap = seekEl.closest('.transport-seek');
+  const fill = wrap?.querySelector('.tp-seek-fill');
+  if (fill) fill.style.width = pctStr;
 }

--- a/tests/mobile-ui.test.js
+++ b/tests/mobile-ui.test.js
@@ -20,6 +20,9 @@ const path = require('path');
 const appJs   = fs.readFileSync(path.join(__dirname, '../public/app/app.js'), 'utf8');
 const html    = fs.readFileSync(path.join(__dirname, '../public/app/index.html'), 'utf8');
 const styleCss = fs.readFileSync(path.join(__dirname, '../public/app/style.css'), 'utf8');
+const mobileCss = fs.readFileSync(path.join(__dirname, '../public/app/mobile.css'), 'utf8');
+const transportCss = fs.readFileSync(path.join(__dirname, '../public/transport-polish.css'), 'utf8');
+const landingCss = fs.readFileSync(path.join(__dirname, '../public/landing.css'), 'utf8');
 
 // ─── Pure --pct calculation (extracted from changed code) ────────────────────
 
@@ -640,5 +643,41 @@ describe('--pct formula — range variable approach (regression for removed asse
     // The formula does not clamp; documents the deliberate no-clamp behaviour
     const r = calcPct(-10, 0, 100);
     expect(parseFloat(r)).toBeLessThan(0);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// 15. Cross-platform transport + visualization mobile styles
+// ═══════════════════════════════════════════════════════════════
+
+describe('mobile.css — transport seek + viz gallery touch targets', () => {
+  test('styles transport-seek container for mobile touch', () => {
+    expect(mobileCss).toContain('.transport-seek');
+    expect(mobileCss).toContain('var(--mob-touch-min)');
+  });
+
+  test('tab-btn has minimum touch height on mobile', () => {
+    expect(mobileCss).toContain('.tab-btn');
+    expect(mobileCss).toContain('touch-action: manipulation');
+  });
+
+  test('gallery mode compact sizing on mobile', () => {
+    expect(mobileCss).toContain('.viz-card.viz-gallery');
+    expect(mobileCss).toContain('.btn-viz-gallery');
+  });
+});
+
+describe('transport-polish.css — coarse pointer seek bar sizing', () => {
+  test('enlarges seek thumb on touch devices', () => {
+    expect(transportCss).toContain('@media (pointer: coarse)');
+    expect(transportCss).toContain('.landing-seek-input');
+    expect(transportCss).toContain('width: 18px');
+  });
+});
+
+describe('landing.css — landing page seek bar touch support', () => {
+  test('transport-seek touch styles for browser landing page', () => {
+    expect(landingCss).toContain('.transport-seek');
+    expect(landingCss).toContain('.landing-seek-input');
   });
 });

--- a/tests/visuals-bootstrap.test.js
+++ b/tests/visuals-bootstrap.test.js
@@ -36,6 +36,11 @@ describe('visuals-bootstrap.js — visualization driver', () => {
     expect(src).toContain('diarCanvas');
   });
 
+  test('handles mobile viewport resize and orientation changes', () => {
+    expect(src).toContain('orientationchange');
+    expect(src).toContain('_resizeVisibleCanvases');
+  });
+
   test('listens for vip:fileLoaded, vip:playStarted, vip:playStopped, vip:processingDone', () => {
     expect(src).toContain("'vip:fileLoaded'");
     expect(src).toContain("'vip:playStarted'");

--- a/tests/visuals-bootstrap.test.js
+++ b/tests/visuals-bootstrap.test.js
@@ -19,8 +19,21 @@ describe('visuals-bootstrap.js — visualization driver', () => {
     expect(src).toContain('drawStatic');
     expect(src).toContain('onTabActivated');
     expect(src).toContain('initPremium');
+    expect(src).toContain('setViewMode');
+    expect(src).toContain('getViewMode');
     expect(src).toContain('start');
     expect(src).toContain('stop');
+  });
+
+  test('supports gallery show-all view mode', () => {
+    expect(src).toContain('viz-gallery');
+    expect(src).toContain('btnVizGallery');
+    expect(src).toContain("mode === 'gallery'");
+  });
+
+  test('wires VisualizationEngine for clusters tab', () => {
+    expect(src).toContain('VisualizationEngine');
+    expect(src).toContain('diarCanvas');
   });
 
   test('listens for vip:fileLoaded, vip:playStarted, vip:playStopped, vip:processingDone', () => {
@@ -110,6 +123,17 @@ describe('visuals-bootstrap loading and event wiring', () => {
     expect(src).toMatch(/startSpectro\(\)[\s\S]*VIP_VISUALS\.start/);
     expect(src).toMatch(/stopSpectro\(\)[\s\S]*VIP_VISUALS\.stop/);
   });
+
+  test('app.js tab switching calls VIP_VISUALS.onTabActivated', () => {
+    const src = fs.readFileSync(APP_JS_PATH, 'utf8');
+    expect(src).toContain('VIP_VISUALS.onTabActivated');
+  });
+
+  test('index.html includes Show All gallery toggle', () => {
+    const html = fs.readFileSync(INDEX_HTML_PATH, 'utf8');
+    expect(html).toContain('btnVizGallery');
+    expect(html).toContain('data-viz-panel');
+  });
 });
 
 describe('visuals-bootstrap module evaluated in jsdom-like sandbox', () => {
@@ -136,5 +160,7 @@ describe('visuals-bootstrap module evaluated in jsdom-like sandbox', () => {
     expect(typeof window.VIP_VISUALS.initPremium).toBe('function');
     expect(typeof window.VIP_VISUALS.start).toBe('function');
     expect(typeof window.VIP_VISUALS.stop).toBe('function');
+    expect(typeof window.VIP_VISUALS.setViewMode).toBe('function');
+    expect(typeof window.VIP_VISUALS.getViewMode).toBe('function');
   });
 });


### PR DESCRIPTION
## Summary
Combined fix for playback seek bar, visualization tabs, gallery mode, and cross-platform mobile/Android/desktop/browser support.

## Changes

### Playback seek bar (from #680)
- Layered \.tp-seek-rail\ + \.tp-seek-fill\ behind transparent range input
- Scoped global range CSS away from transport scrubbers
- Fill paints during scrubbing and transport clock ticks

### Visualizations
- Tab clicks call \VIP_VISUALS.onTabActivated(tab)\
- **Show All** gallery mode displays all 9 viz panels at once
- Live rendering: spectro 3D mirror, waveform/A/B playheads, clusters via VisualizationEngine
- Premium viz (Aura/Topo/Swarm/Liquid) runs concurrently in gallery mode

### Cross-platform (browser, desktop, Android/Capacitor, mobile)
- 44px touch targets for seek bars, viz tabs, Show All toggle
- \	ransport-seek\ mobile layout fix (was targeting wrong grid child)
- Coarse-pointer thumb sizing in \	ransport-polish.css\ (engineer + landing)
- Gallery compact panel heights on mobile
- Orientation/resize handler for canvas relayout

## Verification
- \	ests/transport.test.js\ — 27/27
- \	ests/visuals-bootstrap.test.js\ — pass
- \	ests/mobile-ui.test.js\ — pass (incl. transport/viz mobile CSS)
- Browser + mobile viewport verified

Supersedes #680.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix tab switching, gallery mode, and live seek rendering in visualization UI
> - Adds a gallery mode to the visualizations section with a 'Show All' toggle button, labeled panels, and compact bordered canvas layout driven by `setViewMode`/`getViewMode` in [visuals-bootstrap.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/681/files#diff-97305f1278d299699dbd4b6d6074b123eebb509e482ae1a8caa5cbae8693314f).
> - Tab switching now exits gallery mode when active, targets only `.viz-card .panel[data-viz-panel]` elements, and notifies `VIP_VISUALS.onTabActivated` on each switch.
> - Replaces the seek bar's CSS gradient approach with a dedicated `.tp-seek-fill` rail element whose width is set by JS in both [TransportRegionControls.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/681/files#diff-4d680a156313c63bd2fd957d3c86d31bedd5971e5975ba58c64424bab95dded6) and `_paintTransport`, enabling consistent fill across engineer and landing UIs.
> - Live scrubbing while paused now calls `_paintTransport` to update the fill and time readout without redundantly adjusting the slider value.
> - Risk: generic range input track/thumb styles in [style.css](https://github.com/Joker5514/VoiceIsolate-Pro/pull/681/files#diff-35b8006cad11f725a0bc3cee37866f6a39b941ae71d953d622c215dbd1a8d389) are now scoped away from transport and landing seek inputs, which may affect any custom sliders not yet excluded by the new `:not` selectors.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7d74f9e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->