### PR TITLE
fix(upload): restore file picker and remove live mic

### DIFF
--- a/public/app/app.js
+++ b/public/app/app.js
@@ -25,9 +25,9 @@ import { sliceAudioBuffer } from '/src/core/audio-slice.js';
 import { clearStemCache } from '/src/pipeline/MLStemCache.js';
 import { resetTimings, stageEnd, stageStart } from '/src/pipeline/PipelineTiming.js';
 import { paintSeekFill, wireTransportRegion } from '/src/presentation/TransportRegionControls.js';
-import { isDesktopShell, isMicCaptureEnabled, pickAudioFile } from '/src/core/DesktopBridge.js';
+import { isDesktopShell, pickAudioFile } from '/src/core/DesktopBridge.js';
 import { inferMediaKind } from '/src/core/media-types.js';
-import { openFilePicker as triggerFileInput, primeAudioGesture } from '/src/presentation/UploadWiring.js';
+import { openFilePicker as triggerFileInput, primeAudioGesture, fixUploadTouchTargets } from '/src/presentation/UploadWiring.js';
 import {
   analyzeAcousticEnvironment,
   buildHeuristicMask,
@@ -41,8 +41,6 @@ import {
 /** Hero landing + branded loader — local-only cinematic shell */
 const HeroExperience = (() => {
   let appRef = null;
-  let recording = false;
-  let micCapture = null;
 
   function $(id) { return document.getElementById(id); }
 
@@ -131,34 +129,21 @@ const HeroExperience = (() => {
     }
   }
 
-  function hideMicControls() {
-    for (const id of ['heroCtaRecord', 'micBtn']) {
-      const el = $(id);
-      if (el) {
-        el.hidden = true;
-        el.style.display = 'none';
-        el.setAttribute('aria-hidden', 'true');
-      }
-    }
-  }
-
   function bindHeroCtas(app) {
-    $('heroCtaUpload')?.addEventListener('click', (e) => {
+    $('heroCtaUpload')?.addEventListener('click', async (e) => {
       e.preventDefault();
-      app.dom.fileBtn?.click();
+      if (isDesktopShell()) {
+        try {
+          const file = await pickAudioFile();
+          if (file) await app.handleFile(file);
+        } catch (err) {
+          app.showNotification?.(err?.message || 'Could not open file', 'error');
+        }
+        return;
+      }
+      triggerFileInput(app.dom?.fileInput);
+      primeAudioGesture().catch(() => {});
     });
-    if (isMicCaptureEnabled()) {
-      $('heroCtaRecord')?.addEventListener('click', (e) => {
-        e.preventDefault();
-        toggleMicRecord(app);
-      });
-      $('micBtn')?.addEventListener('click', (e) => {
-        e.preventDefault();
-        toggleMicRecord(app);
-      });
-    } else {
-      hideMicControls();
-    }
     $('heroCtaProcess')?.addEventListener('click', (e) => {
       e.preventDefault();
       if (!app.dom.processBtn?.disabled) app.runPipeline();
@@ -176,47 +161,6 @@ const HeroExperience = (() => {
       app.dom.tpPlay?.click();
     });
     $('abToggle')?.addEventListener('click', () => app.dom.tpAB?.click());
-  }
-
-  async function loadMicCapture() {
-    if (!micCapture) {
-      micCapture = await import('/mic-capture.js');
-    }
-    return micCapture;
-  }
-
-  async function toggleMicRecord(app) {
-    const micBtn = $('micBtn');
-    const heroRec = $('heroCtaRecord');
-    try {
-      const mic = await loadMicCapture();
-      if (recording || mic.isMicRecording()) {
-        const filePromise = mic.stopMicRecording();
-        recording = false;
-        micBtn?.classList.remove('recording');
-        heroRec?.classList.remove('recording');
-        setUiState('idle');
-        setHeroCopy('Processing recording…', false);
-        if (filePromise) {
-          const file = await filePromise;
-          await app.handleFile(file);
-        }
-        return;
-      }
-      await mic.startMicRecording();
-      recording = true;
-      micBtn?.classList.add('recording');
-      heroRec?.classList.add('recording');
-      setUiState('recording');
-      setHeroCopy('Recording from microphone… click again to stop', false);
-    } catch (err) {
-      recording = false;
-      micBtn?.classList.remove('recording');
-      heroRec?.classList.remove('recording');
-      app.showNotification?.(err?.message || 'Microphone access denied', 'error');
-      setUiState('error');
-      setHeroCopy('Microphone unavailable — use file upload', false);
-    }
   }
 
   function patchOverlayRefs() {
@@ -268,10 +212,7 @@ const HeroExperience = (() => {
       patchOverlayRefs();
       setUiState('idle');
       const tierStatus = WorkflowTier.getConfig?.()?.statusIdle;
-      setHeroCopy(
-        tierStatus || (isMicCaptureEnabled() ? 'Ready — upload or record to begin' : 'Ready — upload audio or video to begin'),
-        false,
-      );
+      setHeroCopy(tierStatus || 'Ready — upload audio or video to begin', false);
       window.addEventListener('vip:fileLoaded', () => {
         setUiState('file-ready');
         setHeroCopy('File loaded — processing pipeline starting', true);
@@ -301,10 +242,7 @@ const HeroExperience = (() => {
     onClear() {
       setUiState('idle');
       const tierStatus = WorkflowTier.getConfig?.()?.statusIdle;
-      setHeroCopy(
-        tierStatus || (isMicCaptureEnabled() ? 'Ready — upload or record to begin' : 'Ready — upload audio or video to begin'),
-        false,
-      );
+      setHeroCopy(tierStatus || 'Ready — upload audio or video to begin', false);
       syncStatStrip(null, 'Idle');
     },
     mirrorWaveCanvases,
@@ -901,6 +839,7 @@ class VoiceIsolatePro {
     try {
       this._renderSliders();
       this.bindEvents();
+      fixUploadTouchTargets();
       this._updateProcessButtonsState();
       HeroExperience.init(this);
       WorkflowTier.init(this);
@@ -1618,8 +1557,12 @@ class VoiceIsolatePro {
         }
         return;
       }
-      try { await primeAudioGesture(); } catch { /* best-effort */ }
-      triggerFileInput(this.dom.fileInput);
+      if (!triggerFileInput(this.dom.fileInput)) {
+        structuredLog('warn', '[VIP] file input unavailable for picker');
+        this.showNotification('Upload control unavailable — refresh the page', 'warn');
+        return;
+      }
+      primeAudioGesture().catch(() => {});
     };
     // File input — always read this.dom.fileInput so late patches cannot orphan handlers
     bind('fileBtn', d.fileBtn, 'click', (e) => { e.preventDefault(); openFilePicker(); });
@@ -3273,9 +3216,7 @@ class VoiceIsolatePro {
     return data;
   }
 
-  // Live-microphone ingestion was REMOVED by design (CLAUDE.md §1.1).
-  // Live mic capture API is forbidden in public/app; use /mic-capture.js instead. The
-  // Permissions-Policy header denies the microphone entirely.
+  // Live-microphone ingestion removed — upload-only workflow (CLAUDE.md §1.1).
 
   // ── Transport ─────────────────────────────────────────────────────────────
 

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -216,7 +216,6 @@
         <p id="heroStatus" class="vip-hero-status" role="status" aria-live="polite">Ready — upload audio or video to begin</p>
         <div class="vip-hero-cta-row" role="group" aria-label="Start actions">
           <button id="heroCtaUpload" class="btn btn-primary vip-hero-cta" type="button">Upload Audio or Video</button>
-          <button id="heroCtaRecord" class="btn btn-outline vip-hero-cta btn-mic" type="button">Record Mic</button>
           <button id="heroCtaProcess" class="btn btn-reprocess vip-hero-cta" type="button" disabled>Process Now</button>
         </div>
         <div class="vip-hero-trust" role="status" aria-label="Local processing trust">
@@ -305,7 +304,6 @@
             <p class="upload-title">Drop Audio or Video</p>
             <p class="upload-sub">MP3 · WAV · FLAC · OGG · OPUS · M4A · AAC · AIFF · WMA · MP4 · MOV · MKV · AVI · WEBM · WMV · TS and more</p>
             <button id="fileBtn" class="btn btn-outline" type="button">Browse Files</button>
-            <button id="micBtn" class="btn btn-outline btn-mic" type="button" aria-label="Record from microphone">Record Mic</button>
           </div>
         </div>
         <div class="upload-row">

--- a/public/app/mobile-upload-fix.js
+++ b/public/app/mobile-upload-fix.js
@@ -94,7 +94,7 @@
       '#dz', '#dropZone', '.drop-zone', '#uploadZone',
       '#fi', 'input[type="file"]',
       '.drop-btns', '.drop-btns button',
-      '#micBtn'
+      '#fileBtn'
     ];
     selectors.forEach(function (sel) {
       document.querySelectorAll(sel).forEach(function (el) {

--- a/public/landing.js
+++ b/public/landing.js
@@ -707,8 +707,11 @@ function wireUploadDropZone() {
       }
       return;
     }
-    try { await primeAudioGesture(); } catch { /* best-effort */ }
-    openFilePicker(ui.fileInput);
+    if (!openFilePicker(ui.fileInput)) {
+      setStatus('Upload control unavailable — refresh the page', 'error');
+      return;
+    }
+    primeAudioGesture().catch(() => {});
   };
   zone.addEventListener('click', (event) => {
     if (event.target.closest('#browseBtn')) return;

--- a/src/core/DesktopBridge.js
+++ b/src/core/DesktopBridge.js
@@ -19,13 +19,11 @@ export function isDesktopShell() {
 }
 
 /**
- * Live microphone capture is enabled on web and native mobile (Capacitor),
- * but disabled in the Electron desktop shell.
+ * Live microphone capture is disabled app-wide (upload-only workflow).
  * @returns {boolean}
  */
 export function isMicCaptureEnabled() {
-  if (isDesktopShell()) return false;
-  return true;
+  return false;
 }
 
 /**

--- a/tests/engineer-upload-decode.test.js
+++ b/tests/engineer-upload-decode.test.js
@@ -37,8 +37,11 @@ describe('Engineer upload decode wiring', () => {
     expect(appJs).toContain('triggerFileInput(this.dom.fileInput)');
   });
 
-  test('app.js disables live mic capture on desktop shell', () => {
-    expect(appJs).toContain('isMicCaptureEnabled');
-    expect(appJs).toContain('hideMicControls');
+  test('file picker opens synchronously before primeAudioGesture (preserves user activation)', () => {
+    expect(appJs).toContain('triggerFileInput(this.dom.fileInput)');
+    expect(appJs).toMatch(/triggerFileInput\([\s\S]*?\)[\s\S]*primeAudioGesture\(\)/);
+    expect(appJs).not.toContain("import('/mic-capture.js')");
+    expect(appJs).not.toContain('heroCtaRecord');
+    expect(appJs).not.toContain('id="micBtn"');
   });
 });

--- a/tests/helpers/get-app-code.js
+++ b/tests/helpers/get-app-code.js
@@ -117,7 +117,7 @@ async function resampleToCanonical(buffer) {
   return buffer;
 }
 function isDesktopShell() { return false; }
-function isMicCaptureEnabled() { return true; }
+function isMicCaptureEnabled() { return false; }
 async function pickAudioFile() { return null; }
 `;
 }

--- a/tests/upload-wiring.test.js
+++ b/tests/upload-wiring.test.js
@@ -39,4 +39,9 @@ describe('Landing + Engineer import UploadWiring', () => {
     expect(appJs).toContain("openFilePicker as triggerFileInput");
     expect(appJs).toContain('triggerFileInput(this.dom.fileInput)');
   });
+
+  test('landing opens picker before awaiting primeAudioGesture', () => {
+    expect(landingJs).toContain('openFilePicker(ui.fileInput)');
+    expect(landingJs).toMatch(/openFilePicker\(ui\.fileInput\)[\s\S]*primeAudioGesture/);
+  });
 });


### PR DESCRIPTION
## Summary

Fixes Browse/Upload doing nothing in Engineer Mode (and landing) by opening the native file picker synchronously while the user-gesture is still active. Removes all live microphone capture UI and wiring.

## Root cause

openFilePicker awaited primeAudioGesture() before calling showPicker()/input.click(). That async gap expires transient user activation on mobile Safari and many desktop browsers, so the picker never opens.

## Fix

- Engineer + landing: open picker first, then primeAudioGesture in background
- Hero Upload CTA calls triggerFileInput directly
- fixUploadTouchTargets on Engineer init

## Live mic removed

- Record Mic buttons removed from Engineer HTML
- mic-capture logic removed from app.js
- isMicCaptureEnabled() always false

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Streamlined the landing experience around uploading audio or video files.
  - Added clearer “Upload Audio or Video” and “Browse Files” actions.
  - Improved upload behavior across desktop and mobile devices.

- **Bug Fixes**
  - Added feedback when the upload control is unavailable.
  - Improved touch and pointer handling for mobile file selection.
  - Ensured file selection opens promptly before audio initialization.

- **Changes**
  - Removed live microphone recording from the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove live mic recording controls and restore file picker in upload flow
> - Removes all microphone recording UI and logic from `HeroExperience` and the HTML, replacing mic CTAs with an upload-only flow.
> - `isMicCaptureEnabled` in [DesktopBridge.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/685/files#diff-f4d0ae9864546156bdd15febc8ea11606fb0363f0ac1b4cedb1b2ef90de52476) now always returns `false`, disabling mic capture app-wide.
> - On web, the file picker is now opened before `primeAudioGesture` to preserve user activation; a user-facing error is shown if the upload control is unavailable.
> - `fixUploadTouchTargets` is called on `VoiceIsolatePro` init, and the touch-fix selector is updated from `#micBtn` to `#fileBtn`.
> - Desktop shell path uses the native `pickAudioFile` picker; landing page applies the same open-then-prime ordering.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ffe46d0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->