### PR TITLE
fix: restore WhisperHunter AI and stop process freezes

### DIFF
--- a/public/app/app.js
+++ b/public/app/app.js
@@ -21,7 +21,7 @@ import { SLIDER_REGISTRY, STAGES } from './slider-map.js';
 import { buildHintPanel, mountInfoPopover, removeAllInfoPopovers } from './slider-hint-ui.js';
 import { decodeBlobToAudioBuffer } from '/src/pipeline/media-decode.js';
 import { resampleToCanonical } from '/src/pipeline/FileIngestion.js';
-import { createYieldBudget } from '/src/pipeline/ui-yield.js';
+import { createYieldBudget, yieldToBrowser } from '/src/pipeline/ui-yield.js';
 import { sliceAudioBuffer } from '/src/core/audio-slice.js';
 import { clearStemCache } from '/src/pipeline/MLStemCache.js';
 import { resetTimings, stageEnd, stageStart } from '/src/pipeline/PipelineTiming.js';
@@ -2466,6 +2466,8 @@ class VoiceIsolatePro {
     this._mlIsolationSucceeded = false;
     this._updateProcessButtonsState();
     stageStart('pipeline');
+    // Let the browser paint the processing overlay before heavy work.
+    await yieldToBrowser();
 
     // Hide process buttons, show stop button
     if (this.dom.mobileProcessBtn) {
@@ -2478,16 +2480,12 @@ class VoiceIsolatePro {
       this.dom.mobileStopBtn.style.display = 'inline-flex';
     }
 
-    const wm = this._getWhisperModeState();
-    // Forensic multi-pass multiplies full STFT cost. Cap at 2; auto-process is always 1.
-    let totalPasses = this._forceSinglePass ? 1 : Math.min(2, wm.passes || 1);
-    if (this._autoPipelineRun) {
-      totalPasses = 1;
-      this._autoPipelineRun = false;
-    }
-    // Manual reprocess after a successful ML run: prefer cache (near-instant) and
-    // never re-enter multi-pass DSP unless ML is unavailable.
-    if (this._mlIsolationSucceeded && totalPasses > 1) totalPasses = 1;
+    // Always single-pass isolation on the auto/default path — multi-pass STFT
+    // loops freeze the main thread for multi-minute files. Whisper aggressiveness
+    // is controlled by whisperMode spectral params inside one spectral stage.
+    let totalPasses = 1;
+    if (this._autoPipelineRun) this._autoPipelineRun = false;
+    void this._getWhisperModeState();
 
     this.setStatus('PROCESSING');
     this.updatePipelineProgress(0, totalPasses > 1 ? 'Starting isolation passes…' : 'ML isolation…', 0);
@@ -2718,17 +2716,23 @@ class VoiceIsolatePro {
     // Stereo → process mid once (halves STFT + spectral cost). Re-expand at end.
     const processStereoAsMid = nCh >= 2;
     let channels;
+    const yieldBudget = createYieldBudget(12);
     if (processStereoAsMid) {
       const L = buf.getChannelData(0);
       const R = buf.getChannelData(1);
       const mid = new Float32Array(len);
-      for (let i = 0; i < len; i++) mid[i] = 0.5 * (L[i] + R[i]);
+      const CHUNK = 48000; // ~1 s
+      for (let i = 0; i < len; i++) {
+        mid[i] = 0.5 * (L[i] + R[i]);
+        if (i > 0 && (i % CHUNK) === 0) await yieldBudget();
+      }
       channels = [mid];
       this._dspStereoSources = { L, R, mid };
     } else {
       channels = [buf.getChannelData(0).slice()];
       this._dspStereoSources = null;
     }
+    await yieldToBrowser();
 
     // ── Pass 1–2: input conditioning + time-domain cleanup ──
     this.updatePipelineProgress(3, 'Conditioning input…', 8);
@@ -3077,22 +3081,31 @@ class VoiceIsolatePro {
 
   // S10–S20: spectral isolation on a single channel. Exactly ONE forward STFT
   // and ONE inverse STFT — the single-pass spectral contract (CLAUDE.md §1).
-  // Fast path: FFT 2048 / hop 768 (~33% fewer frames than 512, still COLA-safe).
+  // Fast path: FFT 2048 / hop 1024 (50% COLA, ~2× fewer frames than 512).
   // Forensic (whisperMode ≥ 2): full 4096 / 1024 for whisper recovery quality.
+  // Async STFT yields so long files no longer freeze the browser tab.
   async _spectralStageAsync(data, sr, p, onProgress) {
     const DSP = this._resolveDSP();
     const whisperMode = Math.round(p.whisperMode ?? this.whisperMode ?? 0);
     const forensic = whisperMode >= 2;
     const FFT = forensic ? 4096 : 2048;
-    const HOP = forensic ? 1024 : 768;
-    const FRAME_CHUNK = forensic ? 256 : 640;
+    const HOP = 1024;
+    const FRAME_CHUNK = forensic ? 128 : 256;
     if (!DSP || !data || data.length < FFT) return data;
 
-    const yieldBudget = createYieldBudget(forensic ? 32 : 64);
-    if (onProgress) onProgress(0.05);
+    const yieldBudget = createYieldBudget(forensic ? 10 : 12);
+    if (onProgress) onProgress(0.02);
+    await yieldToBrowser();
 
-    const spec = DSP.forwardSTFT(data, FFT, HOP);
-    if (onProgress) onProgress(0.15);
+    const stftOpts = {
+      yieldEvery: forensic ? 24 : 40,
+      onProgress: (frac) => { if (onProgress) onProgress(0.02 + frac * 0.18); },
+      shouldAbort: () => this.abortFlag,
+    };
+    const spec = typeof DSP.forwardSTFTAsync === 'function'
+      ? await DSP.forwardSTFTAsync(data, FFT, HOP, stftOpts)
+      : DSP.forwardSTFT(data, FFT, HOP);
+    if (onProgress) onProgress(0.22);
     await yieldBudget();
     if (!spec || !Array.isArray(spec.mag) || spec.mag.length === 0) return data;
     const mag = spec.mag;
@@ -3109,6 +3122,7 @@ class VoiceIsolatePro {
       const scale = 1 + (p.nrSensitivity ?? 60) / 100 * 0.6 + (p.nrSpectralSub ?? 50) / 100 * 0.6;
       for (let k = 0; k < noise.length; k++) noise[k] *= scale;
       DSP.wienerMMSE(mag, noise, nrAmount);
+      await yieldBudget();
     }
 
     if ((p.nrFloor ?? -96) > -96) DSP.spectralGate(mag, p.nrFloor ?? -72, sr, HOP);
@@ -3116,6 +3130,7 @@ class VoiceIsolatePro {
     if ((p.nrSmoothing ?? 0) > 0) DSP.temporalSmooth(mag, p.nrSmoothing);
     if (Math.abs(p.specTilt ?? 0) > 0.01) this._applySpectralTilt(mag, sr, p.specTilt, halfN, FFT);
     if (Math.abs(p.formantShift ?? 0) > 0.01) this._applyFormantShiftSpec(mag, p.formantShift, halfN);
+    await yieldBudget();
     const derevTotal = Math.min(100, (p.derevAmt ?? 0) + (p.roomCorrection ?? 0) * 0.5);
     if (derevTotal > 0) {
       const decaySec = 0.12 + (p.derevDecay ?? 50) / 100 * 0.68;
@@ -3128,7 +3143,12 @@ class VoiceIsolatePro {
     if ((p.breathControl ?? 0) > 0) this._applyBreathControl(mag, p.breathControl, halfN);
     if (Math.abs(p.transientShaper ?? 0) > 1) this._applyTransientShaper(mag, p.transientShaper);
     if ((p.subHarmonic ?? 0) > 0) this._applySubHarmonic(mag, sr, p, halfN, FFT);
+    await yieldBudget();
 
+    // Ensure WhisperHunter instance exists when whisper mode is engaged.
+    if (whisperMode > 0 && typeof ensureWhisperHunterInstance === 'function') {
+      ensureWhisperHunterInstance(FFT, sr);
+    }
     const runExtreme = this._extremeSpectralActive(p);
     const hunter = whisperMode > 0 && typeof window !== 'undefined' ? window._vipWhisperHunter : null;
     const mapUi = (typeof window !== 'undefined' && window.mapWhisperUi) ? window.mapWhisperUi : () => 0.5;
@@ -3150,15 +3170,21 @@ class VoiceIsolatePro {
         if (whParams) {
           for (let f = f0; f < f1; f++) hunter.processMagnitudes(mag[f], phase[f], whParams);
         }
-        if (onProgress) onProgress(0.2 + 0.65 * (f1 / totalFrames));
+        if (onProgress) onProgress(0.25 + 0.55 * (f1 / totalFrames));
         await yieldBudget();
       }
     } else if (onProgress) {
-      onProgress(0.85);
+      onProgress(0.80);
     }
 
-    if (onProgress) onProgress(0.92);
-    const rendered = DSP.inverseSTFT(mag, phase, FFT, HOP, data.length);
+    if (onProgress) onProgress(0.85);
+    await yieldToBrowser();
+    const rendered = typeof DSP.inverseSTFTAsync === 'function'
+      ? await DSP.inverseSTFTAsync(mag, phase, FFT, HOP, data.length, {
+        yieldEvery: forensic ? 24 : 40,
+        onProgress: (frac) => { if (onProgress) onProgress(0.85 + frac * 0.14); },
+      })
+      : DSP.inverseSTFT(mag, phase, FFT, HOP, data.length);
     if (onProgress) onProgress(1);
     return (rendered && rendered.length === data.length) ? rendered : data;
   }
@@ -4331,13 +4357,13 @@ const WHISPER_HUNTER = {
         whisperMode: separationScore > 0.65 ? 3 : separationScore > 0.35 ? 2 : 1,
       }, 600);
 
-      const mode = window.VIP_PARAMS?.whisperMode ?? 2;
-      const passPlan = mode >= 3 ? 4 : mode === 2 ? 2 : 1;
-      const numPasses = Math.min(platformProfile.forensicCap, Math.max(platformProfile.minPasses, passPlan));
-      if (numPasses > 1) {
-        await this.runForensicPasses(audioBuffer, numPasses, app, envProfile);
-      } else {
+      // Single pipeline pass keeps the UI responsive. WhisperMode still drives
+      // spectral aggressiveness inside the offline path — multi-pass loops froze tabs.
+      app._forceSinglePass = true;
+      try {
         await app.runPipeline();
+      } finally {
+        app._forceSinglePass = false;
       }
 
       this.reportResults(envProfile, avgMaskConf, app, platformProfile);
@@ -4354,9 +4380,9 @@ const WHISPER_HUNTER = {
     if (envProfile.dominantNoise === 'music' && envProfile.rt60 > 500) return 'Whisper in a Club';
     if (envProfile.dominantNoise === 'crowd' && envProfile.speechPresence < 0.35) return 'Stadium Crowd';
     if (envProfile.voiceRatio < 0.18) return 'Forensic Extract';
-    if (envProfile.rt60 < 200) return 'Whisper Room';
-    if (envProfile.dominantNoise === 'traffic') return 'Forensic Extract';
-    return 'Whisper in a Club';
+    if (envProfile.rt60 < 200) return 'Whisper Boost';
+    if (envProfile.dominantNoise === 'traffic') return 'Surveillance';
+    return 'Whisper Boost';
   },
 
   async runDeepFilterNet(audioBuffer, app, platformProfile = getWhisperPlatformProfile()) {
@@ -4385,32 +4411,27 @@ const WHISPER_HUNTER = {
   },
 
   async runForensicPasses(buffer, numPasses, app, envProfile = {}) {
+    // Cap at 1 — full reprocess loops freeze the browser on multi-minute files.
     app = app || window._vipApp;
-    let current = buffer;
-    for (let pass = 0; pass < numPasses; pass++) {
-      const detail = document.getElementById('pipeDetail');
-      if (detail) detail.textContent = `WhisperHunter pass ${pass + 1}/${numPasses}…`;
-
-      const escalate = pass / Math.max(1, numPasses - 1);
-      await app.morphSlidersTo({
-        crowdNull: Math.min(100, Math.round(62 + escalate * 32)),
-        musicKill: Math.min(100, Math.round((envProfile.dominantNoise === 'music' ? 70 : 48) + escalate * 28)),
-        whisperLift: Math.min(40, Math.round(12 + escalate * 14)),
-        whisperThreshold: Math.min(100, Math.round(45 + escalate * 40)),
-        voiceTunnel: Math.min(100, Math.round(50 + escalate * 30)),
-        snrFloor: Math.round(-76 - escalate * 8),
-      }, 280);
-
-      app.inputBuffer = current;
-      app._forceSinglePass = true;
+    const detail = document.getElementById('pipeDetail');
+    if (detail) detail.textContent = 'WhisperHunter isolation (single pass)…';
+    await app.morphSlidersTo({
+      crowdNull: Math.min(100, Math.round(70 + (envProfile.speechPresence < 0.3 ? 20 : 0))),
+      musicKill: Math.min(100, Math.round(envProfile.dominantNoise === 'music' ? 85 : 55)),
+      whisperLift: 18,
+      whisperThreshold: 62,
+      voiceTunnel: 65,
+      snrFloor: -72,
+      whisperMode: Math.min(2, Math.max(1, Math.round(numPasses > 1 ? 2 : 1))),
+    }, 200);
+    app.inputBuffer = buffer;
+    app._forceSinglePass = true;
+    try {
       await app.runPipeline();
+    } finally {
       app._forceSinglePass = false;
-      current = app.procBuffer || app.outputBuffer || current;
-      this.updateNoiseProfileFromBuffer(current, app);
     }
-    app.procBuffer = current;
-    app.outputBuffer = current;
-    if (typeof app.renderStaticVisuals === 'function') app.renderStaticVisuals(current);
+    this.updateNoiseProfileFromBuffer(app.procBuffer || app.outputBuffer || buffer, app);
   },
 
   updateNoiseProfileFromBuffer(buffer, app) {

--- a/public/app/dsp-core.js
+++ b/public/app/dsp-core.js
@@ -238,6 +238,127 @@ const DSPCore = {
   },
 
   /**
+   * Async STFT — same single-pass math as forwardSTFT, but yields to the UI
+   * every `yieldEvery` frames so long files do not freeze the browser tab.
+   * @param {Float32Array} data
+   * @param {number} [fftSize]
+   * @param {number} [hopSize]
+   * @param {{ yieldEvery?: number, onProgress?: (frac: number) => void, shouldAbort?: () => boolean }} [opts]
+   * @returns {Promise<{ mag: Float32Array[], phase: Float32Array[], frameCount: number }>}
+   */
+  async forwardSTFTAsync(data, fftSize = 4096, hopSize = 1024, opts = {}) {
+    if (!Number.isInteger(fftSize) || fftSize < 2 || (fftSize & (fftSize - 1)) !== 0) {
+      throw new RangeError(`forwardSTFTAsync: fftSize must be a power of two >= 2 (got ${fftSize})`);
+    }
+    const yieldEvery = Math.max(8, opts.yieldEvery || 48);
+    const onProgress = typeof opts.onProgress === 'function' ? opts.onProgress : null;
+    const shouldAbort = typeof opts.shouldAbort === 'function' ? opts.shouldAbort : null;
+    const window = this.hannWindow(fftSize);
+    const halfN = fftSize / 2 + 1;
+    const frameCount = data.length >= fftSize
+      ? Math.floor((data.length - fftSize) / hopSize) + 1
+      : 0;
+    const mag = new Array(frameCount);
+    const phase = new Array(frameCount);
+    const real = new Float32Array(fftSize);
+    const imag = new Float32Array(fftSize);
+
+    const yieldUI = () => new Promise((resolve) => {
+      if (typeof requestAnimationFrame === 'function') {
+        requestAnimationFrame(() => setTimeout(resolve, 0));
+      } else {
+        setTimeout(resolve, 0);
+      }
+    });
+
+    for (let f = 0; f < frameCount; f++) {
+      if (shouldAbort && shouldAbort()) {
+        return { mag: mag.slice(0, f), phase: phase.slice(0, f), frameCount: f };
+      }
+      const offset = f * hopSize;
+      imag.fill(0);
+      for (let i = 0; i < fftSize; i++) {
+        real[i] = (offset + i < data.length) ? data[offset + i] * window[i] : 0;
+      }
+      this._fft(real, imag, false);
+      const m = new Float32Array(halfN);
+      const p = new Float32Array(halfN);
+      for (let k = 0; k < halfN; k++) {
+        m[k] = Math.sqrt(real[k] * real[k] + imag[k] * imag[k]);
+        p[k] = Math.atan2(imag[k], real[k]);
+      }
+      mag[f] = m;
+      phase[f] = p;
+      if (f > 0 && (f % yieldEvery) === 0) {
+        if (onProgress) onProgress(f / frameCount);
+        await yieldUI();
+      }
+    }
+    if (onProgress) onProgress(1);
+    return { mag, phase, frameCount };
+  },
+
+  /**
+   * Async inverse STFT with periodic UI yields (same OLA math as inverseSTFT).
+   */
+  async inverseSTFTAsync(mag, phase, fftSize = 4096, hopSize = 1024, outputLength = 0, opts = {}) {
+    if (!Number.isInteger(fftSize) || fftSize < 2 || (fftSize & (fftSize - 1)) !== 0) {
+      throw new RangeError(`inverseSTFTAsync: fftSize must be a power of two >= 2 (got ${fftSize})`);
+    }
+    const yieldEvery = Math.max(8, opts.yieldEvery || 48);
+    const onProgress = typeof opts.onProgress === 'function' ? opts.onProgress : null;
+    const window = this.hannWindow(fftSize);
+    const windowSq = this._hannSqCache(fftSize, window);
+    const frameCount = mag.length;
+    const halfN = fftSize / 2 + 1;
+    const len = outputLength || (frameCount - 1) * hopSize + fftSize;
+    const output = new Float32Array(len);
+    const windowSum = new Float32Array(len);
+    const real = new Float32Array(fftSize);
+    const imag = new Float32Array(fftSize);
+
+    const yieldUI = () => new Promise((resolve) => {
+      if (typeof requestAnimationFrame === 'function') {
+        requestAnimationFrame(() => setTimeout(resolve, 0));
+      } else {
+        setTimeout(resolve, 0);
+      }
+    });
+
+    for (let f = 0; f < frameCount; f++) {
+      const offset = f * hopSize;
+      const magF = mag[f];
+      const phaseF = phase[f];
+      for (let k = 0; k < halfN; k++) {
+        const rawM = magF[k];
+        const m = (rawM >= 0 && rawM < Infinity) ? rawM : 0;
+        const ph = phaseF[k];
+        real[k] = m * Math.cos(ph);
+        imag[k] = m * Math.sin(ph);
+      }
+      for (let k = halfN; k < fftSize; k++) {
+        real[k] = real[fftSize - k];
+        imag[k] = -imag[fftSize - k];
+      }
+      this._fft(real, imag, true);
+      const nMax = Math.min(fftSize, len - offset);
+      for (let i = 0; i < nMax; i++) {
+        output[offset + i] += real[i] * window[i];
+        windowSum[offset + i] += windowSq[i];
+      }
+      if (f > 0 && (f % yieldEvery) === 0) {
+        if (onProgress) onProgress(f / frameCount);
+        await yieldUI();
+      }
+    }
+    for (let i = 0; i < len; i++) {
+      if (windowSum[i] > 1e-12) output[i] /= windowSum[i];
+    }
+    if (onProgress) onProgress(1);
+    return output;
+  },
+
+  /**
    * Inverse STFT: magnitude + phase → time-domain
    * Single exit point after all spectral operations.
    */

--- a/public/app/style.css
+++ b/public/app/style.css
@@ -1655,12 +1655,16 @@ body::after {
 .wm-btn.active[data-mode="2"] { background: #7c2d12; color: #fb923c; border-color: #9a3412; }
 .wm-btn.active[data-mode="3"] { background: #4c1d95; color: #c4b5fd; border-color: #6d28d9; box-shadow: 0 0 12px #7c3aed44; }
 
+/* Always-visible WhisperHunter CTA (all workflow tiers) */
 #btn-whisper-hunter {
+  display: inline-flex !important;
+  visibility: visible !important;
   width: 100%; margin: 10px 0; padding: 12px;
   background: linear-gradient(135deg, #1a0533, #2d1060);
   border: 1px solid #7c3aed; border-radius: 8px;
   color: #c4b5fd; font-weight: 700; font-size: 0.88em;
-  cursor: pointer; display: flex; align-items: center;
+  cursor: pointer;
+  align-items: center;
   justify-content: center; gap: 8px;
   transition: all 200ms ease;
 }

--- a/public/app/whisper-hunter.js
+++ b/public/app/whisper-hunter.js
@@ -34,41 +34,41 @@ export function getWhisperPlatformProfile(platform = detectWhisperPlatform()) {
     case 'android':
       return {
         platform: 'android',
-        maxChunks: 10,
-        timeoutMs: 8000,
+        maxChunks: 6,
+        timeoutMs: 4000,
         chunkYieldMs: 4,
         mlEnabled: true,
-        forensicCap: 3,
+        forensicCap: 1,
         minPasses: 1,
       };
     case 'ios':
       return {
         platform: 'ios',
-        maxChunks: 10,
-        timeoutMs: 8000,
+        maxChunks: 6,
+        timeoutMs: 4000,
         chunkYieldMs: 2,
         mlEnabled: true,
-        forensicCap: 3,
+        forensicCap: 1,
         minPasses: 1,
       };
     case 'desktop':
       return {
         platform: 'desktop',
-        maxChunks: 24,
-        timeoutMs: 5000,
+        maxChunks: 12,
+        timeoutMs: 3500,
         chunkYieldMs: 0,
         mlEnabled: true,
-        forensicCap: 4,
+        forensicCap: 1,
         minPasses: 1,
       };
     default:
       return {
         platform: 'browser',
-        maxChunks: 18,
-        timeoutMs: 4500,
+        maxChunks: 10,
+        timeoutMs: 3500,
         chunkYieldMs: 0,
         mlEnabled: true,
-        forensicCap: 4,
+        forensicCap: 1,
         minPasses: 1,
       };
   }

--- a/public/app/workflow-tier.js
+++ b/public/app/workflow-tier.js
@@ -17,7 +17,7 @@ export const WORKFLOW_TIERS = Object.freeze({
     showPresetSelect: false,
     showScenePicker: false,
     showSearch: false,
-    showWhisperHunter: false,
+    showWhisperHunter: true,
     showSaveCustom: false,
   },
   studio: {
@@ -28,15 +28,15 @@ export const WORKFLOW_TIERS = Object.freeze({
     statusIdle: 'Studio — pick a scene preset, tune lightly, then process',
     defaultPreset: 'Podcast Clean',
     presets: [
-      'Podcast Clean', 'Phone/Radio', 'Phone Wiretap',
-      'Whisper Boost', 'Heavy Rain Call', 'Voice Clarity', 'Stadium Crowd',
+      'Podcast Clean', 'Phone/Radio',
+      'Whisper Boost', 'Voice Clarity', 'Stadium Crowd', 'Surveillance',
     ],
-    groups: ['gate', 'nr', 'eq', 'dyn', 'sep', 'out'],
+    groups: ['gate', 'nr', 'eq', 'dyn', 'sep', 'out', 'extreme'],
     showPresetGrid: true,
     showPresetSelect: true,
     showScenePicker: true,
     showSearch: true,
-    showWhisperHunter: false,
+    showWhisperHunter: true,
     showSaveCustom: true,
   },
   forensic: {
@@ -62,7 +62,7 @@ export const STUDIO_SCENES = Object.freeze([
   { id: 'film', label: 'Film', preset: 'Voice Clarity' },
   { id: 'interview', label: 'Interview', preset: 'Voice Clarity' },
   { id: 'broadcast', label: 'Broadcast', preset: 'Podcast Clean' },
-  { id: 'restoration', label: 'Restoration', preset: 'Heavy Rain Call' },
+  { id: 'restoration', label: 'Restoration', preset: 'Surveillance' },
   { id: 'custom', label: 'Custom', preset: null },
 ]);
 
@@ -193,8 +193,12 @@ const WorkflowTier = (() => {
 
     const whisperBtn = $('btn-whisper-hunter');
     if (whisperBtn) {
-      whisperBtn.hidden = !tier.showWhisperHunter;
-      whisperBtn.style.display = tier.showWhisperHunter ? '' : 'none';
+      // Always surface WhisperHunter AI — tiers may still flag showWhisperHunter
+      // but we no longer hide the control (was effectively "removed" on Creator/Studio).
+      whisperBtn.hidden = false;
+      whisperBtn.style.display = '';
+      whisperBtn.removeAttribute('hidden');
+      whisperBtn.setAttribute('aria-hidden', 'false');
     }
 
     const sceneRow = $('heroSceneRow');

--- a/src/pipeline/ui-yield.js
+++ b/src/pipeline/ui-yield.js
@@ -4,13 +4,29 @@
 'use strict';
 
 /** Minimum ms between yields during long CPU-bound loops. */
-export const YIELD_BUDGET_MS = 32;
+export const YIELD_BUDGET_MS = 12;
 
 /** Above this sample count, bulk copies may use budgeted chunking. */
 export const LARGE_CHANNEL_SAMPLES = 48000 * 300; // 5 min @ 48 kHz
 
 /** Chunk size when budgeted copying is used (~30 s of audio). */
 export const COPY_CHUNK_SAMPLES = 48000 * 30;
+
+/**
+ * Yield to the browser so paint/input can run (rAF + macrotask).
+ * Prefer this over bare setTimeout(0) during multi-second DSP.
+ * @returns {Promise<void>}
+ */
+export function yieldToBrowser() {
+  return new Promise((resolve) => {
+    const done = () => {
+      if (typeof setTimeout === 'function') setTimeout(resolve, 0);
+      else resolve();
+    };
+    if (typeof requestAnimationFrame === 'function') requestAnimationFrame(done);
+    else done();
+  });
+}
 
 /**
  * @param {number} [intervalMs]
@@ -22,7 +38,7 @@ export function createYieldBudget(intervalMs = YIELD_BUDGET_MS) {
     const now = typeof performance !== 'undefined' ? performance.now() : Date.now();
     if (now - last < intervalMs) return;
     last = now;
-    await new Promise((r) => setTimeout(r, 0));
+    await yieldToBrowser();
   };
 }
 
@@ -48,4 +64,4 @@ export async function copyFloat32Channel(src, opts = {}) {
   return out;
 }
 
-export default { createYieldBudget, copyFloat32Channel, YIELD_BUDGET_MS };
+export default { createYieldBudget, copyFloat32Channel, yieldToBrowser, YIELD_BUDGET_MS };

--- a/tests/engineer-process-speed.test.js
+++ b/tests/engineer-process-speed.test.js
@@ -30,12 +30,14 @@ describe('Engineer processing speed path', () => {
 
   test('spectral stage uses FFT 2048 for non-forensic Engineer path', () => {
     expect(appJs).toMatch(/const FFT = forensic \? 4096 : 2048/);
-    // Fast path hop 768 (~33% fewer frames than 512, still COLA-safe)
-    expect(appJs).toMatch(/const HOP = forensic \? 1024 : 768/);
+    // Hop 1024 for both paths — fewer frames, UI-friendly async STFT
+    expect(appJs).toMatch(/const HOP = 1024/);
+    expect(appJs).toContain('forwardSTFTAsync');
   });
 
-  test('forensic multi-pass is capped at 2', () => {
-    expect(appJs).toMatch(/Math\.min\(2,\s*wm\.passes/);
+  test('isolation always uses a single process pass (UI freeze guard)', () => {
+    expect(appJs).toMatch(/let totalPasses = 1/);
+    expect(appJs).toContain('Always single-pass isolation');
   });
 
   test('extreme noise-floor scan only runs when extreme path is active', () => {

--- a/tests/whisper-ui-freeze.test.js
+++ b/tests/whisper-ui-freeze.test.js
@@ -1,0 +1,66 @@
+/**
+ * WhisperHunter visibility + UI freeze regressions.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const appJs = fs.readFileSync(path.join(ROOT, 'public/app/app.js'), 'utf8');
+const tierJs = fs.readFileSync(path.join(ROOT, 'public/app/workflow-tier.js'), 'utf8');
+const dspCore = fs.readFileSync(path.join(ROOT, 'public/app/dsp-core.js'), 'utf8');
+const yieldJs = fs.readFileSync(path.join(ROOT, 'src/pipeline/ui-yield.js'), 'utf8');
+
+describe('WhisperHunter AI restored', () => {
+  test('button exists in Engineer HTML', () => {
+    const html = fs.readFileSync(path.join(ROOT, 'public/app/index.html'), 'utf8');
+    expect(html).toContain('id="btn-whisper-hunter"');
+  });
+
+  test('all workflow tiers enable WhisperHunter', () => {
+    expect(tierJs).toMatch(/showWhisperHunter:\s*true/);
+    // Must not hide button via display:none for tiers
+    expect(tierJs).toContain("whisperBtn.hidden = false");
+    expect(tierJs).toContain("whisperBtn.style.display = ''");
+  });
+
+  test('WHISPER_HUNTER orchestrator is wired', () => {
+    expect(appJs).toContain('const WHISPER_HUNTER');
+    expect(appJs).toContain('btn-whisper-hunter');
+    expect(appJs).toContain('ensureWhisperHunterInstance');
+  });
+
+  test('dead preset Whisper Room is not selected', () => {
+    expect(appJs).not.toContain("return 'Whisper Room'");
+    expect(appJs).toContain("return 'Whisper Boost'");
+  });
+});
+
+describe('UI freeze mitigations', () => {
+  test('async STFT with UI yields exists in dsp-core', () => {
+    expect(dspCore).toContain('forwardSTFTAsync');
+    expect(dspCore).toContain('inverseSTFTAsync');
+    expect(dspCore).toMatch(/requestAnimationFrame/);
+  });
+
+  test('spectral stage uses async STFT', () => {
+    expect(appJs).toContain('forwardSTFTAsync');
+    expect(appJs).toContain('inverseSTFTAsync');
+    expect(appJs).toContain('yieldToBrowser');
+  });
+
+  test('pipeline paints overlay before heavy work', () => {
+    expect(appJs).toMatch(/stageStart\('pipeline'\)[\s\S]*await yieldToBrowser\(\)/);
+  });
+
+  test('WhisperHunter does not multi-pass freeze the UI', () => {
+    expect(appJs).toContain('app._forceSinglePass = true');
+    expect(appJs).toMatch(/Single pipeline pass keeps the UI responsive|single pass/i);
+  });
+
+  test('yield budget prefers rAF for paint', () => {
+    expect(yieldJs).toContain('yieldToBrowser');
+    expect(yieldJs).toContain('requestAnimationFrame');
+  });
+});


### PR DESCRIPTION
## Summary
- **WhisperHunter AI restored** on Creator/Studio/Forensic (button always visible)
- **Browser freeze fix:** async `forwardSTFTAsync` / `inverseSTFTAsync` with rAF yields; yield before pipeline; hop 1024; single-pass only
- **WhisperHunter:** no multi-pipeline forensic loops; dead `Whisper Room` preset remapped; extreme tab available in Studio
- Faster spectral path + UI paint during long DSP fallback

## Test plan
- [x] tests/whisper-ui-freeze.test.js
- [x] tests/engineer-process-speed.test.js
- [ ] Manual: upload file on /app — UI stays interactive, WhisperHunter button works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * WhisperHunter is now available across all workflow tiers.
  * Added improved presets and updated the Restoration scene selection.

* **Bug Fixes**
  * Reduced UI freezing during intensive voice isolation and spectral processing.
  * Long files now provide more responsive progress while processing.
  * Improved WhisperHunter availability and initialization.

* **Performance**
  * Streamlined isolation into a faster single-pass workflow.
  * Tuned processing limits and timing across desktop, browser, Android, and iOS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix WhisperHunter UI visibility and prevent process freezes with async STFT and single-pass isolation
> - Adds async `forwardSTFTAsync` and `inverseSTFTAsync` methods to [dsp-core.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/702/files#diff-a0208e73d783abbf925631111efe13a82f930ed0c341a9ba580e1ff1adc2a59b) that yield to the browser via `requestAnimationFrame` between frames, preventing main-thread freezes during long spectral operations.
> - Consolidates forensic multi-pass logic into a single pipeline pass in [app.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/702/files#diff-8a8b7ea624d7fccc12a516d122dcb07bd67c6a8f796c80e33b898ee6a7557650), removing the multi-pass loop from `runForensicPasses` and forcing `_forceSinglePass=true` throughout the auto-process path.
> - Forces the WhisperHunter button visible in [workflow-tier.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/702/files#diff-5623e25b1307f0c6ccc9aae3a2cbdf0a02981506d6456a25a3a2024573772165) and [style.css](https://github.com/Joker5514/VoiceIsolate-Pro/pull/702/files#diff-35b8006cad11f725a0bc3cee37866f6a39b941ae71d953d622c215dbd1a8d389), overriding tier config and adding `!important` CSS rules so it appears across all workflows.
> - Reduces the yield budget interval in [ui-yield.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/702/files#diff-5c32cbc85c7b2e15342a2195c746c048477ad33dc5134bf323ede822050e2c39) from 32ms to 12ms and introduces a `yieldToBrowser` helper used throughout the pipeline for paint/input opportunities.
> - Behavioral Change: spectral HOP size is fixed at 1024 for all modes, and WhisperHunter orchestration caps multi-pass at 1 on all platforms, changing prior multi-pass forensic behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2848ee8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->