### PR TITLE
fix(engineer): viz stretch, ResizeObserver loop, playback jank

### DIFF
--- a/public/app/index.html
+++ b/public/app/index.html
@@ -26,6 +26,14 @@
   <!-- DSP math (STFT/iSTFT, filters, Wiener NR) on window.DSPCore. Loaded as a
        classic blocking script so the binding is live before any module imports
        evaluate — app.js captures DSP = globalThis.DSPCore at module init. -->
+  <script>
+    // Benign browser warning when canvas layout + ResizeObserver update in the same frame.
+    window.addEventListener('error', function (e) {
+      if (e && e.message && String(e.message).indexOf('ResizeObserver') >= 0) {
+        e.stopImmediatePropagation();
+      }
+    });
+  </script>
   <script src="./dsp-core.js"></script>
   <script src="./ai-intelligence.js"></script>
   <script type="module" src="./whisper-hunter.js"></script>

--- a/public/app/neon-pulse-card.js
+++ b/public/app/neon-pulse-card.js
@@ -287,19 +287,32 @@
       document.getElementById(`np-freeze-${this._uid}`)
         .addEventListener('click', () => this._toggleFreeze());
 
-      this._ro = new ResizeObserver(() => this._resize());
+      let roPending = false;
+      this._ro = new ResizeObserver(() => {
+        if (roPending) return;
+        roPending = true;
+        requestAnimationFrame(() => {
+          roPending = false;
+          this._resize();
+        });
+      });
       this._ro.observe(this._canvas);
     }
 
     /* ── Resize canvas to display size ────────── */
     _resize() {
-      const dpr = window.devicePixelRatio || 1;
+      const dpr = Math.min(window.devicePixelRatio || 1, 2);
       const rect = this._canvas.getBoundingClientRect();
-      this._canvas.width  = rect.width  * dpr;
-      this._canvas.height = rect.height * dpr;
+      const cssW = Math.max(1, Math.round(rect.width));
+      const cssH = Math.max(1, Math.round(rect.height));
+      this._canvas.width = cssW * dpr;
+      this._canvas.height = cssH * dpr;
+      this._canvas.style.width = cssW + 'px';
+      this._canvas.style.height = cssH + 'px';
+      this._ctx.setTransform(1, 0, 0, 1, 0, 0);
       this._ctx.scale(dpr, dpr);
-      this._W = rect.width;
-      this._H = rect.height;
+      this._W = cssW;
+      this._H = cssH;
     }
 
     /* ── Wire to global PipelineState ─────────── */

