### PR TITLE
feat(android): include landing page in complete offline APK

### DIFF
--- a/public/download/index.html
+++ b/public/download/index.html
@@ -71,7 +71,7 @@
           All releases
         </a>
       </div>
-      <p class="dl-meta dl-ok">Complete offline app · Engineer Mode · models + ORT bundled · real APK binary</p>
+      <p class="dl-meta dl-ok">Complete offline app · Landing + Engineer Mode · models + ORT bundled · real APK binary</p>
       <p class="dl-meta warn">Debug/sideload build · not Play Store signed · Demucs FP32 excluded (BS-RNN default)</p>
       <p class="dl-meta">
         Asset name: <code>VoiceIsolate-Pro-android-debug.apk</code><br />

--- a/scripts/prepare-android-complete.mjs
+++ b/scripts/prepare-android-complete.mjs
@@ -2,11 +2,12 @@
 /**
  * Prepare a complete offline Android app package under build/ before `cap sync`.
  *
- * - Engineer Mode is the app entry (not the marketing landing / Google Fonts)
- * - Ships required ONNX models for isolation (BS-RNN default + denoise + VAD)
- * - Drops demucs FP32 (~353 MB) which is not on the default path and breaks sideload size
- * - Keeps quantized demucs optional for "maximum" isolation if present
- * - Verifies ORT WASM + worklets + Engineer shell exist
+ * - Landing page is the app entry (Stem-Split & Live-Mix UI)
+ * - Engineer Mode remains at /app/ (linked from landing)
+ * - Landing is patched offline (no Google Fonts CDN)
+ * - Ships required ONNX models (BS-RNN default + denoise + VAD)
+ * - Drops demucs FP32 (~353 MB) unused on mobile default path
+ * - Verifies ORT WASM + worklets + landing + Engineer shell
  *
  * Usage: node scripts/prepare-android-complete.mjs
  * Called by: scripts/android-build-win.mjs after `pnpm build`
@@ -43,14 +44,22 @@ const REQUIRED_ORT = [
 ];
 
 const REQUIRED_PATHS = [
+  // Landing (app home)
+  'index.html',
+  'landing.js',
+  'landing.css',
+  'transport-polish.css',
+  // Engineer Mode
   'app/index.html',
   'app/app.js',
   'app/style.css',
   'app/models-manifest.json',
+  // Worklets + ORT
   'src/workers/GateProcessor.js',
   'src/workers/DeEsserProcessor.js',
   'src/workers/MLWorker.js',
   'lib/ort.min.js',
+  'lib/react-mini.js',
 ];
 
 function rmIfExists(p) {
@@ -82,46 +91,71 @@ if (!fs.existsSync(BUILD)) {
 
 console.log('[prepare-android] Preparing complete offline Android package…');
 
-// ── 1. Engineer Mode as root entry (no Google Fonts / marketing landing) ──
-const entryHtml = `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+// ── 1. Keep landing as root entry; strip CDN fonts for 100% offline ──
+const indexPath = path.join(BUILD, 'index.html');
+if (!fs.existsSync(indexPath)) {
+  console.error('[prepare-android] build/index.html missing — landing not copied');
+  process.exit(1);
+}
+let landingHtml = fs.readFileSync(indexPath, 'utf8');
+// Remove Google Fonts (preconnect + stylesheet) — use system UI fonts offline.
+landingHtml = landingHtml
+  .replace(/<link[^>]+fonts\.googleapis\.com[^>]*>\s*/gi, '')
+  .replace(/<link[^>]+fonts\.gstatic\.com[^>]*>\s*/gi, '');
+// Offline font stack + Android polish (viewport-fit, safe areas).
+const offlineFontCss = `
   <meta name="theme-color" content="#0a0a0f" />
   <meta name="color-scheme" content="dark" />
-  <title>VoiceIsolate Pro</title>
-  <style>
-    html,body{margin:0;background:#0a0a0f;color:#e8e8f0;font-family:system-ui,sans-serif;
-      min-height:100%;display:grid;place-items:center}
-    .boot{text-align:center;padding:24px;opacity:.9}
-    .boot b{color:#f87171;letter-spacing:.08em;font-size:.85rem}
-    .boot p{margin:.6rem 0 0;font-size:.8rem;color:#9ca3af}
+  <style id="vip-android-offline-fonts">
+    :root {
+      --font-ui: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+      --font-mono: ui-monospace, "Cascadia Code", "SF Mono", Menlo, Consolas, monospace;
+    }
+    html, body { font-family: var(--font-ui); }
   </style>
-  <script>
-    // Immediate navigation into the full Engineer app (bundled under /app/).
-    // Works on Capacitor https://voiceisolatepro.app origin.
-    location.replace('/app/index.html');
-  </script>
-</head>
-<body>
-  <div class="boot">
-    <b>VOICEISOLATE PRO</b>
-    <p>Starting on-device studio…</p>
-    <p><a href="/app/index.html" style="color:#fca5a5">Open Engineer Mode</a></p>
-  </div>
-</body>
-</html>
 `;
