### PR TITLE
fix(engineer): harden transport, processing cancel, and UI perf

### DIFF
--- a/public/app/app.js
+++ b/public/app/app.js
@@ -1644,9 +1644,16 @@ class VoiceIsolatePro {
     bind('tpRew', d.tpRew, 'click', () => this.seekDelta(-10));
     bind('tpFwd', d.tpFwd, 'click', () => this.seekDelta(10));
     if (d.tpSeek) {
-      d.tpSeek.addEventListener('mousedown', () => { this._transportSeeking = true; });
-      d.tpSeek.addEventListener('touchstart', () => { this._transportSeeking = true; }, { passive: true });
+      d.tpSeek.addEventListener('mousedown', () => {
+        if (this._fixTransportPatched) return;
+        this._transportSeeking = true;
+      });
+      d.tpSeek.addEventListener('touchstart', () => {
+        if (this._fixTransportPatched) return;
+        this._transportSeeking = true;
+      }, { passive: true });
       d.tpSeek.addEventListener('input', (e) => {
+        if (this._fixTransportPatched) return;
         const frac = parseFloat(e.target.value) / 1000;
         const dur = this._getTransportDuration();
         const off = frac * dur;
@@ -1654,6 +1661,7 @@ class VoiceIsolatePro {
         this._paintTransport(off, dur, { skipSeekValue: true });
       });
       d.tpSeek.addEventListener('change', (e) => {
+        if (this._fixTransportPatched) return;
         this._transportSeeking = false;
         this.seekTo(parseFloat(e.target.value) / 1000);
       });
@@ -1865,12 +1873,16 @@ class VoiceIsolatePro {
     if (e.key === 'Escape') {
       if (this.isProcessing) {
         this.abortFlag = true;
+        import('/src/pipeline/StemSeparation.js')
+          .then((m) => { if (m.resetStemSeparation) m.resetStemSeparation(); })
+          .catch(() => {});
       } else {
         this.stop();
       }
       return;
     }
     if (e.key === 'x' || e.key === 'X') {
+      if (this._fixABPatched) return;
       if (!(this.outputBuffer || this.procBuffer)) return;
       if (this.dom && this.dom.tpAB && this.dom.tpAB.disabled) return;
       this.toggleAB();
@@ -2104,7 +2116,11 @@ class VoiceIsolatePro {
     this.stop();
     if (this.isProcessing) {
       this.abortFlag = true;
-      await this._waitForPipelineIdle();
+      try {
+        const { resetStemSeparation } = await import('/src/pipeline/StemSeparation.js');
+        if (resetStemSeparation) resetStemSeparation();
+      } catch (_) {}
+      await this._waitForPipelineIdle(90000);
     }
     this.setStatus('LOADING');
     HeroExperience.onDecodeStart();
@@ -2380,12 +2396,16 @@ class VoiceIsolatePro {
     }
     if (this.isProcessing) {
       structuredLog('warn', '[VIP] Pipeline idle wait timed out — forcing reset.');
+      import('/src/pipeline/StemSeparation.js')
+        .then((m) => { if (m.resetStemSeparation) m.resetStemSeparation(); })
+        .catch(() => {});
       this.isProcessing = false;
       this.abortFlag = false;
       if (typeof this.hideProcessingOverlay === 'function') {
         try { this.hideProcessingOverlay(); } catch (_) {}
       }
       document.body.classList.remove('vip-processing-lock');
+      try { window.dispatchEvent(new CustomEvent('vip:processingDone')); } catch (_) {}
     }
   }
 
@@ -3708,18 +3728,22 @@ class VoiceIsolatePro {
       Promise.resolve(bridge.seek(target)).catch(() => {});
     }
 
-    if (wasPlaying) {
+    if (wasPlaying && !this._fixTransportPatched) {
       this.play();
     }
   }
 
   toggleAB() {
+    if (this._fixABPatched) return;
     const buf = this.outputBuffer || this.procBuffer;
     if (!buf) return;
-    const speed = numFromInput(this.dom.tpSpeed, 1);
-    if (this.isPlaying) {
+    if (this.isPlaying && typeof this._getTransportPosition === 'function') {
+      this.playOffset = this._getTransportPosition();
+    } else if (this.isPlaying) {
+      const speed = numFromInput(this.dom.tpSpeed, 1);
       this.playOffset += (this.ctx.currentTime - this.playStartTime) * speed;
     }
+    this._bridgeBuf = null;
     this.abMode = this.abMode === 'original' ? 'processed' : 'original';
     if (this.dom.tpAB) this.dom.tpAB.classList.toggle('active', this.abMode === 'processed');
     // PATCHED BY vip-fixes.js — consider merging

--- a/public/app/diarization-timeline.js
+++ b/public/app/diarization-timeline.js
@@ -80,7 +80,14 @@ export function initDiarizationTimeline(opts = {}) {
   _onSpeakerClick = opts.onSpeakerClick || null;
 
   if (!_resizeObserver) {
-    _resizeObserver = new ResizeObserver(() => _resize());
+    let roRaf = 0;
+    _resizeObserver = new ResizeObserver(() => {
+      if (roRaf) cancelAnimationFrame(roRaf);
+      roRaf = requestAnimationFrame(() => {
+        roRaf = 0;
+        _resize();
+      });
+    });
     _resizeObserver.observe(_canvas.parentElement || _canvas);
   }
   _resize();

--- a/public/app/vip-fixes.js
+++ b/public/app/vip-fixes.js
@@ -433,8 +433,10 @@
       }
     });
 
-    /* Seek scrubber — app.js owns input/change handlers; sync local offset only */
+    /* Seek scrubber — vip-fixes owns transport when patched */
     if (seek) {
+      seek.addEventListener('mousedown', () => { app._transportSeeking = true; });
+      seek.addEventListener('touchstart', () => { app._transportSeeking = true; }, { passive: true });
       seek.addEventListener('input', () => {
         const dur = (typeof app._getTransportDuration === 'function')
           ? app._getTransportDuration()
@@ -445,8 +447,12 @@
           app._paintTransport(_pauseOffset, dur, { skipSeekValue: true });
         }
         if (!_isPlaying) _syncVideo(_pauseOffset, false);
+        if (window.VIP_VISUALS && typeof window.VIP_VISUALS.paintPlayheads === 'function') {
+          window.VIP_VISUALS.paintPlayheads(_pauseOffset);
+        }
       });
       seek.addEventListener('change', () => {
+        app._transportSeeking = false;
         const dur = (typeof app._getTransportDuration === 'function')
           ? app._getTransportDuration()
           : (_duration || 0);
@@ -564,9 +570,19 @@
         return;
       }
       const next = (app.abMode === 'processed') ? 'original' : 'processed';
+      const wasPlaying = !!app._fixPlayState?.isPlaying;
+      const pos = (typeof app._getTransportPosition === 'function')
+        ? app._getTransportPosition()
+        : (_pauseOffset || app.playOffset || 0);
       app.abMode = next;
+      app._bridgeBuf = null;
       _setABLabel(next === 'processed' ? 'B' : 'A');
-      if (app._fixPlayState?.isPlaying) { app._fixPlayState.resetOffset(); app._fixPlayState.restart(); }
+      if (wasPlaying) {
+        _pauseOffset = pos;
+        app.playOffset = pos;
+        _stopSource();
+        _play();
+      }
       log('A/B toggled to', next);
     }
 
@@ -860,6 +876,12 @@
       const app = window._vipApp;
       if (!app) return;
       _pendingIsolation = { freqLow, freqHigh, source: e.detail?.source || '' };
+      _showIsoConfirm(freqLow, freqHigh);
+    });
+
+    window.addEventListener('vip:processingDone', () => {
+      if (!_pendingIsolation) return;
+      const { freqLow, freqHigh } = _pendingIsolation;
       _showIsoConfirm(freqLow, freqHigh);
     });
 

--- a/public/app/visuals-bootstrap.js
+++ b/public/app/visuals-bootstrap.js
@@ -383,15 +383,6 @@
     }
   }
 
-  function _drawABCompareLive() {
-    const app = global._vipApp;
-    if (!app) return;
-    const inBuf = app.inputBuffer || app.origBuffer;
-    const outBuf = app.outputBuffer || app.procBuffer;
-    if (inBuf) _drawPlayhead($('waveOrigCanvas'), inBuf, '#22d3ee');
-    if (outBuf) _drawPlayhead($('waveProcCanvas'), outBuf, '#69ff47');
-  }
-
   /* ── LUFS + header meters ─────────────────────────────────────────────── */
   function _updateLufs(timeBytes) {
     let sumSq = 0;
@@ -546,14 +537,6 @@
       const freq = $('freqCanvas');
       if (freq) _drawFreqBars(freq, _freqScratch);
     }
-
-    if (_isTabDrawTarget('waveform')) {
-      const app = global._vipApp;
-      const buf = app && (app.inputBuffer || app.origBuffer);
-      if (buf) _drawPlayhead($('waveCanvas'), buf, '#22d3ee');
-    }
-
-    if (_isTabDrawTarget('abcompare')) _drawABCompareLive();
 
     _syncClustersEngine(_freqScratch);
 
@@ -909,7 +892,7 @@
       const app = global._vipApp;
       if (app && (app.inputBuffer || app.origBuffer)) {
         clearInterval(poll);
-        try { window.dispatchEvent(new CustomEvent('vip:fileLoaded')); } catch (_) {}
+        drawStaticVisuals();
       } else if (polls > 600) {
         clearInterval(poll);
       }

--- a/src/pipeline/StemSeparation.js
+++ b/src/pipeline/StemSeparation.js
@@ -129,6 +129,7 @@ export async function separateStems(channelData, sampleRate, options = {}) {
   return new Promise((resolve, reject) => {
     const timer = setTimeout(() => {
       cleanup();
+      resetStemSeparation();
       reject(new Error('[VIP][StemSeparation] processing timeout'));
     }, PROCESS_TIMEOUT_MS);
     const onMsg = (ev) => {

--- a/tests/engineer-hardening.test.js
+++ b/tests/engineer-hardening.test.js
@@ -1,0 +1,78 @@
+const fs = require('fs');
+const path = require('path');
+const getAppCode = require('./helpers/get-app-code');
+
+const APP_JS = getAppCode();
+const VIP_FIXES = fs.readFileSync(path.join(__dirname, '..', 'public', 'app', 'vip-fixes.js'), 'utf8');
+const VISUALS_BOOT = fs.readFileSync(path.join(__dirname, '..', 'public', 'app', 'visuals-bootstrap.js'), 'utf8');
+const STEM_SEP = fs.readFileSync(path.join(__dirname, '..', 'src', 'pipeline', 'StemSeparation.js'), 'utf8');
+const DIAR_TIMELINE = fs.readFileSync(path.join(__dirname, '..', 'public', 'app', 'diarization-timeline.js'), 'utf8');
+
+let VoiceIsolatePro;
+try {
+  const safeCode = APP_JS.replace(/document\.addEventListener\('DOMContentLoaded'[\s\S]*?\}\);/, '');
+  VoiceIsolatePro = new Function('window', 'document', safeCode + '; return VoiceIsolatePro;')({}, {});
+} catch (e) {
+  throw new Error('Failed to load VoiceIsolatePro: ' + e.message);
+}
+
+describe('Engineer Mode hardening', () => {
+  test('StemSeparation terminates worker on processing timeout', () => {
+    expect(STEM_SEP).toMatch(/setTimeout[\s\S]*resetStemSeparation\(\)/);
+  });
+
+  test('app.js guards duplicate tpSeek handlers when vip-fixes owns transport', () => {
+    expect(APP_JS).toMatch(/tpSeek[\s\S]*_fixTransportPatched[\s\S]*return/);
+  });
+
+  test('app.js skips X-key toggleAB when vip-fixes owns A/B', () => {
+    expect(APP_JS).toMatch(/e\.key === 'x'[\s\S]*_fixABPatched[\s\S]*return/);
+  });
+
+  test('app.js seekTo does not replay when vip-fixes owns transport', () => {
+    expect(APP_JS).toMatch(/wasPlaying && !this\._fixTransportPatched/);
+  });
+
+  test('app.js abort resets ML worker and extends idle wait', () => {
+    expect(APP_JS).toMatch(/resetStemSeparation[\s\S]*_waitForPipelineIdle\(90000\)/);
+    expect(APP_JS).toMatch(/Pipeline idle wait timed out[\s\S]*resetStemSeparation/);
+  });
+
+  test('vip-fixes A/B toggle preserves transport position', () => {
+    expect(VIP_FIXES).toMatch(/function _toggleAB[\s\S]*_getTransportPosition[\s\S]*_pauseOffset = pos/);
+    expect(VIP_FIXES).not.toMatch(/function _toggleAB[\s\S]*resetOffset\(\)/);
+  });
+
+  test('vip-fixes refreshes isolation confirm after processingDone', () => {
+    expect(VIP_FIXES).toMatch(/vip:processingDone[\s\S]*_pendingIsolation[\s\S]*_showIsoConfirm/);
+  });
+
+  test('vip-fixes seek sets app._transportSeeking and paints playheads while scrubbing', () => {
+    expect(VIP_FIXES).toContain('app._transportSeeking = true');
+    expect(VIP_FIXES).toContain('VIP_VISUALS.paintPlayheads');
+  });
+
+  test('visuals-bootstrap uses transport tick only for playhead (not main RAF loop)', () => {
+    expect(VISUALS_BOOT).toContain("'vip:transportTick'");
+    expect(VISUALS_BOOT).toContain('paintPlayheads');
+    expect(VISUALS_BOOT).not.toMatch(/function _loop[\s\S]*_drawPlayhead\(\$\('waveCanvas'\)/);
+    expect(VISUALS_BOOT).not.toMatch(/dispatchEvent\(new CustomEvent\('vip:fileLoaded'\)\)/);
+  });
+
+  test('diarization-timeline debounces ResizeObserver', () => {
+    expect(DIAR_TIMELINE).toMatch(/ResizeObserver[\s\S]*requestAnimationFrame[\s\S]*_resize\(\)/);
+  });
+
+  test('toggleAB early-returns when vip-fixes patched', () => {
+    const ctx = {
+      _fixABPatched: true,
+      outputBuffer: { length: 1 },
+      abMode: 'original',
+      isPlaying: false,
+      play: jest.fn(),
+    };
+    VoiceIsolatePro.prototype.toggleAB.call(ctx);
+    expect(ctx.abMode).toBe('original');
+    expect(ctx.play).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Comprehensive Engineer Mode hardening after full test audit.

## Fixes

### Processing stuck / too long
- **ML worker terminate on timeout** — \StemSeparation\ calls \esetStemSeparation()\ when the 180s cap fires so the next run is not queued behind a zombie job
- **Abort/new-file cancel** — Escape and re-upload terminate the ML worker and extend idle wait to 90s; forced idle reset also dispatches \ip:processingDone\

### UI lag / transport desync
- **Duplicate seek handlers** — app.js tpSeek handlers no-op when vip-fixes owns transport; vip-fixes sets \pp._transportSeeking\ during scrub
- **A/B toggle** — preserves playhead position instead of resetting to 0; X-key no longer double-toggles
- **Playhead perf** — removed duplicate playhead draws from visuals RAF loop; only \ip:transportTick\ + scrub paint
- **Diarization ResizeObserver** — debounced via RAF (same pattern as #689)

### Isolation UX
- **Confirm bar refresh** — re-enables after \ip:processingDone\ when a band was drawn during processing

### Build hygiene
- Synced \uild/\ worklet copies (fixes \worklet-packaging\ CI)

## Tests
- New \	ests/engineer-hardening.test.js\ (11 cases)
- All engineer-related suites pass (143 tests)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden transport ownership, processing cancel, and A/B toggle in VoiceIsolatePro
> - Adds `_fixTransportPatched` and `_fixABPatched` guards in [app.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/692/files#diff-8a8b7ea624d7fccc12a516d122dcb07bd67c6a8f796c80e33b898ee6a7557650) so transport seek and A/B toggle handlers defer to `vip-fixes` when it owns those controls.
> - Escape key during processing now triggers `resetStemSeparation()` via dynamic import; `_waitForPipelineIdle` timeout also calls reset and emits `vip:processingDone`, extending the idle wait to 90s.
> - [vip-fixes.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/692/files#diff-e1b2a993f0bf64b447304c6c2d82a496fd3b394e13cc5cda2d6568a7f7a92e9d) fully takes over scrubbing (sets `_transportSeeking`, paints playheads via `VIP_VISUALS`) and reworks A/B toggle to preserve exact transport position using `_getTransportPosition`.
> - Listens for `vip:processingDone` in vip-fixes to re-show the isolation confirm UI if a pending isolation band exists.
> - [visuals-bootstrap.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/692/files#diff-97305f1278d299699dbd4b6d6074b123eebb509e482ae1a8caa5cbae8693314f) removes live AB compare and waveform playhead drawing from the RAF loop; calls `drawStaticVisuals()` directly instead of dispatching `vip:fileLoaded`.
> - [diarization-timeline.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/692/files#diff-36b340ab3dbe85d09541ed5a9e506c50d735112ffb58b742d6a472b27d1da3ab) debounces `ResizeObserver` callbacks via `requestAnimationFrame` to reduce excessive resize calls.
> - [StemSeparation.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/692/files#diff-ee2b9dbe14c9d6ef6bccb4d4a853a8f31db7d6d7487b98f2a39ee6a09058151b) calls `resetStemSeparation()` before rejecting on processing timeout.
> - Behavioral Change: `seekTo` no longer auto-resumes playback when `_fixTransportPatched` is set; visuals bootstrap no longer broadcasts `vip:fileLoaded`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 021ef5a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->