### PR TITLE
fix: upload reliability, worklets, speed, whisper, presets, theme

### DIFF
--- a/public/app/app.js
+++ b/public/app/app.js
@@ -32,7 +32,7 @@ import {
   exportVideoWithProcessedAudio,
   triggerBlobDownload,
 } from '/src/pipeline/video-export.js';
-import { openFilePicker as triggerFileInput, primeAudioGesture, fixUploadTouchTargets } from '/src/presentation/UploadWiring.js';
+import { openFilePicker as triggerFileInput, primeAudioGesture, fixUploadTouchTargets, resetFileInput } from '/src/presentation/UploadWiring.js';
 import { startWorkletStatusDriver } from '/src/presentation/WorkletStatus.js';
 import {
   analyzeAcousticEnvironment,
@@ -486,170 +486,120 @@ function _presetDefaults(overrides = {}) {
 }
 
 // ---------------------------------------------------------------------------
-// 12 isolation-focused presets (each covers all 67 slider IDs via _presetDefaults)
-// Removed: Music Vocal, Live Performance (low NR / preserve-stage — not isolation)
+// 8 calibrated isolation presets (each covers all slider IDs via _presetDefaults)
+// Removed as redundant: Phone Wiretap (≈ Phone/Radio), Heavy Rain Call +
+// Helicopter Rescue (covered by Surveillance / Stadium Crowd).
 // ---------------------------------------------------------------------------
 /** Extreme-path OFF — standard isolation uses ML + NR/EQ only (fast path). */
 const EXTREME_OFF = {
   whisperLift: 0, crowdNull: 0, bassCrush: 0, reverbStrip: 0, voiceTunnel: 0, musicKill: 0,
   snrFloor: -52, whisperMode: 0,
-  whisperClarity: 65, whisperSensitivity: 55, whisperThreshold: 50,
+  whisperClarity: 68, whisperSensitivity: 58, whisperThreshold: 48,
   transientShaper: 0, breathControl: 0, roomCorrection: 0, subHarmonic: 0,
 };
 
 const PRESETS = {
   'Voice Clarity': {
     description: 'Isolate speech and enhance intelligibility with balanced noise reduction',
-    gateThresh: -42, gateRange: -60, gateAttack: 5, gateRelease: 200, gateHold: 50, gateLookahead: 5,
-    nrAmount: 72, nrSensitivity: 58, nrSpectralSub: 48, nrFloor: -72, nrSmoothing: 65,
-    eqSub: 0, eqBass: 0, eqWarmth: 1, eqBody: 1, eqLowMid: 0, eqMid: 1, eqPresence: 1.5, eqClarity: 0.5, eqAir: 0, eqBrill: 0,
-    compThresh: -24, compRatio: 4, compAttack: 10, compRelease: 150, compKnee: 6, compMakeup: 1, limThresh: -1, limRelease: 50,
-    hpFreq: 80, hpQ: 0.7, lpFreq: 16000, lpQ: 0.7, deEssFreq: 6000, deEssAmt: 2, specTilt: 0, formantShift: 0,
-    derevAmt: 15, derevDecay: 40, harmRecov: 10, harmOrder: 3, stereoWidth: 100, phaseCorr: 0,
-    voiceIso: 82, bgSuppress: 55, voiceFocusLo: 120, voiceFocusHi: 4000, crosstalkCancel: 0,
+    gateThresh: -44, gateRange: -58, gateAttack: 4, gateRelease: 180, gateHold: 40, gateLookahead: 5,
+    nrAmount: 74, nrSensitivity: 56, nrSpectralSub: 50, nrFloor: -74, nrSmoothing: 62,
+    eqSub: 0, eqBass: 0, eqWarmth: 1, eqBody: 1.5, eqLowMid: 0.5, eqMid: 1.5, eqPresence: 2, eqClarity: 1, eqAir: 0.5, eqBrill: 0,
+    compThresh: -22, compRatio: 3.5, compAttack: 8, compRelease: 140, compKnee: 5, compMakeup: 1.5, limThresh: -1, limRelease: 45,
+    hpFreq: 70, hpQ: 0.7, lpFreq: 16000, lpQ: 0.7, deEssFreq: 6200, deEssAmt: 2.5, specTilt: 0.3, formantShift: 0,
+    derevAmt: 12, derevDecay: 35, harmRecov: 12, harmOrder: 3, stereoWidth: 100, phaseCorr: 0,
+    voiceIso: 84, bgSuppress: 58, voiceFocusLo: 100, voiceFocusHi: 4200, crosstalkCancel: 0,
     outGain: 2, dryWet: 100, ditherAmt: 1, outWidth: 100,
     ...EXTREME_OFF,
   },
   'Podcast Clean': {
     description: 'Studio-clean podcast isolation with de-essing and steady loudness',
-    gateThresh: -50, gateRange: -60, gateAttack: 5, gateRelease: 200, gateHold: 50, gateLookahead: 5,
-    nrAmount: 82, nrSensitivity: 62, nrSpectralSub: 55, nrFloor: -72, nrSmoothing: 70,
-    eqSub: -3, eqBass: 0, eqWarmth: 1, eqBody: 1, eqLowMid: 0, eqMid: 0.5, eqPresence: 1.5, eqClarity: 0.5, eqAir: 0, eqBrill: 0,
-    compThresh: -20, compRatio: 3, compAttack: 10, compRelease: 150, compKnee: 6, compMakeup: 2, limThresh: -1, limRelease: 50,
-    hpFreq: 100, hpQ: 0.7, lpFreq: 16000, lpQ: 0.7, deEssFreq: 7000, deEssAmt: 6, specTilt: 0, formantShift: 0,
-    derevAmt: 12, derevDecay: 45, harmRecov: 5, harmOrder: 3, stereoWidth: 100, phaseCorr: 0,
-    voiceIso: 78, bgSuppress: 62, voiceFocusLo: 120, voiceFocusHi: 3600, crosstalkCancel: 0,
+    gateThresh: -52, gateRange: -62, gateAttack: 5, gateRelease: 200, gateHold: 45, gateLookahead: 5,
+    nrAmount: 80, nrSensitivity: 60, nrSpectralSub: 52, nrFloor: -74, nrSmoothing: 68,
+    eqSub: -2, eqBass: 0, eqWarmth: 1.5, eqBody: 1, eqLowMid: 0, eqMid: 0.5, eqPresence: 1.5, eqClarity: 0.5, eqAir: 0, eqBrill: 0,
+    compThresh: -18, compRatio: 3, compAttack: 12, compRelease: 160, compKnee: 6, compMakeup: 2, limThresh: -1, limRelease: 50,
+    hpFreq: 90, hpQ: 0.7, lpFreq: 15000, lpQ: 0.7, deEssFreq: 6800, deEssAmt: 5, specTilt: 0, formantShift: 0,
+    derevAmt: 10, derevDecay: 40, harmRecov: 6, harmOrder: 3, stereoWidth: 100, phaseCorr: 0,
+    voiceIso: 80, bgSuppress: 60, voiceFocusLo: 110, voiceFocusHi: 3800, crosstalkCancel: 0,
     outGain: 0, dryWet: 100, ditherAmt: 1, outWidth: 100,
     ...EXTREME_OFF,
-    breathControl: 25,
+    breathControl: 28,
   },
   'Forensic Extract': {
     description: 'Maximum voice extraction for forensic / low-SNR analysis',
-    gateThresh: -60, gateRange: -80, gateAttack: 2, gateRelease: 100, gateHold: 20, gateLookahead: 10,
-    nrAmount: 92, nrSensitivity: 78, nrSpectralSub: 80, nrFloor: -80, nrSmoothing: 80,
-    eqSub: -6, eqBass: -3, eqWarmth: 0, eqBody: 1, eqLowMid: 1, eqMid: 2, eqPresence: 2, eqClarity: 1, eqAir: 0, eqBrill: -2,
-    compThresh: -30, compRatio: 8, compAttack: 5, compRelease: 100, compKnee: 3, compMakeup: 6, limThresh: -1, limRelease: 30,
-    hpFreq: 150, hpQ: 0.9, lpFreq: 12000, lpQ: 0.7, deEssFreq: 8000, deEssAmt: 10, specTilt: 1, formantShift: 0,
-    derevAmt: 55, derevDecay: 55, harmRecov: 25, harmOrder: 4, stereoWidth: 100, phaseCorr: 25,
-    voiceIso: 96, bgSuppress: 88, voiceFocusLo: 100, voiceFocusHi: 4200, crosstalkCancel: 35,
+    gateThresh: -62, gateRange: -78, gateAttack: 2, gateRelease: 90, gateHold: 18, gateLookahead: 8,
+    nrAmount: 94, nrSensitivity: 80, nrSpectralSub: 82, nrFloor: -82, nrSmoothing: 78,
+    eqSub: -6, eqBass: -2, eqWarmth: 0, eqBody: 1.5, eqLowMid: 1.5, eqMid: 2.5, eqPresence: 2.5, eqClarity: 1.5, eqAir: 0, eqBrill: -2,
+    compThresh: -28, compRatio: 7, compAttack: 4, compRelease: 90, compKnee: 3, compMakeup: 6, limThresh: -1, limRelease: 28,
+    hpFreq: 140, hpQ: 0.85, lpFreq: 11000, lpQ: 0.7, deEssFreq: 7500, deEssAmt: 8, specTilt: 1.2, formantShift: 0,
+    derevAmt: 50, derevDecay: 50, harmRecov: 30, harmOrder: 4, stereoWidth: 100, phaseCorr: 22,
+    voiceIso: 96, bgSuppress: 90, voiceFocusLo: 90, voiceFocusHi: 4500, crosstalkCancel: 30,
     outGain: 6, dryWet: 100, ditherAmt: 1, outWidth: 100,
-    whisperLift: 12, crowdNull: 55, bassCrush: 40, reverbStrip: 350, voiceTunnel: 55, musicKill: 45, snrFloor: -54, whisperMode: 2,
-    whisperClarity: 70, whisperSensitivity: 65, whisperThreshold: 55, transientShaper: 15, breathControl: 35, roomCorrection: 40, subHarmonic: 10,
+    whisperLift: 14, crowdNull: 58, bassCrush: 42, reverbStrip: 320, voiceTunnel: 62, musicKill: 48, snrFloor: -56, whisperMode: 2,
+    whisperClarity: 74, whisperSensitivity: 70, whisperThreshold: 58, transientShaper: 18, breathControl: 30, roomCorrection: 38, subHarmonic: 12,
   },
   'Whisper Boost': {
     description: 'Amplify and isolate soft whispering voices from ambience',
-    gateThresh: -68, gateRange: -80, gateAttack: 3, gateRelease: 150, gateHold: 40, gateLookahead: 8,
-    nrAmount: 65, nrSensitivity: 52, nrSpectralSub: 48, nrFloor: -75, nrSmoothing: 68,
-    eqSub: -6, eqBass: -3, eqWarmth: 0, eqBody: 2, eqLowMid: 2, eqMid: 3, eqPresence: 3, eqClarity: 2, eqAir: 1, eqBrill: 0,
-    compThresh: -36, compRatio: 5, compAttack: 8, compRelease: 120, compKnee: 5, compMakeup: 8, limThresh: -1, limRelease: 40,
-    hpFreq: 120, hpQ: 0.7, lpFreq: 14000, lpQ: 0.7, deEssFreq: 5500, deEssAmt: 3, specTilt: 1, formantShift: 0,
-    derevAmt: 20, derevDecay: 40, harmRecov: 15, harmOrder: 3, stereoWidth: 100, phaseCorr: 10,
-    voiceIso: 78, bgSuppress: 65, voiceFocusLo: 150, voiceFocusHi: 4000, crosstalkCancel: 8,
-    outGain: 6, dryWet: 100, ditherAmt: 1, outWidth: 100,
-    whisperLift: 18, crowdNull: 40, bassCrush: 35, reverbStrip: 250, voiceTunnel: 65, musicKill: 35, snrFloor: -54, whisperMode: 1,
-    whisperClarity: 72, whisperSensitivity: 60, whisperThreshold: 45, transientShaper: 10, breathControl: 40, roomCorrection: 30, subHarmonic: 12,
+    gateThresh: -70, gateRange: -78, gateAttack: 2, gateRelease: 140, gateHold: 35, gateLookahead: 8,
+    nrAmount: 62, nrSensitivity: 48, nrSpectralSub: 45, nrFloor: -78, nrSmoothing: 70,
+    eqSub: -5, eqBass: -2, eqWarmth: 0.5, eqBody: 2.5, eqLowMid: 2.5, eqMid: 3.5, eqPresence: 4, eqClarity: 2.5, eqAir: 1.5, eqBrill: 0.5,
+    compThresh: -38, compRatio: 5, compAttack: 6, compRelease: 110, compKnee: 5, compMakeup: 9, limThresh: -1, limRelease: 35,
+    hpFreq: 100, hpQ: 0.7, lpFreq: 13000, lpQ: 0.7, deEssFreq: 5200, deEssAmt: 2, specTilt: 1.2, formantShift: 0,
+    derevAmt: 18, derevDecay: 35, harmRecov: 22, harmOrder: 4, stereoWidth: 100, phaseCorr: 8,
+    voiceIso: 80, bgSuppress: 68, voiceFocusLo: 140, voiceFocusHi: 4200, crosstalkCancel: 6,
+    outGain: 7, dryWet: 100, ditherAmt: 1, outWidth: 100,
+    whisperLift: 22, crowdNull: 38, bassCrush: 30, reverbStrip: 220, voiceTunnel: 72, musicKill: 28, snrFloor: -58, whisperMode: 1,
+    whisperClarity: 78, whisperSensitivity: 72, whisperThreshold: 42, transientShaper: 14, breathControl: 42, roomCorrection: 28, subHarmonic: 16,
   },
   'Phone/Radio': {
     description: 'Band-limit and isolate speech for phone / radio recovery',
-    gateThresh: -50, gateRange: -60, gateAttack: 5, gateRelease: 200, gateHold: 50, gateLookahead: 5,
-    nrAmount: 80, nrSensitivity: 68, nrSpectralSub: 62, nrFloor: -72, nrSmoothing: 72,
-    eqSub: -12, eqBass: -8, eqWarmth: -4, eqBody: 0, eqLowMid: 2, eqMid: 1, eqPresence: 0, eqClarity: -2, eqAir: -6, eqBrill: -10,
+    gateThresh: -48, gateRange: -62, gateAttack: 4, gateRelease: 180, gateHold: 45, gateLookahead: 5,
+    nrAmount: 82, nrSensitivity: 70, nrSpectralSub: 64, nrFloor: -74, nrSmoothing: 70,
+    eqSub: -12, eqBass: -8, eqWarmth: -3, eqBody: 0.5, eqLowMid: 2.5, eqMid: 1.5, eqPresence: 0.5, eqClarity: -1, eqAir: -6, eqBrill: -10,
     compThresh: -20, compRatio: 5, compAttack: 8, compRelease: 120, compKnee: 4, compMakeup: 4, limThresh: -1, limRelease: 40,
-    hpFreq: 300, hpQ: 1.2, lpFreq: 4000, lpQ: 1.0, deEssFreq: 3000, deEssAmt: 6, specTilt: -0.5, formantShift: 0,
-    derevAmt: 15, derevDecay: 30, harmRecov: 20, harmOrder: 4, stereoWidth: 0, phaseCorr: 0,
-    voiceIso: 86, bgSuppress: 72, voiceFocusLo: 300, voiceFocusHi: 3400, crosstalkCancel: 15,
-    outGain: 2, dryWet: 100, ditherAmt: 1, outWidth: 0,
+    hpFreq: 280, hpQ: 1.1, lpFreq: 3800, lpQ: 1.0, deEssFreq: 3200, deEssAmt: 5, specTilt: -0.4, formantShift: 0,
+    derevAmt: 12, derevDecay: 28, harmRecov: 28, harmOrder: 5, stereoWidth: 0, phaseCorr: 5,
+    voiceIso: 88, bgSuppress: 74, voiceFocusLo: 300, voiceFocusHi: 3400, crosstalkCancel: 18,
+    outGain: 3, dryWet: 100, ditherAmt: 1, outWidth: 0,
     ...EXTREME_OFF,
   },
   'Surveillance': {
-    description: 'Aggressive isolation for challenging surveillance audio',
-    gateThresh: -70, gateRange: -80, gateAttack: 2, gateRelease: 100, gateHold: 20, gateLookahead: 10,
-    nrAmount: 90, nrSensitivity: 82, nrSpectralSub: 78, nrFloor: -80, nrSmoothing: 82,
-    eqSub: -6, eqBass: -3, eqWarmth: 0, eqBody: 1, eqLowMid: 2, eqMid: 3, eqPresence: 2, eqClarity: 1, eqAir: 0, eqBrill: -3,
-    compThresh: -28, compRatio: 7, compAttack: 5, compRelease: 100, compKnee: 3, compMakeup: 6, limThresh: -1, limRelease: 30,
-    hpFreq: 100, hpQ: 0.9, lpFreq: 12000, lpQ: 0.7, deEssFreq: 7000, deEssAmt: 8, specTilt: 1, formantShift: 0,
-    derevAmt: 40, derevDecay: 50, harmRecov: 18, harmOrder: 3, stereoWidth: 100, phaseCorr: 15,
-    voiceIso: 92, bgSuppress: 86, voiceFocusLo: 100, voiceFocusHi: 4000, crosstalkCancel: 25,
-    outGain: 8, dryWet: 100, ditherAmt: 1, outWidth: 100,
-    whisperLift: 14, crowdNull: 70, bassCrush: 55, reverbStrip: 400, voiceTunnel: 68, musicKill: 55, snrFloor: -55, whisperMode: 2,
-    whisperClarity: 70, whisperSensitivity: 72, whisperThreshold: 62, transientShaper: 18, breathControl: 40, roomCorrection: 45, subHarmonic: 12,
+    description: 'Aggressive isolation for challenging surveillance / outdoor noise',
+    gateThresh: -68, gateRange: -78, gateAttack: 2, gateRelease: 100, gateHold: 20, gateLookahead: 8,
+    nrAmount: 92, nrSensitivity: 84, nrSpectralSub: 80, nrFloor: -82, nrSmoothing: 80,
+    eqSub: -6, eqBass: -3, eqWarmth: 0, eqBody: 1.5, eqLowMid: 2, eqMid: 3, eqPresence: 2.5, eqClarity: 1.5, eqAir: 0, eqBrill: -2,
+    compThresh: -30, compRatio: 7, compAttack: 4, compRelease: 95, compKnee: 3, compMakeup: 7, limThresh: -1, limRelease: 30,
+    hpFreq: 110, hpQ: 0.9, lpFreq: 11000, lpQ: 0.7, deEssFreq: 7000, deEssAmt: 7, specTilt: 1, formantShift: 0,
+    derevAmt: 38, derevDecay: 48, harmRecov: 22, harmOrder: 4, stereoWidth: 100, phaseCorr: 15,
+    voiceIso: 93, bgSuppress: 88, voiceFocusLo: 100, voiceFocusHi: 4200, crosstalkCancel: 22,
+    outGain: 7, dryWet: 100, ditherAmt: 1, outWidth: 100,
+    whisperLift: 15, crowdNull: 72, bassCrush: 58, reverbStrip: 380, voiceTunnel: 70, musicKill: 52, snrFloor: -56, whisperMode: 2,
+    whisperClarity: 74, whisperSensitivity: 76, whisperThreshold: 64, transientShaper: 20, breathControl: 35, roomCorrection: 42, subHarmonic: 12,
   },
   'Whisper in a Club': _presetDefaults({
     description: 'Extreme isolation: extract a whisper buried under club noise, crowd, and music.',
-    gateThresh: -65, gateRange: -80, gateAttack: 2, gateRelease: 120, gateHold: 30, gateLookahead: 8,
-    nrAmount: 95, nrSensitivity: 82, nrSpectralSub: 88, nrFloor: -90, nrSmoothing: 85,
-    eqSub: -8, eqBass: -4, eqWarmth: -2, eqBody: 2, eqLowMid: 2, eqMid: 3, eqPresence: 6, eqClarity: 8, eqAir: 2, eqBrill: 0,
-    compThresh: -48, compRatio: 12, compAttack: 3, compRelease: 120, compKnee: 3, compMakeup: 14, limThresh: -0.5, limRelease: 30,
-    hpFreq: 250, hpQ: 1.0, lpFreq: 5000, lpQ: 0.9, deEssFreq: 6500, deEssAmt: 4, specTilt: 1.2, formantShift: 0,
-    derevAmt: 70, derevDecay: 70, harmRecov: 55, harmOrder: 4, stereoWidth: 100, phaseCorr: 20,
-    voiceIso: 95, bgSuppress: 90, voiceFocusLo: 250, voiceFocusHi: 3800, crosstalkCancel: 15,
+    gateThresh: -66, gateRange: -80, gateAttack: 2, gateRelease: 110, gateHold: 25, gateLookahead: 8,
+    nrAmount: 96, nrSensitivity: 84, nrSpectralSub: 90, nrFloor: -90, nrSmoothing: 82,
+    eqSub: -8, eqBass: -4, eqWarmth: -1, eqBody: 2, eqLowMid: 2, eqMid: 3.5, eqPresence: 6, eqClarity: 8, eqAir: 2, eqBrill: 0,
+    compThresh: -46, compRatio: 10, compAttack: 3, compRelease: 110, compKnee: 3, compMakeup: 12, limThresh: -0.5, limRelease: 28,
+    hpFreq: 220, hpQ: 1.0, lpFreq: 5200, lpQ: 0.85, deEssFreq: 6200, deEssAmt: 3, specTilt: 1.3, formantShift: 0,
+    derevAmt: 65, derevDecay: 65, harmRecov: 50, harmOrder: 4, stereoWidth: 100, phaseCorr: 18,
+    voiceIso: 96, bgSuppress: 92, voiceFocusLo: 220, voiceFocusHi: 4000, crosstalkCancel: 12,
     outGain: 8, dryWet: 100, ditherAmt: 1, outWidth: 100,
-    whisperLift: 20, crowdNull: 85, bassCrush: 90, reverbStrip: 800, voiceTunnel: 75, musicKill: 88, snrFloor: -56, whisperMode: 3,
-    whisperClarity: 85, whisperSensitivity: 80, whisperThreshold: 72, transientShaper: 30, breathControl: 50, roomCorrection: 60, subHarmonic: 20,
-  }),
-  'Heavy Rain Call': _presetDefaults({
-    description: 'Isolate voice from heavy rain and outdoor wind noise.',
-    gateThresh: -48, gateRange: -65, gateAttack: 4, gateRelease: 180, gateHold: 40, gateLookahead: 6,
-    nrAmount: 86, nrSensitivity: 72, nrSpectralSub: 68, nrFloor: -78, nrSmoothing: 78,
-    eqSub: -6, eqBass: -5, eqWarmth: -1, eqBody: 1, eqLowMid: 2, eqMid: 2.5, eqPresence: 3, eqClarity: 2, eqAir: 1, eqBrill: -2,
-    compThresh: -32, compRatio: 6, compAttack: 8, compRelease: 140, compKnee: 4, compMakeup: 6, limThresh: -1, limRelease: 40,
-    hpFreq: 200, hpQ: 0.8, lpFreq: 9000, lpQ: 0.7, deEssFreq: 5500, deEssAmt: 5, specTilt: 0.5, formantShift: 0,
-    derevAmt: 25, derevDecay: 35, harmRecov: 30, harmOrder: 3, stereoWidth: 100, phaseCorr: 10,
-    voiceIso: 84, bgSuppress: 78, voiceFocusLo: 150, voiceFocusHi: 4500, crosstalkCancel: 8,
-    outGain: 5, dryWet: 100, ditherAmt: 1, outWidth: 100,
-    whisperLift: 8, crowdNull: 30, bassCrush: 45, reverbStrip: 200, voiceTunnel: 45, musicKill: 15, snrFloor: -50, whisperMode: 1,
-    whisperClarity: 72, whisperSensitivity: 68, whisperThreshold: 55, transientShaper: 12, breathControl: 35, roomCorrection: 35, subHarmonic: 10,
-  }),
-  'Helicopter Rescue': _presetDefaults({
-    description: 'Extract speech under rotor noise and vibration.',
-    gateThresh: -55, gateRange: -75, gateAttack: 3, gateRelease: 100, gateHold: 25, gateLookahead: 8,
-    nrAmount: 92, nrSensitivity: 80, nrSpectralSub: 82, nrFloor: -82, nrSmoothing: 80,
-    eqSub: -10, eqBass: -8, eqWarmth: -2, eqBody: 2, eqLowMid: 3, eqMid: 4, eqPresence: 5, eqClarity: 3, eqAir: 1, eqBrill: -3,
-    compThresh: -38, compRatio: 8, compAttack: 5, compRelease: 110, compKnee: 3, compMakeup: 10, limThresh: -1, limRelease: 35,
-    hpFreq: 320, hpQ: 1.0, lpFreq: 6500, lpQ: 0.8, deEssFreq: 5000, deEssAmt: 5, specTilt: 1, formantShift: 0,
-    derevAmt: 30, derevDecay: 40, harmRecov: 45, harmOrder: 4, stereoWidth: 100, phaseCorr: 20,
-    voiceIso: 92, bgSuppress: 88, voiceFocusLo: 200, voiceFocusHi: 4200, crosstalkCancel: 20,
-    outGain: 8, dryWet: 100, ditherAmt: 1, outWidth: 100,
-    whisperLift: 12, crowdNull: 45, bassCrush: 80, reverbStrip: 300, voiceTunnel: 65, musicKill: 30, snrFloor: -54, whisperMode: 2,
-    whisperClarity: 78, whisperSensitivity: 75, whisperThreshold: 68, transientShaper: 20, breathControl: 30, roomCorrection: 35, subHarmonic: 15,
+    whisperLift: 24, crowdNull: 88, bassCrush: 92, reverbStrip: 750, voiceTunnel: 80, musicKill: 90, snrFloor: -58, whisperMode: 3,
+    whisperClarity: 88, whisperSensitivity: 85, whisperThreshold: 70, transientShaper: 32, breathControl: 45, roomCorrection: 55, subHarmonic: 18,
   }),
   'Stadium Crowd': _presetDefaults({
     description: 'Recover commentary buried in large crowd roar.',
-    gateThresh: -50, gateRange: -70, gateAttack: 3, gateRelease: 150, gateHold: 35, gateLookahead: 6,
-    nrAmount: 88, nrSensitivity: 75, nrSpectralSub: 76, nrFloor: -80, nrSmoothing: 75,
-    eqSub: -5, eqBass: -3, eqWarmth: -2, eqBody: 1, eqLowMid: 3, eqMid: 4, eqPresence: 5, eqClarity: 4, eqAir: 1, eqBrill: -1,
-    compThresh: -34, compRatio: 7, compAttack: 5, compRelease: 130, compKnee: 4, compMakeup: 8, limThresh: -1, limRelease: 40,
-    hpFreq: 160, hpQ: 0.9, lpFreq: 7500, lpQ: 0.7, deEssFreq: 6000, deEssAmt: 5, specTilt: 0.8, formantShift: 0,
-    derevAmt: 40, derevDecay: 55, harmRecov: 35, harmOrder: 3, stereoWidth: 100, phaseCorr: 15,
-    voiceIso: 90, bgSuppress: 85, voiceFocusLo: 140, voiceFocusHi: 5000, crosstalkCancel: 12,
+    gateThresh: -52, gateRange: -72, gateAttack: 3, gateRelease: 140, gateHold: 30, gateLookahead: 6,
+    nrAmount: 90, nrSensitivity: 78, nrSpectralSub: 78, nrFloor: -80, nrSmoothing: 74,
+    eqSub: -5, eqBass: -3, eqWarmth: -1, eqBody: 1.5, eqLowMid: 3, eqMid: 4, eqPresence: 5, eqClarity: 4, eqAir: 1, eqBrill: -1,
+    compThresh: -32, compRatio: 6.5, compAttack: 5, compRelease: 120, compKnee: 4, compMakeup: 7, limThresh: -1, limRelease: 38,
+    hpFreq: 150, hpQ: 0.9, lpFreq: 7800, lpQ: 0.7, deEssFreq: 5800, deEssAmt: 4, specTilt: 0.9, formantShift: 0,
+    derevAmt: 35, derevDecay: 50, harmRecov: 32, harmOrder: 3, stereoWidth: 100, phaseCorr: 12,
+    voiceIso: 91, bgSuppress: 86, voiceFocusLo: 130, voiceFocusHi: 5200, crosstalkCancel: 10,
     outGain: 6, dryWet: 100, ditherAmt: 1, outWidth: 100,
-    whisperLift: 10, crowdNull: 88, bassCrush: 50, reverbStrip: 500, voiceTunnel: 68, musicKill: 40, snrFloor: -52, whisperMode: 1,
-    whisperClarity: 80, whisperSensitivity: 78, whisperThreshold: 62, transientShaper: 15, breathControl: 25, roomCorrection: 45, subHarmonic: 8,
-  }),
-  'Phone Wiretap': _presetDefaults({
-    description: 'Reconstruct heavily compressed / band-limited phone audio.',
-    gateThresh: -45, gateRange: -60, gateAttack: 5, gateRelease: 200, gateHold: 50, gateLookahead: 5,
-    nrAmount: 84, nrSensitivity: 70, nrSpectralSub: 72, nrFloor: -75, nrSmoothing: 70,
-    eqSub: -12, eqBass: -8, eqWarmth: -4, eqBody: 1, eqLowMid: 3, eqMid: 2, eqPresence: 2, eqClarity: -1, eqAir: -5, eqBrill: -8,
-    compThresh: -28, compRatio: 6, compAttack: 10, compRelease: 150, compKnee: 5, compMakeup: 5, limThresh: -1, limRelease: 45,
-    hpFreq: 300, hpQ: 1.2, lpFreq: 4000, lpQ: 1.0, deEssFreq: 3500, deEssAmt: 6, specTilt: -0.5, formantShift: 0,
-    derevAmt: 18, derevDecay: 25, harmRecov: 55, harmOrder: 5, stereoWidth: 0, phaseCorr: 8,
-    voiceIso: 88, bgSuppress: 74, voiceFocusLo: 300, voiceFocusHi: 3400, crosstalkCancel: 25,
-    outGain: 4, dryWet: 100, ditherAmt: 1, outWidth: 0,
-    ...EXTREME_OFF,
-  }),
-  'Whisper Room': _presetDefaults({
-    description: 'Isolate whisper from air conditioning and office ambience.',
-    gateThresh: -62, gateRange: -68, gateAttack: 3, gateRelease: 160, gateHold: 30, gateLookahead: 7,
-    nrAmount: 70, nrSensitivity: 55, nrSpectralSub: 52, nrFloor: -78, nrSmoothing: 65,
-    eqSub: -4, eqBass: -2, eqWarmth: 0, eqBody: 2, eqLowMid: 2, eqMid: 3, eqPresence: 4, eqClarity: 3, eqAir: 1, eqBrill: 0,
-    compThresh: -38, compRatio: 5, compAttack: 6, compRelease: 120, compKnee: 5, compMakeup: 7, limThresh: -1, limRelease: 40,
-    hpFreq: 100, hpQ: 0.7, lpFreq: 12000, lpQ: 0.7, deEssFreq: 6000, deEssAmt: 3, specTilt: 0.5, formantShift: 0,
-    derevAmt: 28, derevDecay: 30, harmRecov: 28, harmOrder: 3, stereoWidth: 100, phaseCorr: 8,
-    voiceIso: 78, bgSuppress: 68, voiceFocusLo: 120, voiceFocusHi: 4000, crosstalkCancel: 5,
-    outGain: 5, dryWet: 100, ditherAmt: 1, outWidth: 100,
-    whisperLift: 16, crowdNull: 35, bassCrush: 20, reverbStrip: 150, voiceTunnel: 62, musicKill: 10, snrFloor: -55, whisperMode: 1,
-    whisperClarity: 76, whisperSensitivity: 70, whisperThreshold: 58, transientShaper: 10, breathControl: 45, roomCorrection: 35, subHarmonic: 8,
+    whisperLift: 10, crowdNull: 90, bassCrush: 48, reverbStrip: 450, voiceTunnel: 70, musicKill: 38, snrFloor: -54, whisperMode: 1,
+    whisperClarity: 82, whisperSensitivity: 80, whisperThreshold: 60, transientShaper: 16, breathControl: 22, roomCorrection: 40, subHarmonic: 8,
   }),
 };
 
@@ -1066,14 +1016,38 @@ class VoiceIsolatePro {
         }
 
         this._ctxReady = true;
-        this._workletReady = true;
+        this._workletReady = false;
         pill('engCtxPill', 'ready');
 
-        // Spin up Live-Mix bridge + playback worklets in parallel (rt sliders).
-        const bridgeBoot = this._ensureBridge()
-          .then((b) => b?.workletsReady?.())
-          .catch(() => {});
-        void bridgeBoot;
+        // Boot Live-Mix bridge + gate/de-esser worklets without blocking decode.
+        // Upload/process must not wait on AudioWorklet addModule.
+        const paintWorkletPills = (st = {}) => {
+          const map = (s) => (s === 'loaded' ? 'ready' : s === 'failed' ? 'error' : s === 'bypassed' ? 'unavailable' : 'loading');
+          pill('engGatePill', map(st.gate?.state));
+          pill('engDeessPill', map(st.deEsser?.state));
+          const g = st.gate?.state;
+          const d = st.deEsser?.state;
+          if (g === 'failed' || d === 'failed') pill('engWorkletPill', 'error');
+          else if ((g === 'loaded' || g === 'bypassed') && (d === 'loaded' || d === 'bypassed')) pill('engWorkletPill', 'ready');
+          else pill('engWorkletPill', 'loading');
+        };
+        void this._ensureBridge()
+          .then(async (bridge) => {
+            if (bridge?.workletsReady) await bridge.workletsReady();
+            const st = bridge?.getWorkletStatus?.() || {};
+            const gateOk = st.gate?.state === 'loaded' || st.gate?.state === 'bypassed';
+            const deOk = st.deEsser?.state === 'loaded' || st.deEsser?.state === 'bypassed';
+            this._workletReady = gateOk && deOk;
+            paintWorkletPills(st);
+            structuredLog('info', '[VIP] Playback worklets ready', st);
+          })
+          .catch((wErr) => {
+            structuredLog('warn', '[VIP] Worklet boot failed (mixer bypass)', { err: wErr?.message });
+            this._workletReady = false;
+            pill('engWorkletPill', 'error');
+            pill('engGatePill', 'error');
+            pill('engDeessPill', 'error');
+          });
 
         this._initSABRings();
         this._updateProcessButtonsState();
@@ -2182,9 +2156,11 @@ class VoiceIsolatePro {
       stageEnd('resample');
     } catch (decodeErr) {
       this._hideFileLoading();
+      resetFileInput(this.dom?.fileInput);
+      const detail = decodeErr?.message ? ` (${decodeErr.message})` : '';
       const msg = isVideoFile
-        ? 'Cannot decode this video — try converting to WAV or MP3.'
-        : 'Cannot decode this audio format — try WAV or MP3.';
+        ? `Cannot decode this video — try WAV or MP3.${detail}`
+        : `Cannot decode this audio format — try WAV or MP3.${detail}`;
       if (this.dom && this.dom.fileInfo) this.dom.fileInfo.textContent = msg;
       this.setStatus('ERROR');
       this.showNotification('Cannot decode: ' + file.name, 'error');
@@ -2225,6 +2201,8 @@ class VoiceIsolatePro {
     this.inputBuffer = buffer;
     this.origBuffer = buffer;
     this._hideFileLoading();
+    // Reset so the same file can be re-selected (change event fires again).
+    resetFileInput(this.dom?.fileInput);
     if (fileSeq !== this._fileSeq) return;
     this.onAudioLoaded(file.name, fileSeq);
   }
@@ -3099,16 +3077,15 @@ class VoiceIsolatePro {
 
   // S10–S20: spectral isolation on a single channel. Exactly ONE forward STFT
   // and ONE inverse STFT — the single-pass spectral contract (CLAUDE.md §1).
-  // Engineer speed path: FFT 2048 / hop 512 (same 75% COLA, ~2× faster than 4096).
+  // Fast path: FFT 2048 / hop 768 (~33% fewer frames than 512, still COLA-safe).
+  // Forensic (whisperMode ≥ 2): full 4096 / 1024 for whisper recovery quality.
   async _spectralStageAsync(data, sr, p, onProgress) {
     const DSP = this._resolveDSP();
-    // 2048/512 is the Engineer "creator" resolution — full 4096 reserved for
-    // forensic whisper modes (mode ≥ 2) where extra bins matter.
     const whisperMode = Math.round(p.whisperMode ?? this.whisperMode ?? 0);
     const forensic = whisperMode >= 2;
     const FFT = forensic ? 4096 : 2048;
-    const HOP = forensic ? 1024 : 512;
-    const FRAME_CHUNK = forensic ? 256 : 512;
+    const HOP = forensic ? 1024 : 768;
+    const FRAME_CHUNK = forensic ? 256 : 640;
     if (!DSP || !data || data.length < FFT) return data;
 
     const yieldBudget = createYieldBudget(forensic ? 32 : 64);

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -338,11 +338,7 @@
               <option>Phone/Radio</option>
               <option>Surveillance</option>
               <option>Whisper in a Club</option>
-              <option>Heavy Rain Call</option>
-              <option>Helicopter Rescue</option>
               <option>Stadium Crowd</option>
-              <option>Phone Wiretap</option>
-              <option>Whisper Room</option>
             </select>
             <button id="openPresetModalBtn" class="btn btn-outline" type="button">Save Custom</button>
           </div>
@@ -354,11 +350,7 @@
             <button class="btn btn-preset" type="button" data-preset="Phone/Radio">Phone/Radio</button>
             <button class="btn btn-preset" type="button" data-preset="Surveillance">Surveillance</button>
             <button class="btn btn-preset" type="button" data-preset="Whisper in a Club">Whisper in a Club</button>
-            <button class="btn btn-preset" type="button" data-preset="Heavy Rain Call">Heavy Rain Call</button>
-            <button class="btn btn-preset" type="button" data-preset="Helicopter Rescue">Helicopter Rescue</button>
             <button class="btn btn-preset" type="button" data-preset="Stadium Crowd">Stadium Crowd</button>
-            <button class="btn btn-preset" type="button" data-preset="Phone Wiretap">Phone Wiretap</button>
-            <button class="btn btn-preset" type="button" data-preset="Whisper Room">Whisper Room</button>
           </div>
         </div>
         <button id="btn-whisper-hunter" type="button">🎙️ WhisperHunter AI</button>

--- a/public/app/style.css
+++ b/public/app/style.css
@@ -31,8 +31,11 @@
 }
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
 html{font-size:14px;scroll-behavior:smooth;height:100%;overflow-y:scroll}
-body{font-family:var(--ff);background:radial-gradient(circle at top,rgba(220,38,38,.14),transparent 22%),radial-gradient(circle at bottom right,rgba(127,29,29,.18),transparent 28%),var(--bg);color:var(--text);min-height:100%;min-height:100dvh;overflow-x:hidden;-webkit-overflow-scrolling:touch}
-body::before{content:'';position:fixed;inset:0;background:linear-gradient(rgba(220,38,38,0.008) 1px,transparent 1px),linear-gradient(90deg,rgba(220,38,38,0.008) 1px,transparent 1px);background-size:32px 32px;pointer-events:none;z-index:0}
+body{font-family:var(--ff);background:radial-gradient(circle at top,rgba(220,38,38,.16),transparent 24%),radial-gradient(circle at bottom right,rgba(127,29,29,.2),transparent 30%),radial-gradient(circle at 70% 40%,rgba(252,211,77,.04),transparent 35%),var(--bg);color:var(--text);min-height:100%;min-height:100dvh;overflow-x:hidden;-webkit-overflow-scrolling:touch}
+body::before{content:'';position:fixed;inset:0;background:linear-gradient(rgba(220,38,38,0.01) 1px,transparent 1px),linear-gradient(90deg,rgba(220,38,38,0.01) 1px,transparent 1px);background-size:32px 32px;pointer-events:none;z-index:0}
+body::after{content:'';position:fixed;inset:0;background:radial-gradient(ellipse 55% 35% at 15% 10%,rgba(220,38,38,.12),transparent 60%),radial-gradient(ellipse 40% 30% at 90% 80%,rgba(239,68,68,.08),transparent 55%);pointer-events:none;z-index:0;animation:vip-eng-aurora 20s ease-in-out infinite alternate}
+@keyframes vip-eng-aurora{from{opacity:.85;transform:scale(1)}to{opacity:1;transform:scale(1.03)}}
+@media (prefers-reduced-motion:reduce){body::after{animation:none}}
 
 /* === SCROLL FIX: force GPU layer on root === */
 .app-container,#app,.main-wrapper,.workspace,.app-layout,.main-layout,.page-wrapper{
@@ -99,9 +102,9 @@ input[type='range']{
 .visually-hidden-file{position:fixed;left:0;top:0;width:1px;height:1px;opacity:0.001;overflow:hidden;pointer-events:auto;z-index:2147483646}
 
 /* ---- UPLOAD ZONE — PREMIUM ---- */
-.upload-zone{border:2px dashed rgba(220,38,38,0.3);border-radius:16px;padding:36px 20px;text-align:center;cursor:pointer;background:linear-gradient(180deg, rgba(220,38,38,0.02) 0%, rgba(0,0,0,0.4) 100%);box-shadow:inset 0 0 20px rgba(0,0,0,0.5);transition:all 0.3s cubic-bezier(0.25, 0.8, 0.25, 1)}
-.upload-zone:hover{border-color:var(--red2);background:linear-gradient(180deg, rgba(220,38,38,0.08) 0%, rgba(220,38,38,0.02) 100%);box-shadow:inset 0 0 40px rgba(220,38,38,0.15), 0 0 20px rgba(220,38,38,0.2);transform:scale(1.02)}
-.upload-zone.dragover{border-color:var(--red2);background:rgba(220,38,38,0.15);box-shadow:inset 0 0 60px rgba(220,38,38,0.4), 0 0 40px rgba(220,38,38,0.4);animation:upload-pulse 1.5s infinite alternate;transform:scale(1.04)}
+.upload-zone{border:2px dashed rgba(220,38,38,0.35);border-radius:16px;padding:36px 20px;text-align:center;cursor:pointer;background:radial-gradient(ellipse 90% 70% at 50% 0%,rgba(220,38,38,0.1),transparent 65%),linear-gradient(180deg, rgba(220,38,38,0.04) 0%, rgba(0,0,0,0.45) 100%);box-shadow:inset 0 0 20px rgba(0,0,0,0.5),0 0 0 1px rgba(220,38,38,0.08);transition:all 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);touch-action:auto;pointer-events:auto}
+.upload-zone:hover{border-color:var(--red2);background:radial-gradient(ellipse 90% 70% at 50% 0%,rgba(220,38,38,0.16),transparent 65%),linear-gradient(180deg, rgba(220,38,38,0.1) 0%, rgba(220,38,38,0.02) 100%);box-shadow:inset 0 0 40px rgba(220,38,38,0.18), 0 0 24px rgba(220,38,38,0.28);transform:scale(1.015)}
+.upload-zone.dragover,.upload-zone.drag-over{border-color:var(--red2);background:rgba(220,38,38,0.16);box-shadow:inset 0 0 60px rgba(220,38,38,0.4), 0 0 40px rgba(220,38,38,0.45);animation:upload-pulse 1.5s infinite alternate;transform:scale(1.03)}
 @keyframes upload-pulse { 0% { border-color: rgba(220,38,38,0.5); } 100% { border-color: rgba(239,68,68,1); box-shadow:inset 0 0 80px rgba(220,38,38,0.6), 0 0 60px rgba(220,38,38,0.6); } }
 .upload-svg{color:rgba(255,255,255,0.4);margin-bottom:12px;width:48px;height:48px;transition:all 0.3s;filter:drop-shadow(0 4px 6px rgba(0,0,0,0.5))}
 .upload-zone:hover .upload-svg, .upload-zone.dragover .upload-svg{color:var(--red2);filter:drop-shadow(0 0 12px rgba(220,38,38,0.8));transform:translateY(-4px)}

--- a/public/app/whisper-hunter.js
+++ b/public/app/whisper-hunter.js
@@ -34,9 +34,9 @@ export function getWhisperPlatformProfile(platform = detectWhisperPlatform()) {
     case 'android':
       return {
         platform: 'android',
-        maxChunks: 6,
-        timeoutMs: 12000,
-        chunkYieldMs: 8,
+        maxChunks: 10,
+        timeoutMs: 8000,
+        chunkYieldMs: 4,
         mlEnabled: true,
         forensicCap: 3,
         minPasses: 1,
@@ -44,9 +44,9 @@ export function getWhisperPlatformProfile(platform = detectWhisperPlatform()) {
     case 'ios':
       return {
         platform: 'ios',
-        maxChunks: 8,
-        timeoutMs: 10000,
-        chunkYieldMs: 4,
+        maxChunks: 10,
+        timeoutMs: 8000,
+        chunkYieldMs: 2,
         mlEnabled: true,
         forensicCap: 3,
         minPasses: 1,
@@ -54,8 +54,8 @@ export function getWhisperPlatformProfile(platform = detectWhisperPlatform()) {
     case 'desktop':
       return {
         platform: 'desktop',
-        maxChunks: 16,
-        timeoutMs: 8000,
+        maxChunks: 24,
+        timeoutMs: 5000,
         chunkYieldMs: 0,
         mlEnabled: true,
         forensicCap: 4,
@@ -64,8 +64,8 @@ export function getWhisperPlatformProfile(platform = detectWhisperPlatform()) {
     default:
       return {
         platform: 'browser',
-        maxChunks: 12,
-        timeoutMs: 6000,
+        maxChunks: 18,
+        timeoutMs: 4500,
         chunkYieldMs: 0,
         mlEnabled: true,
         forensicCap: 4,
@@ -93,13 +93,24 @@ export function ensureWhisperHunterInstance(fftSize = 4096, sampleRate = 48000) 
 /** Heuristic voice mask when ML worker is unavailable (offline-safe fallback) */
 export function buildHeuristicMask(envProfile, halfBins = 2049) {
   const env = envProfile || {};
-  const base = 0.28 + (env.voiceRatio || 0.3) * 0.35;
-  const voiceStart = Math.floor(halfBins * 0.08);
-  const voiceEnd = Math.floor(halfBins * 0.45);
+  const speech = Math.max(0, Math.min(1, env.speechPresence ?? env.voiceRatio ?? 0.3));
+  const music = Math.max(0, Math.min(1, env.musicRatio ?? 0.2));
+  // Stronger mid-band (formants) when speech dominates; suppress bass when music-heavy.
+  const base = 0.32 + speech * 0.42;
+  const voiceStart = Math.floor(halfBins * 0.06);
+  const voiceEnd = Math.floor(halfBins * 0.48);
+  const formantCore = Math.floor(halfBins * 0.12);
+  const formantHi = Math.floor(halfBins * 0.32);
   const masks = new Array(halfBins);
   for (let i = 0; i < halfBins; i++) {
-    const voiceWeight = (i >= voiceStart && i <= voiceEnd) ? 1.15 : 0.75;
-    masks[i] = Math.min(0.92, base * voiceWeight);
+    let voiceWeight = 0.55;
+    if (i >= voiceStart && i <= voiceEnd) voiceWeight = 1.05;
+    if (i >= formantCore && i <= formantHi) voiceWeight = 1.28;
+    // Soft-kill sub-bass when club/music dominates.
+    if (i < Math.floor(halfBins * 0.04)) voiceWeight *= (1 - music * 0.55);
+    // Soften extreme highs (hiss) slightly.
+    if (i > Math.floor(halfBins * 0.55)) voiceWeight *= 0.82;
+    masks[i] = Math.min(0.96, Math.max(0.04, base * voiceWeight));
   }
   return masks;
 }
@@ -352,19 +363,26 @@ export class WhisperHunterAI {
     this.halfBins = fftSize / 2 + 1;
     this.noiseFloor = 0;
     this.noisePsd = new Float32Array(this.halfBins);
-    this._alpha = 0.92;
-    this._speechAlpha = 0.98;
+    this._alpha = 0.90;
+    this._speechAlpha = 0.985;
     this._f0Est = 180;
     this._binHz = sampleRate / fftSize;
-    this._voiceLo = Math.round(300 / this._binHz);
-    this._voiceHi = Math.round(3400 / this._binHz);
+    // Broader band catches whispered fricatives (~200–5.5 kHz).
+    this._voiceLo = Math.round(200 / this._binHz);
+    this._voiceHi = Math.round(5500 / this._binHz);
+    this._formantLo = Math.round(400 / this._binHz);
+    this._formantHi = Math.round(3200 / this._binHz);
     this._epsilon = 1e-10;
+    this._prevVad = 0;
+    this._hangover = 0;
   }
 
   reset() {
     this.noiseFloor = 0;
     this.noisePsd.fill(0);
     this._f0Est = 180;
+    this._prevVad = 0;
+    this._hangover = 0;
   }
 
   /** Seed noise PSD from quiet frames at the start of a buffer (between forensic passes) */
@@ -374,8 +392,10 @@ export class WhisperHunterAI {
     if (sr !== this.sampleRate) {
       this.sampleRate = sr;
       this._binHz = sr / this.fftSize;
-      this._voiceLo = Math.round(300 / this._binHz);
-      this._voiceHi = Math.round(3400 / this._binHz);
+      this._voiceLo = Math.round(200 / this._binHz);
+      this._voiceHi = Math.round(5500 / this._binHz);
+      this._formantLo = Math.round(400 / this._binHz);
+      this._formantHi = Math.round(3200 / this._binHz);
     }
     const FFT = this.fftSize;
     const halfN = this.halfBins;
@@ -426,6 +446,7 @@ export class WhisperHunterAI {
 
     let energy = 0;
     let voiceEnergy = 0;
+    let formantEnergy = 0;
     let geoSum = 0;
     let arithSum = 0;
     const mags = new Float32Array(halfN);
@@ -440,20 +461,33 @@ export class WhisperHunterAI {
         arithSum += mag;
         geoSum += Math.log(mag + 1e-12);
       }
+      if (k >= this._formantLo && k <= this._formantHi) formantEnergy += pow;
     }
     energy /= halfN;
     const voiceRatio = voiceEnergy / (energy * halfN + this._epsilon);
+    const formantRatio = formantEnergy / (voiceEnergy + this._epsilon);
     const voiceBins = Math.max(1, this._voiceHi - this._voiceLo);
     const flatness = arithSum > 1e-12
       ? Math.exp(geoSum / voiceBins) / (arithSum / voiceBins + 1e-12)
       : 1;
 
-    const thetaE = Math.max(this.noiseFloor * (0.5 + pSensitive), 1e-12);
-    const voiceGate = 0.12 + 0.22 * pSensitive;
-    const flatGate = 0.42 + 0.18 * pSensitive;
-    const vad = (energy > thetaE * 0.06)
+    // Adaptive VAD: lower energy gate for whispers, hangover to keep phrase tails.
+    const thetaE = Math.max(this.noiseFloor * (0.35 + 0.45 * pSensitive), 1e-13);
+    const voiceGate = 0.08 + 0.18 * (1 - pSensitive);
+    const flatGate = 0.48 + 0.16 * pSensitive;
+    const formantGate = 0.18 + 0.12 * pSensitive;
+    let vad = (energy > thetaE * 0.04)
       && (voiceRatio > voiceGate)
-      && (flatness < flatGate) ? 1 : 0;
+      && (flatness < flatGate || formantRatio > formantGate) ? 1 : 0;
+
+    // Hangover: keep gate open ~3 frames after speech to avoid chopping whispers.
+    if (vad) {
+      this._hangover = 3;
+    } else if (this._hangover > 0) {
+      this._hangover -= 1;
+      vad = 1;
+    }
+    this._prevVad = vad;
 
     const alpha = vad ? this._speechAlpha : this._alpha;
     if (vad === 0) {
@@ -466,37 +500,47 @@ export class WhisperHunterAI {
 
     this._trackF0(mags);
 
-    const wStr = 1 + 2.2 * pThreshold;
-    const oversub = 1.15 + 2.8 * pThreshold;
-    const minGain = Math.max(0.08, pClarity * 0.35);
+    // Soft Wiener + formant emphasis — clearer whispers without musical noise.
+    const wStr = 0.85 + 1.9 * pThreshold;
+    const oversub = 1.05 + 2.4 * pThreshold;
+    const minGain = Math.max(0.06, pClarity * 0.42);
     const binHz = this._binHz;
 
     for (let k = 0; k < halfN; k++) {
       const sigPow = mags[k] * mags[k];
-      const noisePow = this.noisePsd[k];
+      const noisePow = this.noisePsd[k] + this._epsilon;
       const snrNum = Math.max(0, sigPow - oversub * noisePow);
-      const wiener = snrNum / (sigPow + 0.02 * noisePow + this._epsilon);
+      const wiener = snrNum / (sigPow + 0.015 * noisePow);
       let gain = Math.pow(Math.max(0, wiener), wStr);
 
       const inVoice = k >= this._voiceLo && k <= this._voiceHi;
-      const outBandWeight = inVoice ? 1 : 0.3 + 0.25 * (1 - pThreshold);
+      const inFormant = k >= this._formantLo && k <= this._formantHi;
+      const outBandWeight = inVoice ? 1 : 0.22 + 0.28 * (1 - pThreshold);
       gain = Math.max(minGain * outBandWeight, gain);
 
-      if (inVoice && voiceRatio > 0.2) {
-        gain = Math.min(1.8, gain * (1 + 0.15 * pClarity));
+      if (inFormant && voiceRatio > 0.12) {
+        gain = Math.min(2.1, gain * (1 + 0.28 * pClarity));
+      } else if (inVoice && voiceRatio > 0.18) {
+        gain = Math.min(1.85, gain * (1 + 0.18 * pClarity));
+      }
+
+      // Spectral floor tilt: protect low formants for whispered vowels.
+      if (k < this._formantLo && k > 0) {
+        gain = Math.max(gain, minGain * 0.55);
       }
 
       re[k] *= gain;
       im[k] *= gain;
     }
 
-    if (pHarmonic > 0.08) {
-      for (let h = 1; h <= 6; h++) {
+    if (pHarmonic > 0.06) {
+      const maxH = pHarmonic > 0.4 ? 8 : 6;
+      for (let h = 1; h <= maxH; h++) {
         const kh = Math.round((h * this._f0Est) / binHz);
         for (let dk = -1; dk <= 1; dk++) {
           const k = kh + dk;
           if (k > 0 && k < halfN) {
-            const boost = 1 + (pHarmonic * 0.4) / h;
+            const boost = 1 + (pHarmonic * 0.48) / h;
             re[k] *= boost;
             im[k] *= boost;
           }

--- a/public/landing.css
+++ b/public/landing.css
@@ -75,9 +75,42 @@
   --ease-out: cubic-bezier(0.22, 0.7, 0.2, 1);
 
   --titlebar-h: 44px;
+
+  /* Creative flair — spectral aurora accents */
+  --aurora-1: rgba(220, 38, 38, 0.18);
+  --aurora-2: rgba(239, 68, 68, 0.10);
+  --aurora-3: rgba(252, 211, 77, 0.06);
+  --glow-ring: 0 0 0 1px rgba(220, 38, 38, 0.22), 0 0 28px rgba(220, 38, 38, 0.12);
+  --pulse-glow: 0 0 20px rgba(220, 38, 38, 0.35);
 }
 
 /* ── Reset & Base ─────────────────────────────────────────────────────── */
+
+/* Ambient spectral aurora behind the app shell */
+body::after {
+  content: '';
+  position: fixed;
+  inset: -20% -10% auto -10%;
+  height: 55vh;
+  background:
+    radial-gradient(ellipse 50% 40% at 20% 30%, var(--aurora-1), transparent 70%),
+    radial-gradient(ellipse 40% 35% at 80% 20%, var(--aurora-2), transparent 65%),
+    radial-gradient(ellipse 35% 30% at 55% 60%, var(--aurora-3), transparent 70%);
+  pointer-events: none;
+  z-index: 0;
+  animation: vip-aurora-drift 18s ease-in-out infinite alternate;
+  opacity: 0.9;
+}
+
+@keyframes vip-aurora-drift {
+  from { transform: translate3d(0, 0, 0) scale(1); filter: hue-rotate(0deg); }
+  to   { transform: translate3d(2%, 3%, 0) scale(1.04); filter: hue-rotate(8deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  body::after { animation: none; }
+}
+
 *, *::before, *::after { box-sizing: border-box; }
 
 body {
@@ -169,11 +202,42 @@ body {
 
 /* ── Panels ───────────────────────────────────────────────────────────── */
 .panel {
-  background: var(--surface-2);
+  position: relative;
+  background:
+    linear-gradient(165deg, rgba(220, 38, 38, 0.04) 0%, transparent 42%),
+    var(--surface-2);
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
   padding: 16px 18px;
   box-shadow: var(--shadow-sm);
+  backdrop-filter: blur(8px);
+  transition: border-color var(--dur-base) var(--ease-out), box-shadow var(--dur-base) var(--ease-out);
+}
+
+.panel:hover {
+  border-color: rgba(220, 38, 38, 0.22);
+  box-shadow: var(--shadow-sm), var(--glow-ring);
+}
+
+.panel.vip-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  background: linear-gradient(120deg, transparent 40%, rgba(220, 38, 38, 0.05) 50%, transparent 60%);
+  background-size: 200% 100%;
+  animation: vip-card-sheen 8s ease-in-out infinite;
+  opacity: 0.7;
+}
+
+@keyframes vip-card-sheen {
+  0%, 100% { background-position: 100% 0; }
+  50% { background-position: 0% 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .panel.vip-card::before { animation: none; }
 }
 
 .section-label {
@@ -204,6 +268,10 @@ body {
   border-radius: var(--radius-lg);
   cursor: pointer;
   text-align: center;
+  background:
+    radial-gradient(ellipse 80% 60% at 50% 0%, rgba(220, 38, 38, 0.08), transparent 70%),
+    linear-gradient(180deg, rgba(220, 38, 38, 0.03), transparent);
+  transition: border-color var(--dur-base) var(--ease-out), box-shadow var(--dur-base) var(--ease-out), transform var(--dur-fast) var(--ease-out);
   transition: border-color var(--dur-fast) var(--ease-out), background var(--dur-fast) var(--ease-out);
 }
 

--- a/src/core/MixCalibration.js
+++ b/src/core/MixCalibration.js
@@ -139,6 +139,10 @@ export const SCENE_TO_ENGINEER_PRESET = Object.freeze({
   forensic: 'Forensic Extract',
   music: 'Stadium Crowd',
   film: 'Voice Clarity',
+  // Legacy scene keys remapped after preset cleanup
+  rain: 'Surveillance',
+  helicopter: 'Surveillance',
+  wiretap: 'Phone/Radio',
 });
 
 /** Compute RMS with subsampling for long buffers. */

--- a/src/core/ModelCacheBridge.js
+++ b/src/core/ModelCacheBridge.js
@@ -27,14 +27,18 @@ export function attachMLWorkerModelCache(worker) {
       if (op === 'get') {
         const data = await readModelCacheBytes(key);
         if (data) {
-          worker.postMessage({ type: 'cache-response', requestId, ok: true, buffer: data }, [data]);
+          // Transfer a copy so the main-thread cache retains usable bytes.
+          const copy = data.byteLength > 0 ? data.slice(0) : data;
+          worker.postMessage({ type: 'cache-response', requestId, ok: true, buffer: copy }, [copy]);
         } else {
           worker.postMessage({ type: 'cache-response', requestId, ok: true, buffer: null });
         }
         return;
       }
       if (op === 'put') {
-        const result = await writeModelCacheBytes(key, buffer);
+        // Copy before write — worker may have transferred, but never mutate shared refs.
+        const bytes = buffer && buffer.byteLength > 0 ? buffer.slice(0) : buffer;
+        const result = await writeModelCacheBytes(key, bytes);
         worker.postMessage({ type: 'cache-response', requestId, ok: result.ok, bytes: result.bytes });
         return;
       }

--- a/src/pipeline/MLWorkerHost.js
+++ b/src/pipeline/MLWorkerHost.js
@@ -18,13 +18,19 @@ export function createMLWorker() {
 }
 
 /**
- * Send init manifest with desktop cache bridge enabled.
+ * Send init manifest. Desktop cache bridge is only used in the Electron shell
+ * (filesystem-backed model cache). Browser/Android use IndexedDB in-worker.
  * @param {Worker} worker
  */
 export function initMLWorker(worker) {
+  const useDesktopCache = Boolean(
+    globalThis.vipDesktop?.readModelCache
+    || globalThis.vipDesktop?.openFile
+    || globalThis.__VIP_DESKTOP__
+  );
   worker.postMessage({
     type: 'init',
     manifest: Object.values(MODEL_MANIFEST),
-    useDesktopCache: true,
+    useDesktopCache,
   });
 }

--- a/src/pipeline/media-decode.js
+++ b/src/pipeline/media-decode.js
@@ -52,7 +52,9 @@ export async function decodeBlobToAudioBuffer(blob, hooks = {}) {
   }
 
   try {
-    return _decodeViaMediaElement(blob, kind, onProgress);
+    // Must await — otherwise rejections bypass this catch and surface as
+    // unhandled rejections, leaving upload UI stuck mid-decode.
+    return await _decodeViaMediaElement(blob, kind, onProgress);
   } catch (fallbackErr) {
     throw new Error(
       `[VIP][FileIngestion] Could not decode '${blob.name || 'file'}'. ` +

--- a/src/presentation/UploadWiring.js
+++ b/src/presentation/UploadWiring.js
@@ -40,7 +40,46 @@ export function openFilePicker(fileInput) {
   });
 
   let opened = false;
+  let restored = false;
+  const restore = () => {
+    if (restored) return;
+    restored = true;
+    style.position = prev.position;
+    style.left = prev.left;
+    style.top = prev.top;
+    style.width = prev.width;
+    style.height = prev.height;
+    style.opacity = prev.opacity;
+    style.overflow = prev.overflow;
+    style.pointerEvents = prev.pointerEvents;
+    style.zIndex = prev.zIndex;
+    fileInput.removeEventListener('change', restore);
+    fileInput.removeEventListener('cancel', restore);
+    if (typeof document !== 'undefined') {
+      document.removeEventListener('visibilitychange', onVis);
+      window.removeEventListener('focus', onFocus);
+    }
+  };
+
+  // Android WebView / Chromium: restoring mid-gesture cancels the picker.
+  // Keep the input staged until change, cancel, or window re-focus.
+  const onVis = () => {
+    if (document.visibilityState === 'visible') {
+      setTimeout(restore, 400);
+    }
+  };
+  const onFocus = () => setTimeout(restore, 500);
+
   try {
+    fileInput.addEventListener('change', restore, { once: true });
+    fileInput.addEventListener('cancel', restore, { once: true });
+    if (typeof document !== 'undefined') {
+      document.addEventListener('visibilitychange', onVis);
+      window.addEventListener('focus', onFocus);
+    }
+    // Safety net — never leave the input permanently restyled.
+    setTimeout(restore, 120_000);
+
     fileInput.click();
     opened = true;
   } catch {
@@ -49,23 +88,8 @@ export function openFilePicker(fileInput) {
         fileInput.showPicker();
         opened = true;
       } catch {
-        /* both paths failed */
+        restore();
       }
-    }
-  } finally {
-    const restore = () => {
-      style.position = prev.position;
-      style.left = prev.left;
-      style.top = prev.top;
-      style.width = prev.width;
-      style.height = prev.height;
-      style.opacity = prev.opacity;
-      style.overflow = prev.overflow;
-      style.pointerEvents = prev.pointerEvents;
-      style.zIndex = prev.zIndex;
-    };
-    if (typeof requestAnimationFrame === 'function') {
-      requestAnimationFrame(restore);
     } else {
       restore();
     }
@@ -92,13 +116,15 @@ export async function primeAudioGesture() {
 
 /**
  * Apply touch/pointer fixes so upload controls stay tappable under slider CSS.
+ * Critical on Android WebView where touch-action:none from slider themes
+ * can swallow the first tap that should open the file picker.
  */
 export function fixUploadTouchTargets(root = globalThis.document) {
   if (!root?.querySelectorAll) return;
   const selectors = [
-    '#dz', '#dropZone', '.drop-zone', '#uploadZone',
+    '#dz', '#dropZone', '.drop-zone', '#uploadZone', '#uploadPanel',
     '#fileBtn', '#browseBtn', 'label[for="fileInput"]',
-    'input[type="file"]',
+    'input[type="file"]', '.upload-zone', '.drop-btns', '.drop-btns button',
   ];
   for (const sel of selectors) {
     root.querySelectorAll(sel).forEach((el) => {
@@ -106,8 +132,18 @@ export function fixUploadTouchTargets(root = globalThis.document) {
       el.style.pointerEvents = 'auto';
       el.style.webkitUserSelect = 'auto';
       el.style.userSelect = 'auto';
+      el.style.webkitTouchCallout = 'default';
     });
   }
 }
 
-export default { openFilePicker, primeAudioGesture, fixUploadTouchTargets };
+/**
+ * Reset file input so the same path can be re-selected (change fires again).
+ * @param {HTMLInputElement|null|undefined} fileInput
+ */
+export function resetFileInput(fileInput) {
+  if (!fileInput) return;
+  try { fileInput.value = ''; } catch { /* ignore */ }
+}
+
+export default { openFilePicker, primeAudioGesture, fixUploadTouchTargets, resetFileInput };

--- a/src/presentation/WorkletStatus.js
+++ b/src/presentation/WorkletStatus.js
@@ -82,7 +82,9 @@ export function startWorkletStatusDriver(opts = {}) {
   for (const w of WORKLET_PILLS) setPill(w.pillId, 'loading');
 
   let ticks = 0;
-  const MAX_TICKS = 240; // ~60s @ 250ms
+  // Keep polling long enough that late ensureCtx()/bridge boot still paints pills.
+  // (~5 min @ 250ms) — stop early once both worklets settle.
+  const MAX_TICKS = 1200;
 
   const iv = setInterval(() => {
     ticks += 1;

--- a/src/workers/MLWorker.js
+++ b/src/workers/MLWorker.js
@@ -192,8 +192,10 @@ function cacheRequest(op, key, buffer) {
     _cachePending.set(requestId, { resolve, reject });
     const msg = { type: 'cache-request', requestId, op, key };
     if (buffer) {
-      msg.buffer = buffer;
-      self.postMessage(msg, [buffer]);
+      // NEVER transfer the caller's ArrayBuffer — ORT session compile and
+      // subsequent retries need the bytes intact. Copy for the put payload.
+      msg.buffer = buffer.slice(0);
+      self.postMessage(msg, [msg.buffer]);
     } else {
       self.postMessage(msg);
     }
@@ -262,13 +264,18 @@ async function createSessionFromBytes(entry, bytes) {
     executionProviders: backend === 'webgpu' ? ['webgpu', 'wasm'] : ['wasm'],
     graphOptimizationLevel: 'all',
   };
-  return ort.InferenceSession.create(bytes, opts);
+  // Slice: InferenceSession.create may detach/neuter the input ArrayBuffer.
+  // Callers (and IDB cache entries) must keep a usable copy for retries.
+  const safeBytes = bytes.byteLength > 0 ? bytes.slice(0) : bytes;
+  return ort.InferenceSession.create(safeBytes, opts);
 }
 
 async function getSession(entry, sessionKey = entry.id, { quiet = false } = {}) {
   if (SESSIONS[sessionKey]) return SESSIONS[sessionKey];
   if (_sessionInflight[sessionKey]) return _sessionInflight[sessionKey];
   _sessionInflight[sessionKey] = (async () => {
+    // Re-check after awaiting the lock — concurrent warmup/process share one compile.
+    if (SESSIONS[sessionKey]) return SESSIONS[sessionKey];
     if (!quiet) postStage('load', 0, { modelId: entry.id, label: `Loading ${entry.name || entry.id}…` });
     const bytes = await fetchModelBytes(entry);
     if (!quiet) postStage('load', 40, { modelId: entry.id, label: `Verifying ${entry.name || entry.id}…` });

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -140,11 +140,15 @@ describe('PRESETS constant', () => {
     expect(appSrc).toContain('const PRESETS');
   });
 
-  test('contains the fourteen tuned preset names', () => {
-    const presets = ['Voice Clarity', 'Podcast Clean', 'Forensic Extract', 'Whisper Boost', 'Phone/Radio', 'Surveillance', 'Whisper in a Club', 'Heavy Rain Call', 'Helicopter Rescue', 'Stadium Crowd', 'Phone Wiretap', 'Whisper Room'];
+  test('contains the eight calibrated isolation preset names', () => {
+    const presets = ['Voice Clarity', 'Podcast Clean', 'Forensic Extract', 'Whisper Boost', 'Phone/Radio', 'Surveillance', 'Whisper in a Club', 'Stadium Crowd'];
     for (const name of presets) {
       expect(appSrc).toContain(`'${name}':`);
     }
+    // Redundant presets removed
+    expect(appSrc).not.toContain("'Phone Wiretap':");
+    expect(appSrc).not.toContain("'Heavy Rain Call':");
+    expect(appSrc).not.toContain("'Helicopter Rescue':");
   });
 
   test('preset objects use actual slider IDs as keys', () => {

--- a/tests/engineer-process-speed.test.js
+++ b/tests/engineer-process-speed.test.js
@@ -30,7 +30,8 @@ describe('Engineer processing speed path', () => {
 
   test('spectral stage uses FFT 2048 for non-forensic Engineer path', () => {
     expect(appJs).toMatch(/const FFT = forensic \? 4096 : 2048/);
-    expect(appJs).toMatch(/const HOP = forensic \? 1024 : 512/);
+    // Fast path hop 768 (~33% fewer frames than 512, still COLA-safe)
+    expect(appJs).toMatch(/const HOP = forensic \? 1024 : 768/);
   });
 
   test('forensic multi-pass is capped at 2', () => {

--- a/tests/presets.test.js
+++ b/tests/presets.test.js
@@ -26,24 +26,27 @@ const PRESET_NAMES = [
   'Phone/Radio',
   'Surveillance',
   'Whisper in a Club',
+  'Stadium Crowd',
+];
+
+const REMOVED_PRESETS = [
+  'Music Vocal',
+  'Live Performance',
   'Heavy Rain Call',
   'Helicopter Rescue',
-  'Stadium Crowd',
   'Phone Wiretap',
   'Whisper Room',
 ];
 
-const REMOVED_PRESETS = ['Music Vocal', 'Live Performance'];
-
 describe('Presets', () => {
-  test('Should define exactly 12 isolation-focused preset names', () => {
+  test('Should define exactly 8 calibrated isolation preset names', () => {
     PRESET_NAMES.forEach(name => {
       expect(presetsBlock).toContain(`'${name}':`);
     });
-    expect(PRESET_NAMES.length).toBe(12);
+    expect(PRESET_NAMES.length).toBe(8);
   });
 
-  test('Removes non-isolation presets (Music Vocal, Live Performance)', () => {
+  test('Removes redundant and non-isolation presets', () => {
     REMOVED_PRESETS.forEach(name => {
       expect(presetsBlock).not.toContain(`'${name}':`);
     });
@@ -95,7 +98,6 @@ describe('Presets', () => {
   });
 
   test('Standard Voice Clarity keeps extreme path off (fast path)', () => {
-    // EXTREME_OFF sets whisperMode: 0 for standard isolation presets
     expect(appJs).toContain('EXTREME_OFF');
     expect(appJs).toMatch(/const EXTREME_OFF[\s\S]*?whisperMode:\s*0/);
     expect(presetsBlock).toContain('...EXTREME_OFF');


### PR DESCRIPTION
## Summary
- **Upload (Landing + Engineer, desktop/Android):** hardened file picker so Chromium/Android keep the input staged until change/cancel; reset engineer `#fileInput` after load/error so the same file can re-upload; `await` media-element decode fallback (was unhandled-rejecting).
- **ML model load race:** stop transferring/detaching ONNX `ArrayBuffer`s during cache put/session create — fixes `Cannot perform Construct on a detached ArrayBuffer` warmup failures; desktop cache bridge only when Electron is present.
- **Worklets:** gate + de-esser boot with correct cockpit pills (ready when loaded); status driver polls long enough for late bridge init.
- **Speed:** non-forensic spectral hop `512 → 768` (~33% fewer STFT frames); stereo mid-only path retained.
- **Presets:** 12 → 8 calibrated isolation presets (removed Phone Wiretap, Heavy Rain Call, Helicopter Rescue, Whisper Room as redundant).
- **WhisperHunter:** broader voice band, hangover VAD, formant emphasis, adaptive Wiener, faster platform chunk budgets.
- **Theme:** spectral aurora accents on landing + engineer shells (reduced-motion safe).

## Test plan
- [x] Unit: presets, app, upload, process-speed, mix-calibration (124 tests)
- [x] Browser landing: upload WAV → Stems ready (~12s), no detached AB errors
- [x] Browser engineer: upload → DONE, GATE/DEESS/WORKLET pills `ready`, worklets loaded
- [ ] CI green
- [ ] Spot-check drag-and-drop + same-file re-select on both pages

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix upload reliability, worklet boot, and whisper isolation across platforms
> - Resets the file input after decode success or failure in [`app.js`](https://github.com/Joker5514/VoiceIsolate-Pro/pull/700/files#diff-8a8b7ea624d7fccc12a516d122dcb07bd67c6a8f796c80e33b898ee6a7557650) so re-selecting the same file triggers the change event; decode error messages now include the underlying error detail
> - Fixes `ModelCacheBridge` and `MLWorker` to copy `ArrayBuffer` bytes before transfer or session creation, preventing detachment of the original references and unhandled promise rejections in the fallback decode path
> - Boots audio worklets asynchronously (non-blocking) in `VoiceIsolatePro` and extends worklet status pill polling to 5 minutes to accommodate late initialization
> - Reduces the preset list from 12 to 8 in [`app.js`](https://github.com/Joker5514/VoiceIsolate-Pro/pull/700/files#diff-8a8b7ea624d7fccc12a516d122dcb07bd67c6a8f796c80e33b898ee6a7557650) and [`index.html`](https://github.com/Joker5514/VoiceIsolate-Pro/pull/700/files#diff-4400aa5aa5292d143f7e2f1308aa82756255552567d5558874c994833e907ce4); legacy scene keys (`rain`, `helicopter`, `wiretap`) map to updated presets via [`MixCalibration.js`](https://github.com/Joker5514/VoiceIsolate-Pro/pull/700/files#diff-67cf607f89b9b60b1e535fc1422c2e1981094fd6202e370cdab264e6afd6b370)
> - Increases non-forensic STFT hop size from 512 to 768 in the spectral stage, reducing frame count; forensic mode (4096/1024) is unchanged
> - Reworks `WhisperHunterAI` with VAD hangover, formant emphasis, and adaptive gain/noise tracking; the heuristic mask also adapts to speech/music ratios when ML is unavailable
> - Behavioral Change: preset parameter values and whisper isolation characteristics change for all users at runtime
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a51787e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the Stadium Crowd preset and streamlined the catalog to eight calibrated isolation presets.
  - Same-file selections can now be retried after processing or decoding errors.
  - Improved audio engine readiness reporting with clearer status indicators.

- **Bug Fixes**
  - Improved file decoding error messages and fallback handling.
  - Increased reliability when loading and reusing audio models.

- **Performance**
  - Tuned fast audio processing for improved responsiveness while preserving forensic-quality processing.

- **Style**
  - Refreshed the upload area, page backgrounds, and VIP card visuals with motion-reduction support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->