-fs.writeFileSync(path.join(BUILD, 'index.html'), entryHtml, 'utf8');
-console.log('[prepare-android] Root index → Engineer Mode entry');
+if (!landingHtml.includes('vip-android-offline-fonts')) {
+  landingHtml = landingHtml.replace(/<\/head>/i, `${offlineFontCss}</head>`);
+}
+// Download page is not shipped in APK — point nav to Engineer Mode instead.
+landingHtml = landingHtml.replace(
+  /href="\/download\/?"/g,
+  'href="/app/" title="Engineer Mode (full studio)"',
+);
+// Keep a visible Engineer Mode link if only one remains after rewrite.
+if (!landingHtml.includes('href="/app/"') && !landingHtml.includes("href='/app/'")) {
+  landingHtml = landingHtml.replace(
+    '</header>',
+    '<a href="/app/" class="eng-mode-link">Engineer Mode</a></header>',
+  );
+}
+fs.writeFileSync(indexPath, landingHtml, 'utf8');
+console.log('[prepare-android] Root index → offline landing page (Engineer Mode at /app/)');
 
-// ── 2. Strip marketing/docs bloat that is not needed offline ──
-for (const rel of ['docs', 'blueprint', 'download']) {
+// ── 2. Strip heavy docs only (keep landing assets) ──
+for (const rel of ['docs', 'blueprint']) {
   if (rmIfExists(path.join(BUILD, rel))) {
     console.log(`[prepare-android] Removed build/${rel} (not needed in APK)`);
   }
 }
+// Compact download stub so /download links never 404 if something still points there.
+const dlDir = path.join(BUILD, 'download');
+fs.mkdirSync(dlDir, { recursive: true });
+fs.writeFileSync(
+  path.join(dlDir, 'index.html'),
+  `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"/>
+<meta name="viewport" content="width=device-width,initial-scale=1"/>
+<title>VoiceIsolate Pro</title>
+<meta http-equiv="refresh" content="0;url=/app/"/>
+<style>body{margin:0;background:#0a0a0f;color:#e8e8f0;font-family:system-ui,sans-serif;
+display:grid;place-items:center;min-height:100vh;text-align:center;padding:24px}
+a{color:#fca5a5}</style></head><body>
+<p><b>VoiceIsolate Pro</b> — full studio is on-device.</p>
+<p><a href="/">Landing</a> · <a href="/app/">Engineer Mode</a></p>
+</body></html>`,
+  'utf8',
+);
+console.log('[prepare-android] /download → offline stub linking to landing + Engineer Mode');
 
 // ── 3. Models: require core, drop FP32 demucs ──
 const modelsDir = path.join(BUILD, 'app', 'models');
@@ -155,20 +189,32 @@ for (const name of OPTIONAL_MODELS) {
   }
 }
 
-// ── 4. ORT + app shell ──
+// ── 4. Landing + Engineer shell + ORT ──
 for (const rel of REQUIRED_PATHS) mustExist(rel);
 for (const name of REQUIRED_ORT) {
   mustExist(path.join('lib', name).replace(/\\/g, '/'));
 }
-console.log('[prepare-android] ✓ Engineer shell, worklets, ORT present');
+// Confirm landing no longer pulls CDN fonts.
+const patchedLanding = fs.readFileSync(indexPath, 'utf8');
+if (patchedLanding.includes('fonts.googleapis.com') || patchedLanding.includes('fonts.gstatic.com')) {
+  console.error('[prepare-android] FATAL: landing still references Google Fonts');
+  process.exit(1);
+}
+if (!patchedLanding.includes('landing.js') || !patchedLanding.includes('landing.css')) {
+  console.error('[prepare-android] FATAL: landing missing landing.js / landing.css');
+  process.exit(1);
+}
+console.log('[prepare-android] ✓ Landing + Engineer shell, worklets, ORT present');
 
