### PR TITLE
fix(engineer): sync UI transport clock with bridge audio position

### DIFF
--- a/public/app/app.js
+++ b/public/app/app.js
@@ -3290,7 +3290,9 @@ class VoiceIsolatePro {
 
   _getTransportPosition() {
     const bridge = this._bridge;
-    if (bridge?.isPlaying?.() && typeof bridge.currentTime === 'function') {
+    // Bridge clock is authoritative whenever it drives transport — including
+    // the brief seek gap where mixer.isPlaying() is false but app.isPlaying is true.
+    if (this._transportViaBridge && bridge && typeof bridge.currentTime === 'function') {
       return bridge.currentTime();
     }
     if (this.isPlaying && this.ctx && Number.isFinite(this.playStartTime)) {
@@ -3337,6 +3339,11 @@ class VoiceIsolatePro {
       if (!this._transportSeeking) {
         this.playOffset = cur;
         this._paintTransport(cur, dur);
+        try {
+          window.dispatchEvent(new CustomEvent('vip:transportTick', {
+            detail: { position: cur, duration: dur },
+          }));
+        } catch (_) {}
       }
 
       const bridge = this._bridge;
@@ -3505,6 +3512,7 @@ class VoiceIsolatePro {
         this._ensureTransportRegionWiring();
         // Honour the current scrub position, then start.
         this._ensurePlaybackAnalyser();
+        this._transportViaBridge = true;
         Promise.resolve(bridge.seek(this.playOffset || 0))
           .then(() => bridge.play())
           .catch((err) => {
@@ -3522,6 +3530,8 @@ class VoiceIsolatePro {
     if (!bridge && !this._bridgeFailed) {
       this._ensureBridge();
     }
+
+    this._transportViaBridge = false;
 
     // Fallback: direct AudioContext source node (offline-processed buffer).
     if (window._vipOrch && typeof window._vipOrch.buildLiveChain === 'function') {

--- a/public/app/vip-fixes.js
+++ b/public/app/vip-fixes.js
@@ -115,6 +115,9 @@
     }
 
     function _elapsedSeconds() {
+      if (typeof app._getTransportPosition === 'function') {
+        return app._getTransportPosition();
+      }
       const ctx = _getCtx();
       if (_usingBridge && _bridge) {
         return _bridge.isPlaying() ? _bridge.currentTime() : _pauseOffset;
@@ -172,6 +175,7 @@
         } catch (_) {}
         _usingBridge = false;
         _bridge = null;
+        app._transportViaBridge = false;
       }
       _stopSource();
       _isPlaying = false;
@@ -198,6 +202,7 @@
       _stopSource();
       _usingBridge = false;
       _bridge = null;
+      app._transportViaBridge = false;
 
       _duration = buf.duration || 0;
       const dur = $('tpDur');
@@ -226,6 +231,7 @@
           _usingBridge = true;
           _bridge = bridge;
           app._bridge = bridge;
+          app._transportViaBridge = true;
           _analyser = bridge.getAnalyser ? bridge.getAnalyser() : null;
           if (_analyser) window._vipPlayAnalyser = _analyser;
           _startTime = ctx.currentTime;
@@ -250,8 +256,10 @@
         warn('Live-Mix bridge play failed; falling back to direct source', e);
         _usingBridge = false;
         _bridge = null;
+        app._transportViaBridge = false;
       }
 
+      app._transportViaBridge = false;
       _source = ctx.createBufferSource();
       _source.buffer = buf;
       const spSel = $('tpSpeed');

--- a/public/app/visuals-bootstrap.js
+++ b/public/app/visuals-bootstrap.js
@@ -39,6 +39,9 @@
 
   function _getPlayOffset() {
     const app = global._vipApp;
+    if (app && typeof app._getTransportPosition === 'function') {
+      return app._getTransportPosition();
+    }
     if (app && app._fixPlayState && typeof app._fixPlayState.elapsed === 'function') {
       return app._fixPlayState.elapsed();
     }
@@ -146,11 +149,14 @@
     _drawWaveformBase(canvas, audioBuf, color);
   }
 
-  function _drawPlayhead(canvas, buffer, color) {
+  function _drawPlayhead(canvas, buffer, color, positionSec) {
     if (!canvas || !buffer) return;
     if (!_drawWaveformBase(canvas, buffer, color)) return;
     const dur = buffer.duration || 1;
-    const px = Math.round((_getPlayOffset() / dur) * canvas.width);
+    const offset = (typeof positionSec === 'number' && Number.isFinite(positionSec))
+      ? positionSec
+      : _getPlayOffset();
+    const px = Math.round((offset / dur) * canvas.width);
     const lastPx = _playheadPxCache.get(canvas);
     if (lastPx === px) return;
     _playheadPxCache.set(canvas, px);
@@ -162,6 +168,20 @@
     ctx.moveTo(px, 0);
     ctx.lineTo(px, canvas.height);
     ctx.stroke();
+  }
+
+  function paintPlayheads(positionSec) {
+    const app = global._vipApp;
+    if (!app) return;
+    const inBuf = app.inputBuffer || app.origBuffer;
+    const outBuf = app.outputBuffer || app.procBuffer;
+    if (_isTabDrawTarget('waveform') && inBuf) {
+      _drawPlayhead($('waveCanvas'), inBuf, '#22d3ee', positionSec);
+    }
+    if (_isTabDrawTarget('abcompare')) {
+      if (inBuf) _drawPlayhead($('waveOrigCanvas'), inBuf, '#22d3ee', positionSec);
+      if (outBuf) _drawPlayhead($('waveProcCanvas'), outBuf, '#69ff47', positionSec);
+    }
   }
 
   function drawStaticVisuals() {
@@ -876,6 +896,12 @@
       stop();
       _stopAllPremium();
     });
+    window.addEventListener('vip:transportTick', (e) => {
+      const pos = e && e.detail && typeof e.detail.position === 'number'
+        ? e.detail.position
+        : _getPlayOffset();
+      paintPlayheads(pos);
+    });
 
     let polls = 0;
     const poll = setInterval(() => {
@@ -908,6 +934,7 @@
 
   global.VIP_VISUALS = {
     drawStatic: drawStaticVisuals,
+    paintPlayheads,
     start,
     stop,
     onTabActivated: _onTabActivated,

--- a/tests/engineer-transport-sync.test.js
+++ b/tests/engineer-transport-sync.test.js
@@ -1,0 +1,98 @@
+const fs = require('fs');
+const path = require('path');
+const getAppCode = require('./helpers/get-app-code');
+
+const APP_JS = getAppCode();
+const VIP_FIXES = fs.readFileSync(path.join(__dirname, '..', 'public', 'app', 'vip-fixes.js'), 'utf8');
+const VISUALS_BOOT = fs.readFileSync(path.join(__dirname, '..', 'public', 'app', 'visuals-bootstrap.js'), 'utf8');
+
+let VoiceIsolatePro;
+try {
+  const safeCode = APP_JS.replace(/document\.addEventListener\('DOMContentLoaded'[\s\S]*?\}\);/, '');
+  VoiceIsolatePro = new Function('window', 'document', safeCode + '; return VoiceIsolatePro;')({}, {});
+} catch (e) {
+  throw new Error('Failed to load VoiceIsolatePro: ' + e.message);
+}
+
+describe('Engineer Mode transport sync', () => {
+  test('app.js uses bridge clock whenever _transportViaBridge is set', () => {
+    expect(APP_JS).toContain('_transportViaBridge');
+    expect(APP_JS).toMatch(/_transportViaBridge[\s\S]*bridge\.currentTime/);
+    expect(APP_JS).not.toMatch(
+      /_getTransportPosition\(\)[\s\S]*bridge\?\.isPlaying\?\.\(\)[\s\S]*return bridge\.currentTime/,
+    );
+  });
+
+  test('app.js dispatches vip:transportTick from the transport clock', () => {
+    expect(APP_JS).toContain("'vip:transportTick'");
+    expect(APP_JS).toMatch(/_startTransportClock[\s\S]*vip:transportTick/);
+  });
+
+  test('vip-fixes sets _transportViaBridge on bridge play and clears on fallback', () => {
+    expect(VIP_FIXES).toContain('app._transportViaBridge = true');
+    expect(VIP_FIXES).toContain('app._transportViaBridge = false');
+    expect(VIP_FIXES).toMatch(/_elapsedSeconds[\s\S]*app\._getTransportPosition/);
+  });
+
+  test('visuals-bootstrap reads transport from app._getTransportPosition and paints on transport tick', () => {
+    expect(VISUALS_BOOT).toMatch(/_getPlayOffset[\s\S]*app\._getTransportPosition/);
+    expect(VISUALS_BOOT).toContain("'vip:transportTick'");
+    expect(VISUALS_BOOT).toContain('paintPlayheads');
+  });
+
+  describe('_getTransportPosition()', () => {
+    let ctx;
+
+    beforeEach(() => {
+      ctx = {
+        abMode: 'original',
+        isPlaying: false,
+        playOffset: 12,
+        playStartTime: 100,
+        _transportViaBridge: true,
+        ctx: { currentTime: 250 },
+        dom: { tpSpeed: { value: 1 } },
+        _bridge: {
+          isPlaying: () => false,
+          currentTime: () => 45,
+        },
+      };
+    });
+
+    it('returns bridge.currentTime during seek gap (app playing, mixer idle)', () => {
+      ctx.isPlaying = true;
+      expect(VoiceIsolatePro.prototype._getTransportPosition.call(ctx)).toBe(45);
+    });
+
+    it('returns bridge.currentTime while mixer is playing', () => {
+      ctx._bridge.isPlaying = () => true;
+      ctx._bridge.currentTime = () => 67.5;
+      ctx.isPlaying = true;
+      expect(VoiceIsolatePro.prototype._getTransportPosition.call(ctx)).toBe(67.5);
+    });
+
+    it('does not use stale wall-clock math when bridge drives transport', () => {
+      ctx.isPlaying = true;
+      ctx.playOffset = 12;
+      ctx.playStartTime = 100;
+      ctx.ctx.currentTime = 500;
+      expect(VoiceIsolatePro.prototype._getTransportPosition.call(ctx)).toBe(45);
+    });
+
+    it('falls back to wall-clock math when not on bridge transport', () => {
+      ctx._transportViaBridge = false;
+      ctx.isPlaying = true;
+      ctx.playOffset = 10;
+      ctx.playStartTime = 100;
+      ctx.ctx.currentTime = 110;
+      expect(VoiceIsolatePro.prototype._getTransportPosition.call(ctx)).toBe(20);
+    });
+
+    it('returns playOffset when paused off-bridge', () => {
+      ctx._transportViaBridge = false;
+      ctx.isPlaying = false;
+      ctx.playOffset = 33;
+      expect(VoiceIsolatePro.prototype._getTransportPosition.call(ctx)).toBe(33);
+    });
+  });
+});


### PR DESCRIPTION
## Problem

Engineer Mode showed major lag between the transport UI (seek bar, waveform playhead) and audible playback.

## Root cause

During PlaybackMixer.seek() the mixer briefly sets isPlaying=false while tearing down sources. _getTransportPosition() only trusted bridge.currentTime() when bridge.isPlaying() was true, so the transport RAF fell back to wall-clock math using a stale playStartTime from the original play start. The UI could race seconds or minutes ahead of audio.

## Fix

- Add _transportViaBridge flag so transport always reads bridge.currentTime() when the Live-Mix bridge drives playback (including seek gaps)
- Unify playhead position via app._getTransportPosition() in vip-fixes and visuals-bootstrap
- Dispatch vip:transportTick from the transport clock and paint waveform playheads on that lightweight tick

## Tests

- New tests/engineer-transport-sync.test.js

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Sync UI transport clock with bridge audio position in VoiceIsolatePro
> - Introduces `_transportViaBridge` flag in [app.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/691/files#diff-8a8b7ea624d7fccc12a516d122dcb07bd67c6a8f796c80e33b898ee6a7557650) and [vip-fixes.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/691/files#diff-e1b2a993f0bf64b447304c6c2d82a496fd3b394e13cc5cda2d6568a7f7a92e9d) to track whether transport position is driven by the bridge clock; `_getTransportPosition` now uses `bridge.currentTime()` whenever the flag is set, including during seek gaps where `mixer.isPlaying()` may be false.
> - The transport clock loop emits a `vip:transportTick` CustomEvent (with `position` and `duration`) on each tick, which [visuals-bootstrap.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/691/files#diff-97305f1278d299699dbd4b6d6074b123eebb509e482ae1a8caa5cbae8693314f) listens for to repaint playheads using the authoritative bridge position.
> - `_drawPlayhead` is extended to accept an optional `positionSec` argument, and a new `paintPlayheads` helper repaints waveform and A/B compare canvases from a supplied position.
> - Behavioral Change: elapsed-time reads in `vipFixes._elapsedSeconds` and visual offsets in `_getPlayOffset` now delegate to `app._getTransportPosition()` rather than computing position independently from local state.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 09e2395.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved playback timing consistency during bridge-based seeking and short playback transitions.
  * Kept elapsed-time and playhead positioning synchronized across bridge and fallback playback modes.
  * Reduced stale or inaccurate playhead positions when playback is paused or changing modes.

* **Enhancements**
  * Playheads now update directly as transport position changes across supported viewing modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->