### PR TITLE
feat: Android/Capacitor production readiness & runtime capability gate

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:hardwareAccelerated="true"
         android:largeHeap="true"
         android:icon="@mipmap/ic_launcher"

--- a/capacitor.config.json
+++ b/capacitor.config.json
@@ -1,12 +1,17 @@
 {
   "appId": "com.voiceisolatepro.app",
   "appName": "VoiceIsolate Pro",
-  "webDir": "build",
+  "webDir": "public",
   "server": {
     "androidScheme": "https",
     "iosScheme": "capacitor",
     "hostname": "voiceisolatepro.app",
-    "cleartext": false
+    "cleartext": false,
+    "headers": {
+      "Cross-Origin-Opener-Policy": "same-origin",
+      "Cross-Origin-Embedder-Policy": "require-corp",
+      "Cross-Origin-Resource-Policy": "same-origin"
+    }
   },
   "android": {
     "allowMixedContent": false,

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "voiceisolate-pro",
   "version": "24.0.0",
   "type": "module",
-  "description": "Studio-grade voice isolation platform. Upload-only workflow — 32-stage Octa-Pass DSP with hybrid ML + classical spectral processing. Web, Electron desktop, and Capacitor Android.",
+  "description": "Studio-grade voice isolation platform. Upload-only workflow \u2014 32-stage Octa-Pass DSP with hybrid ML + classical spectral processing. Web, Electron desktop, and Capacitor Android.",
   "private": true,
   "main": "electron/main.cjs",
   "keywords": [
@@ -82,7 +82,11 @@
     "electron:dev": "cross-env VIP_ELECTRON_DEV=1 electron .",
     "electron:start": "electron .",
     "build:electron": "node scripts/electron-build-win.mjs",
-    "build:electron:dir": "node scripts/electron-build-win.mjs --dir"
+    "build:electron:dir": "node scripts/electron-build-win.mjs --dir",
+    "assets:sync": "node scripts/sync-local-assets.mjs",
+    "cap:sync:android": "npm run assets:sync && npx cap sync android",
+    "android:build:debug": "npm run cap:sync:android && cd android && ./gradlew assembleDebug",
+    "test:unit": "node --test tests/unit/"
   },
   "devDependencies": {
     "@capacitor/android": "^8.3.1",

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -1,3 +1,69 @@
+
+/* ------------------------------------------------------------------
+ * VoiceIsolate Pro: Android/Capacitor capability gate.
+ * Local-only. No telemetry. No cloud inference.
+ * ------------------------------------------------------------------ */
+(function () {
+  const rt = window.VoiceIsolateRuntime;
+  if (!rt) return;
+  const capabilities = rt.detectRuntime();
+  const mode = rt.selectExecutionMode(capabilities);
+  const state = { capabilities, mode, backend: 'pending', mlReady: false, mlWorker: null };
+  window.VIP_STATE = state;
+  const LIVE_SELECTORS = '[data-vip-control="live"], #live-toggle, #btn-live, .live-toggle, button[data-mode="live"], input[data-mode="live"]';
+  function whenDomReady() { return new Promise((resolve) => { if (document.readyState !== 'loading') { resolve(); return; } document.addEventListener('DOMContentLoaded', resolve, { once: true }); }); }
+  function meta(name, fallback) { const el = document.querySelector(`meta[name="${name}"]`); return el?.content || fallback; }
+  function renderStatus() {
+    const host = document.getElementById('runtime-status'), list = document.getElementById('runtime-status-list');
+    if (!host || !list) return;
+    const messages = rt.statusMessages(state);
+    list.textContent = '';
+    for (const msg of messages) { const li = document.createElement('li'); li.className = `vip-badge vip-badge-${msg.level}`; li.textContent = msg.text; list.appendChild(li); }
+    host.hidden = messages.length === 0;
+    document.body?.setAttribute('data-vip-mode', state.mode);
+  }
+  function disableLiveControls(disabled, reason) {
+    document.querySelectorAll(LIVE_SELECTORS).forEach((el) => {
+      el.disabled = disabled; el.setAttribute('aria-disabled', String(disabled));
+      if (disabled) { el.title = reason; el.dataset.vipDisabledReason = reason; } else { el.title = ''; delete el.dataset.vipDisabledReason; }
+    });
+  }
+  function applyMode() {
+    const liveBlocked = state.mode !== 'full-live';
+    const reason = liveBlocked ? 'Live Mode unavailable: SharedArrayBuffer not supported in this environment' : '';
+    disableLiveControls(liveBlocked, reason); renderStatus();
+  }
+  function guardLiveEvent(event) {
+    const target = event.target instanceof Element ? event.target.closest(LIVE_SELECTORS) : null;
+    if (!target) return;
+    if (state.mode !== 'full-live') { event.preventDefault(); event.stopImmediatePropagation(); renderStatus(); if (typeof target.blur === 'function') target.blur(); }
+  }
+  async function requestMlInit(worker = state.mlWorker) {
+    if (!worker) return;
+    await whenDomReady();
+    try {
+      state.modelUrl = rt.resolveAssetUrl(meta('vip:model', './models/voice_isolate_pro.onnx'), document.baseURI);
+      state.wasmPaths = rt.resolveAssetUrl(meta('vip:ort-wasm', './vendor/onnxruntime-web/'), document.baseURI);
+    } catch (err) { console.error('[VIP] local asset resolution failed', err); state.backend = 'failed'; state.mlReady = false; renderStatus(); return; }
+    worker.postMessage({ type: 'vip:ml:init', modelUrl: state.modelUrl, capabilities: { hasWebGPU: capabilities.hasWebGPU, sabSafe: capabilities.sabSafe, forceSingleThreadWasm: capabilities.androidWebView || !capabilities.sabSafe, wasmPaths: state.wasmPaths } });
+  }
+  function bindMlWorker(worker) {
+    if (!worker || state.mlWorker === worker) return worker;
+    state.mlWorker = worker;
+    worker.addEventListener('message', (event) => {
+      const msg = event.data || {};
+      if (msg.type === 'vip:ml:init:done') { state.backend = msg.backend; state.mlReady = true; renderStatus(); }
+      else if (msg.type === 'vip:ml:init:error') { state.backend = 'failed'; state.mlReady = false; renderStatus(); }
+    });
+    worker.addEventListener('error', () => { state.backend = 'failed'; state.mlReady = false; renderStatus(); });
+    requestMlInit(worker).catch((err) => { console.error('[VIP] ML init request failed', err); state.backend = 'failed'; state.mlReady = false; renderStatus(); });
+    return worker;
+  }
+  window.__vipBindMlWorker = bindMlWorker;
+  window.__vipRequestMlInit = requestMlInit;
+  whenDomReady().then(applyMode).catch(console.error);
+  for (const type of ['click', 'pointerdown', 'change']) { document.addEventListener(type, guardLiveEvent, true); }
+})();
 /**
  * VoiceIsolate Pro — app.js  v24.0.0
  * ====================================

--- a/public/app/dsp-worker.js
+++ b/public/app/dsp-worker.js
@@ -1,3 +1,13 @@
+
+/* VoiceIsolate Pro: fail cleanly if live SAB path is requested without SAB. */
+function vipRequireSharedArrayBuffer() {
+  if (typeof SharedArrayBuffer === 'undefined') {
+    self.postMessage({ type: 'dsp:live:alloc:error', code: 'SAB_UNAVAILABLE', message: 'SharedArrayBuffer unavailable in this environment' });
+    return false;
+  }
+  return true;
+}
+
 /* ============================================
    VoiceIsolate Pro v24.0 — DSP Worker
    Threads from Space v13 · ML Inference Thread

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -98,6 +98,10 @@
       window._vipReportError('unhandledRejection', e.reason);
     });
   </script>
+  <!-- VoiceIsolate Pro: local-only runtime capability gate -->
+  <meta name="vip:model" content="./models/voice_isolate_pro.onnx" />
+  <meta name="vip:ort-wasm" content="./vendor/onnxruntime-web/" />
+  <script src="./runtime.js" defer></script>
 </head>
 <body>
   <div id="vip-boot-error"></div>
@@ -308,7 +312,10 @@
     </div>
   </section>
 
-  <main class="main-grid">
+    <section id="runtime-status" class="vip-runtime-status" role="status" aria-live="polite" hidden>
+    <ul id="runtime-status-list" class="vip-runtime-status-list"></ul>
+  </section>
+<main class="main-grid">
     <section class="col-left">
       <div class="card upload-card">
         <input type="file" id="fileInput" class="visually-hidden-file" accept="audio/mpeg,audio/mp3,audio/wav,audio/x-wav,audio/wave,audio/ogg,audio/flac,audio/x-flac,audio/aac,audio/x-m4a,audio/m4a,audio/mp4,audio/webm,audio/amr,audio/aiff,audio/x-aiff,audio/x-caf,audio/x-ms-wma,audio/opus,audio/ac3,audio/eac3,video/mp4,video/webm,video/quicktime,video/x-msvideo,video/x-matroska,video/ogg,video/3gpp,video/3gpp2,video/x-ms-wmv,video/mpeg,video/mp2t,video/x-flv,audio/*,video/*,.wav,.wave,.mp3,.m4a,.aac,.ogg,.oga,.opus,.flac,.webm,.weba,.aiff,.aif,.caf,.wma,.mka,.m4b,.m4r,.amr,.ac3,.eac3,.mp4,.m4v,.mov,.mkv,.avi,.ogv,.3gp,.3g2,.wmv,.mpeg,.mpg,.ts,.m2ts,.mts,.flv,.f4v,.asf" tabindex="-1" aria-hidden="true" />

--- a/public/app/ml-worker.js
+++ b/public/app/ml-worker.js
@@ -1,3 +1,76 @@
+
+/* ------------------------------------------------------------------
+ * VoiceIsolate Pro deterministic ML initialization.
+ * Local-only. No remote inference. No telemetry.
+ * ------------------------------------------------------------------ */
+const VIP_ML = { session: null, backend: 'pending', initializing: false };
+self.VIP_ML = VIP_ML;
+function vipPost(msg) { self.postMessage(msg); }
+function vipWithTimeout(promise, ms, label) {
+  let timeoutId;
+  const timeout = new Promise((_, reject) => { timeoutId = setTimeout(() => reject(new Error(label)), ms); });
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timeoutId));
+}
+function vipAssertSameOrigin(path) {
+  const url = new URL(path, self.location.href);
+  if (url.origin !== self.location.origin) throw new Error('Remote model URLs are not allowed');
+  return url.href;
+}
+async function vipGetOrt() {
+  if (self.ort) return self.ort;
+  if (typeof importScripts === 'function') {
+    try { importScripts('./vendor/onnxruntime-web/ort.all.min.js'); if (self.ort) return self.ort; } catch (e) {}
+  }
+  try {
+    const mod = await import('./vendor/onnxruntime-web/ort.all.min.mjs');
+    self.ort = mod.default || mod; return self.ort;
+  } catch (e) { throw new Error('onnxruntime-web is not available locally'); }
+}
+async function vipCreateSession(modelUrl, backend, caps) {
+  const ort = await vipGetOrt();
+  const forceSingleThread = caps?.forceSingleThreadWasm === true || caps?.sabSafe !== true;
+  const maxThreads = typeof navigator !== 'undefined' && navigator.hardwareConcurrency ? navigator.hardwareConcurrency : 1;
+  ort.env.wasm.numThreads = forceSingleThread ? 1 : Math.max(1, Math.min(4, maxThreads));
+  ort.env.wasm.proxy = false;
+  if (caps?.wasmPaths) ort.env.wasm.wasmPaths = caps.wasmPaths;
+  const sessionOptions = backend === 'webgpu' ? { executionProviders: ['webgpu'], graphOptimizationLevel: 'all' } : { executionProviders: ['wasm'], graphOptimizationLevel: 'all', enableCpuMemArena: false, enableMemPattern: false };
+  const timeoutMs = backend === 'webgpu' ? 6000 : 12000;
+  return vipWithTimeout(ort.InferenceSession.create(modelUrl, sessionOptions), timeoutMs, `ML ${backend} initialization timed out`);
+}
+async function vipInitModel(request) {
+  if (VIP_ML.initializing) return;
+  VIP_ML.initializing = true;
+  const requestId = request.requestId || 'init';
+  try {
+    const modelUrl = vipAssertSameOrigin(request.modelUrl || './models/voice_isolate_pro.onnx');
+    const caps = request.capabilities || {};
+    const requestedBackend = request.backendPreference || 'auto';
+    let session = null, backend = null;
+    if (requestedBackend !== 'wasm' && caps.hasWebGPU === true) {
+      vipPost({ type: 'vip:ml:init:progress', requestId, stage: 'webgpu-attempt' });
+      try { session = await vipCreateSession(modelUrl, 'webgpu', caps); backend = 'webgpu'; } catch (err) { console.warn('[VIP ML] WebGPU init failed; falling back to WASM', err); }
+    }
+    if (!session) {
+      vipPost({ type: 'vip:ml:init:progress', requestId, stage: 'wasm-attempt' });
+      session = await vipCreateSession(modelUrl, 'wasm', caps); backend = 'wasm';
+    }
+    VIP_ML.session = session; VIP_ML.backend = backend;
+    vipPost({ type: 'vip:ml:init:done', requestId, backend });
+  } catch (err) {
+    VIP_ML.session = null; VIP_ML.backend = 'failed';
+    vipPost({ type: 'vip:ml:init:error', requestId, message: err?.message || 'Local model initialization failed' });
+  } finally { VIP_ML.initializing = false; }
+}
+self.addEventListener('message', (event) => {
+  const msg = event.data || {};
+  if (msg.type === 'vip:ml:init') {
+    vipInitModel(msg).catch((err) => {
+      console.error('[VIP ML] init handler failed', err);
+      vipPost({ type: 'vip:ml:init:error', requestId: msg.requestId || 'init', message: err?.message || 'Local model initialization failed' });
+    });
+  }
+});
+
 // ─────────────────────────────────────────────────────────────────────────────
 // ml-worker.js — VoiceIsolate Pro · Threads from Space v13
 // Standard Web Worker (NOT AudioWorklet).

--- a/public/app/runtime.js
+++ b/public/app/runtime.js
@@ -1,0 +1,79 @@
+/*!
+ * VoiceIsolate Pro runtime capability gate.
+ * Local-only. No telemetry. No remote inference.
+ */
+(function (root, factory) {
+  if (typeof module === 'object' && typeof module.exports === 'object') {
+    module.exports = factory();
+  } else {
+    root.VoiceIsolateRuntime = factory();
+  }
+})(typeof self !== 'undefined' ? self : this, function () {
+  'use strict';
+  const VERSION = '1.0.0';
+  function detectRuntime(env = {}) {
+    const win = env.window || (typeof window !== 'undefined' ? window : undefined);
+    const nav = env.navigator || (typeof navigator !== 'undefined' ? navigator : undefined);
+    const sabCtor = env.SharedArrayBuffer || win?.SharedArrayBuffer;
+    const capacitor = win?.Capacitor;
+    let isCapacitor = false, platform = 'web';
+    if (capacitor) {
+      if (typeof capacitor.isNativePlatform === 'function') isCapacitor = capacitor.isNativePlatform();
+      else isCapacitor = capacitor.Platform !== 'web' && capacitor.Platform != null;
+      if (typeof capacitor.getPlatform === 'function') platform = capacitor.getPlatform();
+      else if (isCapacitor) platform = capacitor.Platform || 'native';
+    }
+    const userAgent = nav?.userAgent || '';
+    const androidWebView = platform === 'android' || (isCapacitor && /Android/i.test(userAgent)) || /; wv\)/i.test(userAgent);
+    if (androidWebView && platform === 'web') platform = 'android';
+    const isolated = typeof win?.crossOriginIsolated === 'boolean' ? win.crossOriginIsolated : false;
+    const hasSharedArrayBuffer = typeof sabCtor === 'function';
+    const sabSafe = isolated && hasSharedArrayBuffer;
+    const AudioContextRef = win?.AudioContext || win?.webkitAudioContext;
+    const hasAudioContext = typeof AudioContextRef === 'function';
+    const hasAudioWorklet = !!(hasAudioContext && AudioContextRef.prototype && 'audioWorklet' in AudioContextRef.prototype && win?.AudioWorkletNode);
+    const hasOfflineAudioContext = !!(win?.OfflineAudioContext || win?.webkitOfflineAudioContext);
+    const hasMediaDevices = !!(nav?.mediaDevices && typeof nav.mediaDevices.getUserMedia === 'function');
+    const hasWebGPU = !!(nav?.gpu);
+    const secureContext = win?.isSecureContext !== false;
+    return { version: VERSION, platform, isCapacitor, androidWebView, secureContext, isolated, hasSharedArrayBuffer, sabSafe, hasAudioContext, hasAudioWorklet, hasOfflineAudioContext, hasMediaDevices, hasWebGPU, userAgent };
+  }
+  function selectExecutionMode(capabilities) {
+    if (!capabilities || !capabilities.secureContext) return 'unsupported';
+    if (capabilities.sabSafe && capabilities.hasAudioWorklet) return 'full-live';
+    if (capabilities.hasAudioWorklet && capabilities.hasOfflineAudioContext) return 'limited-live';
+    if (capabilities.hasOfflineAudioContext) return 'offline-only';
+    return 'unsupported';
+  }
+  function planBootSequence(capabilities, mode) {
+    const steps = ['capability-detect', 'apply-ui-mode'];
+    if (mode === 'unsupported') return steps.concat(['halt-unsupported']);
+    steps.push('ml-init');
+    if (mode === 'full-live') steps.push('worklet-module-add', 'live-arm');
+    if (mode === 'limited-live') steps.push('live-guard', 'offline-arm');
+    if (mode === 'offline-only') steps.push('offline-arm');
+    return steps;
+  }
+  function statusMessages(state) {
+    const caps = state?.capabilities || {}, mode = state?.mode || 'unsupported', backend = state?.backend || 'pending', out = [];
+    if (mode === 'full-live') out.push({ level: 'ok', text: caps.platform === 'android' ? 'Full live mode enabled (isolated Android WebView)' : 'Live mode ready' });
+    else if (mode === 'limited-live') { out.push({ level: 'warn', text: 'Live Mode unavailable: SharedArrayBuffer not supported in this environment' }); out.push({ level: 'info', text: 'Offline / Creator mode is available on this device' }); }
+    else if (mode === 'offline-only') out.push({ level: 'warn', text: 'Offline mode recommended on this device' });
+    else out.push({ level: 'error', text: 'This environment lacks required audio APIs for VoiceIsolate Pro' });
+    if (backend === 'webgpu') out.push({ level: 'ok', text: 'WebGPU inference active' });
+    if (backend === 'wasm') out.push({ level: 'info', text: 'Using WASM inference fallback' });
+    if (backend === 'failed') out.push({ level: 'error', text: 'Local model initialization failed' });
+    if (caps.androidWebView && !caps.isolated) out.push({ level: 'info', text: 'Android WebView is not cross-origin isolated; live ML is disabled by design' });
+    return out;
+  }
+  function resolveAssetUrl(path, base) {
+    if (typeof path !== 'string' || path.length === 0) throw new Error('Asset path must be a non-empty string');
+    if (path.startsWith('data:') || path.startsWith('blob:')) throw new Error('Opaque model URLs are not allowed');
+    const baseUrl = new URL(base || (typeof document !== 'undefined' ? document.baseURI : self.location.href));
+    const resolved = new URL(path, baseUrl);
+    if (resolved.origin !== baseUrl.origin) throw new Error('Model and runtime assets must be same-origin local files');
+    return resolved.href;
+  }
+  function isLiveModeAllowed(capabilities, mode) { return mode === 'full-live' && !!capabilities?.sabSafe && !!capabilities?.hasAudioWorklet; }
+  return { VERSION, detectRuntime, selectExecutionMode, planBootSequence, statusMessages, resolveAssetUrl, isLiveModeAllowed };
+});

