### PR TITLE
fix(docs): correct Android and Windows download links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ node_modules
 *.ipa
 public/download/*.apk
 public/download/*.aab
+public/download/*.exe
 
 # misc
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
   &nbsp;·&nbsp;
   <a href="https://voice-isolate-pro.vercel.app/download/"><strong>Download</strong></a>
   &nbsp;·&nbsp;
-  <a href="https://github.com/Joker5514/VoiceIsolate-Pro/releases"><strong>Android APK</strong></a>
+  <a href="https://github.com/Joker5514/VoiceIsolate-Pro/releases/latest/download/VoiceIsolate-Pro-android-debug.apk"><strong>Android APK</strong></a>
+  &nbsp;·&nbsp;
+  <a href="https://github.com/Joker5514/VoiceIsolate-Pro/releases/latest/download/VoiceIsolate-Pro-24.0.0-win-x64.exe"><strong>Windows</strong></a>
   &nbsp;·&nbsp;
   <a href="docs/README.md">Documentation</a>
   &nbsp;·&nbsp;
@@ -48,7 +50,7 @@
 |-------|---------|--------------|
 | [`/`](https://voice-isolate-pro.vercel.app/) | **Landing — Stem-Split** | Fast ML stem separation (vocals / accompaniment / noise). Upload → auto-process → preview stems. |
 | [`/app/`](https://voice-isolate-pro.vercel.app/app/) | **Engineer Mode v24** | Full 67-slider DSP suite, scene presets, 3D spectrogram, A/B transport, forensic audit log, WhisperHunter AI. |
-| [`/download/`](https://voice-isolate-pro.vercel.app/download/) | **Downloads** | Android APK (GitHub Releases), web links, desktop build notes. |
+| [`/download/`](https://voice-isolate-pro.vercel.app/download/) | **Downloads** | Android APK + Windows installer (GitHub Releases), web app links. |
 
 **Upload controls (both pages):** Browse Files (`<label for="fileInput">`), click the drop zone, drag-and-drop, or **Upload Audio or Video** in the Engineer hero. Shared wiring lives in `src/presentation/UploadWiring.js`.
 
@@ -180,27 +182,36 @@ No `.env` required for local audio processing. Optional payment/licensing vars i
 | `pnpm worklets:verify` | AudioWorklet packaging integrity |
 | `pnpm build:electron:dir` | Desktop unpacked (Windows) |
 
-### Android download
+### Downloads (GitHub Releases — correct asset URLs)
 
 | Channel | URL |
 |---------|-----|
 | **Web download page** | https://voice-isolate-pro.vercel.app/download/ |
-| **GitHub Releases (APK)** | https://github.com/Joker5514/VoiceIsolate-Pro/releases |
-| **Latest APK asset** | https://github.com/Joker5514/VoiceIsolate-Pro/releases/latest/download/VoiceIsolate-Pro-android-debug.apk |
-| **Pinned v24.0.0** | https://github.com/Joker5514/VoiceIsolate-Pro/releases/download/v24.0.0/VoiceIsolate-Pro-android-debug.apk |
+| **All releases** | https://github.com/Joker5514/VoiceIsolate-Pro/releases |
+| **Latest Android APK** | https://github.com/Joker5514/VoiceIsolate-Pro/releases/latest/download/VoiceIsolate-Pro-android-debug.apk |
+| **Pinned Android v24.0.0** | https://github.com/Joker5514/VoiceIsolate-Pro/releases/download/v24.0.0/VoiceIsolate-Pro-android-debug.apk |
+| **Latest Windows installer** | https://github.com/Joker5514/VoiceIsolate-Pro/releases/latest/download/VoiceIsolate-Pro-24.0.0-win-x64.exe |
+| **Pinned Windows v24.0.0** | https://github.com/Joker5514/VoiceIsolate-Pro/releases/download/v24.0.0/VoiceIsolate-Pro-24.0.0-win-x64.exe |
 
-The download page always links to the **real GitHub Release binary** (~303 MB, `application/vnd.android.package-archive`).  
-Same-origin `/download/*.apk` redirects to GitHub so it never serves SPA HTML.
+| Asset | Name | Approx. size |
+|-------|------|----------------|
+| Android complete offline APK | `VoiceIsolate-Pro-android-debug.apk` | ~238 MB |
+| Windows NSIS installer | `VoiceIsolate-Pro-24.0.0-win-x64.exe` | ~480 MB |
+
+The download page always points at **real GitHub Release binaries** (never SPA HTML).  
+Same-origin `/download/*.apk` and `/download/*.exe` redirect to Releases (`vercel.json`).
 
 Build locally (Windows):
 
 ```bash
 pnpm android:build:win
-# → dist/android/VoiceIsolate-Pro-debug.apk
-# → android/app/build/outputs/apk/debug/app-debug.apk
+# → dist/android/VoiceIsolate-Pro-android-debug.apk
+
+pnpm build:electron
+# → dist/electron/VoiceIsolate-Pro-24.0.0-win-x64.exe
 ```
 
-Sideload: enable **Install unknown apps** for your browser/file manager, then open the APK.  
+Sideload APK: enable **Install unknown apps**, then open the file.  
 Details: [download/README.md](download/README.md).
 
 ### Upload troubleshooting

--- a/docs/electron-desktop.md
+++ b/docs/electron-desktop.md
@@ -72,7 +72,12 @@ Output: `dist/electron/`.
 Huge optional weights (`demucs_v4_fp32.onnx`) are **excluded** from the installer to keep size reasonable. Default chain is BS-RNN only (~4 MB).
 
 Publish installer to GitHub Releases; the web download page links there:
-https://voice-isolate-pro.vercel.app/download/
+
+| Channel | URL |
+|---------|-----|
+| Web download page | https://voice-isolate-pro.vercel.app/download/ |
+| Latest Windows installer | https://github.com/Joker5514/VoiceIsolate-Pro/releases/latest/download/VoiceIsolate-Pro-24.0.0-win-x64.exe |
+| Pinned v24.0.0 | https://github.com/Joker5514/VoiceIsolate-Pro/releases/download/v24.0.0/VoiceIsolate-Pro-24.0.0-win-x64.exe |
 
 ## Model Cache (Desktop)
 

--- a/download/README.md
+++ b/download/README.md
@@ -2,51 +2,62 @@
 
 This folder documents **where installers and APKs live**. Large binaries are **not** committed to git.
 
+Canonical host for end users: **GitHub Releases**  
+https://github.com/Joker5514/VoiceIsolate-Pro/releases
+
+Web download page: https://voice-isolate-pro.vercel.app/download/
+
+---
+
 ## Android APK
 
 | Build | Command | Output |
 |-------|---------|--------|
-| Debug (Windows) | `pnpm android:build:win` | `android/app/build/outputs/apk/debug/app-debug.apk` and `dist/android/VoiceIsolate-Pro-debug.apk` |
-| Debug (Unix) | `pnpm android:build` | same under `android/app/build/outputs/apk/debug/` |
-| Release AAB | `pnpm android:bundle` (or CI `release-build.yml`) | `android/app/build/outputs/bundle/release/` |
+| Debug (Windows) | `pnpm android:build:win` | `dist/android/VoiceIsolate-Pro-android-debug.apk` (also `VoiceIsolate-Pro-debug.apk`) |
+| Debug (Unix) | `pnpm android:build` | `android/app/build/outputs/apk/debug/app-debug.apk` |
+| Release AAB | `pnpm android:bundle` | `android/app/build/outputs/bundle/release/` |
 
-### Public download
+### Public download links (correct)
 
-1. **GitHub Releases** (canonical binary host):  
-   https://github.com/Joker5514/VoiceIsolate-Pro/releases  
-   Latest APK asset: `VoiceIsolate-Pro-android-debug.apk`  
-   Direct: `https://github.com/Joker5514/VoiceIsolate-Pro/releases/latest/download/VoiceIsolate-Pro-android-debug.apk`
-2. **Web page:** https://voice-isolate-pro.vercel.app/download/  
-   Primary buttons open the GitHub release asset (real APK, ~303 MB).  
-   Same-origin `/download/*.apk` is **redirected** to GitHub Releases so it never returns SPA HTML.
-3. Do **not** rely on committing APKs under `public/download/` — Vercel SPA rewrites previously turned missing `.apk` paths into `index.html`.
+| Channel | URL |
+|---------|-----|
+| **Latest APK** | https://github.com/Joker5514/VoiceIsolate-Pro/releases/latest/download/VoiceIsolate-Pro-android-debug.apk |
+| **Pinned v24.0.0** | https://github.com/Joker5514/VoiceIsolate-Pro/releases/download/v24.0.0/VoiceIsolate-Pro-android-debug.apk |
+| **All releases** | https://github.com/Joker5514/VoiceIsolate-Pro/releases |
 
-### Publish a release (maintainers)
+Asset name: `VoiceIsolate-Pro-android-debug.apk` · ~238 MB · complete offline app (Landing + Engineer Mode + models).
+
+Same-origin `/download/*.apk` is **redirected** to GitHub Releases (`vercel.json`) so Vercel never serves SPA HTML for APK URLs.
+
+### Publish Android (maintainers)
 
 ```bash
-# After a successful android:build:win
 pnpm android:build:win
-cp dist/android/VoiceIsolate-Pro-debug.apk public/download/VoiceIsolate-Pro-android-debug.apk
-gh release create v24.0.0 public/download/VoiceIsolate-Pro-android-debug.apk \
-  --title "VoiceIsolate Pro v24.0.0" \
-  --notes "Android debug APK + web app"
+# → dist/android/VoiceIsolate-Pro-android-debug.apk
+gh release upload v24.0.0 dist/android/VoiceIsolate-Pro-android-debug.apk --clobber
 ```
 
-Do **not** commit `*.apk` files (see `.gitignore`).
+Do **not** commit `*.apk` under `public/download/` (see `.gitignore`) — nesting an APK inside web assets bloats the next Android package.
+
+---
 
 ## Desktop (Windows) — offline installer
 
+| Goal | Asset / command |
+|------|-----------------|
+| **Latest installer** | https://github.com/Joker5514/VoiceIsolate-Pro/releases/latest/download/VoiceIsolate-Pro-24.0.0-win-x64.exe |
+| **Pinned v24.0.0** | https://github.com/Joker5514/VoiceIsolate-Pro/releases/download/v24.0.0/VoiceIsolate-Pro-24.0.0-win-x64.exe |
+| Local build | `pnpm build:electron` → `dist/electron/VoiceIsolate-Pro-24.0.0-win-x64.exe` |
+| Portable smoke test | `pnpm build:electron:dir` → `dist/electron/win-unpacked/VoiceIsolate Pro.exe` |
+
+Asset name: `VoiceIsolate-Pro-24.0.0-win-x64.exe` · ~480 MB · 100% offline (UI + ORT + default models).
+
+### Publish desktop (maintainers)
+
 ```bash
 pnpm setup:electron
-pnpm build:electron        # NSIS → dist/electron/*.exe  (downloadable)
-pnpm build:electron:dir    # portable win-unpacked/
+pnpm build:electron
+gh release upload v24.0.0 dist/electron/VoiceIsolate-Pro-24.0.0-win-x64.exe --clobber
 ```
 
-| Goal | Command / asset |
-|------|-----------------|
-| End-user download | GitHub Release: `VoiceIsolate-Pro-*-win-x64.exe` |
-| Local smoke test | `dist/electron/win-unpacked/VoiceIsolate Pro.exe` |
-| Web download page | https://voice-isolate-pro.vercel.app/download/ |
-
-Packaged app is **100% offline** for voice isolation: UI, ORT wasm, and default
-ONNX models (BS-RNN + denoise + VAD) are bundled. See [docs/electron-desktop.md](../docs/electron-desktop.md).
+See [docs/electron-desktop.md](../docs/electron-desktop.md).

--- a/public/download/index.html
+++ b/public/download/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Download — VoiceIsolate Pro</title>
-  <meta name="description" content="Download VoiceIsolate Pro for Android, desktop, or open the web app. 100% on-device voice isolation." />
+  <meta name="description" content="Download VoiceIsolate Pro for Android, Windows desktop, or open the web app. 100% on-device voice isolation." />
   <link rel="icon" href="/icon.jpg" />
   <link rel="stylesheet" href="/landing.css" />
   <style>
@@ -26,6 +26,15 @@
     .warn { color: #fcd34d; font-size: 0.85rem; }
     .dl-ok { color: #86efac; font-size: 0.85rem; }
     code { font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.85em; }
+    pre {
+      background: #0a0a10;
+      padding: 12px;
+      border-radius: 8px;
+      overflow: auto;
+      font-size: 12px;
+      color: #c4c4d0;
+      margin: 8px 0 0;
+    }
   </style>
 </head>
 <body>
@@ -39,17 +48,16 @@
     <h1 class="section-label" style="font-size:1.4rem;letter-spacing:.06em;">Download VoiceIsolate Pro</h1>
     <p class="hint">Privacy-first voice isolation. Audio never leaves your device.</p>
 
+    <!-- ── Android ─────────────────────────────────────────────────────── -->
     <section class="dl-card" aria-labelledby="android-dl">
       <h2 id="android-dl">Android (APK) — complete offline app</h2>
       <p>
-        Full on-device studio: Engineer Mode, BS-RNN isolation, worklets, and ONNX models
-        bundled in the APK — <strong>no network required</strong> after install.
+        Full on-device studio: <strong>Landing + Engineer Mode</strong>, BS-RNN isolation,
+        worklets, and ONNX models bundled — <strong>no network required</strong> after install.
         Enable <strong>Install unknown apps</strong>, then open the file.
-        Download from GitHub Releases
-        (content-type <code>application/vnd.android.package-archive</code>).
       </p>
       <div class="dl-actions">
-        <!-- Primary: always GitHub Releases — never rewrite to a same-origin SPA HTML path -->
+        <!-- Always GitHub Releases — never a same-origin SPA HTML path -->
         <a class="btn" id="apkPrimary"
            href="https://github.com/Joker5514/VoiceIsolate-Pro/releases/latest/download/VoiceIsolate-Pro-android-debug.apk"
            rel="noopener noreferrer"
@@ -71,15 +79,81 @@
           All releases
         </a>
       </div>
-      <p class="dl-meta dl-ok">Complete offline app · Landing + Engineer Mode · models + ORT bundled · real APK binary</p>
-      <p class="dl-meta warn">Debug/sideload build · not Play Store signed · Demucs FP32 excluded (BS-RNN default)</p>
+      <p class="dl-meta dl-ok">
+        Complete offline app · Landing + Engineer Mode · models + ORT ·
+        real APK (~238&nbsp;MB)
+      </p>
+      <p class="dl-meta warn">Debug/sideload build · not Play Store signed</p>
       <p class="dl-meta">
-        Asset name: <code>VoiceIsolate-Pro-android-debug.apk</code><br />
-        Latest: <code>…/releases/latest/download/VoiceIsolate-Pro-android-debug.apk</code><br />
-        Pinned: <code>…/releases/download/v24.0.0/VoiceIsolate-Pro-android-debug.apk</code>
+        Asset: <code>VoiceIsolate-Pro-android-debug.apk</code><br />
+        Latest:
+        <a href="https://github.com/Joker5514/VoiceIsolate-Pro/releases/latest/download/VoiceIsolate-Pro-android-debug.apk"
+           rel="noopener noreferrer" target="_blank" style="color:#f87171">
+          …/latest/download/VoiceIsolate-Pro-android-debug.apk
+        </a><br />
+        Pinned v24.0.0:
+        <a href="https://github.com/Joker5514/VoiceIsolate-Pro/releases/download/v24.0.0/VoiceIsolate-Pro-android-debug.apk"
+           rel="noopener noreferrer" target="_blank" style="color:#f87171">
+          …/download/v24.0.0/VoiceIsolate-Pro-android-debug.apk
+        </a>
       </p>
     </section>
 
+    <!-- ── Desktop ─────────────────────────────────────────────────────── -->
+    <section class="dl-card" aria-labelledby="desktop-dl">
+      <h2 id="desktop-dl">Desktop (Windows) — 100% offline</h2>
+      <p>
+        NSIS installer for Windows x64. Install once, then isolate with
+        <strong>no internet</strong>. UI, ORT WASM, and default ONNX models
+        (BS-RNN + denoise + VAD) ship inside the package.
+      </p>
+      <div class="dl-actions">
+        <a class="btn" id="desktopPrimary"
+           href="https://github.com/Joker5514/VoiceIsolate-Pro/releases/latest/download/VoiceIsolate-Pro-24.0.0-win-x64.exe"
+           rel="noopener noreferrer"
+           target="_blank"
+           download="VoiceIsolate-Pro-24.0.0-win-x64.exe">
+          Download Windows installer
+        </a>
+        <a class="btn btn-outline"
+           href="https://github.com/Joker5514/VoiceIsolate-Pro/releases/download/v24.0.0/VoiceIsolate-Pro-24.0.0-win-x64.exe"
+           rel="noopener noreferrer"
+           target="_blank"
+           download="VoiceIsolate-Pro-24.0.0-win-x64.exe">
+          v24.0.0 direct
+        </a>
+        <a class="btn btn-outline"
+           href="https://github.com/Joker5514/VoiceIsolate-Pro/releases"
+           rel="noopener noreferrer"
+           target="_blank">
+          All releases
+        </a>
+      </div>
+      <p class="dl-meta dl-ok">NSIS · models bundled · offline after install · ~480&nbsp;MB</p>
+      <p class="dl-meta warn">Unsigned local builds may trigger SmartScreen — More info → Run anyway</p>
+      <p class="dl-meta">
+        Asset: <code>VoiceIsolate-Pro-24.0.0-win-x64.exe</code><br />
+        Latest:
+        <a href="https://github.com/Joker5514/VoiceIsolate-Pro/releases/latest/download/VoiceIsolate-Pro-24.0.0-win-x64.exe"
+           rel="noopener noreferrer" target="_blank" style="color:#f87171">
+          …/latest/download/VoiceIsolate-Pro-24.0.0-win-x64.exe
+        </a><br />
+        Pinned v24.0.0:
+        <a href="https://github.com/Joker5514/VoiceIsolate-Pro/releases/download/v24.0.0/VoiceIsolate-Pro-24.0.0-win-x64.exe"
+           rel="noopener noreferrer" target="_blank" style="color:#f87171">
+          …/download/v24.0.0/VoiceIsolate-Pro-24.0.0-win-x64.exe
+        </a>
+      </p>
+      <p class="dl-meta">Build locally:</p>
+      <pre>cd VoiceIsolate-Pro
+pnpm install
+pnpm setup:electron
+pnpm build:electron        # NSIS → dist/electron/
+pnpm build:electron:dir    # portable win-unpacked/</pre>
+      <p class="dl-meta">See <code>docs/electron-desktop.md</code> for signing and offline notes.</p>
+    </section>
+
+    <!-- ── Web ─────────────────────────────────────────────────────────── -->
     <section class="dl-card" aria-labelledby="web-dl">
       <h2 id="web-dl">Web (no install)</h2>
       <p>Run fully in the browser — Landing (stem-split) or Engineer Mode (full DSP).</p>
@@ -87,40 +161,6 @@
         <a class="btn" href="/">Open Landing</a>
         <a class="btn btn-outline" href="/app/">Open Engineer Mode</a>
       </div>
-    </section>
-
-    <section class="dl-card" aria-labelledby="desktop-dl">
-      <h2 id="desktop-dl">Desktop (Windows) — 100% offline</h2>
-      <p>
-        Install once, then isolate voice with <strong>no internet</strong>.
-        ONNX models (BS-RNN + denoise + VAD) and the app UI ship inside the installer.
-        Audio never leaves your PC.
-      </p>
-      <div class="dl-actions">
-        <a class="btn" id="desktopPrimary"
-           href="https://github.com/Joker5514/VoiceIsolate-Pro/releases/latest"
-           rel="noopener noreferrer"
-           target="_blank">
-          Download Windows installer
-        </a>
-        <a class="btn btn-outline"
-           href="https://github.com/Joker5514/VoiceIsolate-Pro/releases"
-           rel="noopener noreferrer"
-           target="_blank">
-          All desktop releases
-        </a>
-      </div>
-      <p class="dl-meta dl-ok">NSIS installer · models bundled · works offline after install</p>
-      <p class="dl-meta">
-        Asset name: <code>VoiceIsolate-Pro-*-win-x64.exe</code> (or <code>win-unpacked</code> portable folder)<br />
-        Build locally:
-      </p>
-      <pre style="background:#0a0a10;padding:12px;border-radius:8px;overflow:auto;font-size:12px;color:#c4c4d0;">cd VoiceIsolate-Pro
-pnpm install
-pnpm setup:electron
-pnpm build:electron        # NSIS installer → dist/electron/
-pnpm build:electron:dir    # portable folder (no install)</pre>
-      <p class="dl-meta">See <code>docs/electron-desktop.md</code> for signing, auto-update, and offline notes.</p>
     </section>
   </main>
 </body>

--- a/tests/download-links.test.js
+++ b/tests/download-links.test.js
@@ -1,0 +1,68 @@
+/**
+ * Guardrails: download page + README point at real GitHub Release assets.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const dl = fs.readFileSync(path.join(ROOT, 'public/download/index.html'), 'utf8');
+const readme = fs.readFileSync(path.join(ROOT, 'README.md'), 'utf8');
+const dlDoc = fs.readFileSync(path.join(ROOT, 'download/README.md'), 'utf8');
+const vercel = fs.readFileSync(path.join(ROOT, 'vercel.json'), 'utf8');
+
+const APK_LATEST =
+  'https://github.com/Joker5514/VoiceIsolate-Pro/releases/latest/download/VoiceIsolate-Pro-android-debug.apk';
+const APK_PINNED =
+  'https://github.com/Joker5514/VoiceIsolate-Pro/releases/download/v24.0.0/VoiceIsolate-Pro-android-debug.apk';
+const EXE_LATEST =
+  'https://github.com/Joker5514/VoiceIsolate-Pro/releases/latest/download/VoiceIsolate-Pro-24.0.0-win-x64.exe';
+const EXE_PINNED =
+  'https://github.com/Joker5514/VoiceIsolate-Pro/releases/download/v24.0.0/VoiceIsolate-Pro-24.0.0-win-x64.exe';
+
+describe('Download page links', () => {
+  test('Android APK latest + pinned direct download URLs', () => {
+    expect(dl).toContain(APK_LATEST);
+    expect(dl).toContain(APK_PINNED);
+    expect(dl).toContain('VoiceIsolate-Pro-android-debug.apk');
+  });
+
+  test('Windows installer latest + pinned direct download URLs', () => {
+    expect(dl).toContain(EXE_LATEST);
+    expect(dl).toContain(EXE_PINNED);
+    expect(dl).toContain('VoiceIsolate-Pro-24.0.0-win-x64.exe');
+    // Must not only link the releases index without a direct asset
+    expect(dl).toMatch(/releases\/latest\/download\/VoiceIsolate-Pro-24\.0\.0-win-x64\.exe/);
+  });
+
+  test('reports realistic package sizes (not stale 303 MB)', () => {
+    expect(dl).toMatch(/~?238/);
+    expect(dl).not.toMatch(/~303/);
+  });
+});
+
+describe('README + download docs', () => {
+  test('README lists correct APK and Windows asset URLs', () => {
+    expect(readme).toContain(APK_LATEST);
+    expect(readme).toContain(EXE_LATEST);
+    expect(readme).toContain('VoiceIsolate-Pro-24.0.0-win-x64.exe');
+  });
+
+  test('download/README.md documents both assets', () => {
+    expect(dlDoc).toContain(APK_LATEST);
+    expect(dlDoc).toContain(EXE_LATEST);
+    expect(dlDoc).toContain('VoiceIsolate-Pro-android-debug.apk');
+  });
+});
+
+describe('Vercel download redirects', () => {
+  test('redirects APK and EXE to GitHub Releases', () => {
+    expect(vercel).toContain('VoiceIsolate-Pro-android-debug.apk');
+    expect(vercel).toContain('VoiceIsolate-Pro-24.0.0-win-x64.exe');
+    expect(vercel).toContain('releases/latest/download/VoiceIsolate-Pro-android-debug.apk');
+    expect(vercel).toContain('releases/latest/download/VoiceIsolate-Pro-24.0.0-win-x64.exe');
+    expect(vercel).toContain('.apk');
+    expect(vercel).toContain('.exe');
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -11,7 +11,17 @@
       "permanent": false
     },
     {
+      "source": "/download/VoiceIsolate-Pro-24.0.0-win-x64.exe",
+      "destination": "https://github.com/Joker5514/VoiceIsolate-Pro/releases/latest/download/VoiceIsolate-Pro-24.0.0-win-x64.exe",
+      "permanent": false
+    },
+    {
       "source": "/download/:file(.*\\.apk)",
+      "destination": "https://github.com/Joker5514/VoiceIsolate-Pro/releases/latest/download/:file",
+      "permanent": false
+    },
+    {
+      "source": "/download/:file(.*\\.exe)",
       "destination": "https://github.com/Joker5514/VoiceIsolate-Pro/releases/latest/download/:file",
       "permanent": false
     }


### PR DESCRIPTION
## Summary
Aligns all download links in the repo with the real **GitHub Release** assets for v24.0.0.

## Correct URLs
| Asset | URL |
|-------|-----|
| Android APK (latest) | https://github.com/Joker5514/VoiceIsolate-Pro/releases/latest/download/VoiceIsolate-Pro-android-debug.apk |
| Android APK (v24.0.0) | https://github.com/Joker5514/VoiceIsolate-Pro/releases/download/v24.0.0/VoiceIsolate-Pro-android-debug.apk |
| Windows installer (latest) | https://github.com/Joker5514/VoiceIsolate-Pro/releases/latest/download/VoiceIsolate-Pro-24.0.0-win-x64.exe |
| Windows installer (v24.0.0) | https://github.com/Joker5514/VoiceIsolate-Pro/releases/download/v24.0.0/VoiceIsolate-Pro-24.0.0-win-x64.exe |

## Changes
- `public/download/index.html` — direct download buttons for APK + EXE
- `README.md`, `download/README.md`, `docs/electron-desktop.md`
- `vercel.json` — redirect `.exe` same as `.apk`
- Tests: `tests/download-links.test.js`

## Test plan
- [x] download-links tests
- [ ] Click download page buttons after deploy

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Android and Windows download links and add Windows EXE redirect rules
> - Updates [public/download/index.html](https://github.com/Joker5514/VoiceIsolate-Pro/pull/713/files#diff-1a81e71068fc532cf08efe7cda25e29f3ae0fddceaf5f47f8c13c8147bf1d5b0) to link directly to GitHub Release assets for both Android APK and Windows EXE, with `download` attributes on direct-asset links.
> - Adds Vercel redirect rules in [vercel.json](https://github.com/Joker5514/VoiceIsolate-Pro/pull/713/files#diff-a3265310f552fb66876e8bfe8809737e59e5ba946bdf39138b44d9baf4e21240) for `/download/*.exe` and the specific `VoiceIsolate-Pro-24.0.0-win-x64.exe` filename, mirroring existing APK redirect behavior.
> - Expands [README.md](https://github.com/Joker5514/VoiceIsolate-Pro/pull/713/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) and [download/README.md](https://github.com/Joker5514/VoiceIsolate-Pro/pull/713/files#diff-b9fefb8047c707594f1ddca4ca12dfc12a82283a69aeafb1ea2e7308f9b08709) with correct asset URLs, sizes, and publishing steps for both platforms.
> - Adds a Jest test suite in [tests/download-links.test.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/713/files#diff-675465b386af0e246ffc936d582ea66281ab29496c76fc2add2f8deb5682beeb) that asserts correct URLs and sizes in the download page, docs, and vercel.json.
> - Adds `.exe` binaries to [.gitignore](https://github.com/Joker5514/VoiceIsolate-Pro/pull/713/files#diff-bc37d034bad564583790a46f19d807abfe519c5671395fd494d8cce506c42947) under `public/download/` to prevent accidental commits.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ddd8404.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added direct download links for the latest and pinned Android APK and Windows installer releases.
  * Expanded the download page with Windows desktop support, release details, asset sizes, and offline-use guidance.
  * Added redirects for Windows installer downloads alongside existing Android APK redirects.

* **Documentation**
  * Updated download, desktop, and project documentation with current release links and build instructions.

* **Bug Fixes**
  * Improved download routing to prevent binary links from serving incorrect web page content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->