### PR TITLE
feat(engineer): horizontal viz tab scroll, cycle toggles, minimize

### DIFF
--- a/public/app/index.html
+++ b/public/app/index.html
@@ -497,20 +497,26 @@
         </div>
       </div>
 
-      <div class="card viz-card">
+      <div class="card viz-card" id="vizCard">
         <div class="viz-hdr">
           <span>Visualizations</span>
           <div class="viz-actions">
+            <button id="btnVizTabPrev" class="btn btn-xs btn-viz-tab-nav" type="button" aria-label="Previous visualization" title="Previous visualization"><span aria-hidden="true">&#8249;</span></button>
+            <button id="btnVizTabNext" class="btn btn-xs btn-viz-tab-nav" type="button" aria-label="Next visualization" title="Next visualization"><span aria-hidden="true">&#8250;</span></button>
+            <button id="btnVizMinimize" class="btn btn-xs btn-viz-minimize" type="button" aria-pressed="false" aria-label="Minimize visualizations" title="Minimize visualizations"><span aria-hidden="true">&#8722;</span></button>
             <button id="btnVizGallery" class="btn btn-xs btn-viz-gallery" type="button" aria-pressed="false" title="Show all visualizations at once">Show All</button>
             <button id="fullscreenSpectroBtn" class="btn btn-xs" type="button" aria-label="Toggle Fullscreen" title="Toggle Fullscreen"><span aria-hidden="true">⛶</span></button>
           </div>
         </div>
+        <div id="vizCardBody" class="viz-card-body">
         <div id="neon-pulse-slot" class="neon-pulse-slot"></div>
         <div id="vizIsoConfirm" class="viz-iso-confirm hidden" role="group" aria-label="Confirm isolation processing" aria-hidden="true">
           <span id="vizIsoConfirmLabel" class="viz-iso-confirm-label">Process with selected frequency band?</span>
           <button id="vizIsoConfirmBtn" class="btn btn-xs btn-primary" type="button">Process</button>
           <button id="vizIsoConfirmCancel" class="btn btn-xs btn-outline" type="button">Cancel</button>
         </div>
+        <div class="viz-tab-rail">
+          <div id="vizTabScroll" class="viz-tab-rail__scroll" role="presentation" aria-hidden="true">
         <div id="tabBar" class="tabs" role="tablist" aria-label="Visualization tabs">
           <button id="btn-spectrogram" class="tab-btn active" type="button" role="tab" aria-controls="tab-spectrogram" data-tab="spectrogram" aria-selected="true" tabindex="0">Spectrogram</button>
           <button id="btn-waveform" class="tab-btn" type="button" role="tab" aria-controls="tab-waveform" data-tab="waveform" aria-selected="false" tabindex="-1">Waveform</button>
@@ -521,6 +527,8 @@
           <button id="btn-topo" class="tab-btn" type="button" role="tab" aria-controls="tab-topo" data-tab="topo" aria-selected="false" tabindex="-1">3D Topo</button>
           <button id="btn-swarm" class="tab-btn" type="button" role="tab" aria-controls="tab-swarm" data-tab="swarm" aria-selected="false" tabindex="-1">Swarm</button>
           <button id="btn-liquid" class="tab-btn" type="button" role="tab" aria-controls="tab-liquid" data-tab="liquid" aria-selected="false" tabindex="-1">Liquid</button>
+        </div>
+          </div>
         </div>
           <div id="tab-spectrogram" role="tabpanel" aria-labelledby="btn-spectrogram" class="panel active" data-viz-panel="spectrogram" tabindex="0">
             <div class="viz-panel-label">Spectrogram</div>
