### PR TITLE
feat: architecture v26 research mode, ORT status, parameter schema

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,10 +2,12 @@
 
 | Document | Audience | Description |
 |----------|----------|-------------|
+| [VoiceIsolate_Pro_Architecture_v26.md](VoiceIsolate_Pro_Architecture_v26.md) | Contributors | **Unified architecture** — current vs target, gaps, contracts |
+| [VoiceIsolate_Pro_Technical_Whitepaper.md](VoiceIsolate_Pro_Technical_Whitepaper.md) | Research / eng | Academic-style whitepaper (single-pass spectral, ORT, modes) |
 | [WORKLETS.md](WORKLETS.md) | Contributors | AudioWorklet packaging (web, Android, desktop) |
 | [MODEL_DELIVERY.md](MODEL_DELIVERY.md) | Contributors | ONNX model CDN/Blob delivery strategy |
 | [electron-desktop.md](electron-desktop.md) | Contributors | Electron MVP shell and IPC |
-| [VoiceIsolate-Pro_Master_Blueprint_v2.1.md](VoiceIsolate-Pro_Master_Blueprint_v2.1.md) | Product / eng | Authoritative architecture blueprint |
+| [VoiceIsolate-Pro_Master_Blueprint_v2.1.md](VoiceIsolate-Pro_Master_Blueprint_v2.1.md) | Product / eng | Authoritative product blueprint (cross-platform) |
 | [REVENUECAT_ISOLATION.md](REVENUECAT_ISOLATION.md) | Mobile | In-app purchase boundary rules |
 | [adr/001-firebase-exception.md](adr/001-firebase-exception.md) | Contributors | Why Firebase is the sole cloud exception |
 

--- a/docs/VoiceIsolate_Pro_Architecture_v26.md
+++ b/docs/VoiceIsolate_Pro_Architecture_v26.md
@@ -1,0 +1,177 @@
+# VoiceIsolate Pro — Unified Architecture Summary v26
+
+**Date:** 2026-07-16  
+**Status:** Authoritative synthesis of GitHub code + Master Blueprint v2.1 + CLAUDE.md + audits  
+**Supersedes gaps between:** redesign proposals (Google Drive inputs archived in blueprint), live-SAB experiments, and Stem-Split & Live-Mix shipping architecture  
+
+---
+
+## 1. Executive model
+
+VoiceIsolate Pro is a **100% local**, browser-first voice isolation platform.
+
+| Principle | Rule |
+|-----------|------|
+| Privacy | No audio or derivatives leave the device. Network only for same-origin `.onnx` / static assets. |
+| Separation before mix | Offline ML produces stems; real-time UI only mixes/EQ. |
+| Single STFT / single iSTFT | Exactly one forward + one inverse transform **per processing path** (no repeated phase damage). |
+| Dual execution modes | **Creator/Forensic** (offline OfflineAudioContext / workers) vs **Live-Mix** (real-time AudioParams + playback worklets). |
+| No live microphone | Upload-only. Permissions-Policy denies `microphone=()`. |
+
+---
+
+## 2. Current architecture (code reality)
+
+### 2.1 Two-phase pipeline (shipping)
+
+```
+PHASE 1 — OFFLINE (once per file)
+  File → FileIngestion (decode/resample 48 kHz)
+       → MLWorker (ONNX WebGPU→WASM, SHA-256, IndexedDB)
+       → clean + noise stems (Float32Array[])
+
+PHASE 2 — LIVE-MIX (continuous, zero ML)
+  stems → PlaybackMixer (Gain / EQ / compressor / gate / de-esser)
+       → sliders touch AudioParams only (rAF-coalesced)
+```
+
+| Surface | Entry | Ingestion | Isolation | Playback |
+|---------|-------|-----------|-----------|----------|
+| Landing `/` | `landing.js` | `FileIngestion` | `MLWorker` process | `PlaybackMixer` + `SliderUI` |
+| Engineer `/app/` | `app.js` | `decodeBlobToAudioBuffer` | `StemSeparation` + DSP fallback | `EngineerModeBridge` → `PlaybackMixer` |
+| Desktop | Electron | native open + same web path | same | same |
+| Android | Capacitor WebView | same web path + mobile-upload-fix | same | same |
+
+### 2.2 Layer map (`src/`)
+
+| Layer | Path | Role |
+|-------|------|------|
+| 4 Presentation | `src/presentation/` | DOM, sliders, worklet pills, upload wiring |
+| 3 Pipeline | `src/pipeline/` | Ingestion, stem sep, mixer, export, timing |
+| 2 Workers | `src/workers/` | MLWorker, diarization, spectral cleanup, gate/de-esser AudioWorklets |
+| 1 Core | `src/core/` | Manifest, ring constants, pure DSP math |
+
+Legacy shell: `public/app/*` (Engineer UI, dsp-core, visuals) bridges into `src/` via ES imports.
+
+### 2.3 Active AudioWorklets
+
+| Processor | File | Role |
+|-----------|------|------|
+| `vip-gate` | `src/workers/GateProcessor.js` | Playback noise gate |
+| `vip-deesser` | `src/workers/DeEsserProcessor.js` | Playback de-esser |
+| `dsp-processor` | `public/app/dsp-processor.js` | **Legacy-shipped** STFT/SAB path — not loaded for mic; retained for packaging/research |
+
+### 2.4 ONNX Runtime Web
+
+- Vendored: `public/lib/ort.min.js` + WASM SIMD threaded artifacts.
+- Worker: `src/workers/MLWorker.js` — WebGPU primary, WASM fallback.
+- Models: `src/core/ModelManifest.js` (hash-pinned); default chain `bsrnn_vocals`.
+- Inference **never** inside AudioWorklet `process()`.
+
+### 2.5 Single-pass spectral (Creator path)
+
+Engineer offline fallback (`app.js` `_spectralStageAsync`):
+
+1. One `DSP.forwardSTFT`
+2. In-place magnitude ops (NR, voice focus, WhisperHunter, extreme path)
+3. One `DSP.inverseSTFT`
+
+ML spectral-mask models run STFT→mask→iSTFT **inside MLWorker** as their own single-pass path on transferred PCM.
+
+---
+
+## 3. Target architecture (blueprint v2.1 + research)
+
+| Capability | Target | Status |
+|------------|--------|--------|
+| Offline stem split + live mix | Product default | ✅ Shipping |
+| WebGPU-first ORT + WASM fallback | Required | ✅ Shipping |
+| Playback gate/de-esser worklets | Real-time quality | ✅ Shipping |
+| Ring-buffer constants (HOP % 128 == 0) | Blueprint §III | ✅ Codified in `ring-buffer-constants.js` |
+| Live monitoring spectral SAB path | Optional advanced | 🟡 Processor shipped; **not** wired to mic (forbidden) |
+| Creator multi-model chains | Demucs / BSRNN / RNNoise | ✅ User-selectable |
+| Research mode (config + I/O export) | Academic readiness | 🆕 v26 modules |
+| Benchmark harness | Latency metrics | 🆕 v26 modules |
+| Typed parameter schema (67 sliders) | UX + papers | 🆕 v26 modules |
+| Consumer simplified mode | Landing surface | ✅ Landing; schema-documented |
+
+**Live mode latency target (blueprint):** <80–100 ms end-to-end for monitoring paths — met for Live-Mix (AudioParam only). Spectral SAB live path remains research/optional and **must not** reintroduce `getUserMedia`.
+
+---
+
+## 4. Critical gaps (prioritized)
+
+| # | Gap | Severity | Mitigation in v26 |
+|---|-----|----------|-------------------|
+| G1 | Engineer UI still large legacy `app.js` | Medium | Bridge + typed schema; incremental migration |
+| G2 | `dsp-processor` not product-wired | Low | Document as research/packaged legacy |
+| G3 | No first-class research export | High for academia | `ResearchSession` + UI panel |
+| G4 | Provider/model status not always visible | Medium | `OrtStatus` + UI hooks |
+| G5 | Benchmarks informal (`PipelineTiming`) | Medium | `BenchmarkHarness` |
+| G6 | Live spectral path vs CLAUDE mic ban | Policy | Keep offline-only; no mic |
+
+---
+
+## 5. Execution mode contracts
+
+### Creator / Forensic (offline)
+
+- Decode full file → optional ML → optional single-pass DSP → stems or processed buffer.
+- FFT 2048–4096; forensic may use higher resolution; multi-pass **analysis** allowed only when it does not re-STFT the same path (ML once; forensic Whisper refines time-domain / single spectral stage).
+
+### Live-Mix (real-time)
+
+- No ML. Sliders → `PlaybackMixer` AudioParams + gate/de-esser worklets.
+- Latency ≈ audio hardware + quantum (sub-10 ms parameter response).
+
+### Research
+
+- Log full config (models, FFT, hops, presets, provider).
+- Export JSON session + optional WAV pair + stage timings.
+- Deterministic flags where applicable (no stochastic RNG in DSP core).
+
+---
+
+## 6. Multiplicative mask equation (blueprint)
+
+\[
+X_{out}(t,f) = X(t,f)\cdot\max(M_{hum}M_{noise}M_{speech}M_{speaker}M_{dereverb}M_{res},\,M_{floor})
+\]
+
+Typical \(M_{floor} = -30\,\mathrm{dB}\) (`MASK_FLOOR_DB` in core).
+
+---
+
+## 7. Security & privacy surface
+
+- COOP/COEP for cross-origin isolation / SAB readiness.
+- CSP: no CDN scripts; ORT local only.
+- Auth/paywall may contact APIs for **license display only** — never for audio.
+- Firebase exception documented in `docs/adr/001-firebase-exception.md` (auth state only).
+
+---
+
+## 8. Implementation map (v26 deliverables)
+
+| Deliverable | Path |
+|-------------|------|
+| This document | `docs/VoiceIsolate_Pro_Architecture_v26.md` |
+| Technical whitepaper | `docs/VoiceIsolate_Pro_Technical_Whitepaper.md` |
+| Parameter schema | `src/core/ParameterSchema.js` |
+| Research session | `src/core/ResearchSession.js` |
+| Benchmark harness | `src/pipeline/BenchmarkHarness.js` |
+| ORT status helper | `src/core/OrtStatus.js` |
+| Research UI | `public/app/research-mode.js` |
+
+---
+
+## 9. Non-goals (explicit)
+
+- Cloud inference or telemetry of audio.
+- Restoring live-microphone ingestion.
+- Reintroducing deleted `pipeline-orchestrator.js` live-mic monolith.
+- Multiple STFT/iSTFT cycles on the same signal path for “more quality”.
+
+---
+
+*End of Architecture v26.*

