### PR TITLE
perf(engineer): cut main-thread lag across viz, transport, and processing

### DIFF
--- a/public/app/app.js
+++ b/public/app/app.js
@@ -132,11 +132,28 @@ const HeroExperience = (() => {
       if (fallback) { fallback.hidden = false; fallback.setAttribute('aria-hidden', 'false'); }
       video.style.display = 'none';
     };
+    const releaseHero = () => {
+      try { video.pause(); } catch { /* ignore */ }
+      try {
+        video.removeAttribute('src');
+        video.load();
+      } catch { /* ignore */ }
+      video.style.display = 'none';
+      if (fallback) {
+        fallback.hidden = false;
+        fallback.setAttribute('aria-hidden', 'false');
+      }
+    };
     video.addEventListener('error', showFallback);
     const playAttempt = video.play();
     if (playAttempt && typeof playAttempt.catch === 'function') {
       playAttempt.catch(showFallback);
     }
+    // Hero loop is decorative only — release decoder after a short intro so it
+    // cannot keep the main thread / GPU busy during engineer workflow.
+    setTimeout(releaseHero, 6000);
+    window.addEventListener('vip:fileLoaded', releaseHero, { once: true });
+    window.addEventListener('vip:playStarted', releaseHero, { once: true });
   }
 
   function bindHeroCtas(app) {
@@ -3036,14 +3053,13 @@ class VoiceIsolatePro {
     const DSP = this._resolveDSP();
     const FFT = 4096;
     const HOP = 1024;
-    const FRAME_CHUNK = 256;
+    // Larger chunks = fewer yields during offline spectral work (snappier UI).
+    const FRAME_CHUNK = 512;
     if (!DSP || !data || data.length < FFT) return data;
 
-    const yieldBudget = createYieldBudget(32);
-    if (onProgress) onProgress(0.02);
-    await yieldBudget();
-    if (onProgress) onProgress(0.08);
-    await yieldBudget();
+    // Yield only between real work chunks — empty pre-STFT yields just added lag.
+    const yieldBudget = createYieldBudget(48);
+    if (onProgress) onProgress(0.05);
 
     const spec = DSP.forwardSTFT(data, FFT, HOP);
     if (onProgress) onProgress(0.15);
@@ -3428,11 +3444,19 @@ class VoiceIsolatePro {
       if (!this._transportSeeking) {
         this.playOffset = cur;
         this._paintTransport(cur, dur);
-        try {
-          window.dispatchEvent(new CustomEvent('vip:transportTick', {
-            detail: { position: cur, duration: dur },
-          }));
-        } catch (_) {}
+        // Throttle playhead events ~30 Hz — full 60 Hz CustomEvent + canvas
+        // restores was a major source of engineer-mode lag.
+        const now = (typeof performance !== 'undefined' && performance.now)
+          ? performance.now()
+          : Date.now();
+        if (!this._lastTransportTickEvt || now - this._lastTransportTickEvt >= 32) {
+          this._lastTransportTickEvt = now;
+          try {
+            window.dispatchEvent(new CustomEvent('vip:transportTick', {
+              detail: { position: cur, duration: dur },
+            }));
+          } catch (_) {}
+        }
       }
 
       const bridge = this._bridge;
@@ -3480,7 +3504,8 @@ class VoiceIsolatePro {
     if (!this._playbackAnalyser) {
       try {
         this._playbackAnalyser = this.ctx.createAnalyser();
-        this._playbackAnalyser.fftSize = 2048;
+        // 1024 bins is enough for spectro/LUFS and halves analyser work vs 2048.
+        this._playbackAnalyser.fftSize = 1024;
         this._playbackAnalyser.smoothingTimeConstant = 0.82;
       } catch (_) {
         return null;

--- a/public/app/diarization-timeline.js
+++ b/public/app/diarization-timeline.js
@@ -37,10 +37,13 @@ let _isDragging  = false;
 let _dragStartX  = 0;
 let _dragViewStart = 0;
 let _rafId       = null;
+let _dirty       = true;
 let _resizeObserver = null;
 let _listenersBound = false;
 let _touchStartHandler = null;
 let _touchMoveHandler  = null;
+/** Last canvas playhead X — skip full redraw when only sub-pixel drift. */
+let _lastPlayheadPx = -1;
 
 const PALETTE = [
   '#3b82f6','#a855f7','#10b981','#f59e0b',
@@ -111,7 +114,8 @@ export function initDiarizationTimeline(opts = {}) {
     _listenersBound = true;
   }
 
-  if (!_rafId) _startRAF();
+  // One-shot paint — no continuous RAF (was a major main-thread lag source).
+  _markDirty();
   console.info('[DiarTimeline] initialised on #' + canvasId);
 }
 
@@ -121,6 +125,7 @@ export function onDiarizationResult({ segments = [], duration = 0, speakerCount 
   _duration = duration || (segments.length ? Math.max(...segments.map(s => s.end)) : 0);
   _viewStart = 0;
   _viewEnd   = _duration;
+  _lastPlayheadPx = -1;
 
   // Update badge
   if (_countEl) {
@@ -129,6 +134,7 @@ export function onDiarizationResult({ segments = [], duration = 0, speakerCount 
   }
   // Show playhead
   if (_playheadEl) _playheadEl.style.display = 'block';
+  _markDirty();
 }
 
 // ── Public: playhead sync ─────────────────────────────────────────────────────
@@ -138,16 +144,24 @@ export function seekTimeline(timeSec) {
 
   // Auto-scroll: keep playhead in view
   const viewLen = _viewEnd - _viewStart;
+  let scrolled = false;
   if (_duration > 0 && timeSec > _viewEnd - viewLen * 0.1) {
     _viewStart = Math.min(timeSec - viewLen * 0.1, _duration - viewLen);
     _viewEnd   = _viewStart + viewLen;
+    scrolled = true;
   }
   // Sync playhead DOM element
+  let px = -1;
   if (_playheadEl && _canvas && _duration > 0) {
-    const frac = (_currentTime - _viewStart) / (_viewEnd - _viewStart);
-    const px   = Math.max(0, Math.min(_canvas.offsetWidth, frac * _canvas.offsetWidth));
+    const frac = (_currentTime - _viewStart) / Math.max(1e-6, _viewEnd - _viewStart);
+    px = Math.max(0, Math.min(_canvas.offsetWidth, frac * _canvas.offsetWidth));
     _playheadEl.style.left = px + 'px';
     _playheadEl.style.display = 'block';
+  }
+  // Redraw canvas only when the playhead moved ≥1 px or the view scrolled.
+  if (scrolled || Math.round(px) !== _lastPlayheadPx) {
+    _lastPlayheadPx = Math.round(px);
+    _markDirty();
   }
 }
 
@@ -158,11 +172,13 @@ export function zoomTimeline(factor) {
   const halfLen = (_viewEnd - _viewStart) / 2 / factor;
   _viewStart = Math.max(0, center - halfLen);
   _viewEnd   = Math.min(_duration, center + halfLen);
+  _markDirty();
 }
 
 export function fitTimeline() {
   _viewStart = 0;
   _viewEnd   = _duration || 1;
+  _markDirty();
 }
 
 // ── Public: speaker state passthrough ─────────────────────────────────────────
@@ -180,8 +196,13 @@ function _resize() {
   _canvas.height = h * devicePixelRatio;
   _canvas.style.width  = w + 'px';
   _canvas.style.height = h + 'px';
-  if (_ctx) _ctx.scale(devicePixelRatio, devicePixelRatio);
+  if (_ctx) {
+    _ctx.setTransform(1, 0, 0, 1, 0, 0);
+    _ctx.scale(devicePixelRatio, devicePixelRatio);
+  }
   if (!_viewEnd && _duration) _viewEnd = _duration;
+  _lastPlayheadPx = -1;
+  _markDirty();
 }
 
 function _draw() {
@@ -258,9 +279,24 @@ function _draw() {
   }
 }
 
+/**
+ * Schedule a single redraw on the next animation frame when content is dirty.
+ * Replaces the previous continuous RAF loop that painted every frame forever.
+ */
+function _markDirty() {
+  _dirty = true;
+  if (_rafId != null) return;
+  _rafId = requestAnimationFrame(() => {
+    _rafId = null;
+    if (!_dirty) return;
+    _dirty = false;
+    _draw();
+  });
+}
+
+/** @deprecated Use _markDirty — kept name for older call sites / tests. */
 function _startRAF() {
-  const loop = () => { _draw(); _rafId = requestAnimationFrame(loop); };
-  _rafId = requestAnimationFrame(loop);
+  _markDirty();
 }
 
 // ── Internal: cleanup ─────────────────────────────────────────────────────────
@@ -302,6 +338,8 @@ function _onMouseMove(e) {
   const dSec    = (dx / _canvas.offsetWidth) * viewLen;
   _viewStart    = Math.max(0, Math.min(_duration - viewLen, _dragViewStart - dSec));
   _viewEnd      = _viewStart + viewLen;
+  _lastPlayheadPx = -1;
+  _markDirty();
 }
 function _onMouseUp() {
   _isDragging = false;

--- a/public/app/visuals-bootstrap.js
+++ b/public/app/visuals-bootstrap.js
@@ -152,14 +152,15 @@
 
   function _drawPlayhead(canvas, buffer, color, positionSec) {
     if (!canvas || !buffer) return;
-    if (!_drawWaveformBase(canvas, buffer, color)) return;
     const dur = buffer.duration || 1;
     const offset = (typeof positionSec === 'number' && Number.isFinite(positionSec))
       ? positionSec
       : _getPlayOffset();
-    const px = Math.round((offset / dur) * canvas.width);
+    const px = Math.round((offset / Math.max(1e-6, dur)) * (canvas.width || 1));
     const lastPx = _playheadPxCache.get(canvas);
-    if (lastPx === px) return;
+    // Skip full canvas restore when the playhead has not moved a pixel.
+    if (lastPx === px && _waveBaseCache.get(canvas)) return;
+    if (!_drawWaveformBase(canvas, buffer, color)) return;
     _playheadPxCache.set(canvas, px);
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
@@ -298,6 +299,11 @@
 
   /* ── Spectrogram + frequency bars ─────────────────────────────────────── */
   let _spectroDims = null;
+  /** Reused 1×H ImageData — avoids per-frame GC from createImageData. */
+  let _spectroColImg = null;
+  let _spectroColH = 0;
+  let _lufsDomFrame = 0;
+  let _mirrorFrame = 0;
 
   function _drawSpectro2DColumn(canvas, freqBytes) {
     if (!canvas) return;
@@ -315,7 +321,11 @@
     const colX = w - 1;
     const N = freqBytes.length;
     const lut = global.VIP_INFERNO_LUT;
-    const colImg = ctx.createImageData(1, h);
+    if (!_spectroColImg || _spectroColH !== h) {
+      _spectroColImg = ctx.createImageData(1, h);
+      _spectroColH = h;
+    }
+    const colImg = _spectroColImg;
     for (let y = 0; y < h; y++) {
       const t = 1 - (y / h);
       const idx = Math.min(N - 1, Math.floor(Math.pow(t, 2.0) * (N - 1)));
@@ -344,6 +354,9 @@
   }
 
   function _mirrorSpectro3D() {
+    // 3D mirror is decorative — half rate is enough and cuts GPU blit cost.
+    _mirrorFrame = (_mirrorFrame + 1) % 2;
+    if (_mirrorFrame !== 0) return;
     const src = $('spectro2DCanvas');
     const dst = $('spectroCanvas');
     if (!src || !dst || !src.width) return;
@@ -402,6 +415,10 @@
 
     const meanShort = _lufsShortBuf.reduce((a, b) => a + b, 0) / Math.max(1, _lufsShortBuf.length);
     const meanInt = _lufsIntBuf.reduce((a, b) => a + b, 0) / Math.max(1, _lufsIntBuf.length);
+
+    // DOM meter updates at ~15–20 Hz is plenty; buffer math stays every frame.
+    _lufsDomFrame = (_lufsDomFrame + 1) % 3;
+    if (_lufsDomFrame !== 0) return;
 
     const lufsShort = meanShort > 1e-12 ? 10 * Math.log10(meanShort) - 0.691 : -70;
     const lufsInt = meanInt > 1e-12 ? 10 * Math.log10(meanInt) - 0.691 : -70;
@@ -511,6 +528,9 @@
   function _loop() {
     if (!_running) return;
     _rafId = requestAnimationFrame(_loop);
+    // Minimized viz card: stop burning GPU/CPU on hidden canvases.
+    if (_vizMinimized) return;
+
     const an = _getAnalyser();
     if (!an) return;
 
@@ -539,7 +559,10 @@
       if (freq) _drawFreqBars(freq, _freqScratch);
     }
 
-    _syncClustersEngine(_freqScratch);
+    // Clusters synthetic engine only when that panel is actually shown.
+    if (_isTabDrawTarget(CLUSTERS_TAB)) {
+      _syncClustersEngine(_freqScratch);
+    }
 
     for (const handle of _premiumHandles.values()) {
       if (handle && typeof handle.tick === 'function') {

--- a/public/app/visuals.js
+++ b/public/app/visuals.js
@@ -276,8 +276,10 @@
       // fired, or the user hasn't pressed play).
       var ans = self.getAnalysers();
       if (!ans || !ans.proc) {
-        // Still update diarization timeline so the timebase keeps moving.
-        self._drawDiarization(ts);
+        // Idle: only keep the timeline alive when we already have speaker data.
+        if (self.getSpeakerState && self.getSpeakerState()) {
+          self._drawDiarization(ts);
+        }
         return;
       }
 

--- a/src/pipeline/PlaybackMixer.js
+++ b/src/pipeline/PlaybackMixer.js
@@ -198,7 +198,8 @@ export class PlaybackMixer {
     this.leftSum.gain.value = 1;
     this.rightSum.gain.value = 1;
     this.widthGain.gain.value = 1;   // width 100% → Side unchanged → transparent
-    this.analyser.fftSize = 2048;
+    // 1024 is enough for live meters/spectro and halves analyser CPU vs 2048.
+    this.analyser.fftSize = 1024;
     // Tilt shelves flat by default.
     this.tiltLow.gain.value = 0;
     this.tiltHigh.gain.value = 0;

--- a/tests/engineer-hardening.test.js
+++ b/tests/engineer-hardening.test.js
@@ -64,6 +64,26 @@ describe('Engineer Mode hardening', () => {
     expect(DIAR_TIMELINE).toMatch(/ResizeObserver[\s\S]*requestAnimationFrame[\s\S]*_resize\(\)/);
   });
 
+  test('diarization-timeline does not run a continuous RAF paint loop', () => {
+    expect(DIAR_TIMELINE).toContain('function _markDirty');
+    expect(DIAR_TIMELINE).toMatch(/_markDirty\(\)/);
+    // Must not re-arm RAF unconditionally every frame.
+    expect(DIAR_TIMELINE).not.toMatch(/const loop = \(\) => \{ _draw\(\); _rafId = requestAnimationFrame\(loop\); \}/);
+  });
+
+  test('visuals-bootstrap skips playhead restore when pixel unchanged', () => {
+    expect(VISUALS_BOOT).toMatch(/lastPx === px && _waveBaseCache\.get\(canvas\)/);
+  });
+
+  test('visuals-bootstrap skips paint when viz card is minimized', () => {
+    expect(VISUALS_BOOT).toMatch(/if \(_vizMinimized\) return/);
+  });
+
+  test('app transport tick is throttled for playhead events', () => {
+    expect(APP_JS).toMatch(/_lastTransportTickEvt/);
+    expect(APP_JS).toMatch(/>= 32/);
+  });
+
   test('toggleAB early-returns when vip-fixes patched', () => {
     const ctx = {
       _fixABPatched: true,


### PR DESCRIPTION
## Summary
Engineer Mode felt laggy in the browser shell. This PR targets the main-thread hot paths while keeping processing + AudioWorklets correct.

### Performance
- **Diarization timeline**: replace always-on RAF with dirty-flag redraws only when data/view/playhead actually change
- **Playheads**: skip full waveform restore when the playhead has not moved a pixel
- **Spectrogram**: reuse 1×H ImageData; half-rate 3D mirror blit
- **Meters**: throttle LUFS/header DOM writes (~15–20 Hz)
- **Transport**: throttle `vip:transportTick` to ~30 Hz
- **Hero video**: release decoder after intro / first file load / first play
- **Processing**: remove empty pre-STFT yields; larger spectral frame chunks
- **Analyser**: 1024-point FFT for playback meters (was 2048)

### Correctness checks
- [x] `pnpm worklets:verify` — gate + de-esser + legacy dsp-processor OK
- [x] Unit tests: engineer-hardening, transport-sync, visuals-bootstrap, upload-decode
- [x] `node scripts/engineer-rt-smoke.cjs` — Live-Mix bridge + live sliders all pass

## Test plan
- [ ] Open `/app/`, upload short audio, process — UI stays responsive
- [ ] Play processed — transport + spectro smooth, minimize viz stops paint work
- [ ] Move rt sliders during playback — still live via worklets/bridge
- [ ] GATE / DEESS / WORKLET pills settle to ready after first play


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cut main-thread lag across viz, transport, and spectral processing
> - Replaces the continuous RAF loop in [diarization-timeline.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/696/files#diff-36b340ab3dbe85d09541ed5a9e506c50d735112ffb58b742d6a472b27d1da3ab) with demand-driven redraws via a new `_markDirty` coalescing helper; canvas only repaints on data changes, zoom, seek, or drag.
> - Throttles `vip:transportTick` events to ~30 Hz and skips all canvas updates in [visuals-bootstrap.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/696/files#diff-97305f1278d299699dbd4b6d6074b123eebb509e482ae1a8caa5cbae8693314f) when the visuals card is minimized; clusters engine sync is also gated to its active tab.
> - Halves analyser FFT size from 2048 to 1024 in both [PlaybackMixer.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/696/files#diff-646b05066f8ea1ef7558ebf5da2f3de3eeaafd7d18d7ab2f5254089e2577b0b7) and the playback analyser, reducing CPU at the cost of frequency resolution.
> - Reuses a single `ImageData` buffer per column height in the 2D spectrogram renderer, runs 3D mirror updates every other frame, and throttles LUFS DOM writes to ~15–20 Hz.
> - Releases the hero video (pause, clear src, hide) after 6 s or on file load/play to free decoder resources.
> - Behavioral Change: diarization timeline no longer paints continuously — any code relying on per-frame canvas updates outside the defined triggers will no longer receive them.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bbfd104.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Reduced unnecessary audio visualization processing during playback.
  - Improved responsiveness for offline spectral analysis.
  - Lowered event and rendering activity for smoother playback.
  - Paused visualization work when panels are minimized or inactive.

- **Bug Fixes**
  - Improved hero video cleanup and fallback accessibility.
  - Enhanced timeline redraw behavior during seeking, zooming, resizing, and panning.
  - Prevented redundant playhead and visualization updates.

- **Tests**
  - Added coverage for rendering throttling, minimized visualizations, and transport event handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->