### PR TITLE
fix: make Android APK a real download (not SPA HTML)

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,10 @@ No `.env` required for local audio processing. Optional payment/licensing vars i
 | **Web download page** | https://voice-isolate-pro.vercel.app/download/ |
 | **GitHub Releases (APK)** | https://github.com/Joker5514/VoiceIsolate-Pro/releases |
 | **Latest APK asset** | https://github.com/Joker5514/VoiceIsolate-Pro/releases/latest/download/VoiceIsolate-Pro-android-debug.apk |
+| **Pinned v24.0.0** | https://github.com/Joker5514/VoiceIsolate-Pro/releases/download/v24.0.0/VoiceIsolate-Pro-android-debug.apk |
+
+The download page always links to the **real GitHub Release binary** (~303 MB, `application/vnd.android.package-archive`).  
+Same-origin `/download/*.apk` redirects to GitHub so it never serves SPA HTML.
 
 Build locally (Windows):
 

--- a/download/README.md
+++ b/download/README.md
@@ -12,11 +12,14 @@ This folder documents **where installers and APKs live**. Large binaries are **n
 
 ### Public download
 
-1. **GitHub Releases** (preferred):  
+1. **GitHub Releases** (canonical binary host):  
    https://github.com/Joker5514/VoiceIsolate-Pro/releases  
-   Latest APK asset name: `VoiceIsolate-Pro-android-debug.apk`
+   Latest APK asset: `VoiceIsolate-Pro-android-debug.apk`  
+   Direct: `https://github.com/Joker5514/VoiceIsolate-Pro/releases/latest/download/VoiceIsolate-Pro-android-debug.apk`
 2. **Web page:** https://voice-isolate-pro.vercel.app/download/  
-   (falls back to GitHub Releases; serves a local APK only if present under `public/download/` at deploy time)
+   Primary buttons open the GitHub release asset (real APK, ~303 MB).  
+   Same-origin `/download/*.apk` is **redirected** to GitHub Releases so it never returns SPA HTML.
+3. Do **not** rely on committing APKs under `public/download/` — Vercel SPA rewrites previously turned missing `.apk` paths into `index.html`.
 
 ### Publish a release (maintainers)
 

--- a/public/download/index.html
+++ b/public/download/index.html
@@ -24,6 +24,8 @@
     .dl-nav a { color: #f87171; text-decoration: none; font-size: 0.9rem; }
     .dl-nav a:hover { text-decoration: underline; }
     .warn { color: #fcd34d; font-size: 0.85rem; }
+    .dl-ok { color: #86efac; font-size: 0.85rem; }
+    code { font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.85em; }
   </style>
 </head>
 <body>
@@ -31,7 +33,7 @@
     <nav class="dl-nav" aria-label="Site">
       <a href="/">← Landing</a>
       <a href="/app/">Engineer Mode</a>
-      <a href="https://github.com/Joker5514/VoiceIsolate-Pro">GitHub</a>
+      <a href="https://github.com/Joker5514/VoiceIsolate-Pro" rel="noopener noreferrer" target="_blank">GitHub</a>
     </nav>
 
     <h1 class="section-label" style="font-size:1.4rem;letter-spacing:.06em;">Download VoiceIsolate Pro</h1>
@@ -42,22 +44,39 @@
       <p>
         Sideload the debug APK for phones/tablets. Enable
         <strong>Install unknown apps</strong> for your browser or file manager, then open the file.
+        The button below starts a <strong>real APK download</strong> from GitHub Releases
+        (~303&nbsp;MB, content-type <code>application/vnd.android.package-archive</code>).
       </p>
       <div class="dl-actions">
+        <!-- Primary: always GitHub Releases — never rewrite to a same-origin SPA HTML path -->
         <a class="btn" id="apkPrimary"
-           href="https://github.com/Joker5514/VoiceIsolate-Pro/releases/latest/download/VoiceIsolate-Pro-android-debug.apk">
+           href="https://github.com/Joker5514/VoiceIsolate-Pro/releases/latest/download/VoiceIsolate-Pro-android-debug.apk"
+           rel="noopener noreferrer"
+           target="_blank"
+           download="VoiceIsolate-Pro-android-debug.apk">
           Download Android APK
         </a>
         <a class="btn btn-outline"
-           href="https://github.com/Joker5514/VoiceIsolate-Pro/releases">
+           href="https://github.com/Joker5514/VoiceIsolate-Pro/releases/download/v24.0.0/VoiceIsolate-Pro-android-debug.apk"
+           rel="noopener noreferrer"
+           target="_blank"
+           download="VoiceIsolate-Pro-android-debug.apk">
+          v24.0.0 direct
+        </a>
+        <a class="btn btn-outline"
+           href="https://github.com/Joker5514/VoiceIsolate-Pro/releases"
+           rel="noopener noreferrer"
+           target="_blank">
           All releases
         </a>
-        <a class="btn btn-outline" id="apkLocal" href="./VoiceIsolate-Pro-android-debug.apk" hidden>
-          Local APK (dev server)
-        </a>
       </div>
-      <p class="dl-meta warn">Debug build · not Play Store signed · ~300&nbsp;MB with models/assets</p>
-      <p class="dl-meta">Direct release asset URL uses the latest GitHub Release tag.</p>
+      <p class="dl-meta dl-ok">Hosted on GitHub Releases · real binary · not SPA HTML</p>
+      <p class="dl-meta warn">Debug build · not Play Store signed · ~303&nbsp;MB with models/assets</p>
+      <p class="dl-meta">
+        Asset name: <code>VoiceIsolate-Pro-android-debug.apk</code><br />
+        Latest: <code>…/releases/latest/download/VoiceIsolate-Pro-android-debug.apk</code><br />
+        Pinned: <code>…/releases/download/v24.0.0/VoiceIsolate-Pro-android-debug.apk</code>
+      </p>
     </section>
 
     <section class="dl-card" aria-labelledby="web-dl">
@@ -77,19 +96,5 @@ pnpm build:electron:dir</pre>
       <p class="dl-meta">See <code>docs/electron-desktop.md</code> and <code>pnpm android:build:win</code> for Android rebuilds.</p>
     </section>
   </main>
-  <script>
-    // Prefer local file when present (pnpm dev / deploy that includes the APK).
-    (async function () {
-      try {
-        var local = document.getElementById('apkLocal');
-        var res = await fetch('./VoiceIsolate-Pro-android-debug.apk', { method: 'HEAD' });
-        if (res.ok && local) {
-          local.hidden = false;
-          var primary = document.getElementById('apkPrimary');
-          if (primary) primary.href = './VoiceIsolate-Pro-android-debug.apk';
-        }
-      } catch (e) { /* use GitHub release URL */ }
-    })();
-  </script>
 </body>
 </html>

--- a/vercel.json
+++ b/vercel.json
@@ -4,6 +4,18 @@
   "buildCommand": "node scripts/vercel-build.js",
   "installCommand": "bash scripts/vercel-install.sh",
   "framework": null,
+  "redirects": [
+    {
+      "source": "/download/VoiceIsolate-Pro-android-debug.apk",
+      "destination": "https://github.com/Joker5514/VoiceIsolate-Pro/releases/latest/download/VoiceIsolate-Pro-android-debug.apk",
+      "permanent": false
+    },
+    {
+      "source": "/download/:file(.*\\.apk)",
+      "destination": "https://github.com/Joker5514/VoiceIsolate-Pro/releases/latest/download/:file",
+      "permanent": false
+    }
+  ],
   "rewrites": [
     {
       "source": "/app/models/:filename",
@@ -14,7 +26,7 @@
       "destination": "https://3jq9akm8vl1tub82.public.blob.vercel-storage.com/:filename"
     },
     {
-      "source": "/((?!app/|blueprint/|docs/|lib/|src/|icon\\.jpg|manifest\\.json|sw\\.js|landing\\.js|landing\\.css).*)",
+      "source": "/((?!app/|blueprint/|docs/|download/|lib/|src/|icon\\.jpg|manifest\\.json|sw\\.js|landing\\.js|landing\\.css).*)",
       "destination": "/index.html"
     }
   ],
@@ -194,6 +206,23 @@
         {
           "key": "Cache-Control",
           "value": "public, max-age=86400"
+        }
+      ]
+    },
+    {
+      "source": "/download/(.*\\.apk)",
+      "headers": [
+        {
+          "key": "Content-Type",
+          "value": "application/vnd.android.package-archive"
+        },
+        {
+          "key": "Content-Disposition",
+          "value": "attachment; filename=\"VoiceIsolate-Pro-android-debug.apk\""
+        },
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=3600"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- **Root cause:** Vercel SPA rewrite turned missing \/download/*.apk\ into landing HTML, so the Android package path was not a real binary.
- **Fix:** Redirect \/download/*.apk\ to the GitHub Releases asset; exclude \download/\ from the SPA catch-all; harden \/download/\ buttons to always open the release APK (latest + pinned v24.0.0).
- **Verified asset:** \VoiceIsolate-Pro-android-debug.apk\ on release v24.0.0 — ~318 MB, content-type \pplication/vnd.android.package-archive\, ZIP magic \PK\.

## Smoke tests
- \pnpm worklets:verify\ — all worklets green (vip-gate, vip-deesser, dsp-processor)
- \pnpm test:engineer\ — all RT checks passed
- \pnpm test:landing\ — pipeline/mix/sliders/worklet-driven de-esser path OK; only diarization speaker count failed on short synthetic clip (expected)

## Test plan
- [x] GitHub latest/download returns real APK (302 → release-assets, ZIP magic)
- [x] Worklets packaging integrity
- [x] Engineer RT smoke
- [ ] After deploy: \/download/VoiceIsolate-Pro-android-debug.apk\ redirects to GitHub (not HTML)
- [ ] After deploy: primary Download button fetches real APK


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Android APK download to serve real binary instead of SPA HTML
> - Updates [`public/download/index.html`](https://github.com/Joker5514/VoiceIsolate-Pro/pull/706/files#diff-1a81e71068fc532cf08efe7cda25e29f3ae0fddceaf5f47f8c13c8147bf1d5b0) so the primary Android button links directly to the GitHub Releases APK asset, removing the client-side script that tried a HEAD request for a same-origin local APK and fell back dynamically.
> - Adds a secondary button pinned to the v24.0.0 release APK (~303 MB) for users who need a stable reference.
> - Updates [`vercel.json`](https://github.com/Joker5514/VoiceIsolate-Pro/pull/706/files#diff-a3265310f552fb66876e8bfe8809737e59e5ba946bdf39138b44d9baf4e21240) to redirect `/download/*.apk` requests to GitHub Releases and exclude `/download/` paths from the SPA rewrite, so APK URLs never return HTML.
> - Adds response headers for `/download/*.apk` setting `Content-Type: application/vnd.android.package-archive` and `Content-Disposition: attachment`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized de9da63.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->