### PR TITLE
fix(android): strip nested APK from package assets

### DIFF
--- a/scripts/prepare-android-complete.mjs
+++ b/scripts/prepare-android-complete.mjs
@@ -138,8 +138,10 @@ for (const rel of ['docs', 'blueprint']) {
     console.log(`[prepare-android] Removed build/${rel} (not needed in APK)`);
   }
 }
-// Compact download stub so /download links never 404 if something still points there.
+// Compact download stub so /download links never 404. Never ship host APKs
+// inside the package (a prior APK in public/download would bloat assets ~300MB).
 const dlDir = path.join(BUILD, 'download');
+rmIfExists(dlDir);
 fs.mkdirSync(dlDir, { recursive: true });
 fs.writeFileSync(
   path.join(dlDir, 'index.html'),
@@ -155,6 +157,22 @@ a{color:#fca5a5}</style></head><body>
 </body></html>`,
   'utf8',
 );
+// Sweep any nested installers that may have been copied from public/
+function stripApkBinaries(dir) {
+  if (!fs.existsSync(dir)) return 0;
+  let n = 0;
+  for (const ent of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, ent.name);
+    if (ent.isDirectory()) n += stripApkBinaries(p);
+    else if (/\.(apk|aab|ipa|exe|dmg|blockmap)$/i.test(ent.name)) {
+      fs.unlinkSync(p);
+      n += 1;
+      console.log(`[prepare-android] Removed bundled installer: ${path.relative(BUILD, p)}`);
+    }
+  }
+  return n;
+}
+stripApkBinaries(BUILD);
 console.log('[prepare-android] /download → offline stub linking to landing + Engineer Mode');
 
 // ── 3. Models: require core, drop FP32 demucs ──


### PR DESCRIPTION
## Summary
The complete Android APK had ballooned to ~540 MB because a previous installer under \`public/download/\` was copied into app assets. Packaging now wipes that folder to an offline stub and removes any \`.apk\`/\`.exe\` binaries from the build tree.

## Test plan
- [x] prepare removes nested installers
- [ ] rebuild APK size back ~230–250 MB with landing + models

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Strip nested installer binaries from Android package assets during build
> - Adds a `stripApkBinaries` function in [`prepare-android-complete.mjs`](https://github.com/Joker5514/VoiceIsolate-Pro/pull/712/files#diff-dcc08e786a8f65b401f1f1239b5502aa81c5e90e2c792b7e73b742721df4cad2) that recursively deletes files with extensions `.apk`, `.aab`, `.ipa`, `.exe`, `.dmg`, and `.blockmap` under the build directory, logging each removal.
> - Also deletes the existing download directory before recreating it to avoid stale artifacts.
> - Behavioral Change: the prepare-android build step now modifies the build output by removing installer binaries that may have been bundled in package assets.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 67ee3aa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->