--- a/docs/VoiceIsolate_Pro_Technical_Whitepaper.md
+++ b/docs/VoiceIsolate_Pro_Technical_Whitepaper.md
@@ -1,0 +1,164 @@
+# VoiceIsolate Pro — Technical Whitepaper (v26)
+
+**Audience:** DSP engineers, HCI researchers, and developers extending the stack  
+**Companion:** `docs/VoiceIsolate_Pro_Architecture_v26.md`  
+**Constraint:** 100% local inference; single-pass spectral contract  
+
+---
+
+## Abstract
+
+VoiceIsolate Pro performs **on-device voice isolation** in the browser by separating offline machine-learning source separation from real-time mix controls. A single offline pass produces clean and residual stems; a Web Audio Live-Mix graph then exposes sub-frame parameter control without re-running neural networks. Spectral processing obeys a **single forward STFT and single inverse STFT** per path, avoiding cumulative phase smearing from multi-pass transforms.
+
+---
+
+## 1. Problem setting
+
+Recovering speech from noise, music, or multi-talker scenes is classically solved with spectral subtraction, Wiener filtering, or supervised deep networks. Browser constraints differ from desktop DAWs:
+
+- No guaranteed GPU until WebGPU is available  
+- Strict real-time audio quantum (128 samples)  
+- Memory and GC pressure that destroy live-mic ring-buffer designs  
+
+VoiceIsolate Pro therefore **decouples** heavy isolation from live interaction.
+
+---
+
+## 2. Architecture
+
+### 2.1 Stem-Split & Live-Mix
+
+1. **Stem-Split (offline):** decode → 48 kHz → ONNX (BS-RNN / Demucs / RNNoise chain) → clean + noise stems.  
+2. **Live-Mix (real-time):** dual buffer sources → gains → EQ → compressor → gate/de-esser worklets → destination.
+
+Sliders never call `InferenceSession.run`. This yields **zero ML latency** on parameter changes.
+
+### 2.2 Single-pass spectral contract
+
+For offline DSP refinement:
+
+\[
+x \xrightarrow{\mathrm{STFT}} X \xrightarrow{\text{in-place ops}} X' \xrightarrow{\mathrm{iSTFT}} \hat{x}
+\]
+
+In-place ops include Wiener NR, voice-band focus, WhisperHunter gain, extreme isolation masks. Multiplicative mask composition follows:
+
+\[
+X' = X \cdot \max\!\big( \prod_k M_k,\; M_{\mathrm{floor}} \big)
+\]
+
+with \(M_{\mathrm{floor}}\) typically \(-30\) dB.
+
+### 2.3 Dual mode FFT budgets
+
+| Mode | FFT | Hop | Intent |
+|------|-----|-----|--------|
+| Live-Mix | n/a (PCM stems) | n/a | Sub-10 ms param response |
+| Creator (Engineer default) | 2048 | 768 | Speed / quality balance |
+| Forensic | 4096 | 1024 | Whisper recovery resolution |
+
+Ring-buffer constants require `HOP_SIZE % 128 === 0` for any future quantum-aligned spectral live path (`src/core/ring-buffer-constants.js`).
+
+---
+
+## 3. Machine learning
+
+### 3.1 Runtime
+
+ONNX Runtime Web with:
+
+1. **WebGPU** primary (when `navigator.gpu` adapter exists)  
+2. **WASM** SIMD/threaded fallback  
+
+Models are same-origin, **SHA-256 verified**, cached in IndexedDB (web) or filesystem (desktop).
+
+### 3.2 Model tasks
+
+| Model | Role | Strategy |
+|-------|------|----------|
+| `bsrnn_vocals` | Default vocal mask | Spectral magnitude mask |
+| `rnnoise` | Denoise mask | Spectral magnitude mask |
+| `demucs` | Heavy separation | Waveform segment |
+| Silero VAD | Activity (optional) | Time-domain |
+
+Inference runs in a **classic Worker** (`MLWorker.js`), never inside `AudioWorkletProcessor.process()`.
+
+---
+
+## 4. Latency and quality trade-offs
+
+| Path | Typical cost | Quality notes |
+|------|--------------|---------------|
+| Live-Mix only | Hardware + graph | Perfect for A/B stem balance |
+| BS-RNN isolate | Model size ~4 MB + STFT OLA | Fast first-load after compile |
+| Demucs chain | ~149 MB quantized | Higher quality, long first compile |
+| DSP fallback | Single STFT path on mid channel | Used when ML passthrough |
+
+Stereo files use **mid-channel ML** once, re-expanding with a gain envelope to preserve imaging (~2× faster).
+
+---
+
+## 5. WhisperHunter
+
+WhisperHunter is a **local** adaptive spectral enhancer for low-SNR speech:
+
+- Broader formant band (~200–5500 Hz)  
+- Hangover VAD for whisper tails  
+- Soft Wiener + harmonic reinforcement  
+- Platform profiles (desktop/browser/Android) for chunk budgets  
+
+It augments, not replaces, ML isolation.
+
+---
+
+## 6. Reproducibility (Research Mode)
+
+Enable Research Mode in Engineer UI to:
+
+1. Log model IDs, FFT/hop, full parameter snapshot  
+2. Capture stage timings (`decode`, `ml_isolation`, `pipeline`)  
+3. Export JSON session files locally  
+4. Export the typed parameter schema for papers/supplements  
+
+Modules: `src/core/ResearchSession.js`, `public/app/research-mode.js`, `src/pipeline/BenchmarkHarness.js`.
+
+---
+
+## 7. Extending the system
+
+### Add a model
+
+1. Place `.onnx` under `public/app/models/`  
+2. Add entry + SHA-256 to `src/core/ModelManifest.js`  
+3. Implement strategy branch in `MLWorker.js` if not spectral-mask/waveform  
+
+### Add a Live-Mix control
+
+1. Add AudioParam setter on `PlaybackMixer`  
+2. Map slider in `EngineerModeBridge.PARAM_MAP` or landing `SliderUI`  
+3. Document in `ParameterSchema.js`  
+
+### Add offline spectral stage
+
+Insert **inside** the single STFT window in `_spectralStageAsync` — never open a second STFT/iSTFT pair on the same channel path.
+
+---
+
+## 8. Ethical and privacy notes
+
+- Audio never leaves the device for inference.  
+- License/auth endpoints may exchange tokens only; they must not receive PCM.  
+- Researchers should document browser, WebGPU availability, and model hashes when publishing results.
+
+---
+
+## 9. References (internal)
+
+- `CLAUDE.md` — AI contributor source of truth  
+- `docs/VoiceIsolate-Pro_Master_Blueprint_v2.1.md`  
+- `docs/WORKLETS.md`  
+- `docs/audits/AUDIT-REPORT-2026-06-21.md`  
+
+---
+
+*Whitepaper revision aligned with Architecture v26.*

