### PR TITLE
fix(pages): clean both shells and harden worklet precache

### DIFF
--- a/public/app/dsp-bootstrap.js
+++ b/public/app/dsp-bootstrap.js
@@ -5,11 +5,8 @@
  * Wires three previously disconnected pieces:
  *   1. globalThis.DSP  — exposes forwardSTFT / inverseSTFT so runPipeline()
  *                        produces real audio instead of a silent copy.
- *   2. initAudio()     — patches the existing stub to set up the audio graph.
- *                        Worklet registration and ML worker lifecycle are owned
- *                        exclusively by pipeline-orchestrator.js (CLAUDE.md §2/§3).
- *   3. _vipOrch        — initialises the PipelineOrchestrator and stores it
- *                        on window so slider dispatches route correctly.
+ *   2. initAudio()     — patches AudioContext + SharedArrayBuffers onto the app.
+ *   3. WhisperHunter   — early _vipWhisperHunter init (retries until module loads).
  *
  * CONSTRAINTS MAINTAINED:
  *   • Exactly ONE forward STFT, in-place spectral ops, ONE iSTFT.

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -4,6 +4,9 @@
   <meta charset="UTF-8" />
   <title>VoiceIsolate Pro v24.0 – Engineer Mode</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="VoiceIsolate Pro Engineer Mode — 32-stage local DSP, WhisperHunter AI, and forensic voice isolation. No cloud uploads." />
+  <link rel="manifest" href="/manifest.json" />
+  <link rel="icon" href="/icon.jpg" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet" />
@@ -26,7 +29,7 @@
   <script src="./dsp-core.js"></script>
   <script src="./ai-intelligence.js"></script>
   <script type="module" src="./whisper-hunter.js"></script>
-  <!-- // LOAD ORDER VERIFIED: ring-buffer.js is available before pipeline-orchestrator.js can allocate SAB rings or load the canonical worklet. -->
+  <script src="./dsp-bootstrap.js"></script>
   <script src="./ring-buffer.js"></script>
   <script src="./visuals.js"></script>
   <script src="./premium-visuals.js"></script>
@@ -111,7 +114,7 @@
       <div class="boot-mark" aria-hidden="true">VIP</div>
       <div class="boot-kicker">ENGINEER MODE · v24 · LOCAL DSP STACK</div>
       <h2 class="boot-title">Neural Audio Processor — Initializing</h2>
-      <p id="bootSplashText" class="boot-text">Priming AudioWorklet, ONNX model cache, 32-stage Deca-Pass pipeline, and spectral controls…</p>
+      <p id="bootSplashText" class="boot-text">Loading ONNX model cache, WhisperHunter AI, 32-stage Deca-Pass pipeline, and spectral controls…</p>
       <div class="boot-progress" aria-hidden="true"><div id="bootSplashProgress" class="boot-progress-fill"></div></div>
       <div class="boot-bars" aria-hidden="true">
         <span class="boot-bar"></span>
@@ -149,6 +152,7 @@
       <button id="uiScaleSave" type="button" class="btn-xs" title="Save UI scale" aria-label="Save UI scale">Save</button>
     </div>
     <div class="hdr-actions">
+      <a class="btn btn-outline hdr-link" href="/">Stem-Split</a>
       <a class="btn btn-outline hdr-link" href="how-it-works.html">How It Works</a>
     </div>
     <button id="statsToggle" class="hdr-stats-toggle" aria-label="Toggle stats" title="Toggle stats" aria-expanded="false">&#9660;</button>
@@ -550,10 +554,7 @@
   <div id="toastRegion" aria-live="polite"></div>
 
   <script type="module">
-    // LOAD ORDER VERIFIED: slider-map.js resolves as an app.js dependency before app.js evaluates.
-    // pipeline-orchestrator.js was removed with the live real-time pipeline
-    // (Stem-Split & Live-Mix architecture — see CLAUDE.md). Offline processing
-    // runs through app.js _runFallbackPipeline.
+    // Offline Engineer pipeline runs through app.js (32-stage Deca-Pass + WhisperHunter).
     const _parallel = [
       './processing-overlay.js',
       './session-persist.js',
@@ -592,23 +593,6 @@
       console.warn('[VIP] debug-menu.js not loaded:', err);
     });
   </script>
