### PR TITLE
chore: refresh v24.0.0 download binaries and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,10 +224,13 @@ No `.env` required for local audio processing. Optional payment/licensing vars i
 | **Latest Windows installer** | https://github.com/Joker5514/VoiceIsolate-Pro/releases/latest/download/VoiceIsolate-Pro-24.0.0-win-x64.exe |
 | **Pinned Windows v24.0.0** | https://github.com/Joker5514/VoiceIsolate-Pro/releases/download/v24.0.0/VoiceIsolate-Pro-24.0.0-win-x64.exe |
 
-| Asset | Name | Approx. size |
-|-------|------|----------------|
-| Android complete offline APK | `VoiceIsolate-Pro-android-debug.apk` | ~238 MB |
-| Windows NSIS installer | `VoiceIsolate-Pro-24.0.0-win-x64.exe` | ~480 MB |
+| Asset | Name | Approx. size | Updated |
+|-------|------|----------------|---------|
+| Android complete offline APK | `VoiceIsolate-Pro-android-debug.apk` | ~238 MB | 2026-07-21 |
+| Windows NSIS installer | `VoiceIsolate-Pro-24.0.0-win-x64.exe` | ~178 MB | 2026-07-21 |
+
+Current GitHub Release tag: **[v24.0.0](https://github.com/Joker5514/VoiceIsolate-Pro/releases/tag/v24.0.0)**  
+(includes production analysis workspace + processing-stall fixes).
 
 The download page always points at **real GitHub Release binaries** (never SPA HTML).  
 Same-origin `/download/*.apk` and `/download/*.exe` redirect to Releases (`vercel.json`).

--- a/docs/electron-desktop.md
+++ b/docs/electron-desktop.md
@@ -78,6 +78,8 @@ Publish installer to GitHub Releases; the web download page links there:
 | Web download page | https://voice-isolate-pro.vercel.app/download/ |
 | Latest Windows installer | https://github.com/Joker5514/VoiceIsolate-Pro/releases/latest/download/VoiceIsolate-Pro-24.0.0-win-x64.exe |
 | Pinned v24.0.0 | https://github.com/Joker5514/VoiceIsolate-Pro/releases/download/v24.0.0/VoiceIsolate-Pro-24.0.0-win-x64.exe |
+| Approx. size | ~178 MB (BS-RNN + denoise + VAD offline; Demucs not in installer) |
+| Last release upload | 2026-07-21 |
 
 ## Model Cache (Desktop)
 

--- a/download/README.md
+++ b/download/README.md
@@ -25,7 +25,8 @@ Web download page: https://voice-isolate-pro.vercel.app/download/
 | **Pinned v24.0.0** | https://github.com/Joker5514/VoiceIsolate-Pro/releases/download/v24.0.0/VoiceIsolate-Pro-android-debug.apk |
 | **All releases** | https://github.com/Joker5514/VoiceIsolate-Pro/releases |
 
-Asset name: `VoiceIsolate-Pro-android-debug.apk` · ~238 MB · complete offline app (Landing + Engineer Mode + models).
+Asset name: `VoiceIsolate-Pro-android-debug.apk` · **~238 MB** · complete offline app (Landing + Engineer Mode + models).  
+Last published to **v24.0.0**: 2026-07-21.
 
 Same-origin `/download/*.apk` is **redirected** to GitHub Releases (`vercel.json`) so Vercel never serves SPA HTML for APK URLs.
 
@@ -50,7 +51,8 @@ Do **not** commit `*.apk` under `public/download/` (see `.gitignore`) — nestin
 | Local build | `pnpm build:electron` → `dist/electron/VoiceIsolate-Pro-24.0.0-win-x64.exe` |
 | Portable smoke test | `pnpm build:electron:dir` → `dist/electron/win-unpacked/VoiceIsolate Pro.exe` |
 
-Asset name: `VoiceIsolate-Pro-24.0.0-win-x64.exe` · ~480 MB · 100% offline (UI + ORT + default models).
+Asset name: `VoiceIsolate-Pro-24.0.0-win-x64.exe` · **~178 MB** · 100% offline (UI + ORT + BS-RNN/denoise/VAD; Demucs optional/not bundled).  
+Last published to **v24.0.0**: 2026-07-21.
 
 ### Publish desktop (maintainers)
 

--- a/public/download/index.html
+++ b/public/download/index.html
@@ -85,7 +85,8 @@
       </p>
       <p class="dl-meta warn">Debug/sideload build · not Play Store signed</p>
       <p class="dl-meta">
-        Asset: <code>VoiceIsolate-Pro-android-debug.apk</code><br />
+        Asset: <code>VoiceIsolate-Pro-android-debug.apk</code> · release <strong>v24.0.0</strong><br />
+        Rebuilt <time datetime="2026-07-21">2026-07-21</time> (analysis workspace + stall fixes)<br />
         Latest:
         <a href="https://github.com/Joker5514/VoiceIsolate-Pro/releases/latest/download/VoiceIsolate-Pro-android-debug.apk"
            rel="noopener noreferrer" target="_blank" style="color:#f87171">
@@ -129,10 +130,11 @@
           All releases
         </a>
       </div>
-      <p class="dl-meta dl-ok">NSIS · models bundled · offline after install · ~480&nbsp;MB</p>
-      <p class="dl-meta warn">Unsigned local builds may trigger SmartScreen — More info → Run anyway</p>
+      <p class="dl-meta dl-ok">NSIS · BS-RNN + denoise + VAD bundled · offline after install · ~178&nbsp;MB</p>
+      <p class="dl-meta warn">Unsigned builds may trigger SmartScreen — More info → Run anyway</p>
       <p class="dl-meta">
-        Asset: <code>VoiceIsolate-Pro-24.0.0-win-x64.exe</code><br />
+        Asset: <code>VoiceIsolate-Pro-24.0.0-win-x64.exe</code> · release <strong>v24.0.0</strong><br />
+        Rebuilt <time datetime="2026-07-21">2026-07-21</time> (analysis workspace + stall fixes)<br />
         Latest:
         <a href="https://github.com/Joker5514/VoiceIsolate-Pro/releases/latest/download/VoiceIsolate-Pro-24.0.0-win-x64.exe"
            rel="noopener noreferrer" target="_blank" style="color:#f87171">

--- a/tests/download-links.test.js
+++ b/tests/download-links.test.js
@@ -36,9 +36,12 @@ describe('Download page links', () => {
     expect(dl).toMatch(/releases\/latest\/download\/VoiceIsolate-Pro-24\.0\.0-win-x64\.exe/);
   });
 
-  test('reports realistic package sizes (not stale 303 MB)', () => {
+  test('reports realistic package sizes (not stale 303/480 MB)', () => {
     expect(dl).toMatch(/~?238/);
+    // Windows installer is the lean offline package (~178 MB), not the old ~480 MB build
+    expect(dl).toMatch(/~?178/);
     expect(dl).not.toMatch(/~303/);
+    expect(dl).not.toMatch(/~480/);
   });
 });
 


### PR DESCRIPTION
## Summary
- Rebuilt Android APK + Windows installer from current \main\
- Re-uploaded to GitHub Release **v24.0.0** (\--clobber\)
- Updated download page / README / docs with accurate sizes and 2026-07-21 refresh date

### Downloads
| Asset | Size | URL |
|-------|------|-----|
| Android APK | ~238 MB | https://github.com/Joker5514/VoiceIsolate-Pro/releases/latest/download/VoiceIsolate-Pro-android-debug.apk |
| Windows EXE | ~178 MB | https://github.com/Joker5514/VoiceIsolate-Pro/releases/latest/download/VoiceIsolate-Pro-24.0.0-win-x64.exe |


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refresh v24.0.0 download page metadata with updated sizes and rebuild dates
> Updates download documentation and the public download page to reflect the rebuilt v24.0.0 binaries. Windows installer size drops from ~480 MB to ~178 MB (Demucs no longer bundled; includes BS-RNN, denoise, and VAD). Android and Windows entries both show a rebuild date of 2026-07-21 with a note about production analysis workspace and processing-stall fixes. Test expectations in [download-links.test.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/717/files#diff-675465b386af0e246ffc936d582ea66281ab29496c76fc2add2f8deb5682beeb) are updated to assert `~178` and reject `~480`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fa9a7a2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Android and Windows download information with release version, publication dates, asset sizes, and included components.
  * Clarified that the Android app is fully offline and that Demucs is not included with the Windows installer.
  * Added the current release tag and noted included fixes.

* **Tests**
  * Updated download-page checks to validate the current Windows installer size and reject outdated size information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->