--- a/public/app/dsp-processor.js
+++ b/public/app/dsp-processor.js
@@ -1,8 +1,14 @@
 /**
  * VoiceIsolate Pro — dsp-processor.js
- * AudioWorkletProcessor: Threads from Space v8
+ * AudioWorkletProcessor: Threads from Space v8 (research / packaged path)
  * ==========================================================
- * Architecture:
+ * PRODUCT NOTE (Architecture v26 / CLAUDE.md §1.1):
+ *   This processor implements a real-time STFT ↔ SAB ↔ iSTFT loop for research
+ *   and packaging integrity. The shipping product path is Stem-Split & Live-Mix
+ *   (offline MLWorker + PlaybackMixer). Live microphone ingestion is FORBIDDEN.
+ *   ONNX Runtime must NEVER be called from process() — only via Worker/main.
+ *
+ * Architecture (single-pass spectral hop):
  *   1. Accumulate 128-sample quanta into a 4096-pt ring buffer (mono mix)
  *   2. Every HOP_SIZE (1024) new samples: apply periodic Hann window + single
  *      forward FFT (one STFT per hop — strict single-pass constraint)

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -290,7 +290,8 @@
           <span class="engine-pill" id="engGatePill" data-state="pending" title="vip-gate noise gate">GATE</span>
           <span class="engine-pill" id="engDeessPill" data-state="pending" title="vip-deesser de-esser">DEESS</span>
           <span class="engine-pill" id="engSabPill" data-state="pending">SAB</span>
-          <span class="engine-pill" id="engMlPill" data-state="pending">ML</span>
+          <span class="engine-pill" id="engMlPill" data-state="pending" title="ONNX Runtime provider">ML</span>
+          <span class="engine-pill" id="engOrtPill" data-state="pending" title="WebGPU / WASM status">ORT</span>
           <span class="engine-pill" id="engNetPill" data-state="pending">NET</span>
         </div>
       </div>
@@ -607,6 +608,8 @@
   <!-- Mobile upload fix: iOS Safari decodeAudioData, AudioContext gesture lock,
        touch-action bleed, MIME accept scope. Loads after all modules are bootstrapped. -->
   <script src="./mobile-upload-fix.js"></script>
+  <!-- Research mode: local session export + ORT/benchmark strip (no network) -->
+  <script src="./research-mode.js" defer></script>
 
 
 </body>

--- a/public/app/models-manifest.json
+++ b/public/app/models-manifest.json
@@ -47,7 +47,7 @@
       ]
     }
   },
-  "_sha256_note": "SHA256 last updated: 2026-07-09. Regenerate with: pnpm worklets:hash",
+  "_sha256_note": "SHA256 last updated: 2026-07-16. Regenerate with: pnpm worklets:hash",
   "worklets": {
     "dsp_processor": {
       "filename": "dsp-processor.js",
@@ -58,7 +58,7 @@
         {
           "provider": "same-origin",
           "url": "/app/dsp-processor.js",
-          "sha256": "bfbf2c7a471ee2773fc64db333f54d94b9ed23a4ec53fc20b942b582cdf30270"
+          "sha256": "5a7f3611d03cd6c5433640aceda5bddf59abc111cdfc2850cbddc66da03d0e65"
         }
       ]
     },

--- a/public/app/research-mode.js
+++ b/public/app/research-mode.js
@@ -1,0 +1,207 @@
+/**
+ * research-mode.js — Engineer Mode research / academic export panel
+ *
+ * Loads as a classic deferred script after app.js. Hooks pipeline events
+ * and exposes config + benchmark export (100% local JSON download).
+ */
+(function () {
+  'use strict';
+
+  const PANEL_ID = 'vipResearchPanel';
+  const METRICS_ID = 'vipBenchMetrics';
+
+  function $(id) {
+    return document.getElementById(id);
+  }
+
+  async function loadModules() {
+    const [
+      research,
+      bench,
+      ort,
+      schema,
+    ] = await Promise.all([
+      import('/src/core/ResearchSession.js'),
+      import('/src/pipeline/BenchmarkHarness.js'),
+      import('/src/core/OrtStatus.js'),
+      import('/src/core/ParameterSchema.js'),
+    ]);
+    return { research, bench, ort, schema };
+  }
+
+  function ensurePanel() {
+    if ($(PANEL_ID)) return $(PANEL_ID);
+    const host = document.querySelector('.presets-wrap')
+      || document.querySelector('.main-grid')
+      || document.body;
+    const wrap = document.createElement('div');
+    wrap.id = PANEL_ID;
+    wrap.className = 'vip-research-panel';
+    wrap.setAttribute('role', 'region');
+    wrap.setAttribute('aria-label', 'Research mode');
+    wrap.innerHTML = [
+      '<div class="vip-research-head">',
+      '  <strong>Research Mode</strong>',
+      '  <span id="vipOrtPill" class="vip-ort-pill" data-state="unknown">ORT idle</span>',
+      '</div>',
+      '<p class="vip-research-hint">Logs models, FFT/hop, slider snapshot, stage timings. Local JSON only — no network.</p>',
+      '<label class="vip-research-check"><input type="checkbox" id="vipResearchEnable" /> Enable research logging</label>',
+      '<label class="vip-research-check"><input type="checkbox" id="vipResearchDeterministic" /> Deterministic flags</label>',
+      '<div class="vip-research-actions">',
+      '  <button type="button" class="btn btn-outline" id="vipResearchExport">Export Session JSON</button>',
+      '  <button type="button" class="btn btn-outline" id="vipSchemaExport">Export Parameter Schema</button>',
+      '</div>',
+      '<div id="' + METRICS_ID + '" class="vip-bench-metrics" aria-live="polite">Bench idle</div>',
+    ].join('');
+    host.appendChild(wrap);
+    return wrap;
+  }
+
+  function injectStyles() {
+    if (document.getElementById('vip-research-css')) return;
+    const s = document.createElement('style');
+    s.id = 'vip-research-css';
+    s.textContent = [
+      '.vip-research-panel{margin:12px 0;padding:12px 14px;border:1px solid rgba(220,38,38,.22);border-radius:10px;',
+      'background:linear-gradient(165deg,rgba(220,38,38,.06),rgba(0,0,0,.25));}',
+      '.vip-research-head{display:flex;align-items:center;justify-content:space-between;gap:8px;margin-bottom:6px;}',
+      '.vip-research-head strong{font:600 11px/1 "JetBrains Mono",monospace;letter-spacing:.08em;text-transform:uppercase;color:#fca5a5;}',
+      '.vip-ort-pill{font:500 10px/1 "JetBrains Mono",monospace;padding:4px 8px;border-radius:999px;border:1px solid rgba(255,255,255,.12);}',
+      '.vip-ort-pill[data-state="webgpu"]{color:#86efac;border-color:rgba(34,197,94,.4);}',
+      '.vip-ort-pill[data-state="wasm"]{color:#fcd34d;border-color:rgba(234,179,8,.4);}',
+      '.vip-ort-pill[data-state="error"]{color:#fca5a5;border-color:rgba(239,68,68,.5);}',
+      '.vip-research-hint{margin:0 0 8px;font-size:12px;color:#9090a4;line-height:1.4;}',
+      '.vip-research-check{display:flex;align-items:center;gap:8px;font-size:12px;color:#c4c4d0;margin:4px 0;}',
+      '.vip-research-actions{display:flex;flex-wrap:wrap;gap:8px;margin-top:8px;}',
+      '.vip-bench-metrics{margin-top:10px;font:500 11px/1.4 "JetBrains Mono",monospace;color:#a3a3b8;}',
+    ].join('');
+    document.head.appendChild(s);
+  }
+
+  function downloadJson(obj, filename) {
+    const blob = new Blob([JSON.stringify(obj, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    a.rel = 'noopener';
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    setTimeout(() => URL.revokeObjectURL(url), 2000);
+  }
+
+  function collectVipParams() {
+    const p = (typeof window !== 'undefined' && window.VIP_PARAMS) ? window.VIP_PARAMS : {};
+    return { ...p };
+  }
+
+  async function boot() {
+    injectStyles();
+    ensurePanel();
+    const mods = await loadModules();
+    const { beginResearchSession, getActiveResearchSession, endResearchSession } = mods.research;
+    const { globalBenchmark } = mods.bench;
+    const { subscribeOrtStatus, formatOrtProviderLabel, probeWebGpuAvailable, getOrtStatus } = mods.ort;
+    const { PARAMETER_SCHEMA, snapshotParams } = mods.schema;
+
+    void probeWebGpuAvailable();
+
+    const pill = $('vipOrtPill');
+    const metrics = $(METRICS_ID);
+    const paintOrt = (s) => {
+      if (!pill) return;
+      pill.textContent = formatOrtProviderLabel(s);
+      pill.dataset.state = s.provider || 'unknown';
+    };
+    paintOrt(getOrtStatus());
+    subscribeOrtStatus((s) => {
+      paintOrt(s);
+      // Cockpit ORT + ML pills
+      const setPill = window._setVipEnginePill;
+      if (typeof setPill === 'function') {
+        if (s.provider === 'webgpu') {
+          setPill('engOrtPill', 'ready');
+          setPill('engMlPill', 'ready');
+        } else if (s.provider === 'wasm') {
+          setPill('engOrtPill', 'ready');
+          setPill('engMlPill', 'ready');
+        } else if (s.provider === 'probing') {
+          setPill('engOrtPill', 'loading');
+          setPill('engMlPill', 'loading');
+        } else if (s.provider === 'error') {
+          setPill('engOrtPill', 'error');
+          setPill('engMlPill', 'error');
+        }
+      }
+    });
+
+    const paintBench = () => {
+      if (metrics) metrics.textContent = globalBenchmark.formatStatusLine();
+    };
+    setInterval(paintBench, 1500);
+
+    window.addEventListener('vip:fileLoaded', (ev) => {
+      const enabled = $('vipResearchEnable')?.checked;
+      if (!enabled) return;
+      const name = ev.detail?.name || '';
+      beginResearchSession({
+        sourceName: name,
+        mode: 'creator',
+        params: collectVipParams(),
+        deterministic: Boolean($('vipResearchDeterministic')?.checked),
+        modelIds: ['bsrnn_vocals'],
+      }).mark('file_loaded', { name });
+      globalBenchmark.start('pipeline');
+    });
+
+    window.addEventListener('vip:processingDone', () => {
+      globalBenchmark.end('pipeline');
+      paintBench();
+      const sess = getActiveResearchSession();
+      if (sess) {
+        sess.setMetrics({
+          totalMs: globalBenchmark.summary().lastMs,
+        });
+        sess.updateParams(collectVipParams());
+        sess.mark('processing_done');
+        endResearchSession();
+      }
+    });
+
+    $('vipResearchExport')?.addEventListener('click', () => {
+      let sess = getActiveResearchSession();
+      if (!sess) {
+        sess = beginResearchSession({
+          sourceName: window._vipApp?._sourceName || '',
+          params: collectVipParams(),
+          deterministic: Boolean($('vipResearchDeterministic')?.checked),
+        });
+        sess.mark('manual_export');
+        endResearchSession();
+      }
+      sess.updateParams(collectVipParams());
+      sess.setMetrics({
+        totalMs: globalBenchmark.summary().lastMs,
+      });
+      sess.download();
+    });
+
+    $('vipSchemaExport')?.addEventListener('click', () => {
+      downloadJson({
+        schemaVersion: 1,
+        count: PARAMETER_SCHEMA.length,
+        parameters: PARAMETER_SCHEMA,
+        defaults: snapshotParams({}),
+      }, 'vip-parameter-schema.json');
+    });
+
+    console.info('[VIP] research-mode.js ready');
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => { boot().catch(console.warn); });
+  } else {
+    boot().catch(console.warn);
+  }
+})();

--- a/public/index.html
+++ b/public/index.html
@@ -65,6 +65,7 @@
           <span>Idle — choose a file to begin</span>
         </span>
         <span id="statusText" class="visually-hidden" aria-hidden="true">Idle — choose a file to begin</span>
+        <span id="ortProviderHint" class="ort-provider-hint" aria-live="polite">Inference: local ONNX</span>
       </div>
       <!--
         Realtime processing indicator. Powered by the VoiceIsolate Pro design-

--- a/public/landing.css
+++ b/public/landing.css
@@ -84,6 +84,22 @@
   --pulse-glow: 0 0 20px rgba(220, 38, 38, 0.35);
 }
 
+/* Consumer-mode ORT provider hint (Landing) */
+.ort-provider-hint {
+  margin-left: auto;
+  font: var(--fw-medium) var(--fs-2xs) / 1 var(--font-mono);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  white-space: nowrap;
+}
+.status-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
 /* ── Reset & Base ─────────────────────────────────────────────────────── */
 
 /* Ambient spectral aurora behind the app shell */

--- a/public/landing.js
+++ b/public/landing.js
@@ -583,6 +583,12 @@ function getWorker() {
         if (debugEnabled) {
           console.log('[VIP][landing] MLWorker ready (backend: ' + msg.backend + ')');
         }
+        // Provider status for research / UI (OrtStatus also updated in MLWorkerHost).
+        try {
+          const label = msg.backend === 'webgpu' ? 'WebGPU' : (msg.backend || 'WASM');
+          const el = document.getElementById('ortProviderHint');
+          if (el) el.textContent = `Inference: ${label} (local)`;
+        } catch (_) { /* ignore */ }
         warmupWorkerModels(DEFAULT_WARMUP_CHAIN).catch(() => {});
         break;
       }

--- a/src/core/OrtStatus.js
+++ b/src/core/OrtStatus.js
@@ -1,0 +1,141 @@
+/**
+ * VoiceIsolate Pro — ONNX Runtime provider status (Layer 1: Core)
+ *
+ * Tracks WebGPU vs WASM execution provider for UI and research logs.
+ * Pure state holder — workers post updates via setOrtStatus().
+ */
+'use strict';
+
+/** @typedef {'unknown'|'probing'|'webgpu'|'wasm'|'error'} OrtProviderState */
+
+/**
+ * @typedef {object} OrtStatusSnapshot
+ * @property {OrtProviderState} provider
+ * @property {string|null} detail
+ * @property {number} updatedAt
+ * @property {string[]} modelsLoaded
+ * @property {boolean} webgpuAvailable
+ */
+
+/** @type {OrtStatusSnapshot} */
+let _status = {
+  provider: 'unknown',
+  detail: null,
+  updatedAt: 0,
+  modelsLoaded: [],
+  webgpuAvailable: false,
+};
+
+/** @type {Set<(s: OrtStatusSnapshot) => void>} */
+const _listeners = new Set();
+
+/**
+ * @returns {OrtStatusSnapshot}
+ */
+export function getOrtStatus() {
+  return {
+    ..._status,
+    modelsLoaded: [..._status.modelsLoaded],
+  };
+}
+
+/**
+ * @param {Partial<OrtStatusSnapshot>} patch
+ */
+export function setOrtStatus(patch = {}) {
+  _status = {
+    ..._status,
+    ...patch,
+    modelsLoaded: patch.modelsLoaded
+      ? [...patch.modelsLoaded]
+      : _status.modelsLoaded,
+    updatedAt: Date.now(),
+  };
+  const snap = getOrtStatus();
+  for (const fn of _listeners) {
+    try { fn(snap); } catch { /* ignore listener errors */ }
+  }
+  if (typeof globalThis !== 'undefined') {
+    globalThis.__vipOrtStatus = snap;
+  }
+  return snap;
+}
+
+/**
+ * @param {(s: OrtStatusSnapshot) => void} fn
+ * @returns {() => void}
+ */
+export function subscribeOrtStatus(fn) {
+  if (typeof fn !== 'function') return () => {};
+  _listeners.add(fn);
+  return () => _listeners.delete(fn);
+}
+
+/**
+ * Human-readable label for UI pills.
+ * @param {OrtStatusSnapshot} [s]
+ * @returns {string}
+ */
+export function formatOrtProviderLabel(s = getOrtStatus()) {
+  switch (s.provider) {
+    case 'webgpu': return 'WebGPU active';
+    case 'wasm': return 'WASM fallback';
+    case 'probing': return 'Probing GPU…';
+    case 'error': return s.detail ? `ORT error: ${s.detail}` : 'ORT error';
+    default: return 'ORT idle';
+  }
+}
+
+/**
+ * Probe WebGPU availability on the main thread (does not init ORT).
+ * @returns {Promise<boolean>}
+ */
+export async function probeWebGpuAvailable() {
+  try {
+    const gpu = globalThis.navigator?.gpu;
+    if (!gpu?.requestAdapter) {
+      setOrtStatus({ webgpuAvailable: false });
+      return false;
+    }
+    const adapter = await gpu.requestAdapter();
+    const ok = Boolean(adapter);
+    setOrtStatus({ webgpuAvailable: ok });
+    return ok;
+  } catch {
+    setOrtStatus({ webgpuAvailable: false });
+    return false;
+  }
+}
+
+/**
+ * Apply MLWorker `ready` / `error` / `warmed` messages.
+ * @param {object} msg
+ */
+export function applyMlWorkerMessage(msg = {}) {
+  if (msg.type === 'ready') {
+    const backend = String(msg.backend || '').toLowerCase();
+    setOrtStatus({
+      provider: backend === 'webgpu' ? 'webgpu' : backend === 'wasm' ? 'wasm' : 'unknown',
+      detail: null,
+      webgpuAvailable: backend === 'webgpu' || _status.webgpuAvailable,
+    });
+    return;
+  }
+  if (msg.type === 'warmed' && Array.isArray(msg.modelIds)) {
+    const set = new Set([..._status.modelsLoaded, ...msg.modelIds]);
+    setOrtStatus({ modelsLoaded: [...set] });
+    return;
+  }
+  if (msg.type === 'error' && msg.message) {
+    setOrtStatus({ provider: 'error', detail: String(msg.message).slice(0, 200) });
+  }
+}
+
+export default {
+  getOrtStatus,
+  setOrtStatus,
+  subscribeOrtStatus,
+  formatOrtProviderLabel,
+  probeWebGpuAvailable,
+  applyMlWorkerMessage,
+};

--- a/src/core/ParameterSchema.js
+++ b/src/core/ParameterSchema.js
@@ -1,0 +1,184 @@
+/**
+ * VoiceIsolate Pro — Typed Engineer Parameter Schema (Layer 1: Core)
+ *
+ * Maps Engineer Mode slider IDs to DSP / ML roles for UI tooltips, research
+ * export, and preset validation. Pure data — no DOM, no Web Audio.
+ *
+ * rt:true  → may drive PlaybackMixer / worklet AudioParams during Live-Mix.
+ * rt:false → offline / reprocess-only (spectral, multi-pass, model selection).
+ */
+'use strict';
+
+/**
+ * @typedef {'gate'|'nr'|'eq'|'dynamics'|'filter'|'deess'|'spatial'|'isolation'|'output'|'whisper'|'meta'} ParamCategory
+ * @typedef {'audioParam'|'portMessage'|'offlineOnly'|'display'} ControlPath
+ *
+ * @typedef {object} ParamSpec
+ * @property {string} id
+ * @property {string} label
+ * @property {ParamCategory} category
+ * @property {number} min
+ * @property {number} max
+ * @property {number} default
+ * @property {number} [step]
+ * @property {string} unit
+ * @property {boolean} rt
+ * @property {ControlPath} path
+ * @property {string} effect  Short academic/UI description of perceptual effect
+ * @property {string} [workletParam]
+ */
+
+/** @type {readonly ParamSpec[]} */
+export const PARAMETER_SCHEMA = Object.freeze([
+  // ── Gate ──────────────────────────────────────────────────────────────
+  { id: 'gateThresh', label: 'Gate Threshold', category: 'gate', min: -100, max: 0, default: -42, step: 1, unit: 'dB', rt: true, path: 'audioParam', effect: 'Level below which the gate closes. Raise to cut more residual noise between phrases; lower to preserve quiet speech.', workletParam: 'threshold' },
+  { id: 'gateRange', label: 'Gate Range', category: 'gate', min: -80, max: -5, default: -60, step: 1, unit: 'dB', rt: true, path: 'audioParam', effect: 'Attenuation depth when the gate is closed (UI negative dB; mixer uses positive depth).', workletParam: 'range' },
+  { id: 'gateAttack', label: 'Gate Attack', category: 'gate', min: 0, max: 100, default: 5, step: 1, unit: 'ms', rt: true, path: 'audioParam', effect: 'How fast the gate opens when speech exceeds threshold.', workletParam: 'attack' },
+  { id: 'gateRelease', label: 'Gate Release', category: 'gate', min: 50, max: 2000, default: 200, step: 10, unit: 'ms', rt: true, path: 'audioParam', effect: 'How fast the gate closes after speech falls below threshold.', workletParam: 'release' },
+  { id: 'gateHold', label: 'Gate Hold', category: 'gate', min: 0, max: 500, default: 50, step: 5, unit: 'ms', rt: true, path: 'audioParam', effect: 'Minimum open time to reduce chattering on breathy speech.', workletParam: 'hold' },
+  { id: 'gateLookahead', label: 'Gate Lookahead', category: 'gate', min: 0, max: 20, default: 5, step: 1, unit: 'ms', rt: false, path: 'offlineOnly', effect: 'Offline gate anticipatory delay; not applied in live worklet path.' },
+
+  // ── Noise reduction (offline spectral) ────────────────────────────────
+  { id: 'nrAmount', label: 'NR Amount', category: 'nr', min: 0, max: 100, default: 70, step: 1, unit: '%', rt: false, path: 'offlineOnly', effect: 'Spectral noise reduction strength (Wiener / subtraction). Higher = cleaner but more artifacts.' },
+  { id: 'nrSensitivity', label: 'NR Sensitivity', category: 'nr', min: 0, max: 100, default: 55, step: 1, unit: '%', rt: false, path: 'offlineOnly', effect: 'How aggressively noise PSD is tracked vs speech.' },
+  { id: 'nrSpectralSub', label: 'Spectral Subtraction', category: 'nr', min: 0, max: 100, default: 50, step: 1, unit: '%', rt: false, path: 'offlineOnly', effect: 'Oversubtraction factor for steady-state noise.' },
+  { id: 'nrFloor', label: 'NR Floor', category: 'nr', min: -96, max: -20, default: -72, step: 1, unit: 'dB', rt: false, path: 'offlineOnly', effect: 'Minimum residual noise floor after NR.' },
+  { id: 'nrSmoothing', label: 'NR Smoothing', category: 'nr', min: 0, max: 100, default: 65, step: 1, unit: '%', rt: false, path: 'offlineOnly', effect: 'Temporal smoothing of spectral gain to reduce musical noise.' },
+
+  // ── EQ ────────────────────────────────────────────────────────────────
+  { id: 'eqSub', label: 'EQ Sub', category: 'eq', min: -24, max: 24, default: 0, step: 0.5, unit: 'dB', rt: true, path: 'audioParam', effect: 'Sub-bass shelf gain on the live-mix bus.' },
+  { id: 'eqBass', label: 'EQ Bass', category: 'eq', min: -24, max: 24, default: 0, step: 0.5, unit: 'dB', rt: true, path: 'audioParam', effect: 'Low-band graphic EQ.' },
+  { id: 'eqWarmth', label: 'EQ Warmth', category: 'eq', min: -24, max: 24, default: 0, step: 0.5, unit: 'dB', rt: true, path: 'audioParam', effect: 'Low-mid warmth band.' },
+  { id: 'eqBody', label: 'EQ Body', category: 'eq', min: -24, max: 24, default: 0, step: 0.5, unit: 'dB', rt: true, path: 'audioParam', effect: 'Speech body / chest resonance band.' },
+  { id: 'eqLowMid', label: 'EQ Low-Mid', category: 'eq', min: -24, max: 24, default: 0, step: 0.5, unit: 'dB', rt: true, path: 'audioParam', effect: 'Mud-control low-mid peaking band.' },
+  { id: 'eqMid', label: 'EQ Mid', category: 'eq', min: -24, max: 24, default: 0, step: 0.5, unit: 'dB', rt: true, path: 'audioParam', effect: 'Primary speech intelligibility mid band.' },
+  { id: 'eqPresence', label: 'EQ Presence', category: 'eq', min: -24, max: 24, default: 0, step: 0.5, unit: 'dB', rt: true, path: 'audioParam', effect: 'Presence / consonant clarity.' },
+  { id: 'eqClarity', label: 'EQ Clarity', category: 'eq', min: -24, max: 24, default: 0, step: 0.5, unit: 'dB', rt: true, path: 'audioParam', effect: 'Upper presence / sibilance region balance.' },
+  { id: 'eqAir', label: 'EQ Air', category: 'eq', min: -24, max: 24, default: 0, step: 0.5, unit: 'dB', rt: true, path: 'audioParam', effect: 'High-shelf air / brilliance.' },
+  { id: 'eqBrill', label: 'EQ Brilliance', category: 'eq', min: -24, max: 24, default: 0, step: 0.5, unit: 'dB', rt: true, path: 'audioParam', effect: 'Extreme high-shelf polish.' },
+
+  // ── Dynamics ──────────────────────────────────────────────────────────
+  { id: 'compThresh', label: 'Comp Threshold', category: 'dynamics', min: -60, max: 0, default: -24, step: 1, unit: 'dB', rt: true, path: 'audioParam', effect: 'Compressor onset level.' },
+  { id: 'compRatio', label: 'Comp Ratio', category: 'dynamics', min: 1, max: 20, default: 4, step: 0.1, unit: ':1', rt: true, path: 'audioParam', effect: 'Compression ratio above threshold.' },
+  { id: 'compAttack', label: 'Comp Attack', category: 'dynamics', min: 0, max: 100, default: 10, step: 1, unit: 'ms', rt: true, path: 'audioParam', effect: 'Compressor attack time.' },
+  { id: 'compRelease', label: 'Comp Release', category: 'dynamics', min: 20, max: 1000, default: 150, step: 10, unit: 'ms', rt: true, path: 'audioParam', effect: 'Compressor release time.' },
+  { id: 'compKnee', label: 'Comp Knee', category: 'dynamics', min: 0, max: 40, default: 6, step: 1, unit: 'dB', rt: true, path: 'audioParam', effect: 'Soft-knee width.' },
+  { id: 'compMakeup', label: 'Makeup Gain', category: 'dynamics', min: 0, max: 24, default: 0, step: 0.5, unit: 'dB', rt: true, path: 'audioParam', effect: 'Post-compressor makeup.' },
+  { id: 'limThresh', label: 'Limiter Threshold', category: 'dynamics', min: -12, max: 0, default: -1, step: 0.1, unit: 'dB', rt: true, path: 'audioParam', effect: 'Brickwall limiter ceiling.' },
+  { id: 'limRelease', label: 'Limiter Release', category: 'dynamics', min: 10, max: 500, default: 50, step: 5, unit: 'ms', rt: true, path: 'audioParam', effect: 'Limiter recovery time.' },
+
+  // ── Filters ───────────────────────────────────────────────────────────
+  { id: 'hpFreq', label: 'Highpass', category: 'filter', min: 20, max: 500, default: 80, step: 1, unit: 'Hz', rt: true, path: 'audioParam', effect: 'Removes rumble / subsonic energy below cutoff.' },
+  { id: 'hpQ', label: 'HP Q', category: 'filter', min: 0.1, max: 4, default: 0.7, step: 0.05, unit: '', rt: true, path: 'audioParam', effect: 'Highpass resonance / slope character.' },
+  { id: 'lpFreq', label: 'Lowpass', category: 'filter', min: 2000, max: 20000, default: 16000, step: 10, unit: 'Hz', rt: true, path: 'audioParam', effect: 'Removes hiss / extreme highs above cutoff.' },
+  { id: 'lpQ', label: 'LP Q', category: 'filter', min: 0.1, max: 4, default: 0.7, step: 0.05, unit: '', rt: true, path: 'audioParam', effect: 'Lowpass resonance.' },
+
+  // ── De-esser ──────────────────────────────────────────────────────────
+  { id: 'deEssFreq', label: 'De-Ess Freq', category: 'deess', min: 2000, max: 12000, default: 6000, step: 50, unit: 'Hz', rt: true, path: 'audioParam', effect: 'Sibilance detection band center.', workletParam: 'frequency' },
+  { id: 'deEssAmt', label: 'De-Ess Amount', category: 'deess', min: 0, max: 30, default: 0, step: 0.5, unit: 'dB', rt: true, path: 'audioParam', effect: 'Sibilance reduction depth (legacy dB scale mapped to worklet 0–1).', workletParam: 'amount' },
+
+  // ── Spectral offline ──────────────────────────────────────────────────
+  { id: 'specTilt', label: 'Spectral Tilt', category: 'nr', min: -6, max: 6, default: 0, step: 0.1, unit: 'dB', rt: true, path: 'audioParam', effect: 'Brighten (+) or darken (−) around 1 kHz pivot on the live bus.' },
+  { id: 'formantShift', label: 'Formant Shift', category: 'isolation', min: -12, max: 12, default: 0, step: 0.5, unit: 'st', rt: false, path: 'offlineOnly', effect: 'Offline formant relocation (semitones). Use sparingly.' },
+  { id: 'derevAmt', label: 'Dereverb Amount', category: 'nr', min: 0, max: 100, default: 0, step: 1, unit: '%', rt: false, path: 'offlineOnly', effect: 'Spectral tail subtraction strength.' },
+  { id: 'derevDecay', label: 'Dereverb Decay', category: 'nr', min: 0, max: 100, default: 40, step: 1, unit: '%', rt: false, path: 'offlineOnly', effect: 'Assumed RT60 scale for tail model.' },
+  { id: 'harmRecov', label: 'Harmonic Recovery', category: 'isolation', min: 0, max: 100, default: 0, step: 1, unit: '%', rt: false, path: 'offlineOnly', effect: 'Boosts harmonic structure of voiced speech after isolation.' },
+  { id: 'harmOrder', label: 'Harmonic Order', category: 'isolation', min: 1, max: 8, default: 3, step: 1, unit: '', rt: false, path: 'offlineOnly', effect: 'Number of harmonics reinforced by recovery.' },
+
+  // ── Spatial ───────────────────────────────────────────────────────────
+  { id: 'stereoWidth', label: 'Stereo Width', category: 'spatial', min: 0, max: 200, default: 100, step: 1, unit: '%', rt: true, path: 'audioParam', effect: 'Mid/side width of the live mix.' },
+  { id: 'phaseCorr', label: 'Phase Correction', category: 'spatial', min: 0, max: 100, default: 0, step: 1, unit: '%', rt: false, path: 'offlineOnly', effect: 'Offline inter-channel phase alignment.' },
+
+  // ── Isolation ─────────────────────────────────────────────────────────
+  { id: 'voiceIso', label: 'Voice Isolation', category: 'isolation', min: 0, max: 100, default: 80, step: 1, unit: '%', rt: false, path: 'offlineOnly', effect: 'How strongly non-voice residual is suppressed in offline path.' },
+  { id: 'bgSuppress', label: 'Background Suppress', category: 'isolation', min: 0, max: 100, default: 55, step: 1, unit: '%', rt: false, path: 'offlineOnly', effect: 'Companion background ducking depth.' },
+  { id: 'voiceFocusLo', label: 'Voice Focus Lo', category: 'isolation', min: 40, max: 400, default: 120, step: 1, unit: 'Hz', rt: false, path: 'offlineOnly', effect: 'Lower edge of offline voice focus band.' },
+  { id: 'voiceFocusHi', label: 'Voice Focus Hi', category: 'isolation', min: 2000, max: 10000, default: 4000, step: 10, unit: 'Hz', rt: false, path: 'offlineOnly', effect: 'Upper edge of offline voice focus band.' },
+  { id: 'crosstalkCancel', label: 'Crosstalk Cancel', category: 'isolation', min: 0, max: 100, default: 0, step: 1, unit: '%', rt: false, path: 'offlineOnly', effect: 'Stereo channel bleed reduction (skipped on mid-only path).' },
+
+  // ── Output ────────────────────────────────────────────────────────────
+  { id: 'outGain', label: 'Output Gain', category: 'output', min: -24, max: 24, default: 0, step: 0.5, unit: 'dB', rt: true, path: 'audioParam', effect: 'Post-chain trim.' },
+  { id: 'dryWet', label: 'Dry/Wet', category: 'output', min: 0, max: 100, default: 100, step: 1, unit: '%', rt: true, path: 'audioParam', effect: 'Blend unprocessed vs processed bus.' },
+  { id: 'ditherAmt', label: 'Dither', category: 'output', min: 0, max: 2, default: 1, step: 1, unit: '', rt: false, path: 'offlineOnly', effect: 'Export dither intensity for 16-bit targets.' },
+  { id: 'outWidth', label: 'Out Width', category: 'output', min: 0, max: 200, default: 100, step: 1, unit: '%', rt: true, path: 'audioParam', effect: 'Final stereo width scale.' },
+
+  // ── Whisper / extreme ─────────────────────────────────────────────────
+  { id: 'whisperLift', label: 'Whisper Lift', category: 'whisper', min: 0, max: 40, default: 0, step: 1, unit: 'dB', rt: true, path: 'portMessage', effect: 'Post-mask gain where voice confidence is high. Raise for buried whispers.' },
+  { id: 'crowdNull', label: 'Crowd Null', category: 'whisper', min: 0, max: 100, default: 0, step: 1, unit: '%', rt: false, path: 'offlineOnly', effect: 'Targets 200–2500 Hz crowd murmur (extreme path).' },
+  { id: 'bassCrush', label: 'Bass Crush', category: 'whisper', min: 0, max: 100, default: 0, step: 1, unit: '%', rt: true, path: 'portMessage', effect: 'Attenuates sub/kick that mask whisper formants.' },
+  { id: 'reverbStrip', label: 'Reverb Strip', category: 'whisper', min: 0, max: 2000, default: 0, step: 10, unit: 'ms', rt: false, path: 'offlineOnly', effect: 'Extreme RT60-style spectral dereverb.' },
+  { id: 'voiceTunnel', label: 'Voice Tunnel', category: 'whisper', min: 0, max: 100, default: 0, step: 1, unit: '%', rt: true, path: 'portMessage', effect: 'Narrow formant-band emphasis for intelligibility.' },
+  { id: 'musicKill', label: 'Music Kill', category: 'whisper', min: 0, max: 100, default: 0, step: 1, unit: '%', rt: false, path: 'offlineOnly', effect: 'Suppresses steady harmonic music under speech.' },
+  { id: 'snrFloor', label: 'SNR Floor', category: 'whisper', min: -80, max: -20, default: -52, step: 1, unit: 'dBFS', rt: false, path: 'offlineOnly', effect: 'Bins below this power treated as noise-only in extreme isolation.' },
+  { id: 'whisperMode', label: 'Whisper Mode', category: 'whisper', min: 0, max: 3, default: 0, step: 1, unit: '', rt: false, path: 'offlineOnly', effect: '0=Off, 1=Light, 2=Heavy, 3=Forensic multi-pass aggression.' },
+  { id: 'whisperClarity', label: 'Whisper Clarity', category: 'whisper', min: 0, max: 100, default: 65, step: 1, unit: '%', rt: true, path: 'portMessage', effect: 'Minimum gain floor / clarity for WhisperHunter.' },
+  { id: 'whisperSensitivity', label: 'Whisper Sensitivity', category: 'whisper', min: 0, max: 100, default: 55, step: 1, unit: '%', rt: true, path: 'portMessage', effect: 'VAD energy sensitivity for quiet speech.' },
+  { id: 'whisperThreshold', label: 'Whisper Threshold', category: 'whisper', min: 0, max: 100, default: 50, step: 1, unit: '%', rt: true, path: 'portMessage', effect: 'Suppression curve steepness for WhisperHunter.' },
+  { id: 'transientShaper', label: 'Transient Shaper', category: 'whisper', min: -100, max: 100, default: 0, step: 5, unit: '', rt: true, path: 'portMessage', effect: 'Bipolar consonant transient emphasis.' },
+  { id: 'breathControl', label: 'Breath Control', category: 'whisper', min: 0, max: 100, default: 0, step: 1, unit: '%', rt: false, path: 'offlineOnly', effect: 'Attenuates breath noise between phrases.' },
+  { id: 'roomCorrection', label: 'Room Correction', category: 'whisper', min: 0, max: 100, default: 0, step: 1, unit: '%', rt: false, path: 'offlineOnly', effect: 'Adds to dereverb for room tails.' },
+  { id: 'subHarmonic', label: 'Sub Harmonic', category: 'whisper', min: 0, max: 100, default: 0, step: 1, unit: '%', rt: true, path: 'portMessage', effect: 'Restores low-frequency body under thin whispers.' },
+]);
+
+/** @type {ReadonlyMap<string, ParamSpec>} */
+export const PARAMETER_BY_ID = Object.freeze(
+  new Map(PARAMETER_SCHEMA.map((p) => [p.id, p]))
+);
+
+/**
+ * @param {string} id
+ * @returns {ParamSpec|undefined}
+ */
+export function getParamSpec(id) {
+  return PARAMETER_BY_ID.get(id);
+}
+
+/**
+ * @param {ParamCategory} category
+ * @returns {ParamSpec[]}
+ */
+export function paramsByCategory(category) {
+  return PARAMETER_SCHEMA.filter((p) => p.category === category);
+}
+
+/** Real-time Live-Mix eligible parameter ids. */
+export function realtimeParamIds() {
+  return PARAMETER_SCHEMA.filter((p) => p.rt).map((p) => p.id);
+}
+
+/**
+ * Clamp a value to the schema range for an id.
+ * @param {string} id
+ * @param {number} value
+ * @returns {number}
+ */
+export function clampParam(id, value) {
+  const spec = PARAMETER_BY_ID.get(id);
+  const v = Number(value);
+  if (!spec || !Number.isFinite(v)) return spec ? spec.default : 0;
+  return Math.min(spec.max, Math.max(spec.min, v));
+}
+
+/**
+ * Snapshot current params for research export.
+ * @param {Record<string, number>} values
+ * @returns {object}
+ */
+export function snapshotParams(values = {}) {
+  const out = {};
+  for (const spec of PARAMETER_SCHEMA) {
+    const raw = values[spec.id];
+    out[spec.id] = Number.isFinite(Number(raw)) ? Number(raw) : spec.default;
+  }
+  return out;
+}
+
+export default {
+  PARAMETER_SCHEMA,
+  PARAMETER_BY_ID,
+  getParamSpec,
+  paramsByCategory,
+  realtimeParamIds,
+  clampParam,
+  snapshotParams,
+};

--- a/src/core/ResearchSession.js
+++ b/src/core/ResearchSession.js
@@ -1,0 +1,220 @@
+/**
+ * VoiceIsolate Pro — Research Session Logger (Layer 1: Core)
+ *
+ * Captures reproducible experiment metadata: models, FFT/hop, params,
+ * stage timings, provider. Pure module; export is JSON Blob for download.
+ *
+ * Constraints:
+ *  - Never sends data over the network.
+ *  - No audio bytes stored unless caller explicitly attaches references.
+ */
+'use strict';
+
+import { snapshotParams } from './ParameterSchema.js';
+import { getOrtStatus } from './OrtStatus.js';
+import {
+  QUANTUM,
+  FFT_SIZE_LIVE,
+  FFT_SIZE_CREATOR,
+  HOP_SIZE,
+  MASK_FLOOR_DB,
+} from './ring-buffer-constants.js';
+
+let _seq = 0;
+
+/**
+ * @typedef {object} ResearchStageEvent
+ * @property {string} stage
+ * @property {number} t
+ * @property {number} [ms]
+ * @property {Record<string, unknown>} [meta]
+ */
+
+/**
+ * @typedef {object} ResearchSessionConfig
+ * @property {string} [sourceName]
+ * @property {string[]} [modelIds]
+ * @property {string} [preset]
+ * @property {string} [mode] live|creator|forensic
+ * @property {number} [fftSize]
+ * @property {number} [hopSize]
+ * @property {number} [sampleRate]
+ * @property {Record<string, number>} [params]
+ * @property {boolean} [deterministic]
+ */
+
+export class ResearchSession {
+  /**
+   * @param {ResearchSessionConfig} [config]
+   */
+  constructor(config = {}) {
+    this.id = `vip-rs-${Date.now().toString(36)}-${(++_seq).toString(36)}`;
+    this.startedAt = new Date().toISOString();
+    this.endedAt = null;
+    this.config = {
+      sourceName: config.sourceName || '',
+      modelIds: Array.isArray(config.modelIds) ? [...config.modelIds] : [],
+      preset: config.preset || null,
+      mode: config.mode || 'creator',
+      fftSize: config.fftSize || FFT_SIZE_CREATOR,
+      hopSize: config.hopSize || HOP_SIZE,
+      sampleRate: config.sampleRate || 48000,
+      params: snapshotParams(config.params || {}),
+      deterministic: Boolean(config.deterministic),
+      quantum: QUANTUM,
+      maskFloorDb: MASK_FLOOR_DB,
+      fftSizeLive: FFT_SIZE_LIVE,
+      singlePassSpectral: true,
+      architecture: 'stem-split-live-mix',
+      architectureDoc: 'docs/VoiceIsolate_Pro_Architecture_v26.md',
+    };
+    /** @type {ResearchStageEvent[]} */
+    this.stages = [];
+    /** @type {object[]} */
+    this.notes = [];
+    this._t0 = (typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now();
+    this.metrics = {
+      decodeMs: null,
+      mlMs: null,
+      dspMs: null,
+      totalMs: null,
+      provider: getOrtStatus().provider,
+    };
+  }
+
+  /**
+   * @param {string} stage
+   * @param {Record<string, unknown>} [meta]
+   */
+  mark(stage, meta = {}) {
+    const now = (typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now();
+    const last = this.stages[this.stages.length - 1];
+    const ms = last ? now - (this._t0 + last.t) : now - this._t0;
+    // Store relative time from session start
+    this.stages.push({
+      stage: String(stage),
+      t: now - this._t0,
+      ms: Math.max(0, ms),
+      meta: { ...meta },
+    });
+    return this;
+  }
+
+  /**
+   * @param {Partial<typeof this.metrics>} patch
+   */
+  setMetrics(patch = {}) {
+    Object.assign(this.metrics, patch);
+    this.metrics.provider = getOrtStatus().provider;
+    return this;
+  }
+
+  /**
+   * @param {Record<string, number>} params
+   */
+  updateParams(params) {
+    this.config.params = snapshotParams(params || {});
+    return this;
+  }
+
+  /**
+   * @param {string} text
+   */
+  note(text) {
+    this.notes.push({ t: Date.now(), text: String(text) });
+    return this;
+  }
+
+  finish() {
+    this.endedAt = new Date().toISOString();
+    const now = (typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now();
+    this.metrics.totalMs = now - this._t0;
+    this.metrics.provider = getOrtStatus().provider;
+    return this;
+  }
+
+  /**
+   * @returns {object}
+   */
+  toJSON() {
+    if (!this.endedAt) this.finish();
+    return {
+      schemaVersion: 1,
+      id: this.id,
+      startedAt: this.startedAt,
+      endedAt: this.endedAt,
+      config: this.config,
+      stages: this.stages,
+      metrics: this.metrics,
+      notes: this.notes,
+      ort: getOrtStatus(),
+      reproducibility: {
+        singlePassStft: true,
+        localOnly: true,
+        noCloudInference: true,
+        seedPolicy: this.config.deterministic
+          ? 'deterministic-flags-on (no DSP RNG)'
+          : 'best-effort floating-point',
+      },
+    };
+  }
+
+  /**
+   * @returns {Blob}
+   */
+  toBlob() {
+    const json = JSON.stringify(this.toJSON(), null, 2);
+    return new Blob([json], { type: 'application/json' });
+  }
+
+  /**
+   * Trigger a browser download of the session JSON.
+   * @param {string} [filename]
+   */
+  download(filename) {
+    const blob = this.toBlob();
+    const name = filename || `${this.id}.json`;
+    if (typeof document === 'undefined') return blob;
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = name;
+    a.rel = 'noopener';
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    setTimeout(() => URL.revokeObjectURL(url), 2000);
+    return blob;
+  }
+}
+
+/** @type {ResearchSession|null} */
+let _active = null;
+
+/**
+ * @param {ResearchSessionConfig} [config]
+ * @returns {ResearchSession}
+ */
+export function beginResearchSession(config) {
+  _active = new ResearchSession(config);
+  if (typeof globalThis !== 'undefined') globalThis.__vipResearchSession = _active;
+  return _active;
+}
+
+/** @returns {ResearchSession|null} */
+export function getActiveResearchSession() {
+  return _active;
+}
+
+/** @returns {ResearchSession|null} */
+export function endResearchSession() {
+  if (_active) _active.finish();
+  return _active;
+}
+
+export default {
+  ResearchSession,
+  beginResearchSession,
+  getActiveResearchSession,
+  endResearchSession,
+};

--- a/src/pipeline/BenchmarkHarness.js
+++ b/src/pipeline/BenchmarkHarness.js
@@ -1,0 +1,112 @@
+/**
+ * VoiceIsolate Pro — Benchmark Harness (Layer 3: Pipeline)
+ *
+ * Aggregates PipelineTiming stages + wall-clock measurements for UI and
+ * research export. No network; pure in-process metrics.
+ */
+'use strict';
+
+import { getTimings } from './PipelineTiming.js';
+import { getOrtStatus, formatOrtProviderLabel } from '../core/OrtStatus.js';
+
+/**
+ * @typedef {object} BenchmarkSample
+ * @property {number} t
+ * @property {string} label
+ * @property {number} ms
+ * @property {Record<string, number>} [stages]
+ */
+
+export class BenchmarkHarness {
+  constructor() {
+    /** @type {BenchmarkSample[]} */
+    this.samples = [];
+    this._marks = new Map();
+  }
+
+  /**
+   * @param {string} label
+   */
+  start(label) {
+    const key = String(label || 'job');
+    const t0 = (typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now();
+    this._marks.set(key, t0);
+    return this;
+  }
+
+  /**
+   * @param {string} label
+   * @returns {BenchmarkSample|null}
+   */
+  end(label) {
+    const key = String(label || 'job');
+    const t0 = this._marks.get(key);
+    if (t0 == null) return null;
+    this._marks.delete(key);
+    const t1 = (typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now();
+    const ms = Math.max(0, t1 - t0);
+    const stages = getTimings() || {};
+    const sample = {
+      t: Date.now(),
+      label: key,
+      ms,
+      stages: { ...stages },
+    };
+    this.samples.push(sample);
+    if (this.samples.length > 50) this.samples.shift();
+    if (typeof globalThis !== 'undefined') {
+      globalThis.__vipLastBenchmark = sample;
+    }
+    return sample;
+  }
+
+  /**
+   * Summary for UI strip.
+   * @returns {object}
+   */
+  summary() {
+    const n = this.samples.length;
+    const last = n ? this.samples[n - 1] : null;
+    const avg = n
+      ? this.samples.reduce((s, x) => s + x.ms, 0) / n
+      : 0;
+    return {
+      sampleCount: n,
+      lastMs: last?.ms ?? null,
+      lastLabel: last?.label ?? null,
+      avgMs: avg,
+      lastStages: last?.stages || {},
+      liveTimings: getTimings(),
+      ort: getOrtStatus(),
+      ortLabel: formatOrtProviderLabel(),
+    };
+  }
+
+  /**
+   * Human-readable one-liner for status bars.
+   * @returns {string}
+   */
+  formatStatusLine() {
+    const s = this.summary();
+    if (!s.lastMs && s.lastMs !== 0) return `Bench idle · ${s.ortLabel}`;
+    const stages = s.lastStages || {};
+    const decode = stages.decode != null ? ` decode ${Math.round(stages.decode)}ms` : '';
+    const ml = stages.ml_isolation != null ? ` ml ${Math.round(stages.ml_isolation)}ms` : '';
+    const iso = stages.isolate != null ? ` iso ${Math.round(stages.isolate)}ms` : '';
+    return `${s.lastLabel || 'job'}: ${Math.round(s.lastMs)}ms${decode}${ml}${iso} · ${s.ortLabel}`;
+  }
+
+  clear() {
+    this.samples.length = 0;
+    this._marks.clear();
+  }
+}
+
+/** Shared singleton for Engineer / Landing. */
+export const globalBenchmark = new BenchmarkHarness();
+
+if (typeof globalThis !== 'undefined') {
+  globalThis.__vipBenchmark = globalBenchmark;
+}
+
+export default BenchmarkHarness;

--- a/src/pipeline/MLWorkerHost.js
+++ b/src/pipeline/MLWorkerHost.js
@@ -7,6 +7,7 @@
 
 import { MODEL_MANIFEST } from '../core/ModelManifest.js';
 import { attachMLWorkerModelCache } from '../core/ModelCacheBridge.js';
+import { applyMlWorkerMessage, setOrtStatus } from '../core/OrtStatus.js';
 
 /**
  * @returns {Worker}
@@ -14,6 +15,10 @@ import { attachMLWorkerModelCache } from '../core/ModelCacheBridge.js';
 export function createMLWorker() {
   const worker = new Worker('/src/workers/MLWorker.js');
   attachMLWorkerModelCache(worker);
+  setOrtStatus({ provider: 'probing', detail: null });
+  worker.addEventListener('message', (ev) => {
+    applyMlWorkerMessage(ev.data || {});
+  });
   return worker;
 }
 

--- a/tests/architecture-v26.test.js
+++ b/tests/architecture-v26.test.js
@@ -1,0 +1,102 @@
+/**
+ * Architecture v26 modules — research, schema, ORT status, benchmarks.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+
+describe('Architecture v26 documentation', () => {
+  test('architecture summary exists', () => {
+    const p = path.join(ROOT, 'docs/VoiceIsolate_Pro_Architecture_v26.md');
+    expect(fs.existsSync(p)).toBe(true);
+    const text = fs.readFileSync(p, 'utf8');
+    expect(text).toContain('Stem-Split');
+    expect(text).toMatch(/single STFT|Single STFT|one forward STFT/i);
+    expect(text).toContain('WebGPU');
+    expect(text).toContain('100% local');
+  });
+
+  test('technical whitepaper exists', () => {
+    const p = path.join(ROOT, 'docs/VoiceIsolate_Pro_Technical_Whitepaper.md');
+    expect(fs.existsSync(p)).toBe(true);
+    const text = fs.readFileSync(p, 'utf8');
+    expect(text).toContain('Live-Mix');
+    expect(text).toContain('Research Mode');
+  });
+
+  test('docs README links architecture v26', () => {
+    const text = fs.readFileSync(path.join(ROOT, 'docs/README.md'), 'utf8');
+    expect(text).toContain('VoiceIsolate_Pro_Architecture_v26.md');
+    expect(text).toContain('VoiceIsolate_Pro_Technical_Whitepaper.md');
+  });
+});
+
+describe('Research / schema / ORT / benchmark modules', () => {
+  test('core modules exist', () => {
+    for (const rel of [
+      'src/core/ParameterSchema.js',
+      'src/core/ResearchSession.js',
+      'src/core/OrtStatus.js',
+      'src/pipeline/BenchmarkHarness.js',
+      'public/app/research-mode.js',
+    ]) {
+      expect(fs.existsSync(path.join(ROOT, rel))).toBe(true);
+    }
+  });
+
+  test('ParameterSchema exports PARAMETER_SCHEMA array', () => {
+    const src = fs.readFileSync(path.join(ROOT, 'src/core/ParameterSchema.js'), 'utf8');
+    expect(src).toContain('export const PARAMETER_SCHEMA');
+    expect(src).toContain('snapshotParams');
+    expect(src).toContain('realtimeParamIds');
+  });
+
+  test('ResearchSession is local-only export', () => {
+    const src = fs.readFileSync(path.join(ROOT, 'src/core/ResearchSession.js'), 'utf8');
+    expect(src).toContain('toBlob');
+    expect(src).toContain('download');
+    expect(src).toContain('noCloudInference');
+    expect(src).not.toContain('fetch(');
+  });
+
+  test('OrtStatus tracks webgpu and wasm', () => {
+    const src = fs.readFileSync(path.join(ROOT, 'src/core/OrtStatus.js'), 'utf8');
+    expect(src).toContain('webgpu');
+    expect(src).toContain('wasm');
+    expect(src).toContain('applyMlWorkerMessage');
+  });
+
+  test('MLWorkerHost wires OrtStatus', () => {
+    const src = fs.readFileSync(path.join(ROOT, 'src/pipeline/MLWorkerHost.js'), 'utf8');
+    expect(src).toContain('applyMlWorkerMessage');
+    expect(src).toContain("setOrtStatus({ provider: 'probing'");
+  });
+
+  test('Engineer index loads research-mode.js', () => {
+    const html = fs.readFileSync(path.join(ROOT, 'public/app/index.html'), 'utf8');
+    expect(html).toContain('research-mode.js');
+    expect(html).toContain('engOrtPill');
+  });
+
+  test('Landing exposes ORT provider hint', () => {
+    const html = fs.readFileSync(path.join(ROOT, 'public/index.html'), 'utf8');
+    expect(html).toContain('ortProviderHint');
+  });
+});
+
+describe('Single-pass + local constraints (structural)', () => {
+  test('dsp-processor documents single STFT/iSTFT and no ORT in process', () => {
+    const src = fs.readFileSync(path.join(ROOT, 'public/app/dsp-processor.js'), 'utf8');
+    expect(src).toMatch(/single.*STFT|ONE forward FFT/i);
+    expect(src).toMatch(/inverse FFT|iSTFT/i);
+    expect(src).not.toMatch(/InferenceSession/);
+  });
+
+  test('architecture doc forbids live mic', () => {
+    const text = fs.readFileSync(path.join(ROOT, 'docs/VoiceIsolate_Pro_Architecture_v26.md'), 'utf8');
+    expect(text).toMatch(/No live microphone|upload-only/i);
+  });
+});


### PR DESCRIPTION
## Summary
- **Architecture v26** + technical whitepaper (current vs target, single-pass STFT, dual modes, gaps)
- **Research Mode** (Engineer): enable logging, export session JSON + parameter schema (100% local)
- **OrtStatus**: WebGPU/WASM tracking via MLWorkerHost; cockpit ORT/ML pills + Landing hint
- **ParameterSchema**: typed catalog of Engineer parameters for UX/research
- **BenchmarkHarness**: aggregates stage timings for UI/research
- **dsp-processor**: documented as research/packaged path under CLAUDE constraints

## Constraints honored
- No cloud audio inference
- No live microphone
- Single STFT/iSTFT contract documented and enforced in offline paths
- ORT never in AudioWorklet process()

## Test plan
- [x] `tests/architecture-v26.test.js` (12)
- [x] worklet hashes updated
- [ ] CI green

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add research mode panel, ORT status tracking, and parameter schema to Engineer UI
> - Adds [research-mode.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/701/files#diff-6c98b753099df41ff7151dd5ea5213adab01fa6a681c25c9458da79652e33cf0) to the Engineer UI, injecting a panel that logs reproducible experiment sessions, tracks benchmark metrics, and exports session JSON and parameter schema to local downloads.
> - Introduces [OrtStatus.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/701/files#diff-e3365fc1677a74ec55edc3d909edab0ca1fc5d348e8075da24d2052feff56c11) as a central observable for ONNX Runtime provider state (WebGPU/WASM); [MLWorkerHost.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/701/files#diff-910d701237b02aa7b37687e0fdec7bb8fac8f72863c8c0d8050910b613e2478a) now sets status to 'probing' on worker init and forwards worker messages to update it.
> - Adds [ParameterSchema.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/701/files#diff-5e49444cefddb25f041e5d4be4c55331070e5584039ed8484f5352e6109a88ab) defining a typed, readonly schema for Engineer Mode controls with ranges, defaults, and RT/offline path annotations.
> - Adds [ResearchSession.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/701/files#diff-45e9889a118da00ac831e6d75cb7f43bc2b8b9f251270784c471e842c5648c72) and [BenchmarkHarness.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/701/files#diff-f799b6d802c4db69271d06964a5c98d7acfe586c180ae50545d43790881ae62e) for local-only session logging and wall-clock pipeline benchmarking.
> - Landing page and Engineer UI gain ORT provider hint displays; a new architecture doc and whitepaper (v26) are added to [docs/](https://github.com/Joker5514/VoiceIsolate-Pro/pull/701/files#diff-756dcfcddff993c7fd6cf14a402d97e7cbd9faafa6339aa722d19eeceb6d1391).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 058d403.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Research Mode for local session logging, benchmark tracking, and JSON export.
  * Added ONNX Runtime provider visibility, including WebGPU/WASM status indicators.
  * Added a landing-page hint showing the active local inference backend.
  * Added standardized parameter snapshots for research exports.

* **Documentation**
  * Added architecture and technical whitepaper documentation covering processing modes, privacy, performance, and supported runtime behavior.
  * Updated the documentation index with the new references.

* **Tests**
  * Added coverage validating Architecture v26 documentation and related feature wiring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->