--- a/public/app/premium-visuals.js
+++ b/public/app/premium-visuals.js
@@ -1,30 +1,24 @@
 /**
  * VoiceIsolate Pro — premium-visuals.js
- * 
- * 4 Top-Tier Visualizers with a Premium Red / Dark Aesthetic
- * 1. Circular / Radial Pulsing Aura
- * 2. 3D Topographic Surface Plot (Three.js)
- * 3. Ember Particle Swarm (Three.js)
- * 4. Multi-Layered Liquid Voice Waves
+ *
+ * Premium visualizers driven by a single coordinator RAF (visuals-bootstrap.js).
+ * Each init* returns { tick, resize, stop } — no internal animation loops.
  */
 
 (function (global) {
   'use strict';
 
-  // --- 1. Circular / Radial Pulsing Aura ---
   function initPulsingAura(analyser, canvas) {
-    if (!canvas || !analyser) return { stop: () => {} };
+    if (!canvas || !analyser) return { tick: () => {}, resize: () => {}, stop: () => {} };
     const ctx = canvas.getContext('2d');
-    if (!ctx) return { stop: () => {} };
+    if (!ctx) return { tick: () => {}, resize: () => {}, stop: () => {} };
 
     const bufferLength = analyser.frequencyBinCount;
     const dataArray = new Uint8Array(bufferLength);
-    let rafId = 0;
     let running = true;
 
-    function draw() {
+    function tick() {
       if (!running) return;
-      rafId = requestAnimationFrame(draw);
       analyser.getByteFrequencyData(dataArray);
 
       const w = canvas.width;
@@ -54,65 +48,75 @@
       ctx.shadowColor = '#ff2a2a';
       ctx.stroke();
 
-      // Inner glow
       ctx.beginPath();
       ctx.arc(cx, cy, radius * 0.9, 0, Math.PI * 2);
       ctx.fillStyle = 'rgba(255, 17, 17, 0.1)';
       ctx.fill();
     }
-    draw();
-    return { stop: () => { running = false; cancelAnimationFrame(rafId); } };
+
+    return {
+      tick,
+      resize: () => {},
+      stop: () => { running = false; },
+    };
   }
 
-  // --- 2. 3D Topographic Surface Plot ---
   function initTopographic3D(analyser, container) {
-    if (!container || !analyser || !global.THREE) return { stop: () => {} };
-    
+    if (!container || !analyser || !global.THREE) {
+      return { tick: () => {}, resize: () => {}, stop: () => {} };
+    }
+
     const THREE = global.THREE;
     const scene = new THREE.Scene();
     scene.fog = new THREE.FogExp2(0x060609, 0.03);
 
-    const camera = new THREE.PerspectiveCamera(60, container.clientWidth / container.clientHeight, 0.1, 1000);
+    const camera = new THREE.PerspectiveCamera(60, 1, 0.1, 1000);
     camera.position.set(0, 15, 30);
     camera.lookAt(0, 0, 0);
 
     const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
-    renderer.setSize(container.clientWidth, container.clientHeight);
+    const dpr = Math.min(window.devicePixelRatio || 1, 2);
+    renderer.setPixelRatio(dpr);
     container.innerHTML = '';
     container.appendChild(renderer.domElement);
 
     const bufferLength = analyser.frequencyBinCount;
     const dataArray = new Uint8Array(bufferLength);
-    
-    // Create grid geometry
-    const width = 60, depth = 40;
+
+    const width = 60;
+    const depth = 40;
     const segW = Math.min(bufferLength - 1, 64);
     const segD = 40;
     const geometry = new THREE.PlaneGeometry(width, depth, segW, segD);
     geometry.rotateX(-Math.PI / 2);
-    
-    const material = new THREE.MeshBasicMaterial({ 
-      color: 0xff1111, 
-      wireframe: true, 
+
+    const material = new THREE.MeshBasicMaterial({
+      color: 0xff1111,
+      wireframe: true,
       transparent: true,
-      opacity: 0.6
+      opacity: 0.6,
     });
-    
+
     const plane = new THREE.Mesh(geometry, material);
     scene.add(plane);
 
-    let rafId = 0;
     let running = true;
 
-    function draw() {
+    function resize() {
+      const cw = Math.max(1, container.clientWidth);
+      const ch = Math.max(1, container.clientHeight);
+      camera.aspect = cw / ch;
+      camera.updateProjectionMatrix();
+      renderer.setSize(cw, ch, false);
+    }
+
+    function tick() {
       if (!running) return;
-      rafId = requestAnimationFrame(draw);
       analyser.getByteFrequencyData(dataArray);
 
       const positions = geometry.attributes.position.array;
       const ptsPerRow = segW + 1;
-      
-      // Shift rows back
+
       for (let z = segD; z > 0; z--) {
         for (let x = 0; x < ptsPerRow; x++) {
           const idx = (z * ptsPerRow + x) * 3 + 1;
@@ -120,82 +124,72 @@
           positions[idx] = positions[prevIdx];
         }
       }
-      
-      // Update front row
+
       const step = Math.floor(bufferLength / ptsPerRow);
       for (let x = 0; x < ptsPerRow; x++) {
         const val = dataArray[x * step] || 0;
         const idx = x * 3 + 1;
         positions[idx] = (val / 255) * 10;
       }
-      
+
       geometry.attributes.position.needsUpdate = true;
       renderer.render(scene, camera);
     }
-    draw();
 
-    const resize = () => {
-      camera.aspect = container.clientWidth / container.clientHeight;
-      camera.updateProjectionMatrix();
-      renderer.setSize(container.clientWidth, container.clientHeight);
+    resize();
+
+    return {
+      tick,
+      resize,
+      stop: () => {
+        running = false;
+        renderer.dispose();
+      },
     };
-    window.addEventListener('resize', resize);
-
-    return { stop: () => { 
-      running = false; 
-      cancelAnimationFrame(rafId); 
-      window.removeEventListener('resize', resize);
-      renderer.dispose();
-    }};
   }
 
-  // --- 3. Ember Particle Swarm ---
   function initParticleSwarm(analyser, container) {
-    if (!container || !analyser || !global.THREE) return { stop: () => {} };
-    
+    if (!container || !analyser || !global.THREE) {
+      return { tick: () => {}, resize: () => {}, stop: () => {} };
+    }
+
     const THREE = global.THREE;
     const scene = new THREE.Scene();
-    const camera = new THREE.PerspectiveCamera(60, container.clientWidth / container.clientHeight, 0.1, 1000);
+    const camera = new THREE.PerspectiveCamera(60, 1, 0.1, 1000);
     camera.position.z = 50;
 
     const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
-    renderer.setSize(container.clientWidth, container.clientHeight);
+    const dpr = Math.min(window.devicePixelRatio || 1, 2);
+    renderer.setPixelRatio(dpr);
     container.innerHTML = '';
     container.appendChild(renderer.domElement);
 
     const particleCount = 1500;
     const geometry = new THREE.BufferGeometry();
     const positions = new Float32Array(particleCount * 3);
-    const velocities = [];
 
     for (let i = 0; i < particleCount; i++) {
       const r = 15 + Math.random() * 10;
       const theta = Math.random() * Math.PI * 2;
       const phi = Math.acos(Math.random() * 2 - 1);
-      
-      positions[i*3] = r * Math.sin(phi) * Math.cos(theta);
-      positions[i*3+1] = r * Math.sin(phi) * Math.sin(theta);
-      positions[i*3+2] = r * Math.cos(phi);
-      
-      velocities.push({
-        x: (Math.random() - 0.5) * 0.1,
-        y: (Math.random() - 0.5) * 0.1,
-        z: (Math.random() - 0.5) * 0.1
-      });
+
+      positions[i * 3] = r * Math.sin(phi) * Math.cos(theta);
+      positions[i * 3 + 1] = r * Math.sin(phi) * Math.sin(theta);
+      positions[i * 3 + 2] = r * Math.cos(phi);
     }
 
     geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
-    
-    // Create a circular particle texture procedurally
+
     const canvas = document.createElement('canvas');
-    canvas.width = 32; canvas.height = 32;
+    canvas.width = 32;
+    canvas.height = 32;
     const ctx = canvas.getContext('2d');
     const gradient = ctx.createRadialGradient(16, 16, 0, 16, 16, 16);
     gradient.addColorStop(0, 'rgba(255,255,255,1)');
     gradient.addColorStop(0.2, 'rgba(255,42,42,1)');
     gradient.addColorStop(1, 'rgba(0,0,0,0)');
     ctx.fillStyle = gradient;
-    ctx.fillRect(0,0,32,32);
+    ctx.fillRect(0, 0, 32, 32);
     const texture = new THREE.CanvasTexture(canvas);
 
     const material = new THREE.PointsMaterial({
@@ -204,7 +198,7 @@
       blending: THREE.AdditiveBlending,
       depthWrite: false,
       transparent: true,
-      color: 0xff4444
+      color: 0xff4444,
     });
 
     const particles = new THREE.Points(geometry, material);
@@ -212,56 +206,56 @@
 
     const bufferLength = analyser.frequencyBinCount;
     const dataArray = new Uint8Array(bufferLength);
-    let rafId = 0;
     let running = true;
 
-    function draw() {
+    function resize() {
+      const cw = Math.max(1, container.clientWidth);
+      const ch = Math.max(1, container.clientHeight);
+      camera.aspect = cw / ch;
+      camera.updateProjectionMatrix();
+      renderer.setSize(cw, ch, false);
+    }
+
+    function tick() {
       if (!running) return;
-      rafId = requestAnimationFrame(draw);
       analyser.getByteFrequencyData(dataArray);
-      
+
       let sum = 0;
       for (let i = 0; i < 20; i++) sum += dataArray[i];
       const bass = sum / 20;
       const scale = 1 + (bass / 255) * 0.5;
-      
+
       particles.scale.set(scale, scale, scale);
       particles.rotation.y += 0.005;
       particles.rotation.x += 0.002;
 
       renderer.render(scene, camera);
     }
-    draw();
 
-    const resize = () => {
-      camera.aspect = container.clientWidth / container.clientHeight;
-      camera.updateProjectionMatrix();
-      renderer.setSize(container.clientWidth, container.clientHeight);
+    resize();
+
+    return {
+      tick,
+      resize,
+      stop: () => {
+        running = false;
+        renderer.dispose();
+      },
     };
-    window.addEventListener('resize', resize);
-
-    return { stop: () => { 
-      running = false; cancelAnimationFrame(rafId); 
-      window.removeEventListener('resize', resize);
-      renderer.dispose();
-    }};
   }
 
-  // --- 4. Multi-Layered Liquid Voice Waves ---
   function initLiquidWaves(analyser, canvas) {
-    if (!canvas || !analyser) return { stop: () => {} };
+    if (!canvas || !analyser) return { tick: () => {}, resize: () => {}, stop: () => {} };
     const ctx = canvas.getContext('2d');
-    if (!ctx) return { stop: () => {} };
+    if (!ctx) return { tick: () => {}, resize: () => {}, stop: () => {} };
 
     const bufferLength = analyser.frequencyBinCount;
     const dataArray = new Uint8Array(bufferLength);
-    let rafId = 0;
     let running = true;
     let phase = 0;
 
-    function draw() {
+    function tick() {
       if (!running) return;
-      rafId = requestAnimationFrame(draw);
       analyser.getByteTimeDomainData(dataArray);
 
       let sum = 0;
@@ -275,27 +269,31 @@
 
       ctx.globalCompositeOperation = 'screen';
       const colors = ['rgba(255, 42, 42, 0.5)', 'rgba(220, 20, 60, 0.5)', 'rgba(139, 0, 0, 0.5)'];
-      
+
       phase += 0.05 + amplitude * 0.005;
 
       for (let j = 0; j < 3; j++) {
         ctx.beginPath();
         ctx.moveTo(0, canvas.height / 2);
-        
+
         for (let x = 0; x <= canvas.width; x += 10) {
           const normX = x / canvas.width;
           const yOff = Math.sin(normX * Math.PI * 2 * (j + 1) + phase + j) * (amplitude * 1.5 + 5);
           ctx.lineTo(x, canvas.height / 2 + yOff);
         }
-        
+
         ctx.lineWidth = 3;
         ctx.strokeStyle = colors[j];
         ctx.stroke();
       }
       ctx.globalCompositeOperation = 'source-over';
     }
-    draw();
-    return { stop: () => { running = false; cancelAnimationFrame(rafId); } };
+
+    return {
+      tick,
+      resize: () => {},
+      stop: () => { running = false; },
+    };
   }
 
   global.VIP_initPulsingAura = initPulsingAura;

--- a/public/app/style.css
+++ b/public/app/style.css
@@ -465,6 +465,8 @@ input[type="range"].realtime:not(.tp-seek):not(.landing-seek-input)::-webkit-sli
 .sl-dot{width:8px;height:8px;border-radius:2px;display:inline-block}
 .wave-row{display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-bottom:0}
 .wave-cv{height:70px}
+#auraCanvas,#liquidCanvas{height:180px}
+.viz-card.viz-gallery #auraCanvas,.viz-card.viz-gallery #liquidCanvas{height:140px}
 .freq-cv{height:80px}
 
 /* ---- STATS ---- */

--- a/public/app/visuals-bootstrap.js
+++ b/public/app/visuals-bootstrap.js
@@ -30,6 +30,12 @@
   let _lastDiarSegStart = 0;
   let _lastSpeakerState = null;
   let _vizFullscreen = false;
+  let _roRaf = 0;
+  let _roScheduled = false;
+  let _freqScratch = null;
+  let _timeScratch = null;
+  let _waveBaseCache = new WeakMap();
+  let _playheadPxCache = new WeakMap();
 
   function _getPlayOffset() {
     const app = global._vipApp;
@@ -74,28 +80,30 @@
     return panel.classList.contains('active');
   }
 
-  /* ── Static waveform render ───────────────────────────────────────────── */
-  function _drawWaveformOnto(canvas, audioBuf, color) {
-    if (!canvas || !audioBuf || !audioBuf.getChannelData) return;
+  /* ── Static waveform render (cached — playhead overlays only during playback) ── */
+  function _waveCacheKey(audioBuf, color) {
+    return (audioBuf.length || 0) + ':' + (audioBuf.sampleRate || 0) + ':' + (color || '');
+  }
+
+  function _drawWaveformBase(canvas, audioBuf, color) {
+    if (!canvas || !audioBuf || !audioBuf.getChannelData) return false;
     const ctx = canvas.getContext('2d');
-    if (!ctx) return;
-    const rect = canvas.getBoundingClientRect();
-    const cssH = parseInt(getComputedStyle(canvas).height, 10) || 0;
-    const bw = rect.width > 0 ? rect.width : (canvas.offsetWidth || 800);
-    const bh = rect.height > 0 ? rect.height : (cssH || canvas.offsetHeight || 70);
-    canvas.width = Math.floor(bw);
-    canvas.height = Math.floor(bh);
-    const w = canvas.width || 800;
-    const h = canvas.height || 70;
-    ctx.fillStyle = '#030306';
-    ctx.fillRect(0, 0, w, h);
+    if (!ctx) return false;
+    const { w, h } = _resizeCanvas(canvas, 70);
+    const cacheKey = _waveCacheKey(audioBuf, color);
+    const cached = _waveBaseCache.get(canvas);
+    if (cached && cached.key === cacheKey && cached.w === w && cached.h === h) {
+      ctx.putImageData(cached.image, 0, 0);
+      return true;
+    }
 
     const data = audioBuf.getChannelData(0);
     const step = Math.max(1, Math.floor(data.length / w));
     const mid = h / 2;
 
+    ctx.fillStyle = '#030306';
+    ctx.fillRect(0, 0, w, h);
     ctx.strokeStyle = color || '#22d3ee';
-    ctx.fillStyle = (color || '#22d3ee') + '33';
     ctx.lineWidth = 1;
     ctx.beginPath();
     ctx.moveTo(0, mid);
@@ -121,13 +129,31 @@
     ctx.moveTo(0, mid);
     ctx.lineTo(w, mid);
     ctx.stroke();
+
+    try {
+      _waveBaseCache.set(canvas, {
+        key: cacheKey,
+        w,
+        h,
+        image: ctx.getImageData(0, 0, w, h),
+      });
+    } catch (_) {}
+    _playheadPxCache.delete(canvas);
+    return true;
+  }
+
+  function _drawWaveformOnto(canvas, audioBuf, color) {
+    _drawWaveformBase(canvas, audioBuf, color);
   }
 
   function _drawPlayhead(canvas, buffer, color) {
     if (!canvas || !buffer) return;
-    _drawWaveformOnto(canvas, buffer, color);
+    if (!_drawWaveformBase(canvas, buffer, color)) return;
     const dur = buffer.duration || 1;
-    const px = (_getPlayOffset() / dur) * canvas.width;
+    const px = Math.round((_getPlayOffset() / dur) * canvas.width);
+    const lastPx = _playheadPxCache.get(canvas);
+    if (lastPx === px) return;
+    _playheadPxCache.set(canvas, px);
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
     ctx.strokeStyle = '#ff2a2a';
@@ -139,6 +165,9 @@
   }
 
   function drawStaticVisuals() {
+    _waveBaseCache = new WeakMap();
+    _playheadPxCache = new WeakMap();
+    _resetCanvasDimCache();
     const app = global._vipApp;
     if (!app) return;
     const inBuf = app.inputBuffer || app.origBuffer;
@@ -166,17 +195,34 @@
 
   /* ── Canvas helpers ───────────────────────────────────────────────────── */
   function _resizeCanvas(canvas, fallbackH) {
-    const dpr = window.devicePixelRatio || 1;
+    const dpr = Math.min(window.devicePixelRatio || 1, 2);
     const rect = canvas.getBoundingClientRect();
-    const baseW = rect.width > 0 ? rect.width : (canvas.offsetWidth || canvas.clientWidth || 800);
-    const baseH = rect.height > 0 ? rect.height : (parseInt(getComputedStyle(canvas).height, 10) || canvas.clientHeight || fallbackH || 240);
-    const w = Math.round(baseW * dpr);
-    const h = Math.round(baseH * dpr);
-    if (canvas.width !== w || canvas.height !== h) {
+    const cssW = Math.max(1, Math.round(
+      rect.width > 0 ? rect.width : (canvas.offsetWidth || canvas.clientWidth || 800),
+    ));
+    const cssH = Math.max(1, Math.round(
+      rect.height > 0
+        ? rect.height
+        : (parseInt(getComputedStyle(canvas).height, 10) || canvas.clientHeight || fallbackH || 240),
+    ));
+    const w = Math.round(cssW * dpr);
+    const h = Math.round(cssH * dpr);
+    const prev = canvas.dataset.vipCssSize || '';
+    const next = cssW + 'x' + cssH;
+    if (canvas.width !== w || canvas.height !== h || prev !== next) {
       canvas.width = w;
       canvas.height = h;
+      canvas.style.width = cssW + 'px';
+      canvas.style.height = cssH + 'px';
+      canvas.dataset.vipCssSize = next;
+      _playheadPxCache.delete(canvas);
     }
-    return { w, h };
+    return { w, h, cssW, cssH };
+  }
+
+  function _resetCanvasDimCache() {
+    _spectroDims = null;
+    _freqDims = null;
   }
 
   function _resizeVisibleCanvases() {
@@ -191,9 +237,26 @@
       ['auraCanvas', 180],
       ['liquidCanvas', 180],
     ];
+    let changed = false;
     for (const [id, h] of targets) {
       const c = $(id);
-      if (c && _panelVisible(_canvasTabFor(id))) _resizeCanvas(c, h);
+      if (!c || !_panelVisible(_canvasTabFor(id))) continue;
+      const prev = c.dataset.vipCssSize || '';
+      _resizeCanvas(c, h);
+      if ((c.dataset.vipCssSize || '') !== prev) changed = true;
+    }
+    if (changed) {
+      _resetCanvasDimCache();
+      _waveBaseCache = new WeakMap();
+      _playheadPxCache = new WeakMap();
+    }
+  }
+
+  function _resizePremiumContainers() {
+    for (const handle of _premiumHandles.values()) {
+      if (handle && typeof handle.resize === 'function') {
+        try { handle.resize(); } catch (_) {}
+      }
     }
   }
 
@@ -213,11 +276,16 @@
   }
 
   /* ── Spectrogram + frequency bars ─────────────────────────────────────── */
+  let _spectroDims = null;
+
   function _drawSpectro2DColumn(canvas, freqBytes) {
     if (!canvas) return;
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
-    const { w, h } = _resizeCanvas(canvas, 240);
+    if (!_spectroDims || _spectroDims.canvas !== canvas) {
+      _spectroDims = { canvas, ..._resizeCanvas(canvas, 240) };
+    }
+    const { w, h } = _spectroDims;
     try {
       ctx.drawImage(canvas, 1, 0, w - 1, h, 0, 0, w - 1, h);
     } catch (_) {
@@ -264,11 +332,16 @@
     ctx.drawImage(src, 0, 0, dst.width, dst.height);
   }
 
+  let _freqDims = null;
+
   function _drawFreqBars(canvas, freqBytes) {
     if (!canvas) return;
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
-    const { w, h } = _resizeCanvas(canvas, 80);
+    if (!_freqDims || _freqDims.canvas !== canvas) {
+      _freqDims = { canvas, ..._resizeCanvas(canvas, 80) };
+    }
+    const { w, h } = _freqDims;
     ctx.fillStyle = 'rgba(3,3,6,0.45)';
     ctx.fillRect(0, 0, w, h);
 
@@ -430,26 +503,28 @@
     if (!an) return;
 
     const bins = an.frequencyBinCount;
-    const freqBytes = new Uint8Array(bins);
-    const timeBytes = new Uint8Array(bins);
+    if (!_freqScratch || _freqScratch.length !== bins) {
+      _freqScratch = new Uint8Array(bins);
+      _timeScratch = new Uint8Array(bins);
+    }
     try {
-      an.getByteFrequencyData(freqBytes);
-      an.getByteTimeDomainData(timeBytes);
+      an.getByteFrequencyData(_freqScratch);
+      an.getByteTimeDomainData(_timeScratch);
     } catch (_) {
       return;
     }
 
-    _updateLufs(timeBytes);
+    _updateLufs(_timeScratch);
 
     if (_isTabDrawTarget('spectrogram')) {
       const spec2d = $('spectro2DCanvas');
       if (spec2d) {
         if (spec2d.style.display === 'none') spec2d.style.display = '';
-        _drawSpectro2DColumn(spec2d, freqBytes);
+        _drawSpectro2DColumn(spec2d, _freqScratch);
         _mirrorSpectro3D();
       }
       const freq = $('freqCanvas');
-      if (freq) _drawFreqBars(freq, freqBytes);
+      if (freq) _drawFreqBars(freq, _freqScratch);
     }
 
     if (_isTabDrawTarget('waveform')) {
@@ -460,7 +535,13 @@
 
     if (_isTabDrawTarget('abcompare')) _drawABCompareLive();
 
-    _syncClustersEngine(freqBytes);
+    _syncClustersEngine(_freqScratch);
+
+    for (const handle of _premiumHandles.values()) {
+      if (handle && typeof handle.tick === 'function') {
+        try { handle.tick(); } catch (_) {}
+      }
+    }
   }
 
   function start() {
@@ -537,9 +618,7 @@
 
     if (!_getAnalyser()) return;
     for (const tab of tabsToRun) {
-      if (!_premiumHandles.has(tab)) {
-        requestAnimationFrame(() => _initPremiumTab(tab));
-      }
+      if (!_premiumHandles.has(tab)) _initPremiumTab(tab);
     }
   }
 
@@ -753,19 +832,24 @@
     _wireTabBar();
   }
 
+  function _scheduleLayoutResize() {
+    if (_roScheduled) return;
+    _roScheduled = true;
+    cancelAnimationFrame(_roRaf);
+    _roRaf = requestAnimationFrame(() => {
+      _roScheduled = false;
+      _resizeVisibleCanvases();
+      _resizePremiumContainers();
+    });
+  }
+
   function _wireResizeObserver() {
     const card = document.querySelector('.viz-card');
     if (!card || typeof ResizeObserver === 'undefined') return;
-    const ro = new ResizeObserver(() => {
-      _resizeVisibleCanvases();
-      _syncPremiumViz();
-    });
+    const ro = new ResizeObserver(() => _scheduleLayoutResize());
     ro.observe(card);
     const onViewportChange = () => {
-      setTimeout(() => {
-        _resizeVisibleCanvases();
-        _syncPremiumViz();
-      }, 180);
+      setTimeout(_scheduleLayoutResize, 180);
     };
     window.addEventListener('orientationchange', onViewportChange);
     window.addEventListener('resize', onViewportChange);

--- a/tests/visuals-bootstrap.test.js
+++ b/tests/visuals-bootstrap.test.js
@@ -4,6 +4,7 @@ const path = require('path');
 const VISUALS_BOOT_PATH = path.join(__dirname, '..', 'public', 'app', 'visuals-bootstrap.js');
 const INDEX_HTML_PATH   = path.join(__dirname, '..', 'public', 'app', 'index.html');
 const VIP_FIXES_PATH    = path.join(__dirname, '..', 'public', 'app', 'vip-fixes.js');
+const PREMIUM_VIS_PATH  = path.join(__dirname, '..', 'public', 'app', 'premium-visuals.js');
 const APP_JS_PATH       = path.join(__dirname, '..', 'public', 'app', 'app.js');
 
 describe('visuals-bootstrap.js — visualization driver', () => {
@@ -65,6 +66,13 @@ describe('visuals-bootstrap.js — visualization driver', () => {
     expect(src).toContain('VIP_initLiquidWaves');
   });
 
+  test('premium-visuals.js exposes coordinator tick API (no internal RAF loops)', () => {
+    const premium = fs.readFileSync(PREMIUM_VIS_PATH, 'utf8');
+    expect(premium).toContain('tick');
+    expect(premium).toContain('resize');
+    expect(premium).not.toMatch(/rafId\s*=\s*requestAnimationFrame\(draw\)/);
+  });
+
   test('uses VIP_INFERNO_LUT from visuals.js for spectrogram colors', () => {
     expect(src).toContain('VIP_INFERNO_LUT');
   });
@@ -78,6 +86,19 @@ describe('visuals-bootstrap.js — visualization driver', () => {
     expect(src).toContain('_running');
     // Single _loop function as the RAF callback
     expect(src.match(/function _loop/g) || []).toHaveLength(1);
+    expect(src).toContain('handle.tick');
+  });
+
+  test('debounces ResizeObserver layout work to avoid feedback loops', () => {
+    expect(src).toContain('_scheduleLayoutResize');
+    expect(src).toContain('_resizePremiumContainers');
+    expect(src).not.toMatch(/new ResizeObserver\(\(\) => \{\s*_resizeVisibleCanvases\(\);\s*_syncPremiumViz\(\)/);
+  });
+
+  test('caches waveform bases instead of redrawing full buffers every frame', () => {
+    expect(src).toContain('_waveBaseCache');
+    expect(src).toContain('_drawWaveformBase');
+    expect(src).toContain('putImageData');
   });
 
   test('does NOT define any STFT/iSTFT or fetch — pure tap consumer', () => {


### PR DESCRIPTION
## Problems

- Premium visuals (Aura, Liquid, 3D Topo, Swarm) stretched because canvas internal resolution did not match CSS layout size; Aura/Liquid had no fixed height.
- `ResizeObserver loop completed with undelivered notifications` from canvas resize feedback during layout.
- Playback of processed audio froze the page: full waveform redraw every RAF frame + 5+ competing animation loops (main + each premium viz).

## Solution

- **Canvas sizing**: HiDPI resize syncs CSS px + buffer size; fixed heights for Aura/Liquid.
- **Single RAF coordinator**: Premium visualizers expose `tick()` / `resize()` instead of internal `requestAnimationFrame` loops.
- **Waveform cache**: Static waveform cached via `ImageData`; playhead overlay only when position changes.
- **ResizeObserver**: Debounced via `requestAnimationFrame`; resizes existing premium handles instead of re-initing.
- **Neon pulse card**: Reset canvas transform before DPR scale; debounced RO.

## Testing

- `tests/visuals-bootstrap.test.js` — 32/32 pass

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix visualization stretch, ResizeObserver loop errors, and playback jank in the engineer view
> - Refactors all premium visualizers (`initPulsingAura`, `initTopographic3D`, `initParticleSwarm`, `initLiquidWaves`) to remove self-contained RAF loops and window resize listeners, instead exposing a `{ tick, resize, stop }` API driven by a single coordinator loop in [visuals-bootstrap.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/689/files#diff-97305f1278d299699dbd4b6d6074b123eebb509e482ae1a8caa5cbae8693314f).
> - Debounces ResizeObserver and window resize callbacks via `_scheduleLayoutResize` to coalesce layout work into a single animation frame, eliminating ResizeObserver feedback loops and frame-thrashing.
> - Suppresses benign `ResizeObserver` error events at the window level in [index.html](https://github.com/Joker5514/VoiceIsolate-Pro/pull/689/files#diff-4400aa5aa5292d143f7e2f1308aa82756255552567d5558874c994833e907ce4) via `stopImmediatePropagation`.
> - Adds waveform base caching (`_waveBaseCache`/`_drawWaveformBase`) and playhead pixel caching to skip redundant canvas redraws; caps `devicePixelRatio` at 2 and enforces integer CSS canvas dimensions throughout.
> - Behavioral Change: premium visualizers no longer animate independently — they render only when `tick()` is called by the RAF coordinator each frame.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 52a3609.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved visualization rendering efficiency with smoother animation updates and reduced redundant work.
  * Enhanced waveform, spectrogram, and frequency visualizations through caching and optimized resizing.

* **Bug Fixes**
  * Improved canvas scaling and responsiveness across screen sizes and display densities.
  * Suppressed non-actionable ResizeObserver browser warnings.

* **Style**
  * Adjusted visualization canvas heights for standard and gallery layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->