### PR TITLE
fix: stop blocking processing start on full ML warmup

### DIFF
--- a/public/app/app.js
+++ b/public/app/app.js
@@ -2535,14 +2535,14 @@ class VoiceIsolatePro {
     if (fileSeq !== this._fileSeq) return false;
     try {
       await this.ensureCtx();
-      const warmupP = this._warmupMLModels().catch(() => {});
+      // Warmup may already run from handleFile — keep it in flight but never block
+      // pipeline start on full ONNX compile (can take 30–120s on first load).
+      void this._warmupMLModels().catch(() => {});
       const { separateStems, stemsToAudioBuffer } = await import('/src/pipeline/StemSeparation.js');
       const channelData = [];
       for (let ch = 0; ch < buf.numberOfChannels; ch++) {
         channelData.push(buf.getChannelData(ch));
       }
-      this.updatePipelineProgress(4, 'Loading ML model…', 10);
-      await warmupP;
       this.updatePipelineProgress(4, 'ML isolation…', 15);
       const result = await separateStems(channelData, buf.sampleRate, {
         modelIds: DEFAULT_ML_CHAIN,

--- a/public/landing.js
+++ b/public/landing.js
@@ -687,7 +687,8 @@ async function ingestFrom(file) {
     showSpinner('Decoding…', { indeterminate: true });
     setStatus(`Decoding “${file.name}”…`, 'warn');
     const modelIds = resolveModelIds(ui.modelSelect.value);
-    const warmupP = warmupWorkerModels(modelIds).catch(() => {});
+    // Overlap model prefetch with decode; separateStems reports load progress.
+    void warmupWorkerModels(modelIds).catch(() => {});
     const next = await ingestFile(file, {
       onProgress: (stage, percent = 0) => {
         if (seq !== ingestSeq) return;
@@ -704,9 +705,8 @@ async function ingestFrom(file) {
     if (seq !== ingestSeq) return;
     ingested = next;
     if (isVideoFile(file)) loadVideo(file);
-    await warmupP;
     if (seq !== ingestSeq) return;
-    // Auto-start separation — models warmed during decode; skip the extra click.
+    // Auto-start separation — model load progress shows during onProcess().
     onProcess();
   } catch (err) {
     if (seq !== ingestSeq) return;

--- a/tests/m4a-decode-fallback.test.js
+++ b/tests/m4a-decode-fallback.test.js
@@ -141,8 +141,8 @@ describe('M4A decode fallback — landing.js upload UX', () => {
     expect(ljs).toMatch(/finally[\s\S]*ui\.fileInput\.value\s*=\s*''/);
   });
 
-  test('landing.js awaits ML warmup before auto-processing after decode', () => {
-    expect(ljs).toContain('await warmupP');
-    expect(ljs).toContain('warmupWorkerModels(modelIds)');
+  test('landing.js overlaps ML warmup with decode (non-blocking before process)', () => {
+    expect(ljs).toContain('void warmupWorkerModels(modelIds)');
+    expect(ljs).not.toContain('await warmupP');
   });
 });


### PR DESCRIPTION
## Problem

A prior fix for the 25% freeze added `await warmupP` before ML processing could start. That blocks until the full ONNX model compile finishes — up to **120s** on first load — leaving the UI stuck at "Loading ML model…" (~10%) even after decode completes.

## Solution

- **Engineer Mode**: keep background warmup from `handleFile`, but remove `await warmupP` in `_runMLIsolationPipeline` — `separateStems` already reports model load progress.
- **Landing**: overlap `warmupWorkerModels` with decode again; call `onProcess()` immediately after decode instead of awaiting warmup.

Worklets (gate/de-esser) are unchanged — they load non-blocking for live playback only, not offline processing.

## Testing

- `tests/m4a-decode-fallback.test.js` — updated expectation (non-blocking warmup)
- `tests/engineer-mode-completion.test.js`
- `tests/app.test.js`
- `tests/handle_file_decode.test.js`

All 106 targeted tests pass locally.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop blocking ML isolation pipeline start on full ML model warmup
> - In [`_runMLIsolationPipeline`](https://github.com/Joker5514/VoiceIsolate-Pro/pull/687/files#diff-8a8b7ea624d7fccc12a516d122dcb07bd67c6a8f796c80e33b898ee6a7557650), ML warmup is now fire-and-forget (`void this._warmupMLModels().catch(() => {})`), so stem separation starts immediately rather than waiting for warmup to complete.
> - In [`ingestFrom`](https://github.com/Joker5514/VoiceIsolate-Pro/pull/687/files#diff-be23ec2b8a859b1c83e27ce227d9dd0c367c83c7a8f1a4b104128c882bdb30ab), auto-started separation no longer awaits worker model warmup; warmup runs concurrently and load progress is reported during processing.
> - The 'Loading ML model…' progress stage at 10% is removed; progress now starts at 'ML isolation…' at 15%.
> - Behavioral Change: the visible progress sequence changes and warmup errors are silently ignored in both paths (unchanged from before, but now the pipeline proceeds regardless).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 809981f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * ML model preparation now runs in the background while audio files are decoded and processed.
  * Audio separation can begin sooner without waiting for model warmup to finish.
  * Removed the separate model-loading progress step from the processing flow.

* **Bug Fixes**
  * Updated regression coverage to verify non-blocking model warmup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->