@@ -545,6 +553,7 @@
           <div id="tab-topo" role="tabpanel" aria-labelledby="btn-topo" class="panel" data-viz-panel="topo"><div class="viz-panel-label">3D Topo</div><div class="viz-iso-badge hidden" id="iso-badge-topo"></div><div id="topoContainer" class="spectro3d-container"></div></div>
           <div id="tab-swarm" role="tabpanel" aria-labelledby="btn-swarm" class="panel" data-viz-panel="swarm"><div class="viz-panel-label">Swarm</div><div class="viz-iso-badge hidden" id="iso-badge-swarm"></div><div id="swarmContainer" class="spectro3d-container"></div></div>
           <div id="tab-liquid" role="tabpanel" aria-labelledby="btn-liquid" class="panel" data-viz-panel="liquid"><div class="viz-panel-label">Liquid</div><div class="viz-iso-badge hidden" id="iso-badge-liquid"></div><canvas id="liquidCanvas" class="viz-canvas"></canvas></div>
+        </div>
       </div>
 
       <div id="videoCard" class="card video-card" style="display:none">

--- a/public/app/mobile.css
+++ b/public/app/mobile.css
@@ -606,6 +606,8 @@ html {
     min-height: var(--mob-touch-min);
   }
   .btn-viz-gallery,
+  .btn-viz-tab-nav,
+  .btn-viz-minimize,
   #fullscreenSpectroBtn {
     min-height: var(--mob-touch-min);
     padding: 8px 12px;

--- a/public/app/mobile.css
+++ b/public/app/mobile.css
@@ -378,11 +378,15 @@ html {
   .viz-hdr   { flex-direction: column; align-items: flex-start; gap: 4px; }
   .viz-actions { flex-wrap: wrap; gap: 4px; width: 100%; }
   .btn-viz-gallery,
+  .btn-viz-tab-nav,
+  .btn-viz-minimize,
   #fullscreenSpectroBtn {
     min-height: var(--mob-touch-min);
     padding: 8px 12px;
     touch-action: manipulation;
   }
+  .viz-tab-rail__scroll{scrollbar-width:auto}
+  .viz-card .tab-btn{flex-shrink:0}
   .viz-card.viz-gallery .panel {
     margin-bottom: 10px;
     padding: 6px;

--- a/public/app/style.css
+++ b/public/app/style.css
@@ -440,11 +440,32 @@ input[type="range"].realtime:not(.tp-seek):not(.landing-seek-input)::-webkit-sli
 .viz-card{margin-bottom:8px;position:relative}
 .viz-hdr{display:flex;justify-content:space-between;align-items:center;font-size:0.68rem;color:var(--dim);font-weight:600;text-transform:uppercase;letter-spacing:0.04em;margin-bottom:4px;position:relative;z-index:6}
 .viz-actions{display:flex;align-items:center;gap:6px;position:relative;z-index:6}
-.viz-card .tabs{position:relative;z-index:6}
-.viz-card .tab-btn{position:relative;z-index:6;cursor:pointer;touch-action:manipulation}
+.viz-card .tabs{position:relative;z-index:6;display:flex;flex-wrap:nowrap;gap:3px;margin-bottom:0;overflow:visible;border-bottom:1px solid var(--border)}
+.viz-card .tab-btn{position:relative;z-index:6;cursor:pointer;touch-action:manipulation;flex:0 0 auto;white-space:nowrap}
+.viz-tab-rail{margin-bottom:8px}
+.viz-tab-rail__scroll{
+  overflow-x:auto;
+  overflow-y:hidden;
+  -webkit-overflow-scrolling:touch;
+  scrollbar-width:thin;
+  scrollbar-color:var(--s4) transparent;
+  padding-bottom:4px;
+}
+.viz-tab-rail__scroll::-webkit-scrollbar{height:6px}
+.viz-tab-rail__scroll::-webkit-scrollbar-track{background:rgba(0,0,0,.25);border-radius:3px}
+.viz-tab-rail__scroll::-webkit-scrollbar-thumb{background:var(--s4);border-radius:3px}
+.viz-tab-rail__scroll::-webkit-scrollbar-thumb:hover{background:var(--cyan)}
+.btn-viz-tab-nav{min-width:26px;padding:2px 6px;font-size:0.85rem;line-height:1}
+.btn-viz-tab-nav:hover{border-color:rgba(0,255,231,.35);color:var(--cyan)}
+.btn-viz-minimize.is-active,.btn-viz-minimize[aria-pressed="true"]{border-color:rgba(0,255,231,.45);color:var(--cyan);background:rgba(0,255,231,.08)}
+.viz-card-body{transition:max-height .28s ease,opacity .22s ease}
+.viz-card.viz-minimized .viz-card-body{display:none}
+.viz-card.viz-minimized{margin-bottom:4px}
+.viz-card.viz-minimized .viz-hdr{margin-bottom:0}
 .viz-card.viz-fullscreen{position:fixed;inset:12px;z-index:9998;overflow:auto;margin:0;max-height:none;background:#040408;border:1px solid var(--border);box-shadow:0 24px 80px rgba(0,0,0,.75)}
 .viz-card.viz-fullscreen .viz-hdr{position:sticky;top:0;background:rgba(4,4,8,.92);backdrop-filter:blur(10px);padding:6px 0;margin-bottom:8px;z-index:9}
-.viz-card.viz-fullscreen .tabs{position:sticky;top:36px;background:rgba(4,4,8,.88);backdrop-filter:blur(8px);z-index:8;padding-bottom:4px}
+.viz-card.viz-fullscreen .viz-tab-rail{position:sticky;top:36px;background:rgba(4,4,8,.88);backdrop-filter:blur(8px);z-index:8;padding-bottom:4px}
+.viz-card.viz-fullscreen .tabs{border-bottom-color:rgba(255,255,255,.08)}
 .btn-viz-gallery.is-active{border-color:rgba(0,255,231,.45);color:var(--cyan);background:rgba(0,255,231,.08)}
 .viz-panel-label{display:none;font-size:0.58rem;font-weight:700;letter-spacing:0.08em;text-transform:uppercase;color:var(--cyan);margin-bottom:4px}
 .viz-card.viz-gallery .viz-panel-label{display:block}

--- a/public/app/visuals-bootstrap.js
+++ b/public/app/visuals-bootstrap.js
@@ -30,6 +30,7 @@
   let _lastDiarSegStart = 0;
   let _lastSpeakerState = null;
   let _vizFullscreen = false;
+  let _vizMinimized = false;
   let _roRaf = 0;
   let _roScheduled = false;
   let _freqScratch = null;
@@ -677,9 +678,70 @@
     _syncPremiumViz();
   }
 
+  function _tabOrder() {
+    return qsa('.viz-card .tab-btn[data-tab]').map((b) => b.dataset.tab).filter(Boolean);
+  }
+
+  function _scrollActiveTabIntoView() {
+    const scroll = $('vizTabScroll');
+    const active = $('tabBar')?.querySelector('.tab-btn.active');
+    if (!scroll || !active) return;
+    const target = active.offsetLeft - (scroll.clientWidth - active.offsetWidth) / 2;
+    try {
+      scroll.scrollTo({ left: Math.max(0, target), behavior: 'smooth' });
+    } catch (_) {
+      scroll.scrollLeft = Math.max(0, target);
+    }
+  }
+
+  function cycleTab(delta) {
+    if (_vizMinimized) toggleMinimized(false);
+    const tabs = _tabOrder();
+    if (!tabs.length) return;
+    let idx = tabs.indexOf(_activeTab);
+    if (idx < 0) idx = 0;
+    idx = (idx + delta + tabs.length) % tabs.length;
+    const nextTab = tabs[idx];
+    const btn = document.querySelector('.viz-card .tab-btn[data-tab="' + nextTab + '"]');
+    _activateTab(nextTab, btn);
+  }
+
+  function toggleMinimized(force) {
+    _vizMinimized = typeof force === 'boolean' ? force : !_vizMinimized;
+    const card = $('vizCard') || document.querySelector('.viz-card');
+    const btn = $('btnVizMinimize');
+    if (card) card.classList.toggle('viz-minimized', _vizMinimized);
+    if (btn) {
+      btn.classList.toggle('is-active', _vizMinimized);
+      btn.setAttribute('aria-pressed', String(_vizMinimized));
+      btn.setAttribute('aria-label', _vizMinimized ? 'Expand visualizations' : 'Minimize visualizations');
+      btn.title = _vizMinimized ? 'Expand visualizations' : 'Minimize visualizations';
+      const glyph = btn.querySelector('span[aria-hidden="true"]');
+      if (glyph) glyph.textContent = _vizMinimized ? '+' : '−';
+    }
+    if (_vizMinimized && _vizFullscreen) _exitVizFullscreen();
+    if (!_vizMinimized) {
+      setTimeout(() => {
+        _resizeVisibleCanvases();
+        _syncPremiumViz();
+        _scrollActiveTabIntoView();
+      }, 80);
+    }
+    try {
+      window.dispatchEvent(new CustomEvent('vip:vizMinimizeChanged', {
+        detail: { minimized: _vizMinimized },
+      }));
+    } catch (_) {}
+  }
+
+  function isMinimized() {
+    return _vizMinimized;
+  }
+
   function _activateTab(tab, btn) {
     if (!tab) return;
     if (_viewMode === 'gallery') setViewMode('single');
+    if (_vizMinimized) toggleMinimized(false);
     const tabs = qsa('.viz-card .tab-btn[data-tab]');
     tabs.forEach((b) => {
       const on = b === btn || b.dataset.tab === tab;
@@ -691,6 +753,7 @@
       p.classList.toggle('active', p.dataset.vizPanel === tab);
     });
     _onTabActivated(tab);
+    _scrollActiveTabIntoView();
   }
 
   function _docFullscreenEl() {
@@ -825,14 +888,57 @@
     btn.addEventListener('click', (e) => {
       e.preventDefault();
       e.stopPropagation();
+      if (_vizMinimized) toggleMinimized(false);
       setViewMode(_viewMode === 'gallery' ? 'single' : 'gallery');
     });
+  }
+
+  function _wireTabNav() {
+    const prev = $('btnVizTabPrev');
+    const next = $('btnVizTabNext');
+    if (prev && prev.dataset.vipVizWired !== '1') {
+      prev.dataset.vipVizWired = '1';
+      prev.addEventListener('click', (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        cycleTab(-1);
+      });
+    }
+    if (next && next.dataset.vipVizWired !== '1') {
+      next.dataset.vipVizWired = '1';
+      next.addEventListener('click', (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        cycleTab(1);
+      });
+    }
+  }
+
+  function _wireMinimizeToggle() {
+    const btn = $('btnVizMinimize');
+    if (!btn || btn.dataset.vipVizWired === '1') return;
+    btn.dataset.vipVizWired = '1';
+    btn.addEventListener('click', (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      toggleMinimized();
+    });
+    const hdr = document.querySelector('.viz-card .viz-hdr > span');
+    if (hdr && !hdr.dataset.vipVizWired) {
+      hdr.dataset.vipVizWired = '1';
+      hdr.style.cursor = 'pointer';
+      hdr.title = 'Click to expand or collapse visualizations';
+      hdr.addEventListener('click', () => toggleMinimized());
+    }
   }
 
   function wireChrome() {
     _wireGalleryToggle();
     _wireFullscreen();
     _wireTabBar();
+    _wireTabNav();
+    _wireMinimizeToggle();
+    setTimeout(_scrollActiveTabIntoView, 120);
   }
 
   function _scheduleLayoutResize() {
@@ -922,11 +1028,14 @@
     stop,
     onTabActivated: _onTabActivated,
     activateTab: _activateTab,
+    cycleTab,
     initPremium: _initPremiumTab,
     setViewMode,
     getViewMode,
     syncPremium: _syncPremiumViz,
     toggleFullscreen,
+    toggleMinimized,
+    isMinimized,
     wireChrome,
   };
 })(typeof window !== 'undefined' ? window : this);

--- a/tests/visuals-bootstrap.test.js
+++ b/tests/visuals-bootstrap.test.js
@@ -24,16 +24,22 @@ describe('visuals-bootstrap.js — visualization driver', () => {
     expect(src).toContain('setViewMode');
     expect(src).toContain('getViewMode');
     expect(src).toContain('toggleFullscreen');
+    expect(src).toContain('toggleMinimized');
+    expect(src).toContain('cycleTab');
     expect(src).toContain('wireChrome');
     expect(src).toContain('start');
     expect(src).toContain('stop');
   });
 
-  test('owns viz chrome wiring (tabs, gallery, fullscreen)', () => {
+  test('owns viz chrome wiring (tabs, gallery, fullscreen, minimize)', () => {
     expect(src).toContain('_wireTabBar');
     expect(src).toContain('_wireFullscreen');
     expect(src).toContain('_wireGalleryToggle');
+    expect(src).toContain('_wireTabNav');
+    expect(src).toContain('_wireMinimizeToggle');
     expect(src).toContain('viz-fullscreen');
+    expect(src).toContain('viz-minimized');
+    expect(src).toContain('vizTabScroll');
   });
 
   test('supports gallery show-all view mode', () => {
@@ -218,6 +224,16 @@ describe('visuals-bootstrap loading and event wiring', () => {
     const html = fs.readFileSync(INDEX_HTML_PATH, 'utf8');
     expect(html).toContain('btnVizGallery');
     expect(html).toContain('data-viz-panel');
+  });
+
+  test('index.html includes horizontal tab scroll rail and viz minimize controls', () => {
+    const html = fs.readFileSync(INDEX_HTML_PATH, 'utf8');
+    expect(html).toContain('viz-tab-rail');
+    expect(html).toContain('vizTabScroll');
+    expect(html).toContain('btnVizMinimize');
+    expect(html).toContain('btnVizTabPrev');
+    expect(html).toContain('btnVizTabNext');
+    expect(html).toContain('vizCardBody');
   });
 });
 


### PR DESCRIPTION
## Features

- **Horizontal tab scroll** — visualization tabs sit in a scrollable rail with a visible horizontal scrollbar (swipe on mobile)
- **Prev / Next** — cycle between Spectrogram, Waveform, A/B, LUFS, Clusters, Aura, 3D Topo, Swarm, Liquid
- **Minimize** — collapse the viz body to reclaim space; click the minus button or the Visualizations header to expand again

## Files
- index.html — tab rail wrapper, nav + minimize buttons, collapsible body
- style.css / mobile.css — scroll rail, minimized state, touch targets
- visuals-bootstrap.js — cycleTab, toggleMinimized, scroll-into-view on tab change

## Tests
- visuals-bootstrap.test.js updated

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add horizontal tab scrolling, cycle navigation, and minimize toggle to the Visualizations panel
> - Wraps the tab bar in a horizontally scrollable rail (`#vizTabScroll`) so tabs don't wrap or overflow awkwardly; active tab auto-scrolls into view on activation.
> - Adds prev/next tab buttons (`btnVizTabPrev`/`btnVizTabNext`) wired to a new `cycleTab` function in [visuals-bootstrap.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/694/files#diff-97305f1278d299699dbd4b6d6074b123eebb509e482ae1a8caa5cbae8693314f) that rotates through tabs and auto-expands if minimized.
> - Adds a minimize/expand button (`btnVizMinimize`) that collapses the visualization body via a `viz-minimized` CSS class; expanding resizes and syncs visuals and recenters the active tab.
> - Exposes `cycleTab`, `toggleMinimized`, and `isMinimized` on the `VIP_VISUALS` public API for external callers.
> - Mobile styles in [mobile.css](https://github.com/Joker5514/VoiceIsolate-Pro/pull/694/files#diff-4de7e62e3b678acdf6cea9c342018367d862e5da12350c78eb467cccd6b1995a) apply touch-friendly sizing to the new buttons and enable scrollbar on the tab rail.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fcc02f8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->