### PR TITLE
fix(engineer): A/B toggle scope bug (restartAt)

### DIFF
--- a/public/app/vip-fixes.js
+++ b/public/app/vip-fixes.js
@@ -507,6 +507,11 @@
       get isPlaying() { return _isPlaying; },
       resetOffset()   { _pauseOffset = 0; },
       restart()       { if (_isPlaying) { _stopSource(); _play(); } },
+      restartAt(offsetSec) {
+        _pauseOffset = Math.max(0, offsetSec || 0);
+        app.playOffset = _pauseOffset;
+        if (_isPlaying) { _stopSource(); _play(); }
+      },
       elapsed() {
         return _elapsedSeconds();
       },
@@ -573,15 +578,12 @@
       const wasPlaying = !!app._fixPlayState?.isPlaying;
       const pos = (typeof app._getTransportPosition === 'function')
         ? app._getTransportPosition()
-        : (_pauseOffset || app.playOffset || 0);
+        : (app.playOffset || 0);
       app.abMode = next;
       app._bridgeBuf = null;
       _setABLabel(next === 'processed' ? 'B' : 'A');
-      if (wasPlaying) {
-        _pauseOffset = pos;
-        app.playOffset = pos;
-        _stopSource();
-        _play();
+      if (wasPlaying && typeof app._fixPlayState?.restartAt === 'function') {
+        app._fixPlayState.restartAt(pos);
       }
       log('A/B toggled to', next);
     }

--- a/tests/engineer-hardening.test.js
+++ b/tests/engineer-hardening.test.js
@@ -39,7 +39,8 @@ describe('Engineer Mode hardening', () => {
   });
 
   test('vip-fixes A/B toggle preserves transport position', () => {
-    expect(VIP_FIXES).toMatch(/function _toggleAB[\s\S]*_getTransportPosition[\s\S]*_pauseOffset = pos/);
+    expect(VIP_FIXES).toContain('restartAt(offsetSec)');
+    expect(VIP_FIXES).toMatch(/function _toggleAB[\s\S]*restartAt\(pos\)/);
     expect(VIP_FIXES).not.toMatch(/function _toggleAB[\s\S]*resetOffset\(\)/);
   });
 


### PR DESCRIPTION
Hotfix for #692: A/B toggle while playing referenced patchTransport closure variables from patchAB, causing ReferenceError. Adds \_fixPlayState.restartAt(offset)\ API.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix A/B toggle scope bug by delegating playback restart to `restartAt` in `_fixPlayState`
> - Adds `restartAt(offsetSec)` to the `app._fixPlayState` utility in [vip-fixes.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/693/files#diff-e1b2a993f0bf64b447304c6c2d82a496fd3b394e13cc5cda2d6568a7f7a92e9d), which clamps the offset to >= 0, sets `_pauseOffset` and `app.playOffset`, then restarts the source if playback is active.
> - Fixes the `_toggleAB` handler to call `app._fixPlayState.restartAt(pos)` instead of manually resetting offsets, stopping, and restarting — eliminating the scope bug.
> - The fallback transport position in `_toggleAB` now uses `app.playOffset` only, dropping the previous `_pauseOffset` fallback.
> - Updates assertions in [engineer-hardening.test.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/693/files#diff-74a2b0c33ffd3a55bddce132d5b8f886ea9d656b1bb6a1678afa7a9d71e3a3ab) to verify `restartAt` is called by `_toggleAB` and remove the old `resetOffset()` expectation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d517f78.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->