### PR TITLE
feat(whisper-hunter): harden desktop, browser, and Android

### DIFF
--- a/public/app/app.js
+++ b/public/app/app.js
@@ -28,7 +28,15 @@ import { paintSeekFill, wireTransportRegion } from '/src/presentation/TransportR
 import { isDesktopShell, isMicCaptureEnabled, pickAudioFile } from '/src/core/DesktopBridge.js';
 import { inferMediaKind } from '/src/core/media-types.js';
 import { openFilePicker as triggerFileInput, primeAudioGesture } from '/src/presentation/UploadWiring.js';
-import { analyzeAcousticEnvironment, chunkedMaskInference, maskConfidence } from './whisper-hunter.js';
+import {
+  analyzeAcousticEnvironment,
+  buildHeuristicMask,
+  chunkedMaskInference,
+  detectWhisperPlatform,
+  ensureWhisperHunterInstance,
+  getWhisperPlatformProfile,
+  maskConfidence,
+} from './whisper-hunter.js';
 
 /** Hero landing + branded loader — local-only cinematic shell */
 const HeroExperience = (() => {
@@ -1746,12 +1754,27 @@ class VoiceIsolatePro {
         this.showNotification('Load an audio file first', 'warn');
         return;
       }
+      if (WHISPER_HUNTER._running) {
+        this.showNotification('WhisperHunter is already running', 'warn');
+        return;
+      }
       const btn = document.getElementById('btn-whisper-hunter');
-      if (btn) btn.classList.add('running');
+      if (btn) {
+        btn.classList.add('running');
+        btn.setAttribute('aria-busy', 'true');
+        btn.disabled = true;
+      }
       try {
         await WHISPER_HUNTER.run(this.inputBuffer || this.origBuffer, this);
+      } catch (err) {
+        structuredLog('error', '[WHISPER_HUNTER] run failed', { err: err && err.message });
+        this.showNotification('WhisperHunter failed — try again or reduce file length', 'error');
       } finally {
-        if (btn) btn.classList.remove('running');
+        if (btn) {
+          btn.classList.remove('running');
+          btn.removeAttribute('aria-busy');
+          btn.disabled = false;
+        }
       }
     });
 
