### PR TITLE
fix(process): cut isolation load and processing latency

### DIFF
--- a/android/app/src/main/java/com/voiceisolatepro/app/MainActivity.java
+++ b/android/app/src/main/java/com/voiceisolatepro/app/MainActivity.java
@@ -129,16 +129,57 @@ public class MainActivity extends BridgeActivity {
             if (path == null || path.isEmpty() || "/".equals(path)) {
                 path = "/index.html";
             }
+            // Normalize so asset open matches cap sync layout (public/…).
+            if (!path.startsWith("/")) {
+                path = "/" + path;
+            }
 
             final String assetPath = ASSET_PATH_PREFIX + path;
             try {
                 InputStream is = getAssets().open(assetPath);
-                String mimeType = URLConnection.guessContentTypeFromName(assetPath);
-                if (mimeType == null) mimeType = "application/octet-stream";
+                String mimeType = mimeTypeForAsset(assetPath);
                 return new WebResourceResponse(mimeType, "UTF-8", is);
             } catch (IOException ignored) {
                 return null;
             }
         }
+    }
+
+    /**
+     * Correct MIME for AudioWorklet / classic Workers / ORT WASM.
+     * URLConnection.guessContentTypeFromName often returns null or wrong types
+     * for .js/.wasm, which breaks addModule and wasm instantiation on Android.
+     */
+    private static String mimeTypeForAsset(String assetPath) {
+        String lower = assetPath.toLowerCase();
+        if (lower.endsWith(".js") || lower.endsWith(".mjs") || lower.endsWith(".cjs")) {
+            return "application/javascript";
+        }
+        if (lower.endsWith(".wasm")) {
+            return "application/wasm";
+        }
+        if (lower.endsWith(".onnx")) {
+            return "application/octet-stream";
+        }
+        if (lower.endsWith(".json")) {
+            return "application/json";
+        }
+        if (lower.endsWith(".css")) {
+            return "text/css";
+        }
+        if (lower.endsWith(".html") || lower.endsWith(".htm")) {
+            return "text/html";
+        }
+        if (lower.endsWith(".svg")) {
+            return "image/svg+xml";
+        }
+        if (lower.endsWith(".png")) {
+            return "image/png";
+        }
+        if (lower.endsWith(".woff2")) {
+            return "font/woff2";
+        }
+        String guessed = URLConnection.guessContentTypeFromName(assetPath);
+        return guessed != null ? guessed : "application/octet-stream";
     }
 }

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -2385,15 +2385,20 @@ class VoiceIsolatePro {
 
     // Auto-start pipeline after a short model-warmup race so first isolation
     // does not pay ONNX compile mid-process (the common "loading forever" feel).
+    // Desktop/browser: wait up to 10s. Android: 6s — compile is lighter (WASM, smaller batches).
     _yieldToUI(() => {
       if (fileSeq !== this._fileSeq) return;
       if (this.isProcessing || !(this.inputBuffer || this.origBuffer)) return;
       this._autoPipelineRun = true;
+      const ua = typeof navigator !== 'undefined' ? (navigator.userAgent || '') : '';
+      const mobile = /Android|iPhone|iPad|Mobile|Capacitor/i.test(ua);
+      const warmCapMs = mobile ? 6000 : 10000;
       void (async () => {
         try {
+          this.updatePipelineProgress?.(0, mobile ? 'Warming models…' : 'Preparing ML…', 2);
           await Promise.race([
             this._warmupMLModels().catch(() => {}),
-            new Promise((r) => setTimeout(r, 10000)),
+            new Promise((r) => setTimeout(r, warmCapMs)),
           ]);
         } catch { /* proceed even if warmup flakes */ }
         if (fileSeq !== this._fileSeq || this.isProcessing) return;

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -2383,15 +2383,25 @@ class VoiceIsolatePro {
     try { window.dispatchEvent(new CustomEvent('vip:fileLoaded', { detail: { name } })); } catch (_) {}
     this.showNotification('File loaded: ' + name, 'info');
 
-    // Auto-start pipeline — models warmed during decode (matches Landing latency UX).
+    // Auto-start pipeline after a short model-warmup race so first isolation
+    // does not pay ONNX compile mid-process (the common "loading forever" feel).
     _yieldToUI(() => {
       if (fileSeq !== this._fileSeq) return;
-      if (!this.isProcessing && (this.inputBuffer || this.origBuffer)) {
-        this._autoPipelineRun = true;
+      if (this.isProcessing || !(this.inputBuffer || this.origBuffer)) return;
+      this._autoPipelineRun = true;
+      void (async () => {
+        try {
+          await Promise.race([
+            this._warmupMLModels().catch(() => {}),
+            new Promise((r) => setTimeout(r, 10000)),
+          ]);
+        } catch { /* proceed even if warmup flakes */ }
+        if (fileSeq !== this._fileSeq || this.isProcessing) return;
+        if (!(this.inputBuffer || this.origBuffer)) return;
         this.runPipeline(fileSeq).catch((err) => {
           structuredLog('error', '[VIP] Auto-process failed', { err: err.message });
         });
-      }
+      })();
     });
   }
 
@@ -2660,11 +2670,13 @@ class VoiceIsolatePro {
   _mlChannelPlan(buf) {
     const nCh = buf.numberOfChannels;
     if (nCh < 2) {
-      return { channelData: [buf.getChannelData(0)], expandStereo: false };
+      // Owned copy — safe to transfer to the ML worker without a second memcpy.
+      return { channelData: [new Float32Array(buf.getChannelData(0))], expandStereo: false };
     }
     const left = buf.getChannelData(0);
     const right = buf.getChannelData(1);
     const mid = new Float32Array(left.length);
+    // Unrolled-ish mid mix (single pass).
     for (let i = 0; i < left.length; i++) mid[i] = 0.5 * (left[i] + right[i]);
     return { channelData: [mid], expandStereo: true, left, right, mid };
   }
@@ -2672,13 +2684,15 @@ class VoiceIsolatePro {
   /**
    * Apply mono clean stem as a per-sample gain envelope onto stereo sources.
    * Preserves L/R imaging while only running ML once on the mid channel.
+   * `mid` may be null/detached after worker transfer — recompute from L/R.
    */
   _expandMonoCleanToStereo(cleanMono, mid, left, right) {
     const n = cleanMono.length;
     const cleanL = new Float32Array(n);
     const cleanR = new Float32Array(n);
+    const midOk = mid && mid.length >= n;
     for (let i = 0; i < n; i++) {
-      const m = mid[i];
+      const m = midOk ? mid[i] : 0.5 * (left[i] + right[i]);
       let g = Math.abs(m) > 1e-8 ? cleanMono[i] / m : 0;
       if (g < 0) g = 0;
       else if (g > 1.35) g = 1.35;
@@ -2709,6 +2723,8 @@ class VoiceIsolatePro {
       const result = await separateStems(plan.channelData, buf.sampleRate, {
         modelIds: DEFAULT_ML_CHAIN,
         sourceName: this._sourceName || '',
+        // Owned Float32Arrays from _mlChannelPlan — transfer, don't re-copy.
+        transferOwned: true,
         onProgress: (ev) => {
           if (fileSeq !== this._fileSeq || this.abortFlag) return;
           if (ev.type === 'stage') {
@@ -2771,17 +2787,19 @@ class VoiceIsolatePro {
     // Stereo → process mid once (halves STFT + spectral cost). Re-expand at end.
     const processStereoAsMid = nCh >= 2;
     let channels;
-    const yieldBudget = createYieldBudget(12);
+    // Yield less often during bulk DSP — 24ms budget keeps UI alive without thrashing.
+    const yieldBudget = createYieldBudget(24);
     if (processStereoAsMid) {
       const L = buf.getChannelData(0);
       const R = buf.getChannelData(1);
       const mid = new Float32Array(len);
-      const CHUNK = 48000; // ~1 s
+      const CHUNK = 48000 * 4; // ~4 s between yields
       for (let i = 0; i < len; i++) {
         mid[i] = 0.5 * (L[i] + R[i]);
         if (i > 0 && (i % CHUNK) === 0) await yieldBudget();
       }
       channels = [mid];
+      // Reuse the mid buffer on expand — avoid a second full mid mix.
       this._dspStereoSources = { L, R, mid };
     } else {
       channels = [buf.getChannelData(0).slice()];
@@ -2822,10 +2840,8 @@ class VoiceIsolatePro {
     // Expand mono-processed mid back to stereo with gain envelope.
     if (processStereoAsMid && this._dspStereoSources) {
       const midProc = channels[0];
-      const { L, R } = this._dspStereoSources;
-      const midSrc = new Float32Array(len);
-      for (let i = 0; i < len; i++) midSrc[i] = 0.5 * (L[i] + R[i]);
-      channels = this._expandMonoCleanToStereo(midProc, midSrc, L, R);
+      const { L, R, mid } = this._dspStereoSources;
+      channels = this._expandMonoCleanToStereo(midProc, mid, L, R);
       this._dspStereoSources = null;
     }
 
@@ -3148,12 +3164,13 @@ class VoiceIsolatePro {
     const FRAME_CHUNK = forensic ? 128 : 256;
     if (!DSP || !data || data.length < FFT) return data;
 
-    const yieldBudget = createYieldBudget(forensic ? 10 : 12);
+    const yieldBudget = createYieldBudget(forensic ? 14 : 24);
     if (onProgress) onProgress(0.02);
     await yieldToBrowser();
 
     const stftOpts = {
-      yieldEvery: forensic ? 24 : 40,
+      // Fewer yields = faster STFT on desktop; still paint occasionally.
+      yieldEvery: forensic ? 32 : 64,
       onProgress: (frac) => { if (onProgress) onProgress(0.02 + frac * 0.18); },
       shouldAbort: () => this.abortFlag,
     };
@@ -3236,7 +3253,7 @@ class VoiceIsolatePro {
     await yieldToBrowser();
     const rendered = typeof DSP.inverseSTFTAsync === 'function'
       ? await DSP.inverseSTFTAsync(mag, phase, FFT, HOP, data.length, {
-        yieldEvery: forensic ? 24 : 40,
+        yieldEvery: forensic ? 32 : 64,
         onProgress: (frac) => { if (onProgress) onProgress(0.85 + frac * 0.14); },
       })
       : DSP.inverseSTFT(mag, phase, FFT, HOP, data.length);

--- a/src/core/ModelManifest.js
+++ b/src/core/ModelManifest.js
@@ -84,7 +84,7 @@ export const MODEL_MANIFEST = Object.freeze({
     fftSize: 4096,
     hopSize: 1024,
     bins: 2049,
-    maxBatchFrames: 64,
+    maxBatchFrames: 96,
     sampleRate: 48000,
     io: Object.freeze({
       input: 'input',                // [batch, 2049] Float32 magnitudes
@@ -125,7 +125,7 @@ export const MODEL_MANIFEST = Object.freeze({
     hopSize: 1024,
     bins: 2049,
     // Larger base batches cut session.run overhead (effectiveBatchFrames multiplies further).
-    maxBatchFrames: 64,
+    maxBatchFrames: 128,
     sampleRate: 48000,
     io: Object.freeze({
       input: 'input',                // [batch, 2049] Float32 magnitudes

--- a/src/pipeline/MLWorkerHost.js
+++ b/src/pipeline/MLWorkerHost.js
@@ -12,8 +12,20 @@ import { applyMlWorkerMessage, setOrtStatus } from '../core/OrtStatus.js';
 /**
  * @returns {Worker}
  */
+/** Resolve worker URL for browser / Capacitor / Electron vip:// (absolute same-origin). */
+function resolveWorkerUrl(path) {
+  try {
+    const href = globalThis.location?.href;
+    if (href && href !== 'about:blank') return new URL(path, href).href;
+  } catch { /* fall through */ }
+  return path;
+}
+
 export function createMLWorker() {
-  const worker = new Worker('/src/workers/MLWorker.js');
+  // Absolute path required so Capacitor Android (https://voiceisolatepro.app/…)
+  // and Electron vip://app resolve /src/workers correctly.
+  const workerUrl = resolveWorkerUrl('/src/workers/MLWorker.js');
+  const worker = new Worker(workerUrl, { name: 'vip-ml-worker' });
   attachMLWorkerModelCache(worker);
   setOrtStatus({ provider: 'probing', detail: null });
   worker.addEventListener('message', (ev) => {

--- a/src/pipeline/StemSeparation.js
+++ b/src/pipeline/StemSeparation.js
@@ -119,10 +119,17 @@ export async function separateStems(channelData, sampleRate, options = {}) {
   const w = getWorker();
   const requestId = ++_seq;
   const { onProgress } = options;
-  const yieldBudget = createYieldBudget();
-  const copies = [];
-  for (let ch = 0; ch < channelData.length; ch++) {
-    copies.push(await copyFloat32Channel(channelData[ch], { yieldBudget }));
+  // transferOwned: channel buffers are exclusive copies the worker may detach.
+  // Engineer mid-channel plan always allocates owned arrays — skip a second memcpy.
+  let copies;
+  if (options.transferOwned) {
+    copies = channelData.map((ch) => (ch instanceof Float32Array ? ch : new Float32Array(ch)));
+  } else {
+    const yieldBudget = createYieldBudget();
+    copies = [];
+    for (let ch = 0; ch < channelData.length; ch++) {
+      copies.push(await copyFloat32Channel(channelData[ch], { yieldBudget }));
+    }
   }
   const msg = { type: 'process', requestId, channelData: copies, sampleRate, modelIds };
 

--- a/src/workers/MLWorker.js
+++ b/src/workers/MLWorker.js
@@ -148,10 +148,10 @@ function postStage(stage, percent, extra = {}) {
 
 function effectiveBatchFrames(entry) {
   const base = entry.maxBatchFrames || 64;
-  if (BACKEND === 'webgpu') return Math.min(256, base * 4);
+  if (BACKEND === 'webgpu') return Math.min(384, base * 4);
   // Larger WASM batches amortize ONNX session.run overhead on spectral models.
-  // Cap at 192 to avoid oversized tensor allocs on low-memory devices.
-  return Math.min(192, base * 3);
+  // Cap at 256 — ~2 MB tensors for 2049 bins; safe on desktop/Electron/Android.
+  return Math.min(256, Math.max(base * 3, 128));
 }
 
 // ─── Integrity ───────────────────────────────────────────────────────────────
@@ -228,6 +228,9 @@ async function fetchModelBytes(entry) {
 
   const cached = await cacheGet(cacheKey);
   if (cached) {
+    // Cache key already embeds the pinned SHA-256. Re-hashing multi-MB models
+    // on every process adds 100–500ms+ of pure CPU — trust the key after put.
+    if (entry.sha256) return cached;
     try {
       await verifyIntegrity(entry, cached);
       return cached;
@@ -242,7 +245,8 @@ async function fetchModelBytes(entry) {
   }
   const bytes = await res.arrayBuffer();
   await verifyIntegrity(entry, bytes);
-  await cachePut(cacheKey, bytes);
+  // Fire-and-forget cache write — do not block compile/process on IDB put.
+  void cachePut(cacheKey, bytes);
   return bytes;
 }
 
@@ -263,6 +267,8 @@ async function createSessionFromBytes(entry, bytes) {
   const opts = {
     executionProviders: backend === 'webgpu' ? ['webgpu', 'wasm'] : ['wasm'],
     graphOptimizationLevel: 'all',
+    enableCpuMemArena: true,
+    enableMemPattern: true,
   };
   // Slice: InferenceSession.create may detach/neuter the input ArrayBuffer.
   // Callers (and IDB cache entries) must keep a usable copy for retries.
@@ -423,10 +429,13 @@ async function runSpectralMask(entry, session, samples, onProgress) {
       for (let i = 0; i < avail; i++) re[i] = samples[start + i] * win[i];
       fftInPlace(re, im, false);
       const off = b * bins;
+      // sqrt(re²+im²) is faster than Math.hypot for dense spectral loops.
       for (let k = 0; k < bins; k++) {
-        buf.batchRe[off + k] = re[k];
-        buf.batchIm[off + k] = im[k];
-        buf.batchMags[off + k] = Math.hypot(re[k], im[k]);
+        const rr = re[k];
+        const ii = im[k];
+        buf.batchRe[off + k] = rr;
+        buf.batchIm[off + k] = ii;
+        buf.batchMags[off + k] = Math.sqrt(rr * rr + ii * ii);
       }
     }
   };

--- a/src/workers/MLWorker.js
+++ b/src/workers/MLWorker.js
@@ -146,11 +146,29 @@ function postStage(stage, percent, extra = {}) {
   self.postMessage({ type: 'stage', requestId: ACTIVE_REQUEST_ID, stage, percent, ...extra });
 }
 
+/** True on Android WebView / Capacitor / small phones (lower peak RAM). */
+function isConstrainedDevice() {
+  try {
+    const ua = String(self.navigator?.userAgent || '');
+    if (/Android|Mobile|Capacitor/i.test(ua)) return true;
+    const mem = self.navigator?.deviceMemory; // GiB, Chromium
+    if (typeof mem === 'number' && mem > 0 && mem <= 4) return true;
+    const cores = self.navigator?.hardwareConcurrency || 4;
+    if (cores <= 4 && /Linux/i.test(ua) && !/X11|Wayland/i.test(ua)) return true;
+  } catch { /* ignore */ }
+  return false;
+}
+
 function effectiveBatchFrames(entry) {
   const base = entry.maxBatchFrames || 64;
-  if (BACKEND === 'webgpu') return Math.min(384, base * 4);
-  // Larger WASM batches amortize ONNX session.run overhead on spectral models.
-  // Cap at 256 — ~2 MB tensors for 2049 bins; safe on desktop/Electron/Android.
+  const mobile = isConstrainedDevice();
+  if (BACKEND === 'webgpu') {
+    // WebGPU is fast; still cap mobile VRAM/host allocs.
+    return mobile ? Math.min(192, base * 2) : Math.min(384, base * 4);
+  }
+  // WASM: larger batches cut session.run overhead. Mobile uses a lower cap to
+  // avoid OOM on mid-tier Android while staying faster than tiny batches.
+  if (mobile) return Math.min(128, Math.max(base, 64));
   return Math.min(256, Math.max(base * 3, 128));
 }
 
@@ -660,9 +678,15 @@ self.onmessage = async (event) => {
         for (const entry of msg.manifest || []) MANIFEST[entry.id] = entry;
         USE_DESKTOP_CACHE = Boolean(msg.useDesktopCache);
         if (typeof ort !== 'undefined' && ort.env?.wasm) {
+          // Absolute /lib/ works for browser + Capacitor https origin + Electron vip://.
           ort.env.wasm.wasmPaths = '/lib/';
           const cores = self.navigator?.hardwareConcurrency || 4;
-          ort.env.wasm.numThreads = Math.min(8, Math.max(1, cores - 1));
+          const mobile = isConstrainedDevice();
+          // Threaded WASM needs COOP/COEP (Android MainActivity injects headers).
+          // Cap threads on mobile — oversubscription hurts more than it helps.
+          ort.env.wasm.numThreads = mobile
+            ? Math.min(2, Math.max(1, cores))
+            : Math.min(8, Math.max(1, cores - 1));
         }
         const backend = await resolveBackend();
         self.postMessage({ type: 'ready', backend });

--- a/tests/cross-platform-ml-latency.test.js
+++ b/tests/cross-platform-ml-latency.test.js
@@ -1,0 +1,56 @@
+/**
+ * Browser + Android latency / wiring guards for ML + worklets.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const host = fs.readFileSync(path.join(ROOT, 'src/pipeline/MLWorkerHost.js'), 'utf8');
+const mixer = fs.readFileSync(path.join(ROOT, 'src/pipeline/PlaybackMixer.js'), 'utf8');
+const mlWorker = fs.readFileSync(path.join(ROOT, 'src/workers/MLWorker.js'), 'utf8');
+const mainJava = fs.readFileSync(
+  path.join(ROOT, 'android/app/src/main/java/com/voiceisolatepro/app/MainActivity.java'),
+  'utf8',
+);
+const cap = fs.readFileSync(path.join(ROOT, 'capacitor.config.json'), 'utf8');
+
+describe('Cross-platform ML worker URL', () => {
+  test('resolves Worker URL from location (Capacitor/Electron safe)', () => {
+    expect(host).toContain('resolveWorkerUrl');
+    expect(host).toContain('/src/workers/MLWorker.js');
+    expect(host).toMatch(/new Worker\(workerUrl/);
+  });
+
+  test('wasm paths stay same-origin /lib/', () => {
+    expect(mlWorker).toMatch(/wasmPaths\s*=\s*['"]\/lib\//);
+  });
+});
+
+describe('Android COOP/COEP + MIME for low-latency workers', () => {
+  test('MainActivity injects isolation headers', () => {
+    expect(mainJava).toContain('Cross-Origin-Opener-Policy');
+    expect(mainJava).toContain('Cross-Origin-Embedder-Policy');
+    expect(mainJava).toContain('require-corp');
+  });
+
+  test('serves JS/WASM with correct MIME (worklet + ORT)', () => {
+    expect(mainJava).toContain('mimeTypeForAsset');
+    expect(mainJava).toContain('application/javascript');
+    expect(mainJava).toContain('application/wasm');
+  });
+
+  test('Capacitor webDir is build/ with https scheme', () => {
+    const cfg = JSON.parse(cap);
+    expect(cfg.webDir).toBe('build');
+    expect(cfg.server?.androidScheme).toBe('https');
+  });
+});
+
+describe('Playback worklets multi-platform', () => {
+  test('worklet URL candidates cover Capacitor relative roots', () => {
+    expect(mixer).toContain('workletUrlCandidates');
+    expect(mixer).toContain('resolveWorkletUrl');
+  });
+});

--- a/tests/engineer-process-speed.test.js
+++ b/tests/engineer-process-speed.test.js
@@ -50,11 +50,25 @@ describe('Engineer processing speed path', () => {
     );
   });
 
-  test('bsrnn maxBatchFrames is at least 64', () => {
-    expect(manifest).toMatch(/bsrnn_vocals:[\s\S]*?maxBatchFrames:\s*64/);
+  test('bsrnn maxBatchFrames is at least 128', () => {
+    expect(manifest).toMatch(/bsrnn_vocals:[\s\S]*?maxBatchFrames:\s*128/);
   });
 
   test('MLWorker effectiveBatchFrames uses larger WASM batches', () => {
-    expect(mlWorker).toMatch(/Math\.min\(192,\s*base \* 3\)/);
+    expect(mlWorker).toMatch(/Math\.min\(256,/);
+  });
+
+  test('ML transfers owned mid channel (no second memcpy)', () => {
+    expect(appJs).toContain('transferOwned: true');
+    expect(appJs).toMatch(/new Float32Array\(buf\.getChannelData\(0\)\)/);
+  });
+
+  test('auto-process races model warmup before isolation', () => {
+    expect(appJs).toMatch(/_warmupMLModels\(\)[\s\S]*?runPipeline\(fileSeq\)/);
+    expect(appJs).toMatch(/setTimeout\(r,\s*10000\)/);
+  });
+
+  test('MLWorker skips re-hash when cache key embeds sha256', () => {
+    expect(mlWorker).toMatch(/if \(entry\.sha256\) return cached/);
   });
 });

--- a/tests/engineer-process-speed.test.js
+++ b/tests/engineer-process-speed.test.js
@@ -65,10 +65,15 @@ describe('Engineer processing speed path', () => {
 
   test('auto-process races model warmup before isolation', () => {
     expect(appJs).toMatch(/_warmupMLModels\(\)[\s\S]*?runPipeline\(fileSeq\)/);
-    expect(appJs).toMatch(/setTimeout\(r,\s*10000\)/);
+    expect(appJs).toMatch(/warmCapMs/);
   });
 
   test('MLWorker skips re-hash when cache key embeds sha256', () => {
     expect(mlWorker).toMatch(/if \(entry\.sha256\) return cached/);
+  });
+
+  test('MLWorker uses smaller WASM batches on constrained/Android devices', () => {
+    expect(mlWorker).toContain('isConstrainedDevice');
+    expect(mlWorker).toMatch(/if \(mobile\) return Math\.min\(128/);
   });
 });


### PR DESCRIPTION
## Summary
Cuts isolation load/processing latency for **browser**, **desktop**, and **Android APK**, with mobile-safe batching so phones stay fast without OOMs.

## Latency
- Skip SHA re-hash on trusted model cache hits
- Larger desktop ONNX batches; **smaller mobile-safe batches** on Android
- Transfer owned mid-channel PCM (no double memcpy)
- Warm models before auto-process (10s desktop / **6s Android**)
- Leaner DSP yields + ORT mem arena
- Adaptive WASM thread count (mobile ≤2)

## Browser + Android
- ML Worker URL resolved from `location` (Capacitor `https://voiceisolatepro.app`)
- Android COOP/COEP headers retained; **correct MIME** for `.js` / `.wasm` (worklets + ORT)
- Capacitor `webDir: build`, https scheme

## Test plan
- [x] `tests/engineer-process-speed.test.js`
- [x] `tests/cross-platform-ml-latency.test.js`
- [x] cockpit / viz / architectural suites
- [ ] Browser: drop stereo file — warmup then isolate
- [ ] Android: rebuild APK, drop short clip, confirm process completes without hang

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cut isolation load and processing latency across ML worker and DSP pipeline
> - ML worker now detects constrained devices to cap WASM thread count (≤2 on mobile) and selects device-aware batch sizes (up to 384 frames on desktop WebGPU, 256 on desktop WASM)
> - `maxBatchFrames` is increased for `rnnoise` (64→96) and `bsrnn_vocals` (64→128) in [ModelManifest.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/709/files#diff-5772c6528b54a7034c740cd0399b4f8192393506ba033b63ffbbd50eb69954d7)
> - Auto-pipeline start now awaits a warmup race (`_warmupMLModels()` vs. 6s/10s timeout) before running, reducing mid-process ONNX compile stalls
> - `separateStems` gains a `transferOwned` option to skip the memcpy and transfer buffers directly to the ML worker; mono channel data in `_mlChannelPlan` is now an owned `Float32Array` copy to support this
> - Cached ONNX models skip re-hashing on load; DSP yield budget doubled (12ms→24ms) and mid buffer is reused for stereo expansion to avoid redundant recomputation
> - Worker script path is resolved to an absolute URL via `resolveWorkerUrl` in [MLWorkerHost.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/709/files#diff-910d701237b02aa7b37687e0fdec7bb8fac8f72863c8c0d8050910b613e2478a) to fix loading under Capacitor custom schemes; Android asset handler now returns accurate MIME types for JS/WASM/JSON/CSS via `mimeTypeForAsset`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 81cc1af.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->