### PR TITLE
feat(engineer): confirm before processing click-isolation bands

### DIFF
--- a/public/app/index.html
+++ b/public/app/index.html
@@ -498,6 +498,11 @@
           </div>
         </div>
         <div id="neon-pulse-slot" class="neon-pulse-slot"></div>
+        <div id="vizIsoConfirm" class="viz-iso-confirm hidden" role="group" aria-label="Confirm isolation processing" aria-hidden="true">
+          <span id="vizIsoConfirmLabel" class="viz-iso-confirm-label">Process with selected frequency band?</span>
+          <button id="vizIsoConfirmBtn" class="btn btn-xs btn-primary" type="button">Process</button>
+          <button id="vizIsoConfirmCancel" class="btn btn-xs btn-outline" type="button">Cancel</button>
+        </div>
         <div id="tabBar" class="tabs" role="tablist" aria-label="Visualization tabs">
           <button id="btn-spectrogram" class="tab-btn active" type="button" role="tab" aria-controls="tab-spectrogram" data-tab="spectrogram" aria-selected="true" tabindex="0">Spectrogram</button>
           <button id="btn-waveform" class="tab-btn" type="button" role="tab" aria-controls="tab-waveform" data-tab="waveform" aria-selected="false" tabindex="-1">Waveform</button>

--- a/public/app/style.css
+++ b/public/app/style.css
@@ -1596,6 +1596,17 @@ body::after {
   transition: opacity 0.15s ease;
 }
 .viz-iso-tooltip.visible { opacity: 1; }
+.viz-iso-confirm {
+  display: flex; align-items: center; gap: 8px; flex-wrap: wrap;
+  padding: 8px 10px; margin: 6px 0 4px;
+  background: rgba(0,255,231,0.08); border: 1px solid rgba(0,255,231,0.35);
+  border-radius: 4px;
+}
+.viz-iso-confirm.hidden { display: none; }
+.viz-iso-confirm-label {
+  flex: 1; min-width: 160px;
+  font-family: 'JetBrains Mono', monospace; font-size: 11px; color: #00ffe7;
+}
 .neon-pulse-slot { width: 100%; margin-bottom: 6px; }
 
 /* [WHISPER UPDATE] EXTREME TAB — deep purple accent */

--- a/public/app/vip-fixes.js
+++ b/public/app/vip-fixes.js
@@ -769,6 +769,13 @@
     if (window._vipClickIsoPatched) return;
     window._vipClickIsoPatched = true;
 
+    let _pendingIsolation = null;
+
+    function _fmtIsoHz(hz) {
+      if (hz >= 1000) return (hz / 1000).toFixed(hz >= 10000 ? 0 : 1) + 'kHz';
+      return Math.round(hz) + 'Hz';
+    }
+
     function _syncVoiceFocusSliders(lo, hi) {
       document.querySelectorAll('.sr-row[data-slider-id="voiceFocusLo"] input[type="range"]').forEach((sl) => {
         sl.value = String(lo);
@@ -780,10 +787,33 @@
       });
     }
 
