### PR TITLE
docs: system audit sync — README + Android APK download

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,13 @@ node_modules
 /build
 /dist
 
+# Large installers / APKs (publish via GitHub Releases only)
+*.apk
+*.aab
+*.ipa
+public/download/*.apk
+public/download/*.aab
+
 # misc
 .DS_Store
 *.pem

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 <p align="center">
   <a href="https://voice-isolate-pro.vercel.app"><strong>Live Demo</strong></a>
   &nbsp;·&nbsp;
+  <a href="https://voice-isolate-pro.vercel.app/download/"><strong>Download</strong></a>
+  &nbsp;·&nbsp;
+  <a href="https://github.com/Joker5514/VoiceIsolate-Pro/releases"><strong>Android APK</strong></a>
+  &nbsp;·&nbsp;
   <a href="docs/README.md">Documentation</a>
   &nbsp;·&nbsp;
   <a href="CONTRIBUTING.md">Contributing</a>
@@ -43,9 +47,20 @@
 | Route | Surface | What it does |
 |-------|---------|--------------|
 | [`/`](https://voice-isolate-pro.vercel.app/) | **Landing — Stem-Split** | Fast ML stem separation (vocals / accompaniment / noise). Upload → auto-process → preview stems. |
-| [`/app/`](https://voice-isolate-pro.vercel.app/app/) | **Engineer Mode v24** | Full 67-slider DSP suite, scene presets, 3D spectrogram, A/B transport, forensic audit log. |
+| [`/app/`](https://voice-isolate-pro.vercel.app/app/) | **Engineer Mode v24** | Full 67-slider DSP suite, scene presets, 3D spectrogram, A/B transport, forensic audit log, WhisperHunter AI. |
+| [`/download/`](https://voice-isolate-pro.vercel.app/download/) | **Downloads** | Android APK (GitHub Releases), web links, desktop build notes. |
 
 **Upload controls (both pages):** Browse Files (`<label for="fileInput">`), click the drop zone, drag-and-drop, or **Upload Audio or Video** in the Engineer hero. Shared wiring lives in `src/presentation/UploadWiring.js`.
+
+### Playback worklets & engine status (Engineer)
+
+| Component | Role |
+|-----------|------|
+| `vip-gate` | Real-time noise gate (`src/workers/GateProcessor.js`) |
+| `vip-deesser` | Real-time de-esser (`src/workers/DeEsserProcessor.js`) |
+| Cockpit pills | **CTX · WORKLET · GATE · DEESS · SAB · ML · ORT · NET** — driven by `vip-boot.js` + `PlaybackMixer` |
+
+Verify packaging: `pnpm worklets:verify`.
 
 ---
 
@@ -160,8 +175,29 @@ No `.env` required for local audio processing. Optional payment/licensing vars i
 | `pnpm validate` | Structural integrity gate (CI) |
 | `pnpm lint` | ESLint |
 | `pnpm worklets:verify` | AudioWorklet packaging check |
-| `pnpm android:build:win` | Windows Android debug APK |
+| `pnpm android:build:win` | Windows Android debug APK → `dist/android/` |
+| `pnpm android:build` | Android debug APK (Unix/macOS) |
+| `pnpm worklets:verify` | AudioWorklet packaging integrity |
 | `pnpm build:electron:dir` | Desktop unpacked (Windows) |
+
+### Android download
+
+| Channel | URL |
+|---------|-----|
+| **Web download page** | https://voice-isolate-pro.vercel.app/download/ |
+| **GitHub Releases (APK)** | https://github.com/Joker5514/VoiceIsolate-Pro/releases |
+| **Latest APK asset** | https://github.com/Joker5514/VoiceIsolate-Pro/releases/latest/download/VoiceIsolate-Pro-android-debug.apk |
+
+Build locally (Windows):
+
+```bash
+pnpm android:build:win
+# → dist/android/VoiceIsolate-Pro-debug.apk
+# → android/app/build/outputs/apk/debug/app-debug.apk
+```
+
+Sideload: enable **Install unknown apps** for your browser/file manager, then open the APK.  
+Details: [download/README.md](download/README.md).
 
 ### Upload troubleshooting
 
@@ -199,8 +235,11 @@ android/             Capacitor Android project
 | Topic | Link |
 |-------|------|
 | Full docs index | [docs/README.md](docs/README.md) |
+| Architecture v26 | [docs/VoiceIsolate_Pro_Architecture_v26.md](docs/VoiceIsolate_Pro_Architecture_v26.md) |
+| Technical whitepaper | [docs/VoiceIsolate_Pro_Technical_Whitepaper.md](docs/VoiceIsolate_Pro_Technical_Whitepaper.md) |
 | Contributor contract | [CLAUDE.md](CLAUDE.md) |
 | AudioWorklets | [docs/WORKLETS.md](docs/WORKLETS.md) |
+| Android / desktop downloads | [download/README.md](download/README.md) |
 | Model delivery | [docs/MODEL_DELIVERY.md](docs/MODEL_DELIVERY.md) |
 | Desktop | [docs/electron-desktop.md](docs/electron-desktop.md) |
 | Master Blueprint | [docs/VoiceIsolate-Pro_Master_Blueprint_v2.1.md](docs/VoiceIsolate-Pro_Master_Blueprint_v2.1.md) |
@@ -236,7 +275,11 @@ android/             Capacitor Android project
 
 - **Upload-only workflow** — live mic capture removed; browse, drop-zone, and hero upload CTAs wired through `UploadWiring.js`
 - **Chromium picker fix** — file inputs kept in-viewport; Browse uses native `<label for="fileInput">`
-- **Whisper Hunter** — forensic whisper isolation with cross-platform hardening (desktop, browser, Android)
+- **WhisperHunter AI** — restored on all workflow tiers; single-pass to avoid UI freezes
+- **Playback worklets** — gate + de-esser with resume/retry load; cockpit pills CTX–NET hardened
+- **UI freeze fix** — async STFT/iSTFT with rAF yields on long files
+- **Research mode** — local session JSON export + parameter schema (Engineer)
+- **Android download** — `/download/` page + GitHub Releases APK channel
 - **Page cleanup** — streamlined landing + Engineer shells, hardened worklet precache
 
 ---

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@
 | [VoiceIsolate-Pro_Master_Blueprint_v2.1.md](VoiceIsolate-Pro_Master_Blueprint_v2.1.md) | Product / eng | Authoritative product blueprint (cross-platform) |
 | [REVENUECAT_ISOLATION.md](REVENUECAT_ISOLATION.md) | Mobile | In-app purchase boundary rules |
 | [adr/001-firebase-exception.md](adr/001-firebase-exception.md) | Contributors | Why Firebase is the sole cloud exception |
+| [../download/README.md](../download/README.md) | Users / mobile | Android APK build + GitHub Releases download |
 
 ### Audits
 

--- a/download/README.md
+++ b/download/README.md
@@ -1,1 +1,40 @@
-Here are all the generated files.
+# Android / desktop download artifacts
+
+This folder documents **where installers and APKs live**. Large binaries are **not** committed to git.
+
+## Android APK
+
+| Build | Command | Output |
+|-------|---------|--------|
+| Debug (Windows) | `pnpm android:build:win` | `android/app/build/outputs/apk/debug/app-debug.apk` and `dist/android/VoiceIsolate-Pro-debug.apk` |
+| Debug (Unix) | `pnpm android:build` | same under `android/app/build/outputs/apk/debug/` |
+| Release AAB | `pnpm android:bundle` (or CI `release-build.yml`) | `android/app/build/outputs/bundle/release/` |
+
+### Public download
+
+1. **GitHub Releases** (preferred):  
+   https://github.com/Joker5514/VoiceIsolate-Pro/releases  
+   Latest APK asset name: `VoiceIsolate-Pro-android-debug.apk`
+2. **Web page:** https://voice-isolate-pro.vercel.app/download/  
+   (falls back to GitHub Releases; serves a local APK only if present under `public/download/` at deploy time)
+
+### Publish a release (maintainers)
+
+```bash
+# After a successful android:build:win
+pnpm android:build:win
+cp dist/android/VoiceIsolate-Pro-debug.apk public/download/VoiceIsolate-Pro-android-debug.apk
+gh release create v24.0.0 public/download/VoiceIsolate-Pro-android-debug.apk \
+  --title "VoiceIsolate Pro v24.0.0" \
+  --notes "Android debug APK + web app"
+```
+
+Do **not** commit `*.apk` files (see `.gitignore`).
+
+## Desktop
+
+```bash
+pnpm build:electron:dir
+```
+
+See [docs/electron-desktop.md](../docs/electron-desktop.md).

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -161,6 +161,7 @@
     </div>
     <div class="hdr-actions">
       <a class="btn btn-outline hdr-link" href="/">Stem-Split</a>
+      <a class="btn btn-outline hdr-link" href="/download/">Download</a>
       <a class="btn btn-outline hdr-link" href="how-it-works.html">How It Works</a>
     </div>
     <button id="statsToggle" class="hdr-stats-toggle" aria-label="Toggle stats" title="Toggle stats" aria-expanded="false">&#9660;</button>

--- a/public/download/index.html
+++ b/public/download/index.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Download — VoiceIsolate Pro</title>
+  <meta name="description" content="Download VoiceIsolate Pro for Android, desktop, or open the web app. 100% on-device voice isolation." />
+  <link rel="icon" href="/icon.jpg" />
+  <link rel="stylesheet" href="/landing.css" />
+  <style>
+    .dl-main { max-width: 720px; margin: 0 auto; padding: 32px 16px 64px; }
+    .dl-card {
+      background: linear-gradient(165deg, rgba(220,38,38,.06), rgba(0,0,0,.28));
+      border: 1px solid rgba(255,255,255,.08);
+      border-radius: 14px;
+      padding: 20px 22px;
+      margin: 16px 0;
+    }
+    .dl-card h2 { margin: 0 0 8px; font-size: 1.05rem; color: #fca5a5; }
+    .dl-card p { margin: 0 0 12px; color: #a1a1b5; line-height: 1.5; font-size: 0.95rem; }
+    .dl-actions { display: flex; flex-wrap: wrap; gap: 10px; }
+    .dl-meta { font: 500 11px/1.4 "JetBrains Mono", monospace; color: #6b6b80; margin-top: 10px; }
+    .dl-nav { display: flex; gap: 12px; flex-wrap: wrap; margin-bottom: 20px; }
+    .dl-nav a { color: #f87171; text-decoration: none; font-size: 0.9rem; }
+    .dl-nav a:hover { text-decoration: underline; }
+    .warn { color: #fcd34d; font-size: 0.85rem; }
+  </style>
+</head>
+<body>
+  <main class="dl-main">
+    <nav class="dl-nav" aria-label="Site">
+      <a href="/">← Landing</a>
+      <a href="/app/">Engineer Mode</a>
+      <a href="https://github.com/Joker5514/VoiceIsolate-Pro">GitHub</a>
+    </nav>
+
+    <h1 class="section-label" style="font-size:1.4rem;letter-spacing:.06em;">Download VoiceIsolate Pro</h1>
+    <p class="hint">Privacy-first voice isolation. Audio never leaves your device.</p>
+
+    <section class="dl-card" aria-labelledby="android-dl">
+      <h2 id="android-dl">Android (APK)</h2>
+      <p>
+        Sideload the debug APK for phones/tablets. Enable
+        <strong>Install unknown apps</strong> for your browser or file manager, then open the file.
+      </p>
+      <div class="dl-actions">
+        <a class="btn" id="apkPrimary"
+           href="https://github.com/Joker5514/VoiceIsolate-Pro/releases/latest/download/VoiceIsolate-Pro-android-debug.apk">
+          Download Android APK
+        </a>
+        <a class="btn btn-outline"
+           href="https://github.com/Joker5514/VoiceIsolate-Pro/releases">
+          All releases
+        </a>
+        <a class="btn btn-outline" id="apkLocal" href="./VoiceIsolate-Pro-android-debug.apk" hidden>
+          Local APK (dev server)
+        </a>
+      </div>
+      <p class="dl-meta warn">Debug build · not Play Store signed · ~300&nbsp;MB with models/assets</p>
+      <p class="dl-meta">Direct release asset URL uses the latest GitHub Release tag.</p>
+    </section>
+
+    <section class="dl-card" aria-labelledby="web-dl">
+      <h2 id="web-dl">Web (no install)</h2>
+      <p>Run fully in the browser — Landing (stem-split) or Engineer Mode (full DSP).</p>
+      <div class="dl-actions">
+        <a class="btn" href="/">Open Landing</a>
+        <a class="btn btn-outline" href="/app/">Open Engineer Mode</a>
+      </div>
+    </section>
+
+    <section class="dl-card" aria-labelledby="desktop-dl">
+      <h2 id="desktop-dl">Desktop (Windows)</h2>
+      <p>Build the Electron shell locally (unsigned dir build is the supported path today):</p>
+      <pre style="background:#0a0a10;padding:12px;border-radius:8px;overflow:auto;font-size:12px;color:#c4c4d0;">pnpm install
+pnpm build:electron:dir</pre>
+      <p class="dl-meta">See <code>docs/electron-desktop.md</code> and <code>pnpm android:build:win</code> for Android rebuilds.</p>
+    </section>
+  </main>
+  <script>
+    // Prefer local file when present (pnpm dev / deploy that includes the APK).
+    (async function () {
+      try {
+        var local = document.getElementById('apkLocal');
+        var res = await fetch('./VoiceIsolate-Pro-android-debug.apk', { method: 'HEAD' });
+        if (res.ok && local) {
+          local.hidden = false;
+          var primary = document.getElementById('apkPrimary');
+          if (primary) primary.href = './VoiceIsolate-Pro-android-debug.apk';
+        }
+      } catch (e) { /* use GitHub release URL */ }
+    })();
+  </script>
+</body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -32,6 +32,7 @@
       <span class="arch-badge" id="archBadgeMount">STEM-SPLIT &amp; LIVE-MIX</span>
     </div>
     <div class="titlebar-right">
+      <a href="/download/" class="eng-mode-link">Download</a>
       <a href="/app/" class="eng-mode-link">Engineer Mode</a>
     </div>
   </header>


### PR DESCRIPTION
## Summary
Full-system audit + docs/download readiness:

### Audit results
- **Worklets:** packaging verify all green (gate, deesser, dsp-processor)
- **Unit:** 77 core tests (upload, worklets, pills, whisper freeze, process speed)
- **Browser:** Landing upload controls OK; Engineer worklets **loaded**; all cockpit pills **ready**
- **Android APK:** published on GitHub Releases **v24.0.0** (HTTP 200, ~318 MB)

### Changes
- `public/download/index.html` — public download page (APK + web + desktop)
- Landing nav **Download** link
- README: Android download section, worklet/pill notes, architecture v26 links
- `download/README.md` — build/publish instructions
- `.gitignore` — `*.apk` / `*.aab` (never commit binaries)

### Download URLs
- https://github.com/Joker5514/VoiceIsolate-Pro/releases/latest/download/VoiceIsolate-Pro-android-debug.apk
- https://voice-isolate-pro.vercel.app/download/ (after deploy)

## Test plan
- [x] worklets:verify
- [x] Jest core suites
- [x] Playwright landing + engineer
- [x] APK release HEAD 200
- [ ] CI green

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Android APK download page and update README with build and release docs
> - Adds [public/download/index.html](https://github.com/Joker5514/VoiceIsolate-Pro/pull/705/files#diff-1a81e71068fc532cf08efe7cda25e29f3ae0fddceaf5f47f8c13c8147bf1d5b0), a download hub for Android APK, web app, and desktop builds. The page auto-detects a local `VoiceIsolate-Pro-android-debug.apk` via a HEAD request and switches the primary download link to the local file if present; otherwise it links to the latest GitHub Release.
> - Adds a 'Download' nav link in both [public/index.html](https://github.com/Joker5514/VoiceIsolate-Pro/pull/705/files#diff-c2cc24bc9001b11b6add48a4cd8f893d5d6c6e4d1bd254158bd14ab997f552cd) and [public/app/index.html](https://github.com/Joker5514/VoiceIsolate-Pro/pull/705/files#diff-4400aa5aa5292d143f7e2f1308aa82756255552567d5558874c994833e907ce4) pointing to `/download/`.
> - Updates [README.md](https://github.com/Joker5514/VoiceIsolate-Pro/pull/705/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) with Android build targets, download URLs, WhisperHunter AI, playback worklets, and recent changes.
> - Adds [download/README.md](https://github.com/Joker5514/VoiceIsolate-Pro/pull/705/files#diff-b9fefb8047c707594f1ddca4ca12dfc12a82283a69aeafb1ea2e7308f9b08709) with APK build commands, GitHub Releases publishing steps using `gh` CLI, and output paths.
> - Updates `.gitignore` to exclude `*.apk`, `*.aab`, and `*.ipa` artifacts.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4264e18.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->