-
-  <!--
-    REMOVED: _vipSafetyNet <script> block (was here until this commit).
-
-    ROOT CAUSE of processBtn disappearing after file load:
-      The safety-net listened on DOMContentLoaded and called new VoiceIsolatePro()
-      if window._vipApp was falsy. Because ES module evaluation is async, the
-      safety-net's DOMContentLoaded callback often fired AFTER the module bootstrap
-      set window._vipApp — but in the critical race window it fired BEFORE, creating
-      a second VoiceIsolatePro() instance. That second constructor re-ran cacheDom()
-      and bindEvents(), which left processBtn.disabled = true (its HTML default),
-      overwriting the enabled state set by onAudioLoaded() on the first instance.
-
-    The module bootstrap chain (app.js → vip-boot.js) already has:
-      if (window._vipApp) return;
-    The safety-net was fully redundant. Do not re-add it.
-  -->
 
   <!-- Mobile upload fix: iOS Safari decodeAudioData, AudioContext gesture lock,
        touch-action bleed, MIME accept scope. Loads after all modules are bootstrapped. -->

--- a/public/app/sw.js
+++ b/public/app/sw.js
@@ -33,9 +33,12 @@ const APP_SHELL = [
   '/app/index.html',
   '/app/app.js',
   '/app/style.css',
+  '/app/mobile.css',
   '/app/dsp-core.js',
+  '/app/dsp-bootstrap.js',
   '/app/dsp-processor.js',
-  // Playback-only Live-Mix worklets (Gate + De-esser) — loaded by PlaybackMixer
+  '/app/whisper-hunter.js',
+  // Playback Live-Mix worklets (Gate + De-esser) — loaded by PlaybackMixer on landing + engineer playback
   '/src/workers/GateProcessor.js',
   '/src/workers/DeEsserProcessor.js',
   '/src/pipeline/PlaybackMixer.js',
@@ -44,16 +47,15 @@ const APP_SHELL = [
   '/app/ml-worker.js',
   '/app/ml-worker-fetch-cache.js',
   '/app/ring-buffer.js',
-  '/app/batch-orchestrator.js',
-  '/app/batch-processor.js',
   '/app/visuals.js',
-  '/app/analytics.js',
-  '/app/paywall.js',
   '/app/sw-register.js',
   '/app/model-loader.js',
   '/app/vip-boot.js',
+  '/app/vip-fixes.js',
+  '/app/mobile-upload-fix.js',
   '/app/session-persist.js',
   '/app/slider-map.js',
+  '/app/slider-hint-ui.js',
   '/app/processing-overlay.js',
 ];
 // NOTE: revenuecat.js is intentionally excluded from APP_SHELL pre-cache.

--- a/scripts/vercel-build.js
+++ b/scripts/vercel-build.js
@@ -22,6 +22,14 @@ if (validate.status !== 0) {
   process.exit(validate.status || 1);
 }
 
+const verifyWorklets = spawnSync(process.execPath, [path.join(__dirname, 'verify-worklets.js')], {
+  stdio: 'inherit',
+  env: process.env,
+});
+if (verifyWorklets.status !== 0) {
+  process.exit(verifyWorklets.status || 1);
+}
+
 if (fs.existsSync(DEST)) {
   fs.rmSync(DEST, { recursive: true, force: true });
 }

--- a/tests/engineer-mode-completion.test.js
+++ b/tests/engineer-mode-completion.test.js
@@ -22,10 +22,13 @@ describe('Engineer Mode completion wiring', () => {
     });
   });
 