-// ── 5. Capacitor offline marker (read by app if needed) ──
+// ── 5. Capacitor offline marker ──
 fs.writeFileSync(
   path.join(BUILD, 'vip-android.json'),
   JSON.stringify({
     complete: true,
     offline: true,
-    entry: '/app/index.html',
+    entry: '/',
+    landing: true,
+    engineer: '/app/index.html',
     models: REQUIRED_MODELS,
     version: '24.0.0',
     preparedAt: new Date().toISOString(),

--- a/scripts/verify-android-complete.mjs
+++ b/scripts/verify-android-complete.mjs
@@ -11,8 +11,12 @@ const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
 const ASSETS = path.join(ROOT, 'android', 'app', 'src', 'main', 'assets', 'public');
 
 const REQUIRED = [
+  // Landing home
   'index.html',
+  'landing.js',
+  'landing.css',
   'vip-android.json',
+  // Engineer Mode
   'app/index.html',
   'app/app.js',
   'app/models/bsrnn_vocals.onnx',
@@ -52,12 +56,28 @@ for (const rel of FORBIDDEN) {
 }
 
 const entry = fs.readFileSync(path.join(ASSETS, 'index.html'), 'utf8');
-if (!entry.includes('/app/index.html')) {
-  errors.push('Root index.html must boot into Engineer Mode (/app/index.html)');
+// Landing is the home screen — must keep upload UI + Engineer Mode link.
+if (!entry.includes('landing.js') && !entry.includes('/landing.js')) {
+  errors.push('Root index.html must be the landing page (landing.js)');
+}
+if (!entry.includes('uploadZone') && !entry.includes('fileInput')) {
+  errors.push('Landing must include file upload UI');
+}
+if (!entry.includes('/app/') && !entry.includes('/app/index.html')) {
+  errors.push('Landing must link to Engineer Mode (/app/)');
 }
 // Offline: root entry must not pull Google Fonts (or any CDN).
 if (entry.includes('fonts.googleapis.com') || entry.includes('fonts.gstatic.com')) {
   errors.push('Root entry must not load Google Fonts (offline app)');
+}
+const marker = path.join(ASSETS, 'vip-android.json');
+if (fs.existsSync(marker)) {
+  try {
+    const meta = JSON.parse(fs.readFileSync(marker, 'utf8'));
+    if (meta.landing !== true) warnings.push('vip-android.json should set landing: true');
+  } catch {
+    warnings.push('vip-android.json is not valid JSON');
+  }
 }
 
 const mainJava = path.join(

--- a/tests/android-complete-app.test.js
+++ b/tests/android-complete-app.test.js
@@ -17,13 +17,18 @@ const cap = JSON.parse(fs.readFileSync(path.join(ROOT, 'capacitor.config.json'),
 const dl = fs.readFileSync(path.join(ROOT, 'public/download/index.html'), 'utf8');
 
 describe('Android complete app pipeline', () => {
-  test('prepare script ships Engineer entry + required models', () => {
-    expect(prepare).toContain("location.replace('/app/index.html')");
+  test('prepare script ships offline landing + Engineer + required models', () => {
+    expect(prepare).toContain('landing.js');
+    expect(prepare).toContain('landing.css');
+    expect(prepare).toContain('offline landing');
+    expect(prepare).toContain('fonts.googleapis.com');
     expect(prepare).toContain('bsrnn_vocals.onnx');
     expect(prepare).toContain('rnnoise_suppressor.onnx');
     expect(prepare).toContain('silero_vad.onnx');
     expect(prepare).toContain('demucs_v4_fp32.onnx');
     expect(prepare).toMatch(/EXCLUDE_MODELS/);
+    // Must NOT force-redirect away from landing into Engineer only
+    expect(prepare).not.toContain("location.replace('/app/index.html')");
   });
 
   test('win + package scripts run prepare + verify', () => {
@@ -57,7 +62,9 @@ describe('Android complete app pipeline', () => {
     expect(dl).toMatch(/no network required/i);
   });
 
-  test('verify script rejects Google Fonts on entry + missing models', () => {
+  test('verify script requires landing + rejects Google Fonts + missing models', () => {
+    expect(verify).toContain('landing.js');
+    expect(verify).toContain('uploadZone');
     expect(verify).toContain('fonts.googleapis.com');
     expect(verify).toContain('bsrnn_vocals.onnx');
     expect(verify).toContain('demucs_v4_fp32.onnx');


### PR DESCRIPTION
## Summary
Android APK now opens the **landing page** (upload / isolate / live-mix) as the home screen, with **Engineer Mode** still available at `/app/`.

## Changes
- `prepare-android-complete.mjs` keeps landing `index.html` + `landing.js` / `landing.css`
- Offline patch: remove Google Fonts, system UI fonts, download → Engineer link
- Verify requires landing assets + upload UI + Engineer Mode link
- Models/ORT/worklets packaging unchanged

## Test plan
- [x] prepare + verify scripts
- [x] tests/android-complete-app.test.js
- [ ] Sideload APK — landing first, Engineer Mode from nav

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Include landing page as root entry in complete offline Android APK
> - The offline APK now boots into the landing page at `/` instead of redirecting directly to Engineer Mode at `/app/`.
> - [`prepare-android-complete.mjs`](https://github.com/Joker5514/VoiceIsolate-Pro/pull/711/files#diff-dcc08e786a8f65b401f1f1239b5502aa81c5e90e2c792b7e73b742721df4cad2) removes Google Fonts links from the built landing HTML, injects an offline font stack, rewrites `/download` links to point to `/app/`, and creates an offline redirect stub at `public/download/index.html`.
> - [`verify-android-complete.mjs`](https://github.com/Joker5514/VoiceIsolate-Pro/pull/711/files#diff-afc1e98a4a4d640be2c13eb18de262bff98b7dec1aa2ee27b514c029094bcb51) now validates that the root `index.html` is the landing page (references `landing.js`, includes an upload UI marker, and links to Engineer Mode), and warns if `vip-android.json` does not set `landing:true`.
> - The download page copy in [`public/download/index.html`](https://github.com/Joker5514/VoiceIsolate-Pro/pull/711/files#diff-1a81e71068fc532cf08efe7cda25e29f3ae0fddceaf5f47f8c13c8147bf1d5b0) is updated to describe the APK as including both the landing page and Engineer Mode.
> - Behavioral Change: the APK entry point changes from Engineer Mode to the landing page; `vip-android.json` now sets `entry` to `/` and includes `landing:true`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1b3d241.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->