-    window.addEventListener('vip:isolationBandSet', (e) => {
-      const { freqLow, freqHigh } = e.detail || {};
+    function _hideIsoConfirm() {
+      const bar = $('vizIsoConfirm');
+      if (!bar) return;
+      bar.classList.add('hidden');
+      bar.setAttribute('aria-hidden', 'true');
+    }
+
+    function _showIsoConfirm(freqLow, freqHigh) {
+      const bar = $('vizIsoConfirm');
+      const label = $('vizIsoConfirmLabel');
+      const confirmBtn = $('vizIsoConfirmBtn');
+      if (!bar || !label) return;
+      const app = window._vipApp;
+      const busy = !!(app && app.isProcessing);
+      label.textContent = busy
+        ? `Isolate ${_fmtIsoHz(freqLow)} – ${_fmtIsoHz(freqHigh)} — wait for current processing to finish`
+        : `Isolate ${_fmtIsoHz(freqLow)} – ${_fmtIsoHz(freqHigh)} — confirm to process?`;
+      if (confirmBtn) confirmBtn.disabled = busy;
+      bar.classList.remove('hidden');
+      bar.setAttribute('aria-hidden', 'false');
+    }
+
+    function _applyPendingIsolation() {
+      if (!_pendingIsolation) return;
       const app = window._vipApp;
       if (!app) return;
+      const { freqLow, freqHigh } = _pendingIsolation;
       app.dspParams = app.dspParams || {};
       app.dspParams.isolationFreqLow = freqLow;
       app.dspParams.isolationFreqHigh = freqHigh;
@@ -796,9 +826,38 @@
       _syncVoiceFocusSliders(lo, window.VIP_PARAMS.voiceFocusHi);
       if (typeof app.runPipeline === 'function') app.runPipeline();
       else if (typeof app.reprocess === 'function') app.reprocess();
+      _pendingIsolation = null;
+      _hideIsoConfirm();
+    }
+
+    function _wireIsoConfirmButtons() {
+      if (window._vipIsoConfirmWired) return;
+      window._vipIsoConfirmWired = true;
+      $('vizIsoConfirmBtn')?.addEventListener('click', () => {
+        const app = window._vipApp;
+        if (app?.isProcessing) return;
+        _applyPendingIsolation();
+      });
+      $('vizIsoConfirmCancel')?.addEventListener('click', () => {
+        _pendingIsolation = null;
+        _hideIsoConfirm();
+        window.dispatchEvent(new CustomEvent('vip:isolationBandClear'));
+      });
+    }
+
+    _wireIsoConfirmButtons();
+
+    window.addEventListener('vip:isolationBandSet', (e) => {
+      const { freqLow, freqHigh } = e.detail || {};
+      const app = window._vipApp;
+      if (!app) return;
+      _pendingIsolation = { freqLow, freqHigh, source: e.detail?.source || '' };
+      _showIsoConfirm(freqLow, freqHigh);
     });
 
     window.addEventListener('vip:isolationBandClear', () => {
+      _pendingIsolation = null;
+      _hideIsoConfirm();
       const app = window._vipApp;
       if (!app || !app.dspParams) return;
       app.dspParams.isolationActive = false;

--- a/public/app/visual-click-isolation.js
+++ b/public/app/visual-click-isolation.js
@@ -503,6 +503,11 @@
     target.addEventListener('click', onClick);
   }
 
+  function clearAllIsolationVisuals() {
+    updateSpecBadge(0, 0, false);
+    document.querySelectorAll('.viz-iso-overlay').forEach(clearOverlay);
+  }
+
   function init() {
     bindSpectrogramCanvas($('spectro2DCanvas'), 'spectrogram');
     bindSpectrogramCanvas($('spectroCanvas'), 'spectrogram-3d');
@@ -513,6 +518,8 @@
     bindStemClick($('liquidCanvas'), $('iso-badge-liquid'));
     bindStemClick($('topoContainer'), $('iso-badge-topo'));
     bindStemClick($('swarmContainer'), $('iso-badge-swarm'));
+
+    global.addEventListener('vip:isolationBandClear', clearAllIsolationVisuals);
   }
 
   if (document.readyState === 'loading') {

--- a/tests/visuals-bootstrap.test.js
+++ b/tests/visuals-bootstrap.test.js
@@ -130,6 +130,23 @@ describe('visuals-bootstrap loading and event wiring', () => {
     expect(src).toContain('window._vipPlayAnalyser');
   });
 
+  test('vip-fixes.js requires confirm before click-isolation triggers runPipeline', () => {
+    const src = fs.readFileSync(VIP_FIXES_PATH, 'utf8');
+    const isoBlock = src.match(/vip:isolationBandSet[\s\S]*?vip:isolationBandClear/);
+    expect(isoBlock).toBeTruthy();
+    expect(isoBlock[0]).toContain('_pendingIsolation');
+    expect(isoBlock[0]).toContain('_showIsoConfirm');
+    expect(isoBlock[0]).not.toMatch(/vip:isolationBandSet[\s\S]*?runPipeline\(\)/);
+    expect(src).toContain('vizIsoConfirmBtn');
+    expect(src).toContain('_applyPendingIsolation');
+  });
+
+  test('visual-click-isolation.js clears overlays when isolation is cancelled', () => {
+    const src = fs.readFileSync(path.join(__dirname, '..', 'public', 'app', 'visual-click-isolation.js'), 'utf8');
+    expect(src).toContain('clearAllIsolationVisuals');
+    expect(src).toContain("addEventListener('vip:isolationBandClear', clearAllIsolationVisuals)");
+  });
+
   test('app.js dispatches vip:fileLoaded after onAudioLoaded', () => {
     const src = fs.readFileSync(APP_JS_PATH, 'utf8');
     expect(src).toContain("'vip:fileLoaded'");


### PR DESCRIPTION
## Problem

Drawing an isolation band on the Engineer Mode visual port (spectrogram / frequency bars) immediately triggered `runPipeline()` with no chance to review or cancel.

## Solution

- Show a confirmation bar above the visualization tabs after band selection
- **Process** applies Voice Focus sliders and runs the pipeline
- **Cancel** clears the overlay and badge without processing
- Process button disabled while another pipeline run is in progress

## Testing

- `tests/visuals-bootstrap.test.js` — confirm gate + overlay clear on cancel
- All 29 visuals-bootstrap tests pass locally

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add confirmation step before processing click-isolation bands
> - Clicking a frequency band in click-isolation mode no longer immediately runs the pipeline; instead, a confirmation bar appears with "Process" and "Cancel" buttons.
> - [vip-fixes.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/688/files#diff-e1b2a993f0bf64b447304c6c2d82a496fd3b394e13cc5cda2d6568a7f7a92e9d) stores the selected band in `_pendingIsolation` and shows the `#vizIsoConfirm` bar via `_showIsoConfirm`; the Process button calls `_applyPendingIsolation` and is disabled while `app.isProcessing`.
> - Cancelling dispatches `vip:isolationBandClear`, which now also clears isolation overlays and resets the spectrogram badge via `clearAllIsolationVisuals` in [visual-click-isolation.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/688/files#diff-23f28d0889827ede4c2c8bafe9ceb856a11f426c0ddc03736635cee961280016).
> - Behavioral Change: click-isolation band selection is now a two-step action; existing flows that expected immediate pipeline execution on band click will need to account for the confirmation step.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8bd0490.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->