### PR TITLE
fix: harden engine cockpit pills and worklet status (CTX–NET)

### DIFF
--- a/docs/VoiceIsolate_Pro_Architecture_v26.md
+++ b/docs/VoiceIsolate_Pro_Architecture_v26.md
@@ -162,6 +162,21 @@ Typical \(M_{floor} = -30\,\mathrm{dB}\) (`MASK_FLOOR_DB` in core).
 | Benchmark harness | `src/pipeline/BenchmarkHarness.js` |
 | ORT status helper | `src/core/OrtStatus.js` |
 | Research UI | `public/app/research-mode.js` |
+| Engine cockpit pills | `public/app/vip-boot.js` (CTX/WORKLET/GATE/DEESS/SAB/ML/ORT/NET) |
+| Playback worklet load | `src/pipeline/PlaybackMixer.js` (`ensureWorkletModule`) |
+
+### 8.1 Cockpit pill contracts
+
+| Pill | Ready means |
+|------|-------------|
+| **CTX** | `AudioContext` created (after user gesture) |
+| **WORKLET** | Gate + de-esser modules settled (loaded or bypassed) |
+| **GATE** | `vip-gate` node spliced (or bypassed) |
+| **DEESS** | `vip-deesser` node spliced (or bypassed) |
+| **SAB** | `SharedArrayBuffer` + cross-origin isolation |
+| **ML** | ONNX Runtime present for local worker inference |
+| **ORT** | Worker reported WebGPU or WASM provider |
+| **NET** | `navigator.onLine` (models still local; net only for asset host) |
 
 ---
 

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -833,15 +833,45 @@ class VoiceIsolatePro {
     if (ort && ort.InferenceSession) {
       window.VIP_ML_AVAILABLE = true;
       pill('engMlPill', 'ready');
+      // Provider not known until MLWorker posts `ready` — leave ORT loading.
+      pill('engOrtPill', 'loading');
     } else {
       window.VIP_ML_AVAILABLE = false;
       pill('engMlPill', 'unavailable');
+      pill('engOrtPill', 'unavailable');
     }
 
-    // Lazy AudioContext — requires user gesture
+    // SAB pill — capability is known at boot (COOP/COEP isolation).
+    try {
+      const sabOk = typeof SharedArrayBuffer !== 'undefined'
+        && typeof Atomics !== 'undefined'
+        && (typeof self === 'undefined' || self.crossOriginIsolated !== false);
+      pill('engSabPill', sabOk ? 'ready' : 'error');
+    } catch {
+      pill('engSabPill', 'error');
+    }
+
+    // Probe WebGPU availability for ORT status (non-blocking).
+    void import('/src/core/OrtStatus.js').then(async (m) => {
+      try {
+        await m.probeWebGpuAvailable?.();
+        const st = m.getOrtStatus?.();
+        if (st?.webgpuAvailable) {
+          // Prefer WebGPU label until worker confirms
+          if (!window.__vipOrtStatus || window.__vipOrtStatus.provider === 'unknown') {
+            m.setOrtStatus?.({ provider: 'probing', webgpuAvailable: true });
+          }
+        }
+      } catch { /* ignore */ }
+    }).catch(() => {});
+
+    // Lazy AudioContext — requires user gesture (also kicks worklet addModule).
     if (typeof document !== 'undefined' && typeof document.addEventListener === 'function') {
-      document.addEventListener('click', () => this.ensureCtx(), { once: true });
-      document.addEventListener('keydown', () => this.ensureCtx(), { once: true });
+      const unlock = () => { this.ensureCtx().catch(() => {}); };
+      document.addEventListener('pointerdown', unlock, { once: true, passive: true });
+      document.addEventListener('click', unlock, { once: true });
+      document.addEventListener('keydown', unlock, { once: true });
+      document.addEventListener('touchstart', unlock, { once: true, passive: true });
     }
 
     this._warmupMLModels().catch(() => {});
@@ -1013,11 +1043,17 @@ class VoiceIsolatePro {
           SLIDER_REGISTRY.forEach((s, i) => {
             this.sharedParams[i + 1] = (window.VIP_PARAMS && window.VIP_PARAMS[s.id] !== undefined) ? window.VIP_PARAMS[s.id] : (s.default ?? 0);
           });
+          pill('engSabPill', 'ready');
+        } else {
+          pill('engSabPill', 'error');
         }
 
         this._ctxReady = true;
         this._workletReady = false;
         pill('engCtxPill', 'ready');
+        pill('engWorkletPill', 'loading');
+        pill('engGatePill', 'loading');
+        pill('engDeessPill', 'loading');
 
         // Boot Live-Mix bridge + gate/de-esser worklets without blocking decode.
         // Upload/process must not wait on AudioWorklet addModule.

--- a/public/app/vip-boot.js
+++ b/public/app/vip-boot.js
@@ -109,59 +109,183 @@
     return true;
   }
 