--- a/public/app/style.css
+++ b/public/app/style.css
@@ -2289,3 +2289,13 @@ body::after {
 .aud-gain-label input[type="range"] { flex: 1; min-width: 60px; }
 .aud-empty { font-size: 0.8rem; color: #64748b; margin: 0; }
 .vip-timeline-canvas { width: 100%; height: 100%; touch-action: manipulation; }
+
+
+.vip-runtime-status { margin: 12px 0; padding: 0; }
+.vip-runtime-status-list { display: flex; flex-wrap: wrap; gap: 8px; margin: 0; padding: 0; list-style: none; }
+.vip-badge { display: inline-flex; align-items: center; min-height: 24px; padding: 4px 10px; border: 1px solid rgba(128, 128, 128, 0.35); border-radius: 999px; font-size: 12px; line-height: 1.2; white-space: nowrap; }
+.vip-badge-ok { border-color: rgba(34, 197, 94, 0.45); background: rgba(34, 197, 94, 0.12); }
+.vip-badge-info { border-color: rgba(59, 130, 246, 0.45); background: rgba(59, 130, 246, 0.12); }
+.vip-badge-warn { border-color: rgba(234, 179, 8, 0.5); background: rgba(234, 179, 8, 0.14); }
+.vip-badge-error { border-color: rgba(239, 68, 68, 0.55); background: rgba(239, 68, 68, 0.14); }
+@media (max-width: 640px) { .vip-badge { white-space: normal; } }

--- a/scripts/sync-local-assets.mjs
+++ b/scripts/sync-local-assets.mjs
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+import { cpSync, existsSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = join(__dirname, '..');
+const pairs = [
+  { from: join(root, 'node_modules', 'onnxruntime-web', 'dist'), to: join(root, 'public', 'app', 'vendor', 'onnxruntime-web') },
+  { from: join(root, 'models'), to: join(root, 'public', 'app', 'models') },
+];
+for (const { from, to } of pairs) {
+  if (!existsSync(from)) { console.warn(`[vip-assets] skipping missing source: ${from}`); continue; }
+  mkdirSync(dirname(to), { recursive: true });
+  cpSync(from, to, { recursive: true, force: false, errorOnExist: false });
+  console.log(`[vip-assets] copied ${from} -> ${to}`);
+}

--- a/tests/unit/runtime.test.mjs
+++ b/tests/unit/runtime.test.mjs
@@ -1,0 +1,32 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const runtime = require('../../public/app/runtime.js');
+function makeAudioContext() { function AudioContext() {} AudioContext.prototype.audioWorklet = {}; return AudioContext; }
+test('full live mode on isolated web with SAB and AudioWorklet', () => {
+  const caps = runtime.detectRuntime({ window: { crossOriginIsolated: true, isSecureContext: true, AudioContext: makeAudioContext(), AudioWorkletNode: function () {}, OfflineAudioContext: function () {} }, navigator: { userAgent: 'Mozilla/5.0', gpu: {}, mediaDevices: { getUserMedia: async () => {} } }, SharedArrayBuffer: function () {} });
+  const mode = runtime.selectExecutionMode(caps);
+  assert.equal(caps.sabSafe, true); assert.equal(caps.hasAudioWorklet, true); assert.equal(mode, 'full-live'); assert.equal(runtime.isLiveModeAllowed(caps, mode), true);
+});
+test('Android WebView without isolation does not get full live', () => {
+  const caps = runtime.detectRuntime({ window: { crossOriginIsolated: false, isSecureContext: true, Capacitor: { isNativePlatform: () => true, getPlatform: () => 'android' }, AudioContext: makeAudioContext(), AudioWorkletNode: function () {}, OfflineAudioContext: function () {} }, navigator: { userAgent: 'Mozilla/5.0 (Linux; Android 14; Pixel) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/126.0.0.0 Mobile Safari/537.36; wv)' }, SharedArrayBuffer: undefined });
+  const mode = runtime.selectExecutionMode(caps);
+  assert.equal(caps.androidWebView, true); assert.equal(caps.sabSafe, false); assert.notEqual(mode, 'full-live'); assert.ok(['limited-live', 'offline-only'].includes(mode));
+  const messages = runtime.statusMessages({ capabilities: caps, mode, backend: 'wasm' });
+  assert.ok(messages.some((m) => m.text.includes('SharedArrayBuffer not supported')));
+});
+test('no AudioWorklet but OfflineAudioContext yields offline-only', () => {
+  const caps = runtime.detectRuntime({ window: { crossOriginIsolated: false, isSecureContext: true, OfflineAudioContext: function () {} }, navigator: { userAgent: 'Mozilla/5.0' }, SharedArrayBuffer: undefined });
+  assert.equal(runtime.selectExecutionMode(caps), 'offline-only');
+});
+test('missing required audio APIs yields unsupported', () => {
+  const caps = runtime.detectRuntime({ window: { crossOriginIsolated: false, isSecureContext: true }, navigator: { userAgent: 'Mozilla/5.0' }, SharedArrayBuffer: undefined });
+  assert.equal(runtime.selectExecutionMode(caps), 'unsupported');
+});
+test('asset resolution rejects remote hosts', () => {
+  assert.throws(() => runtime.resolveAssetUrl('https://evil.example/model.onnx', 'https://localhost/app/index.html'));
+});
+test('asset resolution allows same-origin relative paths', () => {
+  assert.equal(runtime.resolveAssetUrl('./models/voice_isolate_pro.onnx', 'https://localhost/app/index.html'), 'https://localhost/app/models/voice_isolate_pro.onnx');
+});


### PR DESCRIPTION
## Summary
This PR implements the next phase of production readiness for VoiceIsolate Pro, focusing on Android/Capacitor deployment without breaking the stable web path. It introduces an explicit runtime capability gate to handle environments where `SharedArrayBuffer` and cross-origin isolation cannot be guaranteed (e.g., Android WebView).

## Changes
- **Runtime Capability Gate (`public/app/runtime.js`)**: Detects `crossOriginIsolated`, `SharedArrayBuffer`, `AudioWorklet`, WebGPU, and Capacitor/Android WebView environments. Selects explicit execution modes (`full-live`, `limited-live`, `offline-only`, `unsupported`).
- **UI & UX Hardening**: Disables live controls safely when SAB/isolation is unavailable. Adds concise status badges explaining why a mode is unavailable.
- **ML Initialization Hardening (`public/app/ml-worker.js`)**: Deterministic WebGPU -> WASM fallback with timeouts. Uses single-threaded WASM when SAB is unavailable or on Android WebView. No hanging boot sequence.
- **Android Packaging**: Updates `capacitor.config.json` and `AndroidManifest.xml` for local-only, secure, same-origin asset loading. Adds `scripts/sync-local-assets.mjs` to ensure ONNX/WASM assets are correctly placed for Capacitor builds.
- **Testing**: Adds `tests/unit/runtime.test.mjs` to verify capability detection, mode selection, and no-crash behavior when SAB is absent.

## Architecture Constraints Preserved
- ✅ 100% local processing only. No cloud APIs, telemetry, or external model fetches.
- ✅ Single-pass spectral architecture maintained (no second STFT/iSTFT).
- ✅ Existing web deployment path and COOP/COEP configuration untouched.
- ✅ Existing live AudioWorklet ring-buffer logic untouched.

## Migration / Build Notes
Run `npm run assets:sync` before `npx cap sync android` to ensure local model and ONNX Runtime assets are copied to the Capacitor web directory.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Android/Capacitor production readiness and runtime capability gate for ML worker
> - Adds [runtime.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/720/files#diff-fe8cbffccf9ebc69ce9a6b8ffb09abf5a1f07e34e73407778a1223a5a08a58fa), a capability detection module that infers platform, SharedArrayBuffer safety, audio/GPU availability, and Android WebView/Capacitor context, then buckets into one of four execution modes: `full-live`, `limited-live`, `offline-only`, or `unsupported`.
> - Adds a capability-gate bootstrap in [app.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/720/files#diff-8a8b7ea624d7fccc12a516d122dcb07bd67c6a8f796c80e33b898ee6a7557650) that disables and event-guards all live UI controls when `full-live` mode is not available, displays runtime status badges, and initializes the ML worker with local model and WASM paths.
> - Adds ML initialization logic in [ml-worker.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/720/files#diff-3ee9cad7ecbd6f101735ef1c00f8cc6705e3419640a54d8a01f4ed76001402d0) that attempts a WebGPU ONNX session first, falls back to WASM with timeouts, enforces same-origin model URLs, and reports progress/completion/failure via `vip:ml:init:*` messages.
> - Updates [capacitor.config.json](https://github.com/Joker5514/VoiceIsolate-Pro/pull/720/files#diff-ec2b53f1220a8bca613b0f050e250e7869ef60b2c5bc3de7cbb55f98ad0999f4) to serve from `public/` and sets COOP/COEP/CORP headers to enable cross-origin isolation on the Capacitor server.
> - Adds a [sync-local-assets.mjs](https://github.com/Joker5514/VoiceIsolate-Pro/pull/720/files#diff-3b9dd812d32552ba0eeaea76b28f451fea481a6561a2672fd117495bdd62c903) script and supporting `package.json` scripts to copy `onnxruntime-web` dist files and local models into `public/app/vendor` and `public/app/models` before Capacitor sync.
> - Risk: COOP/COEP headers will break any cross-origin iframes or popups that are not explicitly opted in.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 71c74a1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added runtime capability detection with clear status messaging and supported execution modes.
  - Added local machine-learning initialization with progress, success, and error feedback.
  - Added support for local model and runtime assets.
  - Added safeguards that disable unavailable live features and provide offline or limited modes.
  - Added Android backup protection and improved security isolation settings.

- **Bug Fixes**
  - Prevented live processing from starting when required browser capabilities are unavailable.

- **Tests**
  - Added coverage for runtime detection, fallback modes, and secure asset loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->