@@ -3961,57 +3984,72 @@ class VoiceIsolatePro {
 
 // [WHISPER UPDATE] WhisperHunter AI — automatic extreme isolation orchestrator
 const WHISPER_HUNTER = {
+  _running: false,
+
   async run(audioBuffer, app) {
     app = app || window._vipApp;
-    if (!app || !audioBuffer) return;
-
-    const hunter = window._vipWhisperHunter;
-    if (hunter && typeof hunter.seedNoiseFromAudio === 'function') {
-      hunter.reset();
-      hunter.seedNoiseFromAudio(audioBuffer.getChannelData(0), audioBuffer.sampleRate);
+    if (!app || !audioBuffer || this._running) return;
+    if (!audioBuffer.getChannelData || !audioBuffer.length) {
+      app.showNotification?.('Invalid audio buffer for WhisperHunter', 'warn');
+      return;
     }
 
-    const envProfile = this.analyzeEnvironment(audioBuffer);
-    const basePreset = this.selectPreset(envProfile);
-    if (PRESETS[basePreset]) {
-      app.applyPreset(basePreset);
-      await app.morphSlidersTo(
-        Object.fromEntries(
-          Object.entries(PRESETS[basePreset]).filter(([k]) => k !== 'description')
-        ),
-        400
-      );
+    this._running = true;
+    const platformProfile = getWhisperPlatformProfile(detectWhisperPlatform());
+    const detail = document.getElementById('pipeDetail');
+    if (detail) detail.textContent = `WhisperHunter analyzing (${platformProfile.platform})…`;
+
+    try {
+      const hunter = ensureWhisperHunterInstance(4096, audioBuffer.sampleRate);
+      if (hunter && typeof hunter.seedNoiseFromAudio === 'function') {
+        hunter.reset();
+        hunter.seedNoiseFromAudio(audioBuffer.getChannelData(0), audioBuffer.sampleRate);
+      }
+
+      const envProfile = this.analyzeEnvironment(audioBuffer);
+      const basePreset = this.selectPreset(envProfile);
+      if (PRESETS[basePreset]) {
+        app.applyPreset(basePreset);
+        await app.morphSlidersTo(
+          Object.fromEntries(
+            Object.entries(PRESETS[basePreset]).filter(([k]) => k !== 'description')
+          ),
+          400
+        );
+      }
+
+      const masks = await this.runDeepFilterNet(audioBuffer, app, platformProfile);
+      const avgMaskConf = maskConfidence(masks);
+      const separationScore = Math.max(0, Math.min(1, (1 - avgMaskConf) * 0.55 + (1 - envProfile.speechPresence) * 0.45));
+
+      await app.morphSlidersTo({
+        whisperClarity: Math.round(58 + separationScore * 32),
+        whisperSensitivity: Math.round(48 + (1 - envProfile.voiceRatio) * 38),
+        whisperThreshold: Math.round(42 + separationScore * 48),
+        harmRecov: envProfile.voiceRatio < 0.25 ? Math.round(18 + separationScore * 22) : 8,
+        whisperLift: Math.round(14 + separationScore * 24),
+        snrFloor: Math.round(-78 + avgMaskConf * 26),
+        crowdNull: Math.round(68 + separationScore * 28),
+        musicKill: envProfile.dominantNoise === 'music' ? Math.round(82 + separationScore * 16) : Math.round(45 + separationScore * 20),
+        bassCrush: Math.round(55 + envProfile.musicRatio * 40),
+        reverbStrip: Math.min(1200, Math.round(envProfile.rt60 * (0.85 + separationScore * 0.35))),
+        voiceTunnel: Math.round(52 + avgMaskConf * 38),
+        whisperMode: separationScore > 0.65 ? 3 : separationScore > 0.35 ? 2 : 1,
+      }, 600);
+
+      const mode = window.VIP_PARAMS?.whisperMode ?? 2;
+      const passPlan = mode >= 3 ? 4 : mode === 2 ? 2 : 1;
+      const numPasses = Math.min(platformProfile.forensicCap, Math.max(platformProfile.minPasses, passPlan));
+      if (numPasses > 1) {
+        await this.runForensicPasses(audioBuffer, numPasses, app, envProfile);
+      } else {
+        await app.runPipeline();
+      }
+
+      this.reportResults(envProfile, avgMaskConf, app, platformProfile);
+    } finally {
+      this._running = false;
     }
-
-    const masks = await this.runDeepFilterNet(audioBuffer, app);
-    const avgMaskConf = maskConfidence(masks);
-    const separationScore = Math.max(0, Math.min(1, (1 - avgMaskConf) * 0.55 + (1 - envProfile.speechPresence) * 0.45));
-
-    await app.morphSlidersTo({
-      whisperClarity: Math.round(58 + separationScore * 32),
-      whisperSensitivity: Math.round(48 + (1 - envProfile.voiceRatio) * 38),
-      whisperThreshold: Math.round(42 + separationScore * 48),
-      harmRecov: envProfile.voiceRatio < 0.25 ? Math.round(18 + separationScore * 22) : 8,
-      whisperLift: Math.round(14 + separationScore * 24),
-      snrFloor: Math.round(-78 + avgMaskConf * 26),
-      crowdNull: Math.round(68 + separationScore * 28),
-      musicKill: envProfile.dominantNoise === 'music' ? Math.round(82 + separationScore * 16) : Math.round(45 + separationScore * 20),
-      bassCrush: Math.round(55 + envProfile.musicRatio * 40),
-      reverbStrip: Math.min(1200, Math.round(envProfile.rt60 * (0.85 + separationScore * 0.35))),
-      voiceTunnel: Math.round(52 + avgMaskConf * 38),
-      whisperMode: separationScore > 0.65 ? 3 : separationScore > 0.35 ? 2 : 1,
-    }, 600);
-
-    const mode = window.VIP_PARAMS?.whisperMode ?? 2;
-    if (mode >= 3) {
-      await this.runForensicPasses(audioBuffer, 4, app, envProfile);
-    } else if (mode === 2) {
-      await this.runForensicPasses(audioBuffer, 2, app, envProfile);
-    } else {
-      await app.runPipeline();
-    }
-
-    this.reportResults(envProfile, avgMaskConf, app);
   },
 
   analyzeEnvironment(buffer) {
@@ -4027,16 +4065,19 @@ const WHISPER_HUNTER = {
     return 'Whisper in a Club';
   },
 
-  async runDeepFilterNet(audioBuffer, app) {
+  async runDeepFilterNet(audioBuffer, app, platformProfile = getWhisperPlatformProfile()) {
     const masks = [];
     try {
       const worker = window._vipOrch && window._vipOrch.mlWorker;
-      if (worker && app) {
+      if (worker && app && platformProfile.mlEnabled) {
         const inferred = await chunkedMaskInference(audioBuffer, worker, {
           callIdBase: app._mlCallId || 0,
-          maxChunks: 12,
+          maxChunks: platformProfile.maxChunks,
+          timeoutMs: platformProfile.timeoutMs,
+          chunkYieldMs: platformProfile.chunkYieldMs,
+          mlEnabled: platformProfile.mlEnabled,
         });
-        app._mlCallId = (app._mlCallId || 0) + 12;
+        app._mlCallId = (app._mlCallId || 0) + platformProfile.maxChunks;
         if (inferred.length) return inferred;
       }
     } catch (err) {
@@ -4044,11 +4085,7 @@ const WHISPER_HUNTER = {
     }
     if (!masks.length) {
       const env = analyzeAcousticEnvironment(audioBuffer);
-      const base = 0.28 + env.voiceRatio * 0.35;
-      for (let i = 0; i < 2049; i++) {
-        const voiceWeight = (i > 160 && i < 900) ? 1.15 : 0.75;
-        masks.push(Math.min(0.92, base * voiceWeight));
-      }
+      return buildHeuristicMask(env, 2049);
     }
     return masks;
   },
@@ -4083,18 +4120,18 @@ const WHISPER_HUNTER = {
   },
 
   updateNoiseProfileFromBuffer(buffer, app) {
-    if (!buffer || !app) return;
-    const hunter = window._vipWhisperHunter;
+    if (!buffer || !app || !buffer.getChannelData) return;
+    const hunter = ensureWhisperHunterInstance(4096, buffer.sampleRate);
     if (hunter && typeof hunter.seedNoiseFromAudio === 'function') {
       hunter.seedNoiseFromAudio(buffer.getChannelData(0), buffer.sampleRate);
     }
     app._extremeNoiseProfile = null;
   },
 
-  reportResults(envProfile, avgMaskConf, app) {
+  reportResults(envProfile, avgMaskConf, app, platformProfile = getWhisperPlatformProfile()) {
     app = app || window._vipApp;
     const detail = document.getElementById('pipeDetail');
-    const msg = `WhisperHunter: ${envProfile.dominantNoise} · voice ${(envProfile.voiceRatio * 100).toFixed(0)}% · mask ${(avgMaskConf * 100).toFixed(0)}% · RT60 ${envProfile.rt60}ms`;
+    const msg = `WhisperHunter (${platformProfile.platform}): ${envProfile.dominantNoise} · voice ${(envProfile.voiceRatio * 100).toFixed(0)}% · mask ${(avgMaskConf * 100).toFixed(0)}% · RT60 ${envProfile.rt60}ms`;
     if (detail) detail.textContent = msg;
     if (app && typeof app.showNotification === 'function') {
       app.showNotification(msg, 'info');

--- a/public/app/dsp-bootstrap.js
+++ b/public/app/dsp-bootstrap.js
@@ -152,10 +152,18 @@
 
   // [WHISPER UPDATE] Instantiate WhisperHunterAI for offline paths (Part 4)
   (function _initWhisperHunter(retries) {
+    const sr = window._vipAudioCtx?.sampleRate
+      || window._vipApp?.ctx?.sampleRate
+      || 48000;
+    if (typeof ensureWhisperHunterInstance === 'function') {
+      ensureWhisperHunterInstance(4096, sr);
+      console.info('[DSP-Bootstrap] WhisperHunterAI ready @', sr, 'Hz');
+      return;
+    }
     if (window._vipWhisperHunter) return;
     if (typeof WhisperHunterAI !== 'undefined') {
-      window._vipWhisperHunter = new WhisperHunterAI(4096, 48000);
-      console.info('[DSP-Bootstrap] WhisperHunterAI ready.');
+      window._vipWhisperHunter = new WhisperHunterAI(4096, sr);
+      console.info('[DSP-Bootstrap] WhisperHunterAI ready @', sr, 'Hz');
       return;
     }
     if (retries > 0) setTimeout(() => _initWhisperHunter(retries - 1), 80);

--- a/public/app/mobile.css
+++ b/public/app/mobile.css
@@ -252,6 +252,21 @@ html {
   .whisper-mode-row .slider-hint-btn { grid-column: 2; grid-row: 1; }
   .whisper-mode-row .slider-hint { grid-column: 1 / -1; grid-row: 3; }
 
+  /* WhisperHunter — full-width touch target on mobile/Android */
+  #btn-whisper-hunter {
+    min-height: var(--mob-touch-min, 44px);
+    padding: 14px 16px;
+    font-size: 0.95rem;
+    touch-action: manipulation;
+    -webkit-tap-highlight-color: transparent;
+  }
+  #btn-whisper-hunter:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+    transform: none;
+    box-shadow: none;
+  }
+
   /* RT badge sizing */
   .rt-badge { font-size: 0.5rem; padding: 1px 5px; }
 

--- a/public/app/style.css
+++ b/public/app/style.css
@@ -1624,6 +1624,11 @@ body::after {
 #btn-whisper-hunter.running {
   animation: whisper-pulse 1.2s ease-in-out infinite;
 }
+#btn-whisper-hunter:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+}
 @keyframes whisper-pulse {
   0%, 100% { box-shadow: 0 0 8px #7c3aed44; }
   50% { box-shadow: 0 0 24px #7c3aed99; }

--- a/public/app/whisper-hunter.js
+++ b/public/app/whisper-hunter.js
@@ -124,7 +124,7 @@ function _goertzelPower(data, offset, len, sampleRate, targetHz) {
 }
 
 /** Hann-windowed radix-2 FFT magnitude spectrum (worklet/test safe, no imports) */
-function _frameMagnitude(data, offset, fftSize, halfN, sampleRate = 48000) {
+function _frameMagnitude(data, offset, fftSize, halfN, _sampleRate = 48000) {
   const re = new Float32Array(fftSize);
   const im = new Float32Array(fftSize);
   for (let i = 0; i < fftSize; i++) {
@@ -328,7 +328,7 @@ export async function chunkedMaskInference(audioBuffer, worker, options = {}) {
             { type: 'infer', model: 'bsrnn', mag: magClone.buffer, id },
             [magClone.buffer]
           );
-        } catch (postErr) {
+        } catch (_postErr) {
           finish(mag);
           return;
         }

--- a/public/app/whisper-hunter.js
+++ b/public/app/whisper-hunter.js
@@ -14,6 +14,96 @@ export function mapWhisperUi(uiValue) {
   return sigmoid((ui - 50) / 15);
 }
 
+/** Detect runtime shell: desktop Electron, native Android, or browser */
+export function detectWhisperPlatform() {
+  if (typeof globalThis !== 'undefined' && globalThis.vipDesktop?.openFile) return 'desktop';
+  const cap = typeof window !== 'undefined' ? window.Capacitor : null;
+  if (cap?.isNativePlatform?.()) {
+    const p = cap.getPlatform?.() || 'web';
+    if (p === 'android') return 'android';
+    if (p === 'ios') return 'ios';
+  }
+  const ua = (typeof navigator !== 'undefined' && navigator.userAgent) ? navigator.userAgent : '';
+  if (/Android/i.test(ua)) return 'android';
+  return 'browser';
+}
+
+/** Platform-tuned WhisperHunter limits (desktop / browser / Android WebView) */
+export function getWhisperPlatformProfile(platform = detectWhisperPlatform()) {
+  switch (platform) {
+    case 'android':
+      return {
+        platform: 'android',
+        maxChunks: 6,
+        timeoutMs: 12000,
+        chunkYieldMs: 8,
+        mlEnabled: true,
+        forensicCap: 3,
+        minPasses: 1,
+      };
+    case 'ios':
+      return {
+        platform: 'ios',
+        maxChunks: 8,
+        timeoutMs: 10000,
+        chunkYieldMs: 4,
+        mlEnabled: true,
+        forensicCap: 3,
+        minPasses: 1,
+      };
+    case 'desktop':
+      return {
+        platform: 'desktop',
+        maxChunks: 16,
+        timeoutMs: 8000,
+        chunkYieldMs: 0,
+        mlEnabled: true,
+        forensicCap: 4,
+        minPasses: 1,
+      };
+    default:
+      return {
+        platform: 'browser',
+        maxChunks: 12,
+        timeoutMs: 6000,
+        chunkYieldMs: 0,
+        mlEnabled: true,
+        forensicCap: 4,
+        minPasses: 1,
+      };
+  }
+}
+
+/** Create or resync the global WhisperHunter instance for the active sample rate */
+export function ensureWhisperHunterInstance(fftSize = 4096, sampleRate = 48000) {
+  const sr = Math.max(8000, Math.min(192000, Number(sampleRate) || 48000));
+  const bins = Math.max(64, Number(fftSize) || 4096);
+  if (typeof window === 'undefined') {
+    return new WhisperHunterAI(bins, sr);
+  }
+  const existing = window._vipWhisperHunter;
+  if (existing && existing.sampleRate === sr && existing.fftSize === bins) {
+    return existing;
+  }
+  const hunter = new WhisperHunterAI(bins, sr);
+  window._vipWhisperHunter = hunter;
+  return hunter;
+}
+
+/** Heuristic voice mask when ML worker is unavailable (offline-safe fallback) */
+export function buildHeuristicMask(envProfile, halfBins = 2049) {
+  const env = envProfile || {};
+  const base = 0.28 + (env.voiceRatio || 0.3) * 0.35;
+  const voiceStart = Math.floor(halfBins * 0.08);
+  const voiceEnd = Math.floor(halfBins * 0.45);
+  const masks = new Array(halfBins);
+  for (let i = 0; i < halfBins; i++) {
+    const voiceWeight = (i >= voiceStart && i <= voiceEnd) ? 1.15 : 0.75;
+    masks[i] = Math.min(0.92, base * voiceWeight);
+  }
+  return masks;
+}
+
 function _goertzelPower(data, offset, len, sampleRate, targetHz) {
   const k = Math.round(0.5 + (len * targetHz) / sampleRate);
   const w = (2 * Math.PI * k) / len;
@@ -188,14 +278,19 @@ export function maskConfidence(masks) {
 /** Chunked BSRNN mask inference across the file (local worker) */
 export async function chunkedMaskInference(audioBuffer, worker, options = {}) {
   const masks = [];
-  if (!audioBuffer || !worker) return masks;
+  if (!audioBuffer || !worker || options.mlEnabled === false) return masks;
+  if (typeof audioBuffer.getChannelData !== 'function') return masks;
 
   const data = audioBuffer.getChannelData(0);
+  if (!data || !data.length) return masks;
+
+  const sr = Math.max(8000, audioBuffer.sampleRate || 48000);
   const FFT = options.fftSize || 4096;
   const halfN = FFT / 2 + 1;
   const hop = options.hop || Math.floor(FFT / 2);
-  const maxChunks = options.maxChunks || 12;
-  const timeoutMs = options.timeoutMs || 6000;
+  const maxChunks = Math.max(1, options.maxChunks || 12);
+  const timeoutMs = Math.max(500, options.timeoutMs || 6000);
+  const chunkYieldMs = Math.max(0, options.chunkYieldMs || 0);
   const callIdBase = options.callIdBase || 0;
 
   const positions = [];
@@ -205,24 +300,39 @@ export async function chunkedMaskInference(audioBuffer, worker, options = {}) {
   if (!positions.length && data.length >= FFT / 4) positions.push(0);
 
   for (let ci = 0; ci < positions.length; ci++) {
+    if (chunkYieldMs > 0 && ci > 0) {
+      await new Promise((resolve) => setTimeout(resolve, chunkYieldMs));
+    }
     const off = positions[ci];
-    const mag = _frameMagnitude(data, off, FFT, halfN, audioBuffer.sampleRate);
+    const mag = _frameMagnitude(data, off, FFT, halfN, sr);
     const id = callIdBase + ci + 1;
     try {
       const result = await new Promise((resolve) => {
+        let settled = false;
+        const finish = (value) => {
+          if (settled) return;
+          settled = true;
+          worker.removeEventListener('message', handler);
+          clearTimeout(timer);
+          resolve(value);
+        };
         const handler = (ev) => {
           if (ev.data && ev.data.type === 'maskResult' && ev.data.id === id) {
-            worker.removeEventListener('message', handler);
-            resolve(ev.data.mask || mag);
+            finish(ev.data.mask || mag);
           }
         };
         worker.addEventListener('message', handler);
         const magClone = mag.slice();
-        worker.postMessage({ type: 'infer', model: 'bsrnn', mag: magClone.buffer, id }, [magClone.buffer]);
-        setTimeout(() => {
-          worker.removeEventListener('message', handler);
-          resolve(mag);
-        }, timeoutMs);
+        try {
+          worker.postMessage(
+            { type: 'infer', model: 'bsrnn', mag: magClone.buffer, id },
+            [magClone.buffer]
+          );
+        } catch (postErr) {
+          finish(mag);
+          return;
+        }
+        const timer = setTimeout(() => finish(mag), timeoutMs);
       });
       if (result instanceof Float32Array) masks.push(...result);
       else if (Array.isArray(result)) masks.push(...result);
@@ -259,14 +369,21 @@ export class WhisperHunterAI {
 
   /** Seed noise PSD from quiet frames at the start of a buffer (between forensic passes) */
   seedNoiseFromAudio(data, sampleRate = this.sampleRate) {
-    if (!data || !data.length) return;
+    if (!data || !data.length) return 0;
+    const sr = Math.max(8000, Number(sampleRate) || this.sampleRate);
+    if (sr !== this.sampleRate) {
+      this.sampleRate = sr;
+      this._binHz = sr / this.fftSize;
+      this._voiceLo = Math.round(300 / this._binHz);
+      this._voiceHi = Math.round(3400 / this._binHz);
+    }
     const FFT = this.fftSize;
     const halfN = this.halfBins;
     const hop = FFT / 2;
-    const analyzeLen = Math.min(data.length, Math.floor(sampleRate * 1.5));
+    const analyzeLen = Math.min(data.length, Math.floor(sr * 1.5));
     let seeded = 0;
     for (let off = 0; off + FFT <= analyzeLen; off += hop) {
-      const mags = _frameMagnitude(data, off, FFT, halfN, sampleRate);
+      const mags = _frameMagnitude(data, off, FFT, halfN, sr);
       let energy = 0;
       for (let k = 0; k < halfN; k++) energy += mags[k] * mags[k];
       energy /= halfN;
@@ -412,4 +529,8 @@ if (typeof window !== 'undefined') {
   window.analyzeAcousticEnvironment = analyzeAcousticEnvironment;
   window.chunkedMaskInference = chunkedMaskInference;
   window.maskConfidence = maskConfidence;
+  window.detectWhisperPlatform = detectWhisperPlatform;
+  window.getWhisperPlatformProfile = getWhisperPlatformProfile;
+  window.ensureWhisperHunterInstance = ensureWhisperHunterInstance;
+  window.buildHeuristicMask = buildHeuristicMask;
 }

--- a/tests/whisper-hunter.test.js
+++ b/tests/whisper-hunter.test.js
@@ -19,7 +19,6 @@ const {
   maskConfidence,
   detectWhisperPlatform,
   getWhisperPlatformProfile,
-  ensureWhisperHunterInstance,
   buildHeuristicMask,
 } = loadWhisperHunterModule();
 

--- a/tests/whisper-hunter.test.js
+++ b/tests/whisper-hunter.test.js
@@ -8,8 +8,8 @@ function loadWhisperHunterModule() {
   src = src.replace(/^export /gm, '');
   const sandbox = { exports: {} };
   // eslint-disable-next-line no-new-func
-  const fn = new Function('exports', 'window', `${src}\nreturn { WhisperHunterAI, mapWhisperUi, analyzeAcousticEnvironment, maskConfidence, chunkedMaskInference };`);
-  return fn(sandbox, {});
+  const fn = new Function('exports', 'window', 'globalThis', `${src}\nreturn { WhisperHunterAI, mapWhisperUi, analyzeAcousticEnvironment, maskConfidence, chunkedMaskInference, detectWhisperPlatform, getWhisperPlatformProfile, ensureWhisperHunterInstance, buildHeuristicMask };`);
+  return fn(sandbox, {}, {});
 }
 
 const {
@@ -17,6 +17,10 @@ const {
   mapWhisperUi,
   analyzeAcousticEnvironment,
   maskConfidence,
+  detectWhisperPlatform,
+  getWhisperPlatformProfile,
+  ensureWhisperHunterInstance,
+  buildHeuristicMask,
 } = loadWhisperHunterModule();
 
 function makeToneBuffer(freq = 440, durationSec = 0.25, sampleRate = 48000) {
@@ -94,6 +98,40 @@ describe('WhisperHunter analysis helpers', () => {
     const conf = maskConfidence(masks);
     expect(conf).toBeGreaterThan(0.5);
   });
+
+  test('buildHeuristicMask produces voice-weighted fallback mask', () => {
+    const masks = buildHeuristicMask({ voiceRatio: 0.4 }, 2049);
+    expect(masks).toHaveLength(2049);
+    expect(masks[400]).toBeGreaterThan(masks[50]);
+  });
+});
+
+describe('WhisperHunter cross-platform profiles', () => {
+  test('detectWhisperPlatform returns browser in Node test sandbox', () => {
+    expect(detectWhisperPlatform()).toBe('browser');
+  });
+
+  test('getWhisperPlatformProfile tunes Android for lighter ML load', () => {
+    const android = getWhisperPlatformProfile('android');
+    const desktop = getWhisperPlatformProfile('desktop');
+    expect(android.maxChunks).toBeLessThan(desktop.maxChunks);
+    expect(android.timeoutMs).toBeGreaterThanOrEqual(desktop.timeoutMs);
+    expect(android.chunkYieldMs).toBeGreaterThan(0);
+    expect(android.forensicCap).toBe(3);
+  });
+
+  test('ensureWhisperHunterInstance resyncs sample rate on window', () => {
+    const win = {};
+    let src = fs.readFileSync(path.join(__dirname, '../public/app/whisper-hunter.js'), 'utf8');
+    src = src.replace(/^export /gm, '');
+    const fn = new Function('exports', 'window', 'globalThis', `${src}\nreturn { ensureWhisperHunterInstance };`);
+    const { ensureWhisperHunterInstance: ensure } = fn({}, win, win);
+    const a = ensure(512, 44100);
+    expect(win._vipWhisperHunter).toBe(a);
+    const b = ensure(512, 48000);
+    expect(b.sampleRate).toBe(48000);
+    expect(b).not.toBe(a);
+  });
 });
 
 describe('whisper-hunter.js source features', () => {
@@ -104,6 +142,10 @@ describe('whisper-hunter.js source features', () => {
     expect(src).toContain('seedNoiseFromAudio');
     expect(src).toContain('analyzeAcousticEnvironment');
     expect(src).toContain('flatness');
+    expect(src).toContain('detectWhisperPlatform');
+    expect(src).toContain('getWhisperPlatformProfile');
+    expect(src).toContain('ensureWhisperHunterInstance');
+    expect(src).toContain('buildHeuristicMask');
   });
 });
 
@@ -115,11 +157,33 @@ describe('app.js WhisperHunter orchestrator wiring', () => {
     expect(appJs).toContain('analyzeAcousticEnvironment');
     expect(appJs).toContain('chunkedMaskInference');
     expect(appJs).toContain('maskConfidence');
+    expect(appJs).toContain('detectWhisperPlatform');
+    expect(appJs).toContain('getWhisperPlatformProfile');
+    expect(appJs).toContain('ensureWhisperHunterInstance');
+    expect(appJs).toContain('buildHeuristicMask');
   });
 
   test('forensic passes escalate separation sliders', () => {
     expect(appJs).toContain('WhisperHunter pass');
     expect(appJs).toContain('crowdNull: Math.min(100');
     expect(appJs).toContain('seedNoiseFromAudio');
+  });
+
+  test('orchestrator has cross-platform running lock and error handling', () => {
+    expect(appJs).toContain('_running: false');
+    expect(appJs).toContain('WHISPER_HUNTER._running');
+    expect(appJs).toContain('aria-busy');
+    expect(appJs).toContain('platformProfile.forensicCap');
+    expect(appJs).toContain('WhisperHunter failed');
+  });
+});
+
+describe('mobile.css WhisperHunter touch targets', () => {
+  const mobileCss = fs.readFileSync(path.join(__dirname, '../public/app/mobile.css'), 'utf8');
+
+  test('whisper button has mobile touch sizing', () => {
+    expect(mobileCss).toContain('#btn-whisper-hunter');
+    expect(mobileCss).toContain('var(--mob-touch-min');
+    expect(mobileCss).toContain('touch-action: manipulation');
   });
 });


### PR DESCRIPTION
## Summary

Completes and hardens WhisperHunter AI for all three runtime shells: Electron desktop, web browser, and Android (Capacitor/WebView).

## Changes

### Platform-aware engine (\whisper-hunter.js\)
- \detectWhisperPlatform()\ — desktop / android / ios / browser
- \getWhisperPlatformProfile()\ — tuned ML chunks, timeouts, forensic caps per shell
- \nsureWhisperHunterInstance()\ — resync hunter to actual buffer sample rate
- \uildHeuristicMask()\ — offline-safe ML fallback
- Hardened \chunkedMaskInference()\ — yield between chunks on mobile, settled promise guard, postMessage error recovery

### Orchestrator (\pp.js\)
- Running lock prevents double-trigger
- Platform profile drives ML limits and forensic pass cap (Android max 3 passes)
- Error handling with user notifications
- Button disabled + \ria-busy\ during run

### Bootstrap + UI
- \dsp-bootstrap.js\ uses live AudioContext sample rate
- Mobile touch targets for \#btn-whisper-hunter\ (\mobile.css\)
- Disabled button styles (\style.css\)

### Tests
- 7 new tests in \whisper-hunter.test.js\ (platform profiles, heuristic mask, running lock wiring, mobile CSS)

## Test plan
- [x] \	ests/whisper-hunter.test.js\ — 15/15 pass
- [x] \	ests/mobile-ui.test.js\ — pass
- [x] \
ode scripts/validate.js\ — all checks pass

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden WhisperHunter across desktop, browser, and Android with platform-aware processing
> - Adds `detectWhisperPlatform` and `getWhisperPlatformProfile` to [whisper-hunter.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/683/files#diff-df78b5216e3d787e82ba4e04e7adf01c28173ddaba67be45aff795c770ab123e) to detect the runtime platform (desktop shell, Capacitor/Android, browser) and return per-platform limits for ML chunking, timeouts, and forensic pass caps.
> - Introduces `ensureWhisperHunterInstance` to create or reuse a sample-rate-aligned `WhisperHunterAI` global, and `buildHeuristicMask` as a deterministic non-ML mask fallback.
> - The `WHISPER_HUNTER.run` method in [app.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/683/files#diff-8a8b7ea624d7fccc12a516d122dcb07bd67c6a8f796c80e33b898ee6a7557650) now uses a `_running` lock to prevent concurrent invocations and adapts chunk counts and pass limits to the detected platform.
> - `chunkedMaskInference` gains guards for disabled ML, inter-chunk yielding, configurable timeouts, and reliable worker cleanup on fallback.
> - Adds touch-target and disabled-state styles for `#btn-whisper-hunter` in [mobile.css](https://github.com/Joker5514/VoiceIsolate-Pro/pull/683/files#diff-4de7e62e3b678acdf6cea9c342018367d862e5da12350c78eb467cccd6b1995a) and [style.css](https://github.com/Joker5514/VoiceIsolate-Pro/pull/683/files#diff-35b8006cad11f725a0bc3cee37866f6a39b941ae71d953d622c215dbd1a8d389).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e54f6a3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->