-  // -- Pill driver (poll-based, self-terminating) --------------------------
+  /**
+   * Map PlaybackMixer load states → pill states.
+   * loaded→ready, pending→loading, failed→error, bypassed→unavailable
+   */
+  function mapWorkletLoadState(s) {
+    if (s === 'loaded') return 'ready';
+    if (s === 'pending') return 'loading';
+    if (s === 'failed') return 'error';
+    if (s === 'bypassed') return 'unavailable';
+    return 'pending';
+  }
+
+  /** Read gate/de-esser status from Engineer bridge, landing mixer, or global. */
+  function readPlaybackWorkletStatus() {
+    try {
+      var app = window._vipApp;
+      var bridge = app && app._bridge;
+      if (bridge && typeof bridge.getWorkletStatus === 'function') {
+        return bridge.getWorkletStatus();
+      }
+      if (bridge && bridge.mixer && typeof bridge.mixer.getWorkletStatus === 'function') {
+        return bridge.mixer.getWorkletStatus();
+      }
+      var landing = window.__vipDiagnostics && window.__vipDiagnostics.mixer;
+      if (landing && typeof landing.getWorkletStatus === 'function') {
+        return landing.getWorkletStatus();
+      }
+      if (window.__vipWorkletStatus) return window.__vipWorkletStatus;
+    } catch (e) { /* ignore */ }
+    return null;
+  }
+
+  function setPillTitle(id, title) {
+    var el = document.getElementById(id);
+    if (el && title) el.title = title;
+  }
+
+  // -- Pill driver: keeps ALL cockpit pills (CTX/WORKLET/GATE/DEESS/SAB/ML/ORT/NET) fresh --
   function startPillDriver() {
-    // Synchronous capability pills
-    setEnginePill('engSabPill',     hasSAB() ? 'ready' : 'error');
-    setEnginePill('engWorkletPill', hasAudioWorklet() ? 'loading' : 'error');
-    if (hasAudioWorklet()) {
-      setEnginePill('engGatePill', 'loading');
-      setEnginePill('engDeessPill', 'loading');
-    } else {
-      setEnginePill('engGatePill', 'error');
-      setEnginePill('engDeessPill', 'error');
-    }
+    var awOk = hasAudioWorklet();
+    setEnginePill('engSabPill', hasSAB() ? 'ready' : 'error');
+    setPillTitle('engSabPill', hasSAB()
+      ? 'SharedArrayBuffer available (cross-origin isolated)'
+      : 'SharedArrayBuffer missing — need COOP/COEP');
+    setEnginePill('engNetPill', getInitialNetworkState() ? 'ready' : 'error');
+    setEnginePill('engCtxPill', hasAudioContext() ? 'loading' : 'error');
+    setPillTitle('engCtxPill', 'AudioContext awaits first user gesture');
+    setEnginePill('engWorkletPill', awOk ? 'loading' : 'error');
+    setEnginePill('engGatePill', awOk ? 'loading' : 'error');
+    setEnginePill('engDeessPill', awOk ? 'loading' : 'error');
+    setEnginePill('engMlPill', 'loading');
+    setEnginePill('engOrtPill', 'loading');
 
-    var startedAt = Date.now();
-    var POLL_MS   = 250;
-    var TIMEOUT   = (typeof process !== 'undefined' && process.env.NODE_ENV === 'test') ? 500 : 30000;
-
-    var ctxResolved = false;
-    var mlResolved  = false;
+    var POLL_MS = 250;
+    // Keep polling long enough that late ensureCtx()/worklet boot still paints pills.
+    // (~10 min). Stops early once every pill has left pending/loading where possible.
+    var MAX_TICKS = 2400;
+    var ticks = 0;
+    var workletsSettled = false;
 
     var iv = setInterval(function () {
-      // CTX pill -- ready as soon as app instance owns an AudioContext
-      if (!ctxResolved) {
-        var app = window._vipApp;
-        if (app && app.ctx && typeof app.ctx.state === 'string') {
-          setEnginePill('engCtxPill', 'ready');
-          ctxResolved = true;
-        } else if (hasAudioContext()) {
-          // Constructor exists; actual context awaits user gesture
-          setEnginePill('engCtxPill', 'loading');
-        }
-      }
+      ticks += 1;
 
-      // ML pill -- ready when orchestrator reports the worker is up
-      if (!mlResolved) {
-        var orch = window._vipOrch;
-        if (orch && orch.mlReady === true) {
-          setEnginePill('engMlPill', 'ready');
-          mlResolved = true;
-        } else if (window.VIP_ML_AVAILABLE === false) {
-          // Models genuinely missing -- degrade to classical DSP
-          setEnginePill('engMlPill', 'unavailable');
-          mlResolved = true;
+      // SAB — re-check isolation (headers can matter after nav)
+      var sabOk = hasSAB();
+      setEnginePill('engSabPill', sabOk ? 'ready' : 'error');
+
+      // NET
+      var online = (typeof navigator !== 'undefined' && typeof navigator.onLine === 'boolean')
+        ? navigator.onLine : true;
+      setEnginePill('engNetPill', online ? 'ready' : 'error');
+
+      // CTX
+      var app = window._vipApp;
+      if (app && app.ctx && typeof app.ctx.state === 'string') {
+        if (app.ctx.state === 'closed') {
+          setEnginePill('engCtxPill', 'error');
+          setPillTitle('engCtxPill', 'AudioContext closed');
         } else {
-          setEnginePill('engMlPill', 'loading');
+          setEnginePill('engCtxPill', 'ready');
+          setPillTitle('engCtxPill', 'AudioContext ' + app.ctx.state);
+        }
+      } else if (hasAudioContext()) {
+        setEnginePill('engCtxPill', 'loading');
+        setPillTitle('engCtxPill', 'Click or press a key to unlock Web Audio');
+      } else {
+        setEnginePill('engCtxPill', 'error');
+      }
+
+      // GATE / DEESS / WORKLET from live mixer status
+      if (awOk) {
+        var st = readPlaybackWorkletStatus();
+        if (st && st.gate && st.deEsser) {
+          var gState = st.gate.state || 'pending';
+          var dState = st.deEsser.state || 'pending';
+          setEnginePill('engGatePill', mapWorkletLoadState(gState));
+          setEnginePill('engDeessPill', mapWorkletLoadState(dState));
+          setPillTitle('engGatePill', 'vip-gate — ' + gState + (st.gate.node ? ' (node active)' : ''));
+          setPillTitle('engDeessPill', 'vip-deesser — ' + dState + (st.deEsser.node ? ' (node active)' : ''));
+
+          var gBad = gState === 'failed';
+          var dBad = dState === 'failed';
+          var gOk = gState === 'loaded' || gState === 'bypassed';
+          var dOk = dState === 'loaded' || dState === 'bypassed';
+          if (gBad || dBad) setEnginePill('engWorkletPill', 'error');
+          else if (gOk && dOk) {
+            setEnginePill('engWorkletPill', 'ready');
+            workletsSettled = true;
+          } else {
+            setEnginePill('engWorkletPill', 'loading');
+          }
+          setPillTitle('engWorkletPill', 'Playback worklets gate=' + gState + ' deess=' + dState);
+        } else if (app && app._workletReady === true) {
+          setEnginePill('engWorkletPill', 'ready');
+          setEnginePill('engGatePill', 'ready');
+          setEnginePill('engDeessPill', 'ready');
+          workletsSettled = true;
+        } else {
+          // API present but modules not loaded yet (await user gesture / ensureCtx)
+          setEnginePill('engWorkletPill', 'loading');
+          setPillTitle('engWorkletPill', 'Worklets load after first click unlocks audio');
         }
       }
 
-      if ((ctxResolved && mlResolved) || (Date.now() - startedAt) > TIMEOUT) {
+      // ML + ORT — prefer live worker/provider status over a stale VIP_ML_AVAILABLE=false
+      // (app.js may set false before ort.min.js finishes evaluating on window).
+      var ortGlobal = window.ort || (typeof globalThis !== 'undefined' && globalThis.ort);
+      var ortSt = window.__vipOrtStatus;
+      var providerLive = ortSt && (ortSt.provider === 'webgpu' || ortSt.provider === 'wasm');
+      var ortApi = !!(ortGlobal && ortGlobal.InferenceSession);
+      var orchReady = !!(window._vipOrch && window._vipOrch.mlReady === true);
+
+      if (providerLive || orchReady || window.VIP_ML_AVAILABLE === true || ortApi) {
+        setEnginePill('engMlPill', 'ready');
+        setPillTitle('engMlPill', 'Local ONNX inference ready'
+          + (providerLive ? (' (' + ortSt.provider + ')') : ''));
+        if (window.VIP_ML_AVAILABLE !== true) window.VIP_ML_AVAILABLE = true;
+      } else if (window.VIP_ML_AVAILABLE === false && !ortSt) {
+        setEnginePill('engMlPill', 'unavailable');
+        setPillTitle('engMlPill', 'ONNX Runtime not loaded — classical DSP fallback');
+      } else {
+        setEnginePill('engMlPill', 'loading');
+      }
+
+      // ORT provider pill
+      if (providerLive) {
+        setEnginePill('engOrtPill', 'ready');
+        setPillTitle('engOrtPill', 'ORT provider: ' + ortSt.provider
+          + (ortSt.modelsLoaded && ortSt.modelsLoaded.length
+            ? ' · models: ' + ortSt.modelsLoaded.join(',')
+            : ''));
+      } else if (ortSt && ortSt.provider === 'error') {
+        setEnginePill('engOrtPill', 'error');
+        setPillTitle('engOrtPill', ortSt.detail || 'ORT error');
+      } else if (ortSt && ortSt.provider === 'probing') {
+        setEnginePill('engOrtPill', 'loading');
+        setPillTitle('engOrtPill', 'Probing WebGPU / WASM…');
+      } else if (ortApi) {
+        setEnginePill('engOrtPill', 'loading');
+        setPillTitle('engOrtPill', 'Waiting for MLWorker provider (WebGPU/WASM)');
+      } else if (window.VIP_ML_AVAILABLE === false && !ortSt) {
+        setEnginePill('engOrtPill', 'unavailable');
+      } else {
+        setEnginePill('engOrtPill', 'loading');
+      }
+
+      // Stop only when worklets settled (or API missing) and we have polled enough
+      // to cover late ensureCtx — never abandon GATE/DEESS as permanent "loading"
+      // after 30s the way the old driver did.
+      if (ticks >= MAX_TICKS) {
         clearInterval(iv);
+      } else if (workletsSettled && ticks > 40) {
+        // Slow down after worklets are up (still refresh NET/SAB occasionally)
+        if (ticks % 8 !== 0) return;
       }
     }, POLL_MS);
-    // Expose handle so test teardown can clear it without waiting for timeout
+
     if (typeof window !== 'undefined') window._vipPillDriverIv = iv;
   }
 

--- a/src/pipeline/MLWorkerHost.js
+++ b/src/pipeline/MLWorkerHost.js
@@ -18,6 +18,22 @@ export function createMLWorker() {
   setOrtStatus({ provider: 'probing', detail: null });
   worker.addEventListener('message', (ev) => {
     applyMlWorkerMessage(ev.data || {});
+    // Mirror ORT/ML cockpit pills when the worker reports provider/backend.
+    const msg = ev.data || {};
+    const setPill = globalThis._setVipEnginePill;
+    if (typeof setPill !== 'function') return;
+    if (msg.type === 'ready') {
+      const backend = String(msg.backend || '').toLowerCase();
+      setPill('engOrtPill', backend === 'webgpu' || backend === 'wasm' ? 'ready' : 'loading');
+      setPill('engMlPill', 'ready');
+      try {
+        const el = globalThis.document?.getElementById?.('engOrtPill');
+        if (el) el.title = `ORT provider: ${backend || 'unknown'}`;
+      } catch { /* ignore */ }
+    } else if (msg.type === 'error' && !msg.requestId) {
+      setPill('engOrtPill', 'error');
+      setPill('engMlPill', 'error');
+    }
   });
   return worker;
 }

--- a/tests/engine-pills.test.js
+++ b/tests/engine-pills.test.js
@@ -1,0 +1,75 @@
+/**
+ * Engineer cockpit pills — CTX / WORKLET / GATE / DEESS / SAB / ML / ORT / NET
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const html = fs.readFileSync(path.join(ROOT, 'public/app/index.html'), 'utf8');
+const boot = fs.readFileSync(path.join(ROOT, 'public/app/vip-boot.js'), 'utf8');
+const app = fs.readFileSync(path.join(ROOT, 'public/app/app.js'), 'utf8');
+const host = fs.readFileSync(path.join(ROOT, 'src/pipeline/MLWorkerHost.js'), 'utf8');
+
+const PILL_IDS = [
+  'engCtxPill',
+  'engWorkletPill',
+  'engGatePill',
+  'engDeessPill',
+  'engSabPill',
+  'engMlPill',
+  'engOrtPill',
+  'engNetPill',
+];
+
+describe('Engine pill markup', () => {
+  test.each(PILL_IDS)('HTML defines #%s', (id) => {
+    expect(html).toContain(`id="${id}"`);
+  });
+});
+
+describe('vip-boot pill driver', () => {
+  test('drives all eight cockpit pills', () => {
+    for (const id of PILL_IDS) {
+      expect(boot).toContain(`'${id}'`);
+    }
+  });
+
+  test('reads live gate/deess status from bridge or diagnostics', () => {
+    expect(boot).toContain('readPlaybackWorkletStatus');
+    expect(boot).toContain('getWorkletStatus');
+    expect(boot).toContain('__vipWorkletStatus');
+  });
+
+  test('does not abandon worklet pills after 30s', () => {
+    // Old driver cleared after 30000ms without resolving GATE/DEESS
+    expect(boot).not.toMatch(/TIMEOUT\s*=\s*30000/);
+    expect(boot).toContain('MAX_TICKS');
+  });
+
+  test('maps loaded → ready for worklets', () => {
+    expect(boot).toContain("if (s === 'loaded') return 'ready'");
+  });
+});
+
+describe('app.js + MLWorkerHost pill hooks', () => {
+  test('ensureCtx paints CTX and worklet loading then ready', () => {
+    expect(app).toContain("pill('engCtxPill', 'ready')");
+    expect(app).toContain("pill('engWorkletPill', 'loading')");
+    expect(app).toContain("pill('engGatePill'");
+    expect(app).toContain("pill('engDeessPill'");
+    expect(app).toContain("pill('engSabPill'");
+  });
+
+  test('unlocks audio on pointer/touch as well as click', () => {
+    expect(app).toContain("addEventListener('pointerdown'");
+    expect(app).toContain("addEventListener('touchstart'");
+  });
+
+  test('MLWorker ready message updates ORT + ML pills', () => {
+    expect(host).toContain("setPill('engOrtPill'");
+    expect(host).toContain("setPill('engMlPill', 'ready')");
+    expect(host).toContain("msg.type === 'ready'");
+  });
+});


### PR DESCRIPTION
## Summary
Hardens all Engineer cockpit status pills so they actually resolve:

| Pill | Behavior |
|------|----------|
| **CTX** | Ready after AudioContext unlock (click/pointer/touch/key) |
| **WORKLET / GATE / DEESS** | Live from PlaybackMixer `getWorkletStatus` until loaded |
| **SAB** | Cross-origin isolation / SharedArrayBuffer |
| **ML / ORT** | Local ORT + MLWorker provider (WebGPU/WASM) |
| **NET** | `navigator.onLine` |

### Fixes
- Old pill driver stopped after 30s while GATE/DEESS still “loading”
- `VIP_ML_AVAILABLE=false` could stick even after MLWorker was ready
- ORT pill only updated from research-mode; now also vip-boot + MLWorkerHost
- Audio unlock also on `pointerdown` / `touchstart`

### Verified
- Browser: all 8 pills **ready** after ensureCtx; gate+deess nodes active
- Unit: `tests/engine-pills.test.js` + worklet-loading

## Test plan
- [x] Unit tests
- [x] Playwright engineer pills
- [ ] CI green

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden cockpit pill status for CTX, WORKLET, GATE, DEESS, SAB, ML, ORT, and NET indicators
> - Rewrites the pill driver in [`vip-boot.js`](https://github.com/Joker5514/VoiceIsolate-Pro/pull/704/files#diff-d6447136c99a779d448499ff3268cc9d81921868b44edec80e177d9e1e96f384) to continuously poll and reflect live states for all eight cockpit pills using mixer and ORT status hooks, removing the previous 30s timeout that left worklets stuck in `loading`.
> - Updates [`app.js`](https://github.com/Joker5514/VoiceIsolate-Pro/pull/704/files#diff-8a8b7ea624d7fccc12a516d122dcb07bd67c6a8f796c80e33b898ee6a7557650) to paint SAB, ML, and ORT pills at boot based on capability detection, probe WebGPU via `OrtStatus`, and unlock audio on `pointerdown`/`touchstart` in addition to `click`/`keydown`.
> - Extends [`MLWorkerHost.js`](https://github.com/Joker5514/VoiceIsolate-Pro/pull/704/files#diff-910d701237b02aa7b37687e0fdec7bb8fac8f72863c8c0d8050910b613e2478a) to update ORT and ML pills in real time when the ML worker reports provider readiness or errors.
> - Adds a Jest suite in [`engine-pills.test.js`](https://github.com/Joker5514/VoiceIsolate-Pro/pull/704/files#diff-cf0739f120251bf68c2e2ccb7920185b9f5741b90e085a4b1d2810c88c018721) verifying pill element presence, ID references, status hooks, and state mappings.
> - Documents pill readiness contracts for all eight indicators in [`VoiceIsolate_Pro_Architecture_v26.md`](https://github.com/Joker5514/VoiceIsolate-Pro/pull/704/files#diff-366e11c305f06d651b10ff15633f9a9a21557bbda26fe3eecf77c96ef723b525).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 764cd8f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added expanded engine readiness indicators for audio context, worklets, gating, de-essing, shared memory, machine learning, runtime, and network status.
  * Added live status updates and diagnostic tooltips for engine components.
  * Improved detection of audio capability, runtime availability, and WebGPU support.
  * Audio initialization now responds to pointer, touch, click, and keyboard interaction.

* **Documentation**
  * Documented readiness criteria for each engine indicator.

* **Tests**
  * Added coverage validating indicator markup, state transitions, and runtime readiness reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->