### PR TITLE
fix(engineer): end stuck processing — ML timeouts, overlay sync, UI reset

### DIFF
--- a/public/app/app.js
+++ b/public/app/app.js
@@ -205,8 +205,11 @@ const HeroExperience = (() => {
     if (chip) chip.textContent = `◉ ${label}`;
     const barWrap = $('pipelineStage');
     if (barWrap) barWrap.setAttribute('aria-valuenow', String(Math.round(p)));
-    if (p > 0 && p < 100) setUiState('processing');
     if (p >= 100) setUiState('processed');
+    else if (p > 0) setUiState('processing');
+    else if (appRef?.outputBuffer || appRef?.procBuffer) setUiState('processed');
+    else if (appRef?.inputBuffer || appRef?.origBuffer) setUiState('file-ready');
+    else setUiState('idle');
     if (appRef && typeof appRef._updateProcessButtonsState === 'function') {
       appRef._updateProcessButtonsState();
     }
@@ -1016,6 +1019,9 @@ class VoiceIsolatePro {
     if (spinner) spinner.style.display = (p > 0 && p < 100) ? '' : 'none';
     const lbl = badge && badge.querySelector('.vip-pb-label');
     if (lbl) lbl.textContent = detail || (p >= 100 ? 'Done' : 'Ready');
+    if (typeof this.updateProcessingOverlay === 'function') {
+      this.updateProcessingOverlay(detail || '', p, stageIndex);
+    }
     HeroExperience.onPipelineProgress(stageIndex, detail, p);
   }
 
@@ -2432,13 +2438,7 @@ class VoiceIsolatePro {
         this.inputBuffer = pass === 0 ? (this.inputBuffer || this.origBuffer) : (this.procBuffer || sourceBuf);
         sourceBuf = this.inputBuffer;
 
-        if (window._vipOrch && typeof window._vipOrch.run === 'function') {
-          const result = await window._vipOrch.run(this.inputBuffer, window.VIP_PARAMS || {});
-          if (result) {
-            this.outputBuffer = result;
-            this.procBuffer = result;
-          }
-        } else if (pass === 0) {
+        if (pass === 0) {
           // ML inference runs exactly once per file (CLAUDE.md §1). Whisper
           // forensic passes are DSP-only refinement on procBuffer.
           stageStart('ml_isolation');
@@ -2467,6 +2467,8 @@ class VoiceIsolatePro {
 
       if (fileSeq !== this._fileSeq) {
         stageEnd('pipeline');
+        this.setStatus('READY');
+        this.updatePipelineProgress(0, 'Cancelled (new file loaded)', 0);
         return;
       }
       if (this.abortFlag) {
@@ -2951,8 +2953,12 @@ class VoiceIsolatePro {
     const yieldBudget = createYieldBudget(32);
     if (onProgress) onProgress(0.02);
     await yieldBudget();
+    if (onProgress) onProgress(0.08);
+    await yieldBudget();
 
     const spec = DSP.forwardSTFT(data, FFT, HOP);
+    if (onProgress) onProgress(0.15);
+    await yieldBudget();
     if (!spec || !Array.isArray(spec.mag) || spec.mag.length === 0) return data;
     const mag = spec.mag;
     const phase = spec.phase;

--- a/src/pipeline/StemSeparation.js
+++ b/src/pipeline/StemSeparation.js
@@ -21,6 +21,8 @@ let _warmupWaiters = [];
 let _warmupHooked = false;
 
 const WARMUP_TIMEOUT_MS = 120000;
+/** Max wait for a single separation job before falling back to DSP. */
+const PROCESS_TIMEOUT_MS = 180000;
 
 function getWorker() {
   if (_worker) return _worker;
@@ -128,7 +130,7 @@ export async function separateStems(channelData, sampleRate, options = {}) {
     const timer = setTimeout(() => {
       cleanup();
       reject(new Error('[VIP][StemSeparation] processing timeout'));
-    }, 600000);
+    }, PROCESS_TIMEOUT_MS);
     const onMsg = (ev) => {
       const m = ev.data || {};
       if (m.requestId !== requestId) return;

--- a/src/workers/MLWorker.js
+++ b/src/workers/MLWorker.js
@@ -79,6 +79,20 @@ let BACKEND = null;
 /** Active process request id for stage/progress messages. */
 let ACTIVE_REQUEST_ID = null;
 
+const SESSION_COMPILE_TIMEOUT_MS = 90000;
+
+function withTimeout(promise, ms, label) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`[VIP][MLWorker] ${label} timed out after ${ms}ms`));
+    }, ms);
+    promise.then(
+      (value) => { clearTimeout(timer); resolve(value); },
+      (err) => { clearTimeout(timer); reject(err); },
+    );
+  });
+}
+
 /** When true, cache I/O is proxied to the main thread (filesystem-first on desktop). */
 let USE_DESKTOP_CACHE = false;
 
@@ -258,7 +272,11 @@ async function getSession(entry, sessionKey = entry.id, { quiet = false } = {}) 
     const bytes = await fetchModelBytes(entry);
     if (!quiet) postStage('load', 40, { modelId: entry.id, label: `Verifying ${entry.name || entry.id}…` });
     if (!quiet) postStage('load', 55, { modelId: entry.id, label: `Compiling ${entry.name || entry.id}…` });
-    const session = await createSessionFromBytes(entry, bytes);
+    const session = await withTimeout(
+      createSessionFromBytes(entry, bytes),
+      SESSION_COMPILE_TIMEOUT_MS,
+      `Compile ${entry.id}`,
+    );
     SESSIONS[sessionKey] = session;
     if (!quiet) postStage('load', 100, { modelId: entry.id, label: `${entry.name || entry.id} ready` });
     return session;
@@ -640,7 +658,10 @@ self.onmessage = async (event) => {
         break;
       }
       case 'warmup':
-        await warmupModels(msg.modelIds);
+        // Non-blocking — process messages must not queue behind a long compile.
+        void warmupModels(msg.modelIds).catch((err) => {
+          console.warn('[VIP][MLWorker] Warmup failed:', err?.message || err);
+        });
         break;
       default:
         self.postMessage({ type: 'error', message: `Unknown message type '${msg.type}'` });

--- a/tests/engineer-mode-completion.test.js
+++ b/tests/engineer-mode-completion.test.js
@@ -73,6 +73,20 @@ describe('app.js completion helpers', () => {
     expect(appJs).toContain('const busy = Boolean(this.isProcessing)');
     expect(appJs).toContain('Processing already in progress');
   });
+
+  test('app.js syncs pipeline progress to processing overlay and clears hero state on cancel', () => {
+    expect(appJs).toContain('this.updateProcessingOverlay(detail');
+    expect(appJs).not.toContain('window._vipOrch.run');
+    expect(appJs).toContain("updatePipelineProgress(0, 'Cancelled (new file loaded)', 0)");
+  });
+});
+
+describe('StemSeparation timeouts', () => {
+  const stemJs = fs.readFileSync(path.join(__dirname, '../src/pipeline/StemSeparation.js'), 'utf8');
+
+  test('caps ML separation wait so Engineer Mode can fall back to DSP', () => {
+    expect(stemJs).toContain('PROCESS_TIMEOUT_MS = 180000');
+  });
 });
 
 describe('How It Works page', () => {


### PR DESCRIPTION
## Problem

Engineer Mode could appear to process forever:
- ML worker blocked on model compile with no timeout (warmup queued ahead of process)
- Progress overlay stuck at 0% (not wired to `updatePipelineProgress`)
- Hero UI stayed in `processing` after cancel/error (pct reset to 0)
- Dead `_vipOrch.run` branch could stall if a legacy orchestrator was present

## Solution

- **MLWorker**: 90s compile timeout; warmup is non-blocking so `process` is not queued behind compile
- **StemSeparation**: 180s separation timeout → DSP fallback via existing catch path
- **app.js**: sync overlay progress; remove dead orchestrator branch; reset UI on cancel/new-file
- **Hero UI**: restore `file-ready` / `idle` when progress returns to 0

## Testing

- `tests/engineer-mode-completion.test.js`
- `tests/visuals-bootstrap.test.js`
- `tests/m4a-decode-fallback.test.js`

69 targeted tests pass.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix stuck processing by adding ML timeouts, unblocking warmup, and resetting UI on cancellation
> - Reduces `StemSeparation` ML timeout from 10 minutes to 3 minutes via `PROCESS_TIMEOUT_MS = 180000` in [StemSeparation.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/690/files#diff-ee2b9dbe14c9d6ef6bccb4d4a853a8f31db7d6d7487b98f2a39ee6a09058151b)
> - Adds `withTimeout` helper to [MLWorker.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/690/files#diff-feb98479b700cf9bcf10c1482f1408a8217b243653a510f90b27c617f61cf8a4) and applies a 90s timeout to ONNX session compilation so hung model compiles now fail fast
> - Makes model warmup fire-and-forget in `MLWorker`, so pending `process` messages are no longer queued behind compilation
> - Removes the `window._vipOrch.run` branch from `runPipeline`; the internal ML pipeline now always runs first on the initial pass
> - When a new file supersedes an in-progress run, the pipeline sets status to `READY` and emits a `Cancelled (new file loaded)` progress update; UI state now also distinguishes idle, file-ready, processing, and processed based on buffer presence
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 59485bc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->