-  test('index.html includes model status containers and How It Works link', () => {
+  test('index.html includes model status containers and navigation links', () => {
     expect(indexHtml).toContain('id="modelStatusPills"');
     expect(indexHtml).toContain('id="cdnHealthPanel"');
     expect(indexHtml).toContain('href="how-it-works.html"');
+    expect(indexHtml).toContain('href="/">Stem-Split</a>');
+    expect(indexHtml).toContain('src="./dsp-bootstrap.js"');
+    expect(indexHtml).toContain('rel="manifest"');
   });
 
   test('index.html loads visuals.js (classic, load-order-sensitive) and the processing-overlay module', () => {

--- a/tests/worklet-packaging.test.js
+++ b/tests/worklet-packaging.test.js
@@ -65,6 +65,14 @@ describe('AudioWorklet packaging (all platforms)', () => {
     }
   });
 
+  test('public/app/sw.js APP_SHELL precaches WhisperHunter and dsp-bootstrap', () => {
+    const sw = fs.readFileSync(path.join(ROOT, 'public/app/sw.js'), 'utf8');
+    expect(sw).toContain("'/app/whisper-hunter.js'");
+    expect(sw).toContain("'/app/dsp-bootstrap.js'");
+    expect(sw).not.toContain("'/app/batch-orchestrator.js'");
+    expect(sw).not.toContain("'/app/paywall.js'");
+  });
+
   test('capacitor.config.json webDir is build (worklets flow through pnpm build)', () => {
     const cfg = JSON.parse(fs.readFileSync(path.join(ROOT, 'capacitor.config.json'), 'utf8'));
     expect(cfg.webDir).toBe('build');
@@ -73,6 +81,13 @@ describe('AudioWorklet packaging (all platforms)', () => {
   test('electron-builder.yml packs build/** (includes worklets)', () => {
     const yml = fs.readFileSync(path.join(ROOT, 'electron/electron-builder.yml'), 'utf8');
     expect(yml).toContain('build/**/*');
+  });
+
+  test('landing and engineer pages cross-link each other', () => {
+    const landing = fs.readFileSync(path.join(ROOT, 'public/index.html'), 'utf8');
+    const engineer = fs.readFileSync(path.join(ROOT, 'public/app/index.html'), 'utf8');
+    expect(landing).toContain('href="/app/"');
+    expect(engineer).toContain('href="/">Stem-Split</a>');
   });
 
   test('PlaybackMixer allowlists only Gate + DeEsser for addModule', () => {


### PR DESCRIPTION
## Summary

Audits the landing + Engineer pages, removes stale references, adds missing wiring, and ensures all three AudioWorklets ship correctly via APP_SHELL and Vercel build.

## Engineer page (\public/app/index.html\)
- Added meta description, manifest, and favicon (parity with landing)
- Added **Stem-Split** nav link back to landing
- Loads \dsp-bootstrap.js\ (WhisperHunter early init + AudioContext patch)
- Removed obsolete pipeline-orchestrator comments and safety-net essay
- Updated boot splash copy

## Service worker (\public/app/sw.js\)
- **Added** to APP_SHELL: \whisper-hunter.js\, \dsp-bootstrap.js\, \mobile.css\, \ip-fixes.js\, \mobile-upload-fix.js\, \slider-hint-ui.js\
- **Removed** unused precache entries: \atch-orchestrator\, \atch-processor\, \nalytics\, \paywall\
- All 3 worklet URLs unchanged and verified: Gate, DeEsser, dsp-processor

## Deploy
- \scripts/vercel-build.js\ now runs \erify-worklets.js\ after validate (blocks deploy on hash/sync failures)

## Tests
- Cross-page nav link test (landing ↔ engineer)
- APP_SHELL WhisperHunter/dsp-bootstrap assertions
- Engineer page manifest + dsp-bootstrap wiring

## Test plan
- [x] \
ode scripts/validate.js\
- [x] \
ode scripts/verify-worklets.js\
- [x] \	ests/worklet-packaging.test.js\ — 11/11
- [x] \	ests/engineer-mode-completion.test.js\ — pass

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix service worker pre-cache list and add worklet build verification
> - Updates the `APP_SHELL` pre-cache list in [sw.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/684/files#diff-250b21046481fe40a92fc1e71bdad3b4651823f62f3a0fcc491360c4d506dae6) to include `mobile.css`, `dsp-bootstrap.js`, `whisper-hunter.js`, and related UI scripts, while removing `batch-orchestrator.js`, `batch-processor.js`, `analytics.js`, and `paywall.js`.
> - Adds a pre-build verification step in [vercel-build.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/684/files#diff-3637b425f4a5ffef792ffcad1a8527fb0624a591d6c6c48d25b2520489b20487) that runs `verify-worklets.js` and fails the build early if worklets are missing or invalid.
> - Updates [index.html](https://github.com/Joker5514/VoiceIsolate-Pro/pull/684/files#diff-4400aa5aa5292d143f7e2f1308aa82756255552567d5558874c994833e907ce4) to load `dsp-bootstrap.js` and add a 'Stem-Split' nav link back to the landing page (`/`).
> - Behavioral Change: assets removed from `APP_SHELL` will no longer be pre-cached on service worker install; previously cached copies will be evicted on next cache update.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 125c610.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->