### PR TITLE
fix: video upload decode/preview and processed video download

### DIFF
--- a/public/app/app.js
+++ b/public/app/app.js
@@ -26,8 +26,12 @@ import { sliceAudioBuffer } from '/src/core/audio-slice.js';
 import { clearStemCache } from '/src/pipeline/MLStemCache.js';
 import { resetTimings, stageEnd, stageStart } from '/src/pipeline/PipelineTiming.js';
 import { paintSeekFill, wireTransportRegion } from '/src/presentation/TransportRegionControls.js';
-import { isDesktopShell, pickAudioFile } from '/src/core/DesktopBridge.js';
-import { inferMediaKind } from '/src/core/media-types.js';
+import { isDesktopShell, pickAudioFile, saveExportBlob, filtersForFilename } from '/src/core/DesktopBridge.js';
+import { inferMediaKind, isVideoSource } from '/src/core/media-types.js';
+import {
+  exportVideoWithProcessedAudio,
+  triggerBlobDownload,
+} from '/src/pipeline/video-export.js';
 import { openFilePicker as triggerFileInput, primeAudioGesture, fixUploadTouchTargets } from '/src/presentation/UploadWiring.js';
 import { startWorkletStatusDriver } from '/src/presentation/WorkletStatus.js';
 import {
@@ -785,6 +789,10 @@ class VoiceIsolatePro {
     this.isPlaying = false;
     this.isProcessing = false;
     this.isVideo = false;
+    /** @type {File|Blob|null} original upload — retained for video remux export */
+    this._sourceFile = null;
+    /** @type {string|null} object URL currently assigned to #videoPlayer */
+    this._videoObjectUrl = null;
 
     // Playback state
     this.inputBuffer = null;
@@ -1688,15 +1696,7 @@ class VoiceIsolatePro {
       if (this.origBuffer || this.inputBuffer) downloadWav(this.origBuffer || this.inputBuffer, 'original-' + Date.now() + '.wav');
     });
     bind('saveProcBtn', d.saveProcBtn, 'click', async () => {
-      let buf = this.procBuffer || this.outputBuffer;
-      if (!buf) return;
-      await this.ensureCtx();
-      const transport = this._getTransportMixer();
-      if (transport?.hasCrop?.()) {
-        const { in: cropIn, out: cropOut } = transport.getCropRegion();
-        buf = sliceAudioBuffer(this.ctx, buf, cropIn, cropOut);
-      }
-      downloadWav(buf, 'processed-' + Date.now() + '.wav');
+      await this._downloadProcessed();
     });
     bind('auditLogBtn', d.auditLogBtn, 'click', () => this.downloadAuditLog());
 
@@ -2138,25 +2138,17 @@ class VoiceIsolatePro {
     }
     if (fileSeq !== this._fileSeq) return;
 
-    // Detect video by MIME type or container extension. The <video> element is
-    // then shown and kept in sync with the Web Audio transport so the picture
-    // plays alongside the *processed* audio (video stays muted; sound comes
-    // from the processed/original AudioBuffer). decodeAudioData demuxes the
-    // audio track from most MP4/WEBM/MOV containers directly.
-    const mimeLower = (file.type || '').toLowerCase();
-    const isVideoFile = mediaKind === 'video'
-      || (mimeLower.startsWith('video/') && mediaKind !== 'audio')
-      || (mimeLower === 'audio/mp4' && /\.(mp4|m4v|mov)$/i.test(file.name || ''));
+    // Detect video by MIME / extension. The muted <video> element shows the
+    // picture while Web Audio plays processed audio; export remuxes them.
+    const isVideoFile = isVideoSource(file);
+    this._sourceFile = file;
+    this.isVideo = isVideoFile;
 
-    // Release any previously-loaded video source first, so reloading a new clip
-    // neither leaks the old object URL nor leaves the old picture on screen.
-    if (this.dom && this.dom.videoPlayer && this.dom.videoPlayer.src) {
-      const prev = this.dom.videoPlayer;
-      try { URL.revokeObjectURL(prev.src); } catch { /* ignore */ }
-      try {
-        if (typeof prev.removeAttribute === 'function') prev.removeAttribute('src');
-        else prev.src = '';
-      } catch { /* ignore */ }
+    // Always tear down any previous object URL so a new clip cannot keep the
+    // old picture. Check getAttribute('src') — the IDL .src is never empty
+    // after a prior absolute URL assignment.
+    if (typeof this._clearVideoElement === 'function') {
+      this._clearVideoElement();
     }
 
     let buffer;
@@ -2197,36 +2189,118 @@ class VoiceIsolatePro {
     }
     if (fileSeq !== this._fileSeq) return;
 
-    // Show & wire the <video> element for video files (covers the common path
-    // where decodeAudioData succeeded). The transport plays the processed audio
-    // through Web Audio while the muted video supplies the picture in sync.
-    if (isVideoFile && this.dom && this.dom.videoPlayer) {
+    // Always assign a fresh object URL for video (never rely on a stale/empty
+    // IDL .src check — that previously left the preview blank after reload).
+    if (isVideoFile && this.dom?.videoPlayer) {
       this.isVideo = true;
       try {
-        if (!this.dom.videoPlayer.src) {
-          this.dom.videoPlayer.src = URL.createObjectURL(file);
-        }
-      } catch { /* ignore */ }
-      this.dom.videoPlayer.muted = true;
+        const url = URL.createObjectURL(file);
+        this._videoObjectUrl = url;
+        this.dom.videoPlayer.src = url;
+        this.dom.videoPlayer.muted = true;
+        this.dom.videoPlayer.load?.();
+      } catch (err) {
+        structuredLog('warn', '[VIP] video preview URL failed', { err: err?.message });
+      }
       if (this.dom.videoCard) this.dom.videoCard.style.display = '';
     } else {
       this.isVideo = false;
-      if (this.dom && this.dom.videoPlayer) {
-        const vp = this.dom.videoPlayer;
-        try {
-          if (vp.src) { try { URL.revokeObjectURL(vp.src); } catch { /* ignore */ } }
-          if (typeof vp.removeAttribute === 'function') vp.removeAttribute('src');
-          else vp.src = '';
-        } catch { /* ignore */ }
-      }
-      if (this.dom && this.dom.videoCard) this.dom.videoCard.style.display = 'none';
+      if (this.dom?.videoCard) this.dom.videoCard.style.display = 'none';
     }
+    if (typeof this._updateSaveButtonLabels === 'function') this._updateSaveButtonLabels();
 
     this.inputBuffer = buffer;
     this.origBuffer = buffer;
     this._hideFileLoading();
     if (fileSeq !== this._fileSeq) return;
     this.onAudioLoaded(file.name, fileSeq);
+  }
+
+  /** Revoke object URL and detach <video> source without leaving a dead URL. */
+  _clearVideoElement() {
+    const vp = this.dom?.videoPlayer;
+    if (!vp) return;
+    try { if (typeof vp.pause === 'function') vp.pause(); } catch { /* ignore */ }
+    const attrSrc = typeof vp.getAttribute === 'function' ? vp.getAttribute('src') : null;
+    const blobUrl = this._videoObjectUrl
+      || (attrSrc && attrSrc.startsWith('blob:') ? attrSrc : null)
+      || (typeof vp.src === 'string' && vp.src.startsWith('blob:') ? vp.src : null);
+    if (blobUrl) {
+      try { URL.revokeObjectURL(blobUrl); } catch { /* ignore */ }
+    }
+    this._videoObjectUrl = null;
+    try {
+      if (typeof vp.removeAttribute === 'function') vp.removeAttribute('src');
+      else vp.src = '';
+      if (typeof vp.load === 'function') vp.load();
+    } catch { /* ignore */ }
+  }
+
+  _updateSaveButtonLabels() {
+    const btn = this.dom?.saveProcBtn;
+    if (!btn) return;
+    btn.textContent = this.isVideo ? 'Save Processed Video' : 'Save Processed WAV';
+    btn.title = this.isVideo
+      ? 'Download video with isolated/processed audio track'
+      : 'Download processed audio as WAV';
+  }
+
+  /**
+   * Download processed audio, remuxed into the original video container when
+   * the source was a video file. Falls back to WAV if remux is unavailable.
+   */
+  async _downloadProcessed() {
+    const fullBuf = this.procBuffer || this.outputBuffer;
+    if (!fullBuf) {
+      this.showNotification('Nothing to save yet — process a file first.', 'info');
+      return;
+    }
+    await this.ensureCtx();
+
+    let cropIn = 0;
+    let cropOut = fullBuf.duration;
+    const transport = this._getTransportMixer?.();
+    if (transport?.hasCrop?.()) {
+      const region = transport.getCropRegion();
+      cropIn = region.in;
+      cropOut = region.out;
+    }
+
+    const wantsVideo = this.isVideo && this._sourceFile && isVideoSource(this._sourceFile);
+    if (wantsVideo) {
+      try {
+        this.showNotification('Encoding processed video…', 'info');
+        // Pass the full buffer + crop window so the picture seeks to crop-in
+        // while audio is sliced to the same window inside the exporter.
+        const result = await exportVideoWithProcessedAudio(this._sourceFile, fullBuf, {
+          startSec: cropIn,
+          endSec: cropOut,
+          onProgress: (pct, stage) => {
+            if (pct === 100 || stage === 'complete') return;
+            this.updatePipelineProgress?.(Math.round(pct), `Exporting video… ${Math.round(pct)}%`, 1);
+          },
+        });
+        if (isDesktopShell()) {
+          await saveExportBlob(result.blob, {
+            defaultName: result.filename,
+            filters: filtersForFilename(result.filename),
+          });
+        } else {
+          triggerBlobDownload(result.blob, result.filename);
+        }
+        this.showNotification('Processed video saved: ' + result.filename, 'info');
+        return;
+      } catch (err) {
+        structuredLog('warn', '[VIP] video export failed — falling back to WAV', { err: err?.message });
+        this.showNotification('Video remux unavailable — saving WAV instead.', 'info');
+      }
+    }
+
+    let buf = fullBuf;
+    if (cropIn > 0 || cropOut < fullBuf.duration) {
+      buf = sliceAudioBuffer(this.ctx, fullBuf, cropIn, cropOut);
+    }
+    downloadWav(buf, 'processed-' + Date.now() + '.wav');
   }
 
   /** @deprecated Use decodeBlobToAudioBuffer — kept for legacy patch scripts. */
@@ -2278,6 +2352,7 @@ class VoiceIsolatePro {
   _clearFile() {
     clearStemCache();
     this._sourceName = '';
+    this._sourceFile = null;
     this._transportRegionWired = false;
     this._syncTransportRegion = null;
     HeroExperience.onClear();
@@ -2287,16 +2362,9 @@ class VoiceIsolatePro {
     this.origBuffer = null;
     this.procBuffer = null;
     this.isVideo = false;
-    if (this.dom && this.dom.videoPlayer) {
-      const vp = this.dom.videoPlayer;
-      try {
-        if (typeof vp.pause === 'function') vp.pause();
-        if (vp.src) { try { URL.revokeObjectURL(vp.src); } catch { /* ignore */ } }
-        if (typeof vp.removeAttribute === 'function') vp.removeAttribute('src');
-        else vp.src = '';
-      } catch { /* ignore */ }
-    }
+    this._clearVideoElement();
     if (this.dom && this.dom.videoCard) this.dom.videoCard.style.display = 'none';
+    this._updateSaveButtonLabels();
     if (this.dom.fileInfo) this.dom.fileInfo.textContent = 'No file loaded';
     if (this.dom.fileInput) this.dom.fileInput.value = '';
     [this.dom.processBtn, this.dom.reprocessBtn, this.dom.saveProcBtn,
@@ -2484,6 +2552,7 @@ class VoiceIsolatePro {
       if (this.dom.mobileReprocessBtn) this.dom.mobileReprocessBtn.disabled = false;
       if (this.dom.saveProcBtn) this.dom.saveProcBtn.disabled = false;
       if (this.dom.auditLogBtn) this.dom.auditLogBtn.disabled = false;
+      this._updateSaveButtonLabels();
 
       this._setProcessedPlaybackMode();
 

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -424,7 +424,7 @@
 
       <div class="card save-row">
         <button id="saveOrigBtn" class="btn btn-save" disabled>Save Original WAV</button>
-        <button id="saveProcBtn" class="btn btn-save-proc" disabled>Save Processed WAV</button>
+        <button id="saveProcBtn" class="btn btn-save-proc" disabled title="Download processed audio (or video with processed audio when the source is a video)">Save Processed</button>
         <button id="exportBtn" class="btn btn-save-proc vip-export-alias" type="button" disabled hidden aria-hidden="true">Export WAV</button>
       </div>
 

--- a/public/index.html
+++ b/public/index.html
@@ -140,6 +140,14 @@
       -->
       <div id="outputMeterMount" class="output-meter" hidden></div>
 
+      <div class="export-row" id="exportRow" hidden>
+        <button id="downloadBtn" class="vip-btn vip-btn--primary" type="button" disabled
+                title="Download isolated voice (video with processed audio when the source is a video)">
+          Download Processed
+        </button>
+        <span id="downloadStatus" class="hint" role="status" aria-live="polite"></span>
+      </div>
+
       <div class="slider-grid">
         <div class="slider-row">
           <label for="noiseReductionSlider">Noise Reduction</label>

--- a/public/landing.css
+++ b/public/landing.css
@@ -246,11 +246,16 @@ body {
 /* ── Form rows ────────────────────────────────────────────────────────── */
 .upload-row,
 .transport-row,
-.status-row {
+.status-row,
+.export-row {
   display: flex;
   align-items: center;
   gap: 10px;
   flex-wrap: wrap;
+}
+
+.export-row {
+  margin: 12px 0 4px;
 }
 
 .inline-label {

--- a/public/landing.js
+++ b/public/landing.js
@@ -19,6 +19,12 @@ import { LANDING_PRESETS, calibrateFromStems } from '/src/core/MixCalibration.js
 import { SpeakerControls } from '/src/presentation/SpeakerControls.js';
 import { LandingVisualizer } from '/src/presentation/LandingVisualizer.js';
 import { getModel } from '/src/core/ModelManifest.js';
+import { isVideoSource } from '/src/core/media-types.js';
+import { saveExportBlob, filtersForFilename } from '/src/core/DesktopBridge.js';
+import {
+  exportVideoWithProcessedAudio,
+  triggerBlobDownload,
+} from '/src/pipeline/video-export.js';
 
 import { detectSpeakers as detectSpeakersPipeline } from '/src/pipeline/SpeakerDetection.js';
 import { DEFAULT_ML_MODEL_IDS } from '/src/core/ml-defaults.js';
@@ -116,6 +122,9 @@ const ui = {
   speakerCardsGrid: $('speakerCardsGrid'),
   // Upload panel — used as the drag-and-drop target.
   uploadPanel: $('uploadPanel'),
+  exportRow: $('exportRow'),
+  downloadBtn: $('downloadBtn'),
+  downloadStatus: $('downloadStatus'),
 };
 
 let mixer = null;
@@ -126,10 +135,13 @@ let worker = null;
 let _syncTransportRegion = null;
 
 let ingested = null;
+/** @type {File|Blob|null} original upload retained for video remux export */
+let sourceFile = null;
 let requestSeq = 0;
 let ingestSeq = 0;
 let ingestInFlight = false;
 let processingInFlight = false;
+let downloadInFlight = false;
 
 let currentJobLabel = 'Separating stems…';
 /** Object URL backing the <video> preview; revoked when a new file loads. */
@@ -300,26 +312,36 @@ function hideSpinner() {
 
 /** Treat as video by MIME type, or by container extension when MIME is absent. */
 function isVideoFile(file) {
-  if (file.type && file.type.startsWith('video/')) return true;
-  return /\.(mp4|webm|mov|m4v|ogv|mkv|avi)$/i.test(file.name || '');
+  return isVideoSource(file);
 }
 
 function loadVideo(file) {
   clearVideo();
+  if (!ui.videoPlayer || !ui.videoCard) return;
   videoUrl = URL.createObjectURL(file);
   const v = ui.videoPlayer;
   v.muted = true; // audio always comes from the Web Audio mixer
   // Reveal only once the element can actually paint a frame, so we never flash
   // an empty black box; drop the preview if the container's video track can't
   // be displayed (audio-only processing still works).
-  v.onloadedmetadata = () => { ui.videoCard.hidden = false; };
+  v.onloadedmetadata = () => {
+    // Prefer videoWidth so pure-audio .webm with a video MIME still hides.
+    if ((v.videoWidth || 0) > 0 || (v.readyState || 0) >= 1) {
+      ui.videoCard.hidden = false;
+    }
+  };
   v.onerror = () => clearVideo();
   v.src = videoUrl;
+  try { v.load(); } catch { /* best-effort */ }
 }
 
 function clearVideo() {
-  if (!videoUrl && ui.videoCard.hidden) return; // nothing loaded — avoid empty-src churn
+  if (!videoUrl && (!ui.videoCard || ui.videoCard.hidden)) return; // nothing loaded
   const v = ui.videoPlayer;
+  if (!v) {
+    videoUrl = null;
+    return;
+  }
   // Detach handlers first: removeAttribute('src') + load() fires a spurious
   // 'error' during teardown, which would otherwise re-enter clearVideo.
   v.onloadedmetadata = null;
@@ -327,11 +349,150 @@ function clearVideo() {
   try { v.pause(); } catch { /* not playing */ }
   v.removeAttribute('src');
   try { v.load(); } catch { /* reset is best-effort */ }
-  ui.videoCard.hidden = true;
+  if (ui.videoCard) ui.videoCard.hidden = true;
   if (videoUrl) { URL.revokeObjectURL(videoUrl); videoUrl = null; }
 }
 
-function hasVideo() { return Boolean(videoUrl) && !ui.videoCard.hidden; }
+function hasVideo() { return Boolean(videoUrl) && ui.videoCard && !ui.videoCard.hidden; }
+
+function updateDownloadButton() {
+  const ready = Boolean(mixer?.cleanBuffer);
+  if (ui.exportRow) ui.exportRow.hidden = !ready;
+  if (!ui.downloadBtn) return;
+  ui.downloadBtn.disabled = !ready || downloadInFlight;
+  ui.downloadBtn.textContent = (sourceFile && isVideoFile(sourceFile))
+    ? 'Download Processed Video'
+    : 'Download Processed WAV';
+}
+
+/** Encode clean stem to a 16-bit stereo/mono WAV Blob. */
+function encodeCleanStemWav(audioBuffer) {
+  const numCh = Math.min(2, audioBuffer.numberOfChannels || 1);
+  const sr = audioBuffer.sampleRate;
+  const len = audioBuffer.length;
+  const bytesPerSample = 2;
+  const blockAlign = numCh * bytesPerSample;
+  const dataSize = len * blockAlign;
+  const buf = new ArrayBuffer(44 + dataSize);
+  const view = new DataView(buf);
+  const ws = (off, str) => {
+    for (let i = 0; i < str.length; i++) view.setUint8(off + i, str.charCodeAt(i));
+  };
+  ws(0, 'RIFF');
+  view.setUint32(4, 36 + dataSize, true);
+  ws(8, 'WAVE');
+  ws(12, 'fmt ');
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true);
+  view.setUint16(22, numCh, true);
+  view.setUint32(24, sr, true);
+  view.setUint32(28, sr * blockAlign, true);
+  view.setUint16(32, blockAlign, true);
+  view.setUint16(34, 16, true);
+  ws(36, 'data');
+  view.setUint32(40, dataSize, true);
+  let offset = 44;
+  const channels = [];
+  for (let ch = 0; ch < numCh; ch++) channels.push(audioBuffer.getChannelData(ch));
+  for (let i = 0; i < len; i++) {
+    for (let ch = 0; ch < numCh; ch++) {
+      const s = Math.max(-1, Math.min(1, channels[ch][i]));
+      view.setInt16(offset, s < 0 ? s * 0x8000 : s * 0x7fff, true);
+      offset += 2;
+    }
+  }
+  return new Blob([buf], { type: 'audio/wav' });
+}
+
+async function onDownloadProcessed() {
+  if (!mixer?.cleanBuffer || downloadInFlight) return;
+  downloadInFlight = true;
+  updateDownloadButton();
+  const setDl = (msg) => { if (ui.downloadStatus) ui.downloadStatus.textContent = msg || ''; };
+
+  try {
+    let cropIn = 0;
+    let cropOut = mixer.cleanBuffer.duration;
+    if (mixer.hasCrop?.()) {
+      const region = mixer.getCropRegion();
+      cropIn = region.in;
+      cropOut = region.out;
+    }
+
+    const full = mixer.cleanBuffer;
+
+    if (sourceFile && isVideoFile(sourceFile)) {
+      setDl('Encoding video with processed audio…');
+      setStatus('Encoding processed video…', 'warn');
+      try {
+        // Full buffer + crop window keeps picture/audio aligned on remux.
+        const result = await exportVideoWithProcessedAudio(sourceFile, full, {
+          startSec: cropIn,
+          endSec: cropOut,
+          onProgress: (pct) => setDl(`Encoding video… ${Math.round(pct)}%`),
+        });
+        if (isDesktopShell()) {
+          await saveExportBlob(result.blob, {
+            defaultName: result.filename,
+            filters: filtersForFilename(result.filename),
+          });
+        } else {
+          triggerBlobDownload(result.blob, result.filename);
+        }
+        setDl(`Saved ${result.filename}`);
+        setStatus(`Processed video ready — ${result.filename}`, 'active');
+        return;
+      } catch (err) {
+        console.warn('[VIP][landing] video export failed, falling back to WAV:', err);
+        setDl('Video remux unavailable — saving WAV…');
+      }
+    }
+
+    // WAV path: materialize crop window into a new buffer.
+    const sr = full.sampleRate;
+    const start = Math.max(0, Math.floor(cropIn * sr));
+    const end = Math.min(full.length, Math.ceil(cropOut * sr));
+    const length = Math.max(1, end - start);
+    const channels = Math.min(2, full.numberOfChannels);
+    let exportBuf;
+    if (typeof AudioBuffer === 'function') {
+      try {
+        exportBuf = new AudioBuffer({ numberOfChannels: channels, length, sampleRate: sr });
+      } catch { exportBuf = null; }
+    }
+    if (!exportBuf) {
+      const Offline = globalThis.OfflineAudioContext || globalThis.webkitOfflineAudioContext;
+      const offline = new Offline(channels, length, sr);
+      exportBuf = offline.createBuffer(channels, length, sr);
+    }
+    for (let ch = 0; ch < channels; ch++) {
+      exportBuf.copyToChannel(full.getChannelData(ch).subarray(start, start + length), ch);
+    }
+
+    const wavBlob = encodeCleanStemWav(exportBuf);
+    const base = (sourceFile?.name || ingested?.sourceName || 'export')
+      .replace(/\.[^.]+$/, '')
+      .slice(0, 80) || 'export';
+    const filename = `${base}-processed.wav`;
+    if (isDesktopShell()) {
+      await saveExportBlob(wavBlob, {
+        defaultName: filename,
+        filters: filtersForFilename(filename),
+      });
+    } else {
+      triggerBlobDownload(wavBlob, filename);
+    }
+    setDl(`Saved ${filename}`);
+    setStatus(`Processed audio ready — ${filename}`, 'active');
+  } catch (err) {
+    console.error('[VIP][landing] download failed:', err);
+    setDl(err?.message || 'Download failed');
+    setStatus(err?.message || 'Download failed', 'error');
+  } finally {
+    downloadInFlight = false;
+    updateDownloadButton();
+  }
+}
 
 /**
  * Reconcile the muted <video> to the mixer, which is the single playback clock.
@@ -676,8 +837,11 @@ async function ingestFrom(file) {
   ingestInFlight = true;
   resetTimings();
   clearStemCache();
+  sourceFile = file;
   ui.processBtn.disabled = true;
   ui.fileInput.disabled = true;
+  if (ui.downloadBtn) ui.downloadBtn.disabled = true;
+  if (ui.exportRow) ui.exportRow.hidden = true;
   // Unlock Web Audio inside the user gesture (required on mobile + some desktop builds).
   try { await primeAudioGesture(); } catch { /* best-effort */ }
   // Avoid loading the preview <video> during decode — demuxing the same file twice
@@ -704,6 +868,7 @@ async function ingestFrom(file) {
     });
     if (seq !== ingestSeq) return;
     ingested = next;
+    // Always attempt preview for video sources after decode succeeds.
     if (isVideoFile(file)) loadVideo(file);
     if (seq !== ingestSeq) return;
     // Auto-start separation — model load progress shows during onProcess().
@@ -715,7 +880,9 @@ async function ingestFrom(file) {
     console.error('[VIP][landing] ingestion failed:', err);
     setStatus(err.message, 'error');
     ingested = null;
+    sourceFile = null;
     ui.processBtn.disabled = true;
+    updateDownloadButton();
   } finally {
     ingestInFlight = false;
     // Keep input locked while ML isolation runs; onStems/error re-enables it.
@@ -878,10 +1045,12 @@ function onStems({ requestId, clean, noise, sampleRate, passthrough, _cacheKey }
   visualizer.loadStems(clean, noise, mixer.duration());
   syncMuteButtons();
   startOutputMeter();
+  updateDownloadButton();
 
   for (const el of [ui.playBtn, ui.pauseBtn, ui.stopBtn,
     ui.muteVoiceBtn, ui.muteNoiseBtn, ui.presetSelect,
     ui.seekSlider, ui.loopBtn, ui.cropInBtn, ui.cropOutBtn, ui.cropClearBtn,
+    ui.downloadBtn,
     ...ui.mixSliders]) {
     if (el) el.disabled = false;
   }
@@ -1073,6 +1242,7 @@ window.addEventListener('unhandledrejection', (event) => {
 });
 ui.processBtn.addEventListener('click', onProcess);
 ui.presetSelect.addEventListener('change', () => applyPreset(ui.presetSelect.value));
+ui.downloadBtn?.addEventListener('click', () => { onDownloadProcessed().catch(() => {}); });
 wireReadouts();
 wireSliderHints();
 wireTransport();

--- a/src/core/media-types.js
+++ b/src/core/media-types.js
@@ -1,10 +1,15 @@
 'use strict';
 
 /** Common audio container extensions browsers can demux via decodeAudioData or media element. */
-export const AUDIO_EXTENSIONS = /\.(wav|wave|mp3|m4a|aac|ogg|oga|opus|flac|webm|weba|wma|aiff?|caf|mka|m4b|m4r|amr|3ga|ape|wv|tta|ac3|eac3|dts)$/i;
+// Note: `.webm` is intentionally NOT listed here — it is ambiguous (audio or video).
+// Use `inferMediaKind()` / `isVideoSource()` which prefer MIME for ambiguous containers.
+export const AUDIO_EXTENSIONS = /\.(wav|wave|mp3|m4a|aac|ogg|oga|opus|flac|weba|wma|aiff?|caf|mka|m4b|m4r|amr|3ga|ape|wv|tta|ac3|eac3|dts)$/i;
 
 /** Common video container extensions (audio track extracted via decode or media element). */
 export const VIDEO_EXTENSIONS = /\.(mp4|m4v|mov|mkv|avi|ogv|3gp|3g2|wmv|mpeg|mpg|webm|ts|m2ts|mts|flv|f4v|asf|divx)$/i;
+
+/** Containers that may be audio-only or video depending on tracks / MIME. */
+export const AMBIGUOUS_MEDIA_EXTENSIONS = /\.(webm)$/i;
 
 /** MIDI is never supported by the Web Audio decode path. */
 export const MIDI_EXTENSIONS = /\.(mid|midi)$/i;
@@ -52,12 +57,49 @@ export function inferMediaKind(blob) {
   const name = blob?.name || '';
 
   if (MIDI_MIMES.has(type) || MIDI_EXTENSIONS.test(name)) return 'midi';
-  // Extension wins over misleading MIME (e.g. .m4a reported as video/mp4).
+
+  // Voice memos labeled video/mp4 — extension wins.
+  if (/\.(m4a|m4b|m4r)$/i.test(name)) return 'audio';
+
+  // Ambiguous containers (e.g. .webm): prefer MIME when present.
+  if (AMBIGUOUS_MEDIA_EXTENSIONS.test(name)) {
+    if (type.startsWith('video/')) return 'video';
+    if (type.startsWith('audio/')) return 'audio';
+    // Phone voice notes often omit MIME — treat as audio unless proven video later.
+    return 'audio';
+  }
+
+  // Extension wins over misleading MIME for unambiguous types.
   if (AUDIO_EXTENSIONS.test(name)) return 'audio';
   if (VIDEO_EXTENSIONS.test(name)) return 'video';
   if (type.startsWith('audio/')) return 'audio';
   if (type.startsWith('video/')) return 'video';
   return null;
+}
+
+/**
+ * True when the source should drive the picture preview and video remux export.
+ * Slightly broader than `inferMediaKind === 'video'` so video/* MIME wins for
+ * containers like .webm that can also be pure audio.
+ *
+ * @param {Blob|File|null|undefined} blob
+ * @returns {boolean}
+ */
+export function isVideoSource(blob) {
+  if (!blob) return false;
+  const type = (blob.type || '').toLowerCase();
+  const name = blob.name || '';
+  // Voice memos mislabeled as video/mp4.
+  if (/\.(m4a|m4b|m4r)$/i.test(name)) return false;
+  // Explicit audio MIME wins for ambiguous containers (e.g. audio/webm notes).
+  // Exception: .mp4/.mov sometimes report audio/mp4 but still have a picture track.
+  if (type.startsWith('audio/') && !/\.(mp4|m4v|mov)$/i.test(name)) return false;
+  if (type.startsWith('video/')) return true;
+  if (inferMediaKind(blob) === 'video') return true;
+  if (/\.(mp4|m4v|mov)$/i.test(name) && (type === 'audio/mp4' || type === 'audio/x-m4a' || !type)) {
+    return true;
+  }
+  return VIDEO_EXTENSIONS.test(name) && !AUDIO_EXTENSIONS.test(name) && !type.startsWith('audio/');
 }
 
 /**
@@ -70,9 +112,11 @@ export function isIngestibleMedia(blob) {
 
 export default {
   inferMediaKind,
+  isVideoSource,
   isIngestibleMedia,
   AUDIO_EXTENSIONS,
   VIDEO_EXTENSIONS,
+  AMBIGUOUS_MEDIA_EXTENSIONS,
   FILE_INPUT_ACCEPT,
   AUDIO_OPEN_EXTENSIONS,
   VIDEO_OPEN_EXTENSIONS,

--- a/src/pipeline/media-decode.js
+++ b/src/pipeline/media-decode.js
@@ -237,7 +237,11 @@ async function _decodeViaMediaElement(blob, kind, onProgress) {
   const tag = kind === 'video' ? 'video' : 'audio';
   const media = doc.createElement(tag);
   media.preload = 'auto';
-  media.muted = true;
+  // Prefer volume=0 over muted=true: WebKit/Safari (and some Chromium paths)
+  // feed silence into MediaElementAudioSourceNode when muted is set, which
+  // makes video fallback decode produce empty stems.
+  media.muted = false;
+  try { media.volume = 0; } catch { /* ignore */ }
   media.setAttribute('playsinline', '');
   media.style.cssText = 'position:fixed;left:-9999px;width:1px;height:1px;opacity:0;pointer-events:none';
   doc.body.appendChild(media);
@@ -320,8 +324,13 @@ async function _decodeViaMediaElement(blob, kind, onProgress) {
     if (ctx.state === 'suspended') await ctx.resume();
     const source = ctx.createMediaElementSource(media);
     spn = ctx.createScriptProcessor(SPN_BLOCK_SIZE, numChannels, numChannels);
+    // Zero-gain sink: SPN must stay connected for onaudioprocess to fire, but
+    // we must not blast 16×-rate audio through the speakers during decode.
+    const silentGain = ctx.createGain();
+    silentGain.gain.value = 0;
     source.connect(spn);
-    spn.connect(ctx.destination);
+    spn.connect(silentGain);
+    silentGain.connect(ctx.destination);
 
     spn.onaudioprocess = (e) => {
       if (captureDone) return;

--- a/src/pipeline/video-export.js
+++ b/src/pipeline/video-export.js
@@ -1,0 +1,316 @@
+/**
+ * VoiceIsolate Pro — Video export (Layer 3: Pipeline)
+ *
+ * Remuxes processed audio onto the original video picture using browser APIs
+ * only (no cloud, no ffmpeg dependency). Strategy:
+ *   1. <video>.captureStream() for the picture track(s)
+ *   2. AudioBufferSourceNode → MediaStreamDestination for the new audio
+ *   3. MediaRecorder on the combined stream
+ *
+ * Falls back with a clear error so callers can offer WAV instead.
+ */
+'use strict';
+
+import { isVideoSource } from '../core/media-types.js';
+
+export { isVideoSource };
+
+/**
+ * Pick a MediaRecorder MIME type the browser can actually record.
+ * @returns {string}
+ */
+export function pickVideoRecorderMime() {
+  if (typeof MediaRecorder === 'undefined') return '';
+  const candidates = [
+    'video/webm;codecs=vp9,opus',
+    'video/webm;codecs=vp8,opus',
+    'video/webm;codecs=vp9',
+    'video/webm;codecs=vp8',
+    'video/webm',
+    'video/mp4;codecs=avc1.42E01E,mp4a.40.2',
+    'video/mp4',
+  ];
+  for (const type of candidates) {
+    try {
+      if (MediaRecorder.isTypeSupported(type)) return type;
+    } catch { /* ignore */ }
+  }
+  return '';
+}
+
+/**
+ * @param {string} mime
+ * @returns {string} file extension without the leading dot
+ */
+export function extensionForVideoMime(mime) {
+  if ((mime || '').includes('mp4')) return 'mp4';
+  return 'webm';
+}
+
+/**
+ * Build a download filename: "clip.mp4" + processed → "clip-processed.webm".
+ * @param {string} [sourceName]
+ * @param {string} ext
+ * @param {string} [suffix='processed']
+ */
+export function processedVideoFilename(sourceName, ext, suffix = 'processed') {
+  const base = String(sourceName || 'export')
+    .replace(/\.[^.]+$/, '')
+    .replace(/[^\w.\- ()[\]]+/g, '_')
+    .slice(0, 80) || 'export';
+  return `${base}-${suffix}.${ext}`;
+}
+
+/**
+ * Trigger a browser download (or return the blob for desktop save).
+ * @param {Blob} blob
+ * @param {string} filename
+ */
+export function triggerBlobDownload(blob, filename) {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.rel = 'noopener';
+  a.style.display = 'none';
+  document.body.appendChild(a);
+  a.click();
+  setTimeout(() => {
+    try { a.remove(); } catch { /* ignore */ }
+    try { URL.revokeObjectURL(url); } catch { /* ignore */ }
+  }, 4000);
+}
+
+/**
+ * Remux processed audio onto the original video picture.
+ *
+ * @param {File|Blob} sourceVideo
+ * @param {AudioBuffer} audioBuffer  processed mix (mono or stereo)
+ * @param {object} [opts]
+ * @param {(pct: number, stage: string) => void} [opts.onProgress]
+ * @param {number} [opts.startSec=0] crop in
+ * @param {number} [opts.endSec] crop out (defaults to full audio)
+ * @returns {Promise<{ blob: Blob, filename: string, mime: string }>}
+ */
+export async function exportVideoWithProcessedAudio(sourceVideo, audioBuffer, opts = {}) {
+  if (!(sourceVideo instanceof Blob)) {
+    throw new TypeError('[VIP][video-export] sourceVideo must be a File or Blob.');
+  }
+  if (!audioBuffer || !audioBuffer.length || !audioBuffer.sampleRate) {
+    throw new TypeError('[VIP][video-export] audioBuffer is required.');
+  }
+  if (typeof document === 'undefined' || !document.createElement) {
+    throw new Error('[VIP][video-export] Browser document required for video export.');
+  }
+  if (typeof MediaRecorder === 'undefined') {
+    throw new Error('[VIP][video-export] MediaRecorder is not available in this browser.');
+  }
+
+  const onProgress = typeof opts.onProgress === 'function' ? opts.onProgress : () => {};
+  const startSec = Math.max(0, Number(opts.startSec) || 0);
+  const endSec = Number.isFinite(opts.endSec)
+    ? Math.max(startSec + 0.05, opts.endSec)
+    : audioBuffer.duration;
+  const exportDuration = Math.max(0.05, endSec - startSec);
+
+  const mime = pickVideoRecorderMime();
+  if (!mime) {
+    throw new Error('[VIP][video-export] No supported video MediaRecorder MIME type.');
+  }
+
+  onProgress(2, 'loading-video');
+
+  const objectUrl = URL.createObjectURL(sourceVideo);
+  const video = document.createElement('video');
+  video.playsInline = true;
+  video.muted = true; // picture only — audio comes from the AudioBuffer
+  video.preload = 'auto';
+  video.crossOrigin = 'anonymous';
+  video.style.cssText = 'position:fixed;left:-9999px;width:1px;height:1px;opacity:0;pointer-events:none';
+  document.body.appendChild(video);
+  video.src = objectUrl;
+
+  let audioCtx = null;
+  let recorder = null;
+
+  try {
+    await waitForVideoReady(video);
+    onProgress(8, 'preparing');
+
+    // Seek video to crop start before capturing the stream.
+    try {
+      video.currentTime = startSec;
+      await waitForSeek(video);
+    } catch { /* best-effort */ }
+
+    if (typeof video.captureStream !== 'function' && typeof video.mozCaptureStream !== 'function') {
+      throw new Error('[VIP][video-export] Video captureStream() is not supported.');
+    }
+    const captureFn = video.captureStream || video.mozCaptureStream;
+    /** @type {MediaStream} */
+    const pictureStream = captureFn.call(video);
+
+    const videoTracks = pictureStream.getVideoTracks();
+    if (!videoTracks.length) {
+      throw new Error('[VIP][video-export] No video track available to remux.');
+    }
+
+    const AudioCtx = globalThis.AudioContext || globalThis.webkitAudioContext;
+    audioCtx = new AudioCtx({ sampleRate: audioBuffer.sampleRate });
+    if (audioCtx.state === 'suspended') {
+      try { await audioCtx.resume(); } catch { /* ignore */ }
+    }
+
+    const dest = audioCtx.createMediaStreamDestination();
+    const sliced = sliceAudioBufferWindow(audioCtx, audioBuffer, startSec, endSec);
+    const bufferSource = audioCtx.createBufferSource();
+    bufferSource.buffer = sliced;
+    bufferSource.connect(dest);
+
+    const mixed = new MediaStream([
+      ...videoTracks,
+      ...dest.stream.getAudioTracks(),
+    ]);
+
+    const chunks = [];
+    recorder = new MediaRecorder(mixed, {
+      mimeType: mime,
+      videoBitsPerSecond: 4_000_000,
+      audioBitsPerSecond: 192_000,
+    });
+
+    const recorded = new Promise((resolve, reject) => {
+      recorder.ondataavailable = (ev) => {
+        if (ev.data && ev.data.size > 0) chunks.push(ev.data);
+      };
+      recorder.onerror = () => reject(new Error('[VIP][video-export] MediaRecorder failed.'));
+      recorder.onstop = () => {
+        const blob = new Blob(chunks, { type: mime.split(';')[0] || 'video/webm' });
+        if (!blob.size) {
+          reject(new Error('[VIP][video-export] Recorded video is empty.'));
+          return;
+        }
+        resolve(blob);
+      };
+    });
+
+    onProgress(12, 'recording');
+    recorder.start(250);
+
+    // Start audio + picture together.
+    const playPromise = video.play();
+    bufferSource.start(0);
+    if (playPromise && typeof playPromise.then === 'function') {
+      await playPromise.catch(() => {
+        /* muted autoplay should succeed; ignore if not */
+      });
+    }
+
+    // Progress ticker while recording in (near) real time.
+    const t0 = performance.now();
+    await new Promise((resolve) => {
+      const tick = () => {
+        const elapsed = (performance.now() - t0) / 1000;
+        const pct = Math.min(96, 12 + Math.round((elapsed / exportDuration) * 84));
+        onProgress(pct, 'recording');
+        if (elapsed >= exportDuration - 0.02) {
+          resolve();
+          return;
+        }
+        // Prefer requestVideoFrameCallback when available for smoother progress.
+        if (typeof video.requestVideoFrameCallback === 'function') {
+          video.requestVideoFrameCallback(() => tick());
+        } else {
+          setTimeout(tick, 100);
+        }
+      };
+      setTimeout(tick, 50);
+      setTimeout(resolve, Math.ceil(exportDuration * 1000) + 400);
+    });
+
+    try { video.pause(); } catch { /* ignore */ }
+    try { bufferSource.stop(); } catch { /* ignore */ }
+    if (recorder.state !== 'inactive') recorder.stop();
+
+    const blob = await recorded;
+    onProgress(100, 'complete');
+
+    const ext = extensionForVideoMime(mime);
+    const filename = processedVideoFilename(sourceVideo.name, ext);
+    return { blob, filename, mime: blob.type || mime };
+  } finally {
+    try { if (recorder && recorder.state !== 'inactive') recorder.stop(); } catch { /* ignore */ }
+    try { video.pause(); } catch { /* ignore */ }
+    try { video.removeAttribute('src'); video.load(); } catch { /* ignore */ }
+    try { video.remove(); } catch { /* ignore */ }
+    try { URL.revokeObjectURL(objectUrl); } catch { /* ignore */ }
+    if (audioCtx) {
+      try { await audioCtx.close(); } catch { /* ignore */ }
+    }
+  }
+}
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+function waitForVideoReady(video) {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      reject(new Error('[VIP][video-export] Timed out loading source video.'));
+    }, 120_000);
+    const done = () => {
+      if (settled) return;
+      if ((video.videoWidth || 0) <= 0 && (video.readyState || 0) < 1) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve();
+    };
+    const fail = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      reject(new Error(video.error?.message || 'Source video failed to load.'));
+    };
+    video.addEventListener('loadeddata', done, { once: true });
+    video.addEventListener('loadedmetadata', done, { once: true });
+    video.addEventListener('error', fail, { once: true });
+    if (video.readyState >= 2) done();
+  });
+}
+
+function waitForSeek(video) {
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, 2000);
+    const onSeeked = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+    video.addEventListener('seeked', onSeeked, { once: true });
+  });
+}
+
+/**
+ * Copy a time window of an AudioBuffer into a new buffer on the given context.
+ * @param {AudioContext} ctx
+ * @param {AudioBuffer} buffer
+ * @param {number} startSec
+ * @param {number} endSec
+ * @returns {AudioBuffer}
+ */
+function sliceAudioBufferWindow(ctx, buffer, startSec, endSec) {
+  const sr = buffer.sampleRate;
+  const start = Math.max(0, Math.floor(startSec * sr));
+  const end = Math.min(buffer.length, Math.ceil(endSec * sr));
+  const length = Math.max(1, end - start);
+  const channels = Math.min(2, buffer.numberOfChannels || 1);
+  const out = ctx.createBuffer(channels, length, sr);
+  for (let ch = 0; ch < channels; ch++) {
+    const src = buffer.getChannelData(Math.min(ch, buffer.numberOfChannels - 1));
+    out.copyToChannel(src.subarray(start, start + length), ch);
+  }
+  return out;
+}
+
+export default exportVideoWithProcessedAudio;

--- a/tests/file-ingestion.test.js
+++ b/tests/file-ingestion.test.js
@@ -4,11 +4,14 @@ let inferMediaKind;
 let isIngestibleMedia;
 let assertIngestible;
 
+let isVideoSource;
+
 beforeAll(async () => {
   const mediaTypes = await import('../src/core/media-types.js');
   const fileIngestion = await import('../src/pipeline/FileIngestion.js');
   inferMediaKind = mediaTypes.inferMediaKind;
   isIngestibleMedia = mediaTypes.isIngestibleMedia;
+  isVideoSource = mediaTypes.isVideoSource;
   assertIngestible = fileIngestion.assertIngestible;
 });
 
@@ -44,6 +47,15 @@ describe('media-types', () => {
 
   test('returns null for unknown binary files', () => {
     expect(inferMediaKind({ type: 'application/octet-stream', name: 'data.bin' })).toBe(null);
+  });
+
+  test('isVideoSource detects video containers for remux/preview', () => {
+    expect(isVideoSource({ type: 'video/mp4', name: 'clip.mp4' })).toBe(true);
+    expect(isVideoSource({ type: '', name: 'clip.mov' })).toBe(true);
+    expect(isVideoSource({ type: 'video/webm', name: 'clip.webm' })).toBe(true);
+    expect(isVideoSource({ type: 'audio/webm', name: 'note.webm' })).toBe(false);
+    expect(isVideoSource({ type: 'video/mp4', name: 'memo.m4a' })).toBe(false);
+    expect(isVideoSource({ type: 'audio/wav', name: 'a.wav' })).toBe(false);
   });
 });
 

--- a/tests/video-export-wiring.test.js
+++ b/tests/video-export-wiring.test.js
@@ -1,0 +1,62 @@
+/**
+ * Static wiring contract for processed video download (landing + engineer).
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const landingJs = fs.readFileSync(path.join(ROOT, 'public/landing.js'), 'utf8');
+const landingHtml = fs.readFileSync(path.join(ROOT, 'public/index.html'), 'utf8');
+const appJs = fs.readFileSync(path.join(ROOT, 'public/app/app.js'), 'utf8');
+const videoExport = fs.readFileSync(path.join(ROOT, 'src/pipeline/video-export.js'), 'utf8');
+const mediaDecode = fs.readFileSync(path.join(ROOT, 'src/pipeline/media-decode.js'), 'utf8');
+
+describe('Video export module', () => {
+  test('exports remux helpers without ffmpeg/CDN deps', () => {
+    expect(videoExport).toContain('export async function exportVideoWithProcessedAudio');
+    expect(videoExport).toContain('MediaRecorder');
+    expect(videoExport).toContain('captureStream');
+    expect(videoExport).not.toMatch(/cdn\.|unpkg|jsdelivr/i);
+  });
+});
+
+describe('Media decode video fallback', () => {
+  test('does not mute the capture element (WebKit silence bug)', () => {
+    expect(mediaDecode).toMatch(/media\.muted\s*=\s*false/);
+    expect(mediaDecode).toMatch(/media\.volume\s*=\s*0/);
+    expect(mediaDecode).toContain('silentGain');
+  });
+});
+
+describe('Landing — processed download', () => {
+  test('has a download control in the shell', () => {
+    expect(landingHtml).toContain('id="downloadBtn"');
+    expect(landingHtml).toContain('id="exportRow"');
+  });
+
+  test('wires video remux on download for video sources', () => {
+    expect(landingJs).toContain('exportVideoWithProcessedAudio');
+    expect(landingJs).toContain('onDownloadProcessed');
+    expect(landingJs).toContain('isVideoSource');
+    expect(landingJs).toContain('sourceFile');
+    expect(landingJs).toMatch(/Download Processed Video/);
+  });
+});
+
+describe('Engineer — processed download', () => {
+  test('save processed remuxes video when source is video', () => {
+    expect(appJs).toContain('_downloadProcessed');
+    expect(appJs).toContain('exportVideoWithProcessedAudio');
+    expect(appJs).toContain('isVideoSource');
+    expect(appJs).toContain('_sourceFile');
+    expect(appJs).toContain('Save Processed Video');
+  });
+
+  test('always assigns a fresh object URL for video preview', () => {
+    expect(appJs).toContain('_videoObjectUrl');
+    expect(appJs).toContain('_clearVideoElement');
+    expect(appJs).toMatch(/this\.dom\.videoPlayer\.src\s*=\s*url/);
+  });
+});


### PR DESCRIPTION
## Summary
- Fix video decode fallback that could produce silence (`muted=true` → `volume=0` + silent gain sink)
- Always rebind a fresh object URL for video preview on landing + Engineer Mode
- Improve `isVideoSource()` detection (webm audio vs video, m4a edge cases)
- Add browser-side video remux export (`captureStream` + `MediaRecorder`) so processed downloads keep the picture with isolated audio
- Landing: new **Download Processed** control; Engineer: **Save Processed** exports video when the source was video (WAV fallback)

## Test plan
- [x] Unit tests: file-ingestion, handle_file_*, landing-video-spinner, video-export-wiring
- [ ] Manual: upload short MP4 on `/` and `/app/` — stems generate, preview shows
- [ ] Manual: Download/Save processed → receives video with processed audio (or WAV fallback)
- [ ] Manual: audio-only upload still downloads WAV


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix video upload decode/preview and add processed video download export
> - Fixes fallback media-element decode in [`media-decode.js`](https://github.com/Joker5514/VoiceIsolate-Pro/pull/695/files#diff-55e5ad8acd800e02c653d814a59f6ca794f9a3f6823bcb1f88b9fd16698230bf) where `muted=true` caused silence on WebKit; now uses `volume=0` with a zero-gain node to keep `onaudioprocess` firing without audible output.
> - Fixes video preview on reload by always creating a fresh object URL and revoking stale ones via a new `_clearVideoElement()` helper, preventing stale previews and memory leaks.
> - Adds a new [`video-export.js`](https://github.com/Joker5514/VoiceIsolate-Pro/pull/695/files#diff-f16024fb51e9cea209222c2eafe07e0d7e58c3264d17ec520d5880a29d9e5844) module that remuxes processed audio back into the original video container using `captureStream()`, `AudioBufferSourceNode`, and `MediaRecorder`, with no external encoders.
> - Exposes a "Download Processed" button on the landing page and a "Save Processed Video/WAV" button in the engineer UI, both routing through the new export path with fallback to WAV on failure.
> - Improves `.webm` and `m4a`/`m4b`/`m4r` classification in [`media-types.js`](https://github.com/Joker5514/VoiceIsolate-Pro/pull/695/files#diff-88886fad6bda135fb33af6b2ca0b425b6addd710760be4a991fb945cdce64cd6) via a new `isVideoSource` helper that prefers MIME type for ambiguous containers.
> - Risk: video remux relies on `MediaRecorder` with `captureStream()`, which may not be supported in all browsers; the export silently falls back to WAV in that case.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6e0b213.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->