### PR TITLE
fix: cockpit pills, worklets, model health, desktop viz scroll

### DIFF
--- a/public/app/app.js
+++ b/public/app/app.js
@@ -983,6 +983,14 @@ class VoiceIsolatePro {
           MODEL_STATUS_KEYS,
           { healthContainer: $('cdnHealthPanel') }
         );
+        // Ensure same-origin health is probed even if the classic loader script
+        // loaded after the first paint (or Electron vip:// cold start).
+        if (window.ModelCDNLoader?.probeSameOriginHealth) {
+          void window.ModelCDNLoader.probeSameOriginHealth()
+            .then(() => this._modelStatusUI?.refreshHealth?.())
+            .catch(() => {});
+        }
+        void this._modelStatusUI.refreshStatus?.().catch?.(() => {});
       } catch (e) {
         structuredLog('warn', '[VIP] ModelStatusUI init failed', { err: e.message });
       }

--- a/public/app/diarization-timeline.js
+++ b/public/app/diarization-timeline.js
@@ -189,16 +189,31 @@ export function setSpeakerSolo(id, solo)  { /* legacy stub — SpeakerControls i
 // ── Internal: render ──────────────────────────────────────────────────────────
 function _resize() {
   if (!_canvas) return;
+  // Match _draw() which divides by devicePixelRatio — keep the same scale factor.
+  const dpr = (typeof devicePixelRatio === 'number' && devicePixelRatio > 0) ? devicePixelRatio : 1;
   const parent = _canvas.parentElement;
-  const w = parent ? parent.clientWidth : 600;
+  const card = typeof _canvas.closest === 'function'
+    ? _canvas.closest('.viz-card, .col-right, .panel')
+    : null;
+  let w = Math.max(
+    parent ? parent.clientWidth : 0,
+    card ? card.clientWidth : 0,
+    _canvas.clientWidth || 0,
+  );
+  if (card && card.clientWidth > 0) {
+    w = Math.min(w || card.clientWidth, card.clientWidth);
+  }
+  w = Math.max(1, w || 280);
   const h = Math.max(80, _canvas.clientHeight || 90);
-  _canvas.width  = w * devicePixelRatio;
-  _canvas.height = h * devicePixelRatio;
-  _canvas.style.width  = w + 'px';
+  _canvas.width  = Math.round(w * dpr);
+  _canvas.height = Math.round(h * dpr);
+  // Fluid width so desktop grid columns reflow; keep explicit height for slot.
+  _canvas.style.width  = '100%';
+  _canvas.style.maxWidth = '100%';
   _canvas.style.height = h + 'px';
   if (_ctx) {
     _ctx.setTransform(1, 0, 0, 1, 0, 0);
-    _ctx.scale(devicePixelRatio, devicePixelRatio);
+    _ctx.scale(dpr, dpr);
   }
   if (!_viewEnd && _duration) _viewEnd = _duration;
   _lastPlayheadPx = -1;

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -37,6 +37,8 @@
   <script src="./dsp-core.js"></script>
   <script src="./ai-intelligence.js"></script>
   <script type="module" src="./whisper-hunter.js"></script>
+  <!-- Same-origin model loader (window.ModelCDNLoader) — Local Model Health + cache pills -->
+  <script src="./model-cdn-loader.js"></script>
   <script src="./dsp-bootstrap.js"></script>
   <script src="./ring-buffer.js"></script>
   <script src="./visuals.js"></script>

--- a/public/app/model-cdn-loader.js
+++ b/public/app/model-cdn-loader.js
@@ -11,11 +11,57 @@
 
   const PROVIDER_PRIORITY = ['same-origin'];
 
-  // In-memory registry of which providers are known-healthy this session
-  const providerHealth = { 'same-origin': true };
+  // In-memory registry of which providers are known-healthy this session.
+  // Start undefined until first successful probe / fetch so UI can show "unknown"
+  // then flip to healthy/degraded — never leave the panel stuck forever.
+  const providerHealth = { 'same-origin': null };
 
   // Track which provider served each model in this session (for diagnostics)
   const modelProviderMap = {};
+
+  let _healthProbePromise = null;
+
+  /**
+   * probeSameOriginHealth — lightweight HEAD/GET of models-manifest.json so
+   * Local Model Health leaves "unknown" on boot (web / Electron vip:// / Capacitor).
+   */
+  async function probeSameOriginHealth() {
+    if (_healthProbePromise) return _healthProbePromise;
+    _healthProbePromise = (async () => {
+      try {
+        const urls = [
+          '/app/models-manifest.json',
+          './models-manifest.json',
+          '/app/models/models-manifest.json',
+        ];
+        let ok = false;
+        for (const url of urls) {
+          try {
+            const resp = await fetch(url, {
+              method: 'GET',
+              credentials: 'omit',
+              cache: 'no-cache',
+            });
+            if (resp.ok) {
+              ok = true;
+              break;
+            }
+          } catch {
+            /* try next */
+          }
+        }
+        providerHealth['same-origin'] = ok;
+        return ok;
+      } catch {
+        providerHealth['same-origin'] = false;
+        return false;
+      } finally {
+        // Allow a later re-probe after network reconnect
+        setTimeout(() => { _healthProbePromise = null; }, 30_000);
+      }
+    })();
+    return _healthProbePromise;
+  }
 
   // Service Worker cache name — must match sw-register.js
   const CACHE_NAME = 'vip-models-v1';
@@ -178,23 +224,40 @@
   let _manifest = null;
   async function getManifest() {
     if (_manifest) return _manifest;
-    const MANIFEST_URL = '/app/models-manifest.json'; // canonical loader manifest; model binaries remain under /app/models/
-    const resp = await fetch(MANIFEST_URL);
-    if (!resp.ok) throw new Error('Cannot load models-manifest.json');
-    const json = await resp.json();
-    if (Array.isArray(json?.models)) {
-      _manifest = {
-        ...json,
-        models: Object.fromEntries(json.models.map((entry) => [entry.id, {
-          filename: entry.filename,
-          eager: entry.load_priority === 'eager' || entry.eager === true,
-          sources: [{ provider: 'same-origin', url: entry.path || `/app/models/${entry.filename}` }],
-        }])),
-      };
-    } else {
-      _manifest = json;
+    const candidates = [
+      '/app/models-manifest.json', // canonical
+      './models-manifest.json',
+      '/app/models/models-manifest.json',
+    ];
+    let lastErr;
+    for (const MANIFEST_URL of candidates) {
+      try {
+        const resp = await fetch(MANIFEST_URL, { credentials: 'omit' });
+        if (!resp.ok) {
+          lastErr = new Error(`HTTP ${resp.status} for ${MANIFEST_URL}`);
+          continue;
+        }
+        const json = await resp.json();
+        providerHealth['same-origin'] = true;
+        if (Array.isArray(json?.models)) {
+          _manifest = {
+            ...json,
+            models: Object.fromEntries(json.models.map((entry) => [entry.id, {
+              filename: entry.filename,
+              eager: entry.load_priority === 'eager' || entry.eager === true,
+              sources: [{ provider: 'same-origin', url: entry.path || `/app/models/${entry.filename}` }],
+            }])),
+          };
+        } else {
+          _manifest = json;
+        }
+        return _manifest;
+      } catch (err) {
+        lastErr = err;
+      }
     }
-    return _manifest;
+    providerHealth['same-origin'] = false;
+    throw lastErr || new Error('Cannot load models-manifest.json');
   }
 
   window.ModelCDNLoader = {
@@ -203,8 +266,14 @@
     getProviderHealthReport,
     getModelProvider,
     getManifest,
+    probeSameOriginHealth,
     PROVIDER_PRIORITY,
     providerHealth,
     modelProviderMap
   };
+
+  // Non-blocking boot probe so Local Model Health leaves "unknown" quickly.
+  if (typeof window !== 'undefined') {
+    void probeSameOriginHealth();
+  }
 })();

--- a/public/app/model-status-ui.js
+++ b/public/app/model-status-ui.js
@@ -189,11 +189,22 @@ export class ModelStatusUI {
 
   /**
    * refreshHealth — pull current provider health from window.ModelCDNLoader and update rows.
+   * When still unknown, kick a same-origin probe so the panel does not stay stuck.
    */
   refreshHealth() {
     if (!this._healthContainer) return;
-    if (!window.ModelCDNLoader || !window.ModelCDNLoader.getProviderHealthReport) return;
+    if (!window.ModelCDNLoader || !window.ModelCDNLoader.getProviderHealthReport) {
+      // Loader script missing — surface degraded so operators notice wiring issues.
+      for (const provider of Object.keys(this._healthRows)) {
+        const el = this._healthRows[provider];
+        el.classList.remove('vip-cdn-health-status--healthy', 'vip-cdn-health-status--degraded', 'vip-cdn-health-status--unknown');
+        el.classList.add('vip-cdn-health-status--unknown');
+        el.textContent = 'loader missing';
+      }
+      return;
+    }
     const report = window.ModelCDNLoader.getProviderHealthReport();
+    let needsProbe = false;
     for (const provider of Object.keys(this._healthRows)) {
       const el = this._healthRows[provider];
       const healthy = report[provider];
@@ -206,8 +217,32 @@ export class ModelStatusUI {
         el.textContent = 'degraded';
       } else {
         el.classList.add('vip-cdn-health-status--unknown');
-        el.textContent = 'unknown';
+        el.textContent = 'probing…';
+        needsProbe = true;
       }
+    }
+    if (needsProbe && typeof window.ModelCDNLoader.probeSameOriginHealth === 'function') {
+      window.ModelCDNLoader.probeSameOriginHealth()
+        .then(() => {
+          // Re-paint after probe settles (avoid recursive probe storm via needsProbe).
+          const next = window.ModelCDNLoader.getProviderHealthReport();
+          for (const provider of Object.keys(this._healthRows)) {
+            const el = this._healthRows[provider];
+            const healthy = next[provider];
+            el.classList.remove('vip-cdn-health-status--healthy', 'vip-cdn-health-status--degraded', 'vip-cdn-health-status--unknown');
+            if (healthy === true) {
+              el.classList.add('vip-cdn-health-status--healthy');
+              el.textContent = 'healthy';
+            } else if (healthy === false) {
+              el.classList.add('vip-cdn-health-status--degraded');
+              el.textContent = 'degraded';
+            } else {
+              el.classList.add('vip-cdn-health-status--unknown');
+              el.textContent = 'unknown';
+            }
+          }
+        })
+        .catch(() => {});
     }
   }
 
@@ -225,7 +260,10 @@ export class ModelStatusUI {
 
   _startHealthPolling() {
     if (this._healthTimer || !this._healthContainer) return;
-    this._healthTimer = setInterval(() => this.refreshHealth(), 10000);
+    // Faster first paint for health (was 10s — looked stuck on "unknown")
+    this._healthTimer = setInterval(() => this.refreshHealth(), 2500);
+    // One immediate refresh after loader's boot probe may have finished
+    setTimeout(() => this.refreshHealth(), 400);
   }
 
   destroy() {

--- a/public/app/style.css
+++ b/public/app/style.css
@@ -60,17 +60,23 @@ canvas{
   isolation:isolate;
   position:relative;
   overflow:hidden;
+  max-width:100%;
+  box-sizing:border-box;
 }
 .header,.toolbar,.top-bar,nav,.nav,.sidebar,.side-panel,.hdr{
   will-change:transform;
   transform:translateZ(0);
   backface-visibility:hidden;
 }
-#spectrogram-3d,.spectrogram-3d,[id*='spectrogram'],[class*='spectrogram']{
-  position:absolute !important;
+/* ONLY the dedicated 3D spectro host — never match #tab-spectrogram / #btn-spectrogram
+   (substring selectors previously forced those absolute and broke desktop scroll + size). */
+#spectrogram-3d.spectrogram-3d,
+#spectrogram-3d,
+.spectro3d-container > canvas.spectrogram-3d{
+  position:absolute;
   top:0;left:0;
-  width:100% !important;
-  height:100% !important;
+  width:100%;
+  height:100%;
   contain:strict;
 }
 input[type='range']{
@@ -92,10 +98,14 @@ input[type='range']{
 .hs-lbl{font-size:0.55rem;color:var(--dim);letter-spacing:0.05em;text-transform:uppercase}
 
 /* ---- MAIN GRID ---- */
-.main-grid{position:relative;z-index:1;max-width:1520px;margin:8px auto;padding:0 10px 10px;display:grid;grid-template-columns:380px 1fr;gap:10px}
+/* minmax(0,…) so the right column can shrink and host horizontal scroll (tabs/canvases).
+   Without min-width:0, grid items expand to content width and body overflow-x:hidden clips them. */
+.main-grid{position:relative;z-index:1;max-width:1520px;margin:8px auto;padding:0 10px 10px;display:grid;grid-template-columns:minmax(260px,380px) minmax(0,1fr);gap:10px}
+.col-left,.col-right{min-width:0;max-width:100%}
+.col-right{overflow-x:auto;overflow-y:visible;-webkit-overflow-scrolling:touch}
 
 /* ---- CARDS — v25 PREMIUM GLASSMORPHISM ---- */
-.card{background:linear-gradient(165deg,rgba(16,10,12,.6) 0%,rgba(6,4,6,.8) 100%);backdrop-filter:blur(32px) saturate(180%);border-radius:var(--r);padding:14px;border:1px solid rgba(255,255,255,0.06);box-shadow:inset 0 1px 0 rgba(255,255,255,0.1),0 24px 60px rgba(0,0,0,.6),0 0 20px rgba(220,38,38,0.1);transition:border-color .3s,box-shadow .3s, transform .2s}
+.card{background:linear-gradient(165deg,rgba(16,10,12,.6) 0%,rgba(6,4,6,.8) 100%);backdrop-filter:blur(32px) saturate(180%);border-radius:var(--r);padding:14px;border:1px solid rgba(255,255,255,0.06);box-shadow:inset 0 1px 0 rgba(255,255,255,0.1),0 24px 60px rgba(0,0,0,.6),0 0 20px rgba(220,38,38,0.1);transition:border-color .3s,box-shadow .3s, transform .2s;min-width:0;max-width:100%;box-sizing:border-box}
 .card:hover{border-color:rgba(220,38,38,0.3);box-shadow:inset 0 1px 0 rgba(255,255,255,0.15),0 24px 60px rgba(0,0,0,.8),0 0 40px rgba(220,38,38,0.2);transform:translateY(-2px)}
 
 /* Visually hidden file input — must stay in viewport for Chromium picker */
@@ -440,58 +450,105 @@ input[type="range"].realtime:not(.tp-seek):not(.landing-seek-input)::-webkit-sli
 .osc-mode.active{border-color:var(--green);color:var(--green);background:rgba(255, 85, 0,0.06)}
 
 /* ---- VISUALIZATIONS ---- */
-.viz-card{margin-bottom:8px;position:relative}
-.viz-hdr{display:flex;justify-content:space-between;align-items:center;font-size:0.68rem;color:var(--dim);font-weight:600;text-transform:uppercase;letter-spacing:0.04em;margin-bottom:4px;position:relative;z-index:6}
-.viz-actions{display:flex;align-items:center;gap:6px;position:relative;z-index:6}
-.viz-card .tabs{position:relative;z-index:6;display:flex;flex-wrap:nowrap;gap:3px;margin-bottom:0;overflow:visible;border-bottom:1px solid var(--border)}
+.viz-card{margin-bottom:8px;position:relative;min-width:0;max-width:100%;overflow:hidden}
+.viz-hdr{display:flex;justify-content:space-between;align-items:center;font-size:0.68rem;color:var(--dim);font-weight:600;text-transform:uppercase;letter-spacing:0.04em;margin-bottom:4px;position:relative;z-index:6;gap:8px;min-width:0}
+.viz-hdr > span{flex:0 1 auto;min-width:0}
+.viz-actions{display:flex;align-items:center;gap:6px;position:relative;z-index:6;flex:0 0 auto;flex-wrap:wrap;justify-content:flex-end}
+/* Tabs scroll on the rail — keep nowrap + visible overflow so the rail owns horizontal scroll */
+.viz-card .tabs{position:relative;z-index:6;display:flex;flex-wrap:nowrap!important;gap:3px;margin-bottom:0;overflow:visible!important;width:max-content;min-width:100%;border-bottom:1px solid var(--border)}
 .viz-card .tab-btn{position:relative;z-index:6;cursor:pointer;touch-action:manipulation;flex:0 0 auto;white-space:nowrap}
-.viz-tab-rail{margin-bottom:8px}
+.viz-tab-rail{margin-bottom:8px;min-width:0;max-width:100%}
 .viz-tab-rail__scroll{
   overflow-x:auto;
   overflow-y:hidden;
   -webkit-overflow-scrolling:touch;
+  overscroll-behavior-x:contain;
   scrollbar-width:thin;
   scrollbar-color:var(--s4) transparent;
   padding-bottom:4px;
+  min-width:0;
+  width:100%;
+  max-width:100%;
+  touch-action:pan-x;
 }
-.viz-tab-rail__scroll::-webkit-scrollbar{height:6px}
+.viz-tab-rail__scroll::-webkit-scrollbar{height:8px}
 .viz-tab-rail__scroll::-webkit-scrollbar-track{background:rgba(0,0,0,.25);border-radius:3px}
 .viz-tab-rail__scroll::-webkit-scrollbar-thumb{background:var(--s4);border-radius:3px}
 .viz-tab-rail__scroll::-webkit-scrollbar-thumb:hover{background:var(--cyan)}
 .btn-viz-tab-nav{min-width:26px;padding:2px 6px;font-size:0.85rem;line-height:1}
 .btn-viz-tab-nav:hover{border-color:rgba(0,255,231,.35);color:var(--cyan)}
 .btn-viz-minimize.is-active,.btn-viz-minimize[aria-pressed="true"]{border-color:rgba(0,255,231,.45);color:var(--cyan);background:rgba(0,255,231,.08)}
-.viz-card-body{transition:max-height .28s ease,opacity .22s ease}
+.viz-card-body{transition:max-height .28s ease,opacity .22s ease;min-width:0;max-width:100%;overflow-x:auto;overflow-y:visible}
+.viz-card .panel{min-width:0;max-width:100%;box-sizing:border-box;overflow-x:auto}
 .viz-card.viz-minimized .viz-card-body{display:none}
 .viz-card.viz-minimized{margin-bottom:4px}
 .viz-card.viz-minimized .viz-hdr{margin-bottom:0}
-.viz-card.viz-fullscreen{position:fixed;inset:12px;z-index:9998;overflow:auto;margin:0;max-height:none;background:#040408;border:1px solid var(--border);box-shadow:0 24px 80px rgba(0,0,0,.75)}
+.viz-card.viz-fullscreen{position:fixed;inset:12px;z-index:9998;overflow:auto;margin:0;max-height:none;max-width:none;background:#040408;border:1px solid var(--border);box-shadow:0 24px 80px rgba(0,0,0,.75)}
 .viz-card.viz-fullscreen .viz-hdr{position:sticky;top:0;background:rgba(4,4,8,.92);backdrop-filter:blur(10px);padding:6px 0;margin-bottom:8px;z-index:9}
 .viz-card.viz-fullscreen .viz-tab-rail{position:sticky;top:36px;background:rgba(4,4,8,.88);backdrop-filter:blur(8px);z-index:8;padding-bottom:4px}
 .viz-card.viz-fullscreen .tabs{border-bottom-color:rgba(255,255,255,.08)}
 .btn-viz-gallery.is-active{border-color:rgba(0,255,231,.45);color:var(--cyan);background:rgba(0,255,231,.08)}
 .viz-panel-label{display:none;font-size:0.58rem;font-weight:700;letter-spacing:0.08em;text-transform:uppercase;color:var(--cyan);margin-bottom:4px}
 .viz-card.viz-gallery .viz-panel-label{display:block}
-.viz-card.viz-gallery .panel{display:block!important;border:1px solid var(--border);border-radius:8px;padding:8px;margin-bottom:8px;background:rgba(0,0,0,.18)}
-.viz-card.viz-gallery .panel .spectro3d-container{height:140px}
+/* Desktop gallery: responsive multi-column; each tile scrolls/sizes independently */
+.viz-card.viz-gallery .viz-card-body{
+  display:grid;
+  grid-template-columns:repeat(auto-fit,minmax(min(100%,320px),1fr));
+  gap:10px;
+  align-items:start;
+}
+.viz-card.viz-gallery .viz-tab-rail,
+.viz-card.viz-gallery #neon-pulse-slot,
+.viz-card.viz-gallery #vizIsoConfirm{grid-column:1 / -1}
+.viz-card.viz-gallery .panel{
+  display:block!important;
+  border:1px solid var(--border);
+  border-radius:8px;
+  padding:8px;
+  margin-bottom:0;
+  background:rgba(0,0,0,.18);
+  min-width:0;
+  max-width:100%;
+  overflow:hidden;
+}
+.viz-card.viz-gallery .panel .spectro3d-container{height:140px;max-width:100%}
 .viz-card.viz-gallery .spectro2d{height:80px}
 .viz-card.viz-gallery .freq-cv{height:56px}
 .viz-card.viz-gallery .wave-cv{height:56px}
-.viz-card.viz-gallery .wave-row{grid-template-columns:1fr 1fr}
+.viz-card.viz-gallery .wave-row{grid-template-columns:minmax(0,1fr) minmax(0,1fr)}
 .viz-hint{font-size:0.55rem;color:var(--dim);font-weight:400;text-transform:none;letter-spacing:0}
-.viz-canvas{width:100%;display:block;border-radius:4px;background:#030306}
+.viz-canvas{width:100%;max-width:100%;height:auto;display:block;border-radius:4px;background:#030306;box-sizing:border-box}
 .spectro2d{height:110px}
 .spectro-scale{display:flex;justify-content:space-between;font-family:var(--fm);font-size:0.5rem;color:var(--dim);padding:2px 0}
-.spectro3d-container{width:100%;height:200px;border-radius:4px;background:#030306;overflow:hidden;cursor:grab;position:relative}
-.spectro3d-container canvas{width:100%!important;height:100%!important;display:block}
+.spectro3d-container{width:100%;max-width:100%;height:200px;border-radius:4px;background:#030306;overflow:hidden;cursor:grab;position:relative;box-sizing:border-box}
+.spectro3d-container canvas{width:100%!important;height:100%!important;display:block;max-width:100%}
 .spectro-legend{display:flex;gap:10px;margin-top:4px;flex-wrap:wrap}
 .sl-item{display:flex;align-items:center;gap:3px;font-size:0.55rem;color:var(--dim)}
 .sl-dot{width:8px;height:8px;border-radius:2px;display:inline-block}
-.wave-row{display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-bottom:0}
+.wave-row{display:grid;grid-template-columns:minmax(0,1fr) minmax(0,1fr);gap:8px;margin-bottom:0;min-width:0;max-width:100%}
 .wave-cv{height:70px}
-#auraCanvas,#liquidCanvas{height:180px}
+#auraCanvas,#liquidCanvas{height:180px;max-width:100%}
 .viz-card.viz-gallery #auraCanvas,.viz-card.viz-gallery #liquidCanvas{height:140px}
 .freq-cv{height:80px}
+
+/* Desktop Electron / wide windows — ensure viz rail scrollbar is visible & usable */
+@media (min-width:961px){
+  .viz-tab-rail__scroll{
+    scrollbar-width:auto;
+  }
+  .viz-tab-rail__scroll::-webkit-scrollbar{height:10px}
+  .col-right{
+    /* Prefer in-card scroll; only spill horizontally as last resort */
+    overflow-x:hidden;
+  }
+  .viz-card.viz-gallery .viz-card-body{
+    grid-template-columns:repeat(auto-fit,minmax(min(100%,360px),1fr));
+  }
+  .viz-card.viz-fullscreen .spectro3d-container{height:min(42vh,420px)}
+  .viz-card.viz-fullscreen .spectro2d{height:min(28vh,240px)}
+  .viz-card.viz-fullscreen .wave-cv,.viz-card.viz-fullscreen #auraCanvas,
+  .viz-card.viz-fullscreen #liquidCanvas{height:min(22vh,200px)}
+}
 
 /* ---- STATS ---- */
 .stats-row{display:grid;grid-template-columns:repeat(4,1fr);gap:6px}
@@ -585,7 +642,8 @@ input[type="range"]:focus-visible::-moz-range-thumb{
 .engine-pill::before{content:'';display:inline-block;width:5px;height:5px;border-radius:50%;background:currentColor;box-shadow:0 0 5px currentColor}
 .engine-pill[data-state="pending"]{color:var(--dim)}
 .engine-pill[data-state="loading"]{color:var(--yellow);border-color:rgba(234,179,8,.32);animation:engPulse 1.1s ease-in-out infinite}
-.engine-pill[data-state="ready"]{color:#ff1111;border-color:rgba(0,255,231,.28);background:rgba(0,255,231,.05);box-shadow:0 0 10px rgba(0,255,231,.08)}
+/* Ready = cyan/green (was #ff1111 red — looked identical to error) */
+.engine-pill[data-state="ready"]{color:#00ffe7;border-color:rgba(0,255,231,.4);background:rgba(0,255,231,.08);box-shadow:0 0 10px rgba(0,255,231,.12)}
 .engine-pill[data-state="error"]{color:#ef4444;border-color:rgba(239,68,68,.4);background:rgba(239,68,68,.05)}
 .engine-pill[data-state="unavailable"]{color:var(--yellow);border-color:rgba(234,179,8,.22)}
 @keyframes engPulse{0%,100%{opacity:1;transform:scale(1)}50%{opacity:0.55;transform:scale(0.97)}}

--- a/public/app/vip-boot.js
+++ b/public/app/vip-boot.js
@@ -362,6 +362,10 @@
     Object.keys(window.ModelCDNLoader.providerHealth).forEach(function (k) {
       window.ModelCDNLoader.providerHealth[k] = true;
     });
+    // Re-probe so Local Model Health flips off "unknown" after reconnect
+    if (typeof window.ModelCDNLoader.probeSameOriginHealth === 'function') {
+      try { window.ModelCDNLoader.probeSameOriginHealth(); } catch (e) { /* ignore */ }
+    }
     return true;
   }
 

--- a/public/app/visuals-bootstrap.js
+++ b/public/app/visuals-bootstrap.js
@@ -216,17 +216,41 @@
   }
 
   /* ── Canvas helpers ───────────────────────────────────────────────────── */
-  function _resizeCanvas(canvas, fallbackH) {
-    const dpr = Math.min(window.devicePixelRatio || 1, 2);
+  function _measureCanvasCss(canvas, fallbackH) {
+    // Prefer layout box of the panel / container so Electron desktop and
+    // gallery grids size correctly (getBoundingClientRect can be 0 while
+    // parent is still laying out, or inflated when overflow is clipped).
+    const parent = canvas.parentElement;
+    const panel = canvas.closest?.('.panel, .viz-card-body, .spectro3d-container') || parent;
     const rect = canvas.getBoundingClientRect();
-    const cssW = Math.max(1, Math.round(
-      rect.width > 0 ? rect.width : (canvas.offsetWidth || canvas.clientWidth || 800),
-    ));
-    const cssH = Math.max(1, Math.round(
-      rect.height > 0
+    const parentW = Math.max(
+      parent?.clientWidth || 0,
+      panel?.clientWidth || 0,
+      canvas.offsetWidth || 0,
+      canvas.clientWidth || 0,
+    );
+    // Cap to the viz card content width so we never paint wider than the column.
+    const card = canvas.closest?.('.viz-card, .col-right');
+    const cardW = card ? Math.max(0, card.clientWidth - 8) : 0;
+    let cssW = Math.round(rect.width > 2 ? rect.width : parentW);
+    if (cardW > 0) cssW = Math.min(cssW || cardW, cardW);
+    if (!cssW || cssW < 2) cssW = Math.max(parentW, 280);
+    cssW = Math.max(1, Math.min(cssW, 4096));
+
+    const styleH = parseInt(getComputedStyle(canvas).height, 10);
+    let cssH = Math.round(
+      rect.height > 2
         ? rect.height
-        : (parseInt(getComputedStyle(canvas).height, 10) || canvas.clientHeight || fallbackH || 240),
-    ));
+        : (styleH || canvas.clientHeight || fallbackH || 240),
+    );
+    cssH = Math.max(1, Math.min(cssH || fallbackH || 240, 2048));
+    return { cssW, cssH };
+  }
+
+  function _resizeCanvas(canvas, fallbackH) {
+    if (!canvas) return { w: 1, h: 1, cssW: 1, cssH: 1 };
+    const dpr = Math.min(window.devicePixelRatio || 1, 2);
+    const { cssW, cssH } = _measureCanvasCss(canvas, fallbackH);
     const w = Math.round(cssW * dpr);
     const h = Math.round(cssH * dpr);
     const prev = canvas.dataset.vipCssSize || '';
@@ -234,7 +258,10 @@
     if (canvas.width !== w || canvas.height !== h || prev !== next) {
       canvas.width = w;
       canvas.height = h;
-      canvas.style.width = cssW + 'px';
+      // Fluid CSS width so grid/desktop column resizes reflow correctly;
+      // height stays explicit so empty canvases keep their slot.
+      canvas.style.width = '100%';
+      canvas.style.maxWidth = '100%';
       canvas.style.height = cssH + 'px';
       canvas.dataset.vipCssSize = next;
       _playheadPxCache.delete(canvas);
@@ -976,15 +1003,30 @@
   }
 
   function _wireResizeObserver() {
-    const card = document.querySelector('.viz-card');
-    if (!card || typeof ResizeObserver === 'undefined') return;
+    if (typeof ResizeObserver === 'undefined') {
+      window.addEventListener('resize', () => setTimeout(_scheduleLayoutResize, 180));
+      return;
+    }
     const ro = new ResizeObserver(() => _scheduleLayoutResize());
-    ro.observe(card);
+    const targets = [
+      document.querySelector('.viz-card'),
+      document.querySelector('.col-right'),
+      document.getElementById('vizCardBody'),
+      document.getElementById('vizTabScroll'),
+      document.getElementById('spectro3d-container'),
+    ].filter(Boolean);
+    for (const el of targets) {
+      try { ro.observe(el); } catch (_) { /* ignore */ }
+    }
     const onViewportChange = () => {
       setTimeout(_scheduleLayoutResize, 180);
     };
     window.addEventListener('orientationchange', onViewportChange);
     window.addEventListener('resize', onViewportChange);
+    // Electron desktop: first paint often has 0-width panels until the window shows.
+    setTimeout(_scheduleLayoutResize, 50);
+    setTimeout(_scheduleLayoutResize, 300);
+    setTimeout(_scheduleLayoutResize, 1000);
   }
 
   /* ── Event wiring ─────────────────────────────────────────────────────── */

--- a/src/pipeline/PlaybackMixer.js
+++ b/src/pipeline/PlaybackMixer.js
@@ -71,17 +71,47 @@ function getInflightMap(ctx) {
 /**
  * Resolve a same-origin worklet URL. Absolute URLs are required by some
  * Android WebViews / Capacitor shells when the page is not at `/`.
+ * Uses location.href as base so Electron vip://app/... and Capacitor hosts
+ * keep the correct authority (origin-only can drop the hostname on custom schemes).
  * @param {string} path
  * @returns {string}
  */
 export function resolveWorkletUrl(path) {
   if (!path) return path;
-  if (/^https?:\/\//i.test(path) || path.startsWith('blob:')) return path;
+  if (/^(https?:|blob:|vip:)/i.test(path)) return path;
+  try {
+    const href = globalThis.location?.href;
+    if (href && href !== 'about:blank') return new URL(path, href).href;
+  } catch { /* fall through */ }
   try {
     const origin = globalThis.location?.origin;
     if (origin && origin !== 'null') return new URL(path, origin).href;
   } catch { /* fall through */ }
   return path;
+}
+
+/**
+ * Candidate URLs for addModule across web / Electron vip:// / Capacitor.
+ * @param {string} path
+ * @returns {string[]}
+ */
+export function workletUrlCandidates(path) {
+  const abs = resolveWorkletUrl(path);
+  const out = [];
+  const push = (u) => { if (u && !out.includes(u)) out.push(u); };
+  push(abs);
+  push(path);
+  // Relative to page (helps when document is under /app/ and /src is sibling).
+  try {
+    if (globalThis.location?.href) {
+      push(new URL(path.replace(/^\//, ''), globalThis.location.href).href);
+      // From /app/index.html → ../src/workers/...
+      if (path.startsWith('/src/')) {
+        push(new URL(`..${path}`, globalThis.location.href).href);
+      }
+    }
+  } catch { /* ignore */ }
+  return out;
 }
 
 /**
@@ -105,21 +135,24 @@ export async function ensureWorkletModule(ctx, path) {
     if (ctx.state === 'suspended') {
       try { await ctx.resume(); } catch { /* best-effort */ }
     }
-    const absolute = resolveWorkletUrl(path);
+    const candidates = workletUrlCandidates(path);
     let lastErr = null;
-    for (let attempt = 0; attempt < 2; attempt++) {
-      try {
-        const src = attempt === 0
-          ? absolute
-          : `${absolute}${absolute.includes('?') ? '&' : '?'}vipwk=${Date.now()}`;
-        // Literal-ish call kept for allowlists; path is a constant from callers.
-        await ctx.audioWorklet.addModule(src);
-        loaded.add(path);
-        return;
-      } catch (err) {
-        lastErr = err;
-        if (ctx.state === 'suspended') {
-          try { await ctx.resume(); } catch { /* ignore */ }
+    for (let i = 0; i < candidates.length; i++) {
+      const base = candidates[i];
+      for (let attempt = 0; attempt < 2; attempt++) {
+        try {
+          const src = attempt === 0
+            ? base
+            : `${base}${base.includes('?') ? '&' : '?'}vipwk=${Date.now()}`;
+          // Literal-ish call kept for allowlists; path is a constant from callers.
+          await ctx.audioWorklet.addModule(src);
+          loaded.add(path);
+          return;
+        } catch (err) {
+          lastErr = err;
+          if (ctx.state === 'suspended') {
+            try { await ctx.resume(); } catch { /* ignore */ }
+          }
         }
       }
     }
@@ -413,12 +446,14 @@ export class PlaybackMixer {
     const NodeCtor = globalThis.AudioWorkletNode;
     if (!aw || typeof aw.addModule !== 'function' || typeof NodeCtor !== 'function') {
       this._gateLoadState = 'bypassed';
+      try { globalThis.__vipWorkletStatus = this.getWorkletStatus(); } catch { /* ignore */ }
       return;
     }
     this._gateLoadState = 'pending';
+    try { globalThis.__vipWorkletStatus = this.getWorkletStatus(); } catch { /* ignore */ }
     try {
-      // ensureWorkletModule: resume + absolute URL + retry. Falls back to a
-      // literal addModule call so validate.js allowlist scanners still see it.
+      // ensureWorkletModule: resume + absolute URL + multi-candidate retry.
+      // Falls back to a literal addModule call so validate.js allowlist scanners still see it.
       try {
         await ensureWorkletModule(this.ctx, '/src/workers/GateProcessor.js');
       } catch (primary) {
@@ -444,8 +479,10 @@ export class PlaybackMixer {
       }
       this.gate = gate;
       this._gateLoadState = 'loaded';
+      try { globalThis.__vipWorkletStatus = this.getWorkletStatus(); } catch { /* ignore */ }
     } catch (err) {
       this._gateLoadState = 'failed';
+      try { globalThis.__vipWorkletStatus = this.getWorkletStatus(); } catch { /* ignore */ }
       console.error('[VIP][PlaybackMixer] noise-gate worklet failed to load; bypassing.', err);
       // Keep graph connected: gateInput → highpass must stay live.
       try { this.gateInput.connect(this.highpass); } catch { /* already connected */ }
@@ -461,9 +498,11 @@ export class PlaybackMixer {
     const NodeCtor = globalThis.AudioWorkletNode;
     if (!aw || typeof aw.addModule !== 'function' || typeof NodeCtor !== 'function') {
       this._deEsserLoadState = 'bypassed';
+      try { globalThis.__vipWorkletStatus = this.getWorkletStatus(); } catch { /* ignore */ }
       return;
     }
     this._deEsserLoadState = 'pending';
+    try { globalThis.__vipWorkletStatus = this.getWorkletStatus(); } catch { /* ignore */ }
     try {
       try {
         await ensureWorkletModule(this.ctx, '/src/workers/DeEsserProcessor.js');
@@ -490,8 +529,10 @@ export class PlaybackMixer {
       }
       this.deEsser = deEsser;
       this._deEsserLoadState = 'loaded';
+      try { globalThis.__vipWorkletStatus = this.getWorkletStatus(); } catch { /* ignore */ }
     } catch (err) {
       this._deEsserLoadState = 'failed';
+      try { globalThis.__vipWorkletStatus = this.getWorkletStatus(); } catch { /* ignore */ }
       console.error('[VIP][PlaybackMixer] de-esser worklet failed to load; bypassing.', err);
       try { this.deEsserInput.connect(this.limiter); } catch { /* already connected */ }
     }

--- a/tests/cockpit-status-health.test.js
+++ b/tests/cockpit-status-health.test.js
@@ -1,0 +1,74 @@
+/**
+ * Cockpit pills + Local Model Health — regression guards.
+ * Ready must not look like error; ModelCDNLoader must load; worklet URLs resolve.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const css = fs.readFileSync(path.join(ROOT, 'public/app/style.css'), 'utf8');
+const html = fs.readFileSync(path.join(ROOT, 'public/app/index.html'), 'utf8');
+const loader = fs.readFileSync(path.join(ROOT, 'public/app/model-cdn-loader.js'), 'utf8');
+const statusUi = fs.readFileSync(path.join(ROOT, 'public/app/model-status-ui.js'), 'utf8');
+const mixer = fs.readFileSync(path.join(ROOT, 'src/pipeline/PlaybackMixer.js'), 'utf8');
+const workletStatus = fs.readFileSync(path.join(ROOT, 'src/presentation/WorkletStatus.js'), 'utf8');
+
+describe('Engine pill ready styling', () => {
+  test('ready state is cyan/green, not error red', () => {
+    // Historical bug: data-state=ready used color:#ff1111 (looked broken)
+    const readyRule = css.match(/\.engine-pill\[data-state="ready"\]\{[^}]+\}/);
+    expect(readyRule).toBeTruthy();
+    expect(readyRule[0]).not.toMatch(/color:\s*#ff1111/i);
+    expect(readyRule[0]).not.toMatch(/color:\s*#ef4444/i);
+    expect(readyRule[0]).toMatch(/color:\s*#00ffe7/i);
+  });
+
+  test('error state remains distinct red', () => {
+    const errorRule = css.match(/\.engine-pill\[data-state="error"\]\{[^}]+\}/);
+    expect(errorRule).toBeTruthy();
+    expect(errorRule[0]).toMatch(/#ef4444/);
+  });
+});
+
+describe('ModelCDNLoader wiring', () => {
+  test('index.html loads model-cdn-loader.js before app modules', () => {
+    expect(html).toMatch(/src=["']\.\/model-cdn-loader\.js["']/);
+    const loaderIdx = html.indexOf('model-cdn-loader.js');
+    const appIdx = html.indexOf("import('./app.js')");
+    expect(loaderIdx).toBeGreaterThan(-1);
+    expect(appIdx).toBeGreaterThan(loaderIdx);
+  });
+
+  test('loader exposes probeSameOriginHealth + getProviderHealthReport', () => {
+    expect(loader).toContain('probeSameOriginHealth');
+    expect(loader).toContain('getProviderHealthReport');
+    expect(loader).toContain("providerHealth['same-origin']");
+  });
+
+  test('ModelStatusUI probes when health is unknown', () => {
+    expect(statusUi).toContain('probeSameOriginHealth');
+    expect(statusUi).toContain('probing…');
+  });
+});
+
+describe('Playback worklet URL resolution', () => {
+  test('resolveWorkletUrl uses location.href base (Electron vip:// safe)', () => {
+    expect(mixer).toContain('export function resolveWorkletUrl');
+    expect(mixer).toContain('location?.href');
+    expect(mixer).toMatch(/vip:/);
+  });
+
+  test('workletUrlCandidates tries multiple paths for Capacitor/Electron', () => {
+    expect(mixer).toContain('export function workletUrlCandidates');
+    expect(mixer).toContain('ensureWorkletModule');
+    expect(mixer).toMatch(/workletUrlCandidates\(path\)/);
+  });
+
+  test('gate/deess publish __vipWorkletStatus for cockpit drivers', () => {
+    expect(mixer).toContain('__vipWorkletStatus');
+    expect(workletStatus).toContain('__vipWorkletStatus');
+    expect(workletStatus).toContain('startWorkletStatusDriver');
+  });
+});

--- a/tests/desktop-viz-scroll.test.js
+++ b/tests/desktop-viz-scroll.test.js
@@ -1,0 +1,49 @@
+/**
+ * Desktop visualizations — horizontal scroll + correct sizing guards.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const css = fs.readFileSync(path.join(ROOT, 'public/app/style.css'), 'utf8');
+const bootstrap = fs.readFileSync(path.join(ROOT, 'public/app/visuals-bootstrap.js'), 'utf8');
+
+describe('Desktop viz layout CSS', () => {
+  test('does not force absolute layout on every id containing "spectrogram"', () => {
+    // Historical bug: [id*='spectrogram'] matched #tab-spectrogram / #btn-spectrogram
+    // and broke desktop column sizing + tab rail horizontal scroll.
+    expect(css).not.toMatch(/\[id\*=['"]spectrogram['"]\]/);
+    expect(css).not.toMatch(/\[class\*=['"]spectrogram['"]\]/);
+  });
+
+  test('main grid right column can shrink (minmax 0) for scroll hosts', () => {
+    expect(css).toMatch(/grid-template-columns:\s*minmax\([^)]+\)\s*minmax\(0,\s*1fr\)/);
+    expect(css).toMatch(/\.col-left,\s*\.col-right\{min-width:0/);
+  });
+
+  test('viz tab rail owns horizontal scroll with min-width 0', () => {
+    expect(css).toMatch(/\.viz-tab-rail__scroll\{[\s\S]*?overflow-x:\s*auto/);
+    expect(css).toMatch(/\.viz-tab-rail__scroll\{[\s\S]*?min-width:\s*0/);
+    expect(css).toMatch(/\.viz-card \.tabs\{[\s\S]*?flex-wrap:\s*nowrap/);
+  });
+
+  test('viz canvases cap at 100% width', () => {
+    expect(css).toMatch(/\.viz-canvas\{[^}]*max-width:\s*100%/);
+    expect(css).toMatch(/\.viz-card\{[^}]*min-width:\s*0/);
+  });
+});
+
+describe('Canvas resize fluid sizing', () => {
+  test('resize uses 100% width (not fixed px lock) for desktop reflow', () => {
+    expect(bootstrap).toContain("canvas.style.width = '100%'");
+    expect(bootstrap).toContain('_measureCanvasCss');
+    expect(bootstrap).toMatch(/closest\?\.\(['"]\.viz-card/);
+  });
+
+  test('observes col-right and tab scroll for desktop layout', () => {
+    expect(bootstrap).toContain("'.col-right'");
+    expect(bootstrap).toContain("getElementById('vizTabScroll')");
+  });
+});


### PR DESCRIPTION
## Summary
- **Cockpit pills:** Ready state was painted red (`#ff1111`) and looked broken — now cyan. Worklet load/status hardened for web, Electron `vip://`, and Capacitor/Android.
- **Local Model Health:** `model-cdn-loader.js` was never loaded, so health stayed `unknown`. Loader is wired + same-origin probe on boot.
- **Desktop visualizations:** Tabs did not scroll horizontally and canvases sized wrong. Fixed grid `min-width:0`, tab-rail scroll, and fluid canvas measure (no absolute spectrogram substring rule).

## Changes
- `style.css` — ready pill color; grid/min-width; viz tab rail + gallery layout; remove bad `[id*='spectrogram']` absolute rule
- `model-cdn-loader.js` / `model-status-ui.js` / `index.html` / `app.js` / `vip-boot.js` — load loader, probe health, refresh UI
- `PlaybackMixer.js` — multi-candidate worklet URLs, `__vipWorkletStatus` publish
- `visuals-bootstrap.js` / `diarization-timeline.js` — fluid canvas width + ResizeObserver targets
- Tests: `cockpit-status-health.test.js`, `desktop-viz-scroll.test.js`

## Platforms
Web browser · Electron desktop · Android APK (shared static assets / Capacitor web assets)

## Test plan
- [x] `tests/cockpit-status-health.test.js`
- [x] `tests/desktop-viz-scroll.test.js`
- [x] Related worklet / engine-pill / architectural tests
- [ ] Manual: open Engineer cockpit — pills go cyan when ready; Local Model Health → healthy
- [ ] Manual desktop: viz tab bar scrolls horizontally; canvases fill right column; Show All gallery tiles size correctly

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix cockpit pills, model health probing, worklet loading, and desktop viz scroll
> - Engine 'ready' pills now render in cyan instead of red; error pills remain red. Tests in [cockpit-status-health.test.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/708/files#diff-7e313ed8768c2499dc7a5024c339de5f00fe18798df010789a992b8e6275c4d3) assert this.
> - `same-origin` provider health initializes as `null` (unknown) in [model-cdn-loader.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/708/files#diff-59a177638546e0bbce7e697b31b52614d6d5fae147b6bc4ca1a0528012e42a63), with active probing via `probeSameOriginHealth()` triggered at boot and on reconnect. Health UI shows 'probing…' during unknown state and updates once resolved.
> - AudioWorklet loading in [PlaybackMixer.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/708/files#diff-646b05066f8ea1ef7558ebf5da2f3de3eeaafd7d18d7ab2f5254089e2577b0b7) now tries multiple URL candidates (including `vip:` scheme and page-relative paths) with per-candidate retries, and publishes load state to `globalThis.__vipWorkletStatus`.
> - Canvas and viz layout in [visuals-bootstrap.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/708/files#diff-97305f1278d299699dbd4b6d6074b123eebb509e482ae1a8caa5cbae8693314f) and [diarization-timeline.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/708/files#diff-36b340ab3dbe85d09541ed5a9e506c50d735112ffb58b742d6a472b27d1da3ab) is now fluid and container-aware, using `devicePixelRatio`-scaled sizing and `ResizeObserver` targets expanded to include `.col-right` and `#vizTabScroll`.
> - Behavioral Change: health polling interval drops from 10s to 2.5s with an additional 400ms early refresh.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7eaef47.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->