### PR TITLE
feat(usm): Universal Source Matrix for multi-source mute/solo/query

### DIFF
--- a/docs/guides/ANALYSIS_WORKSPACE.md
+++ b/docs/guides/ANALYSIS_WORKSPACE.md
@@ -18,6 +18,7 @@ Production analysis path for Engineer Mode (`/app/`).
 | Worker | `src/workers/FullAnalysisWorker.js` |
 | Host | `src/pipeline/FullAnalysisHost.js` |
 | Audition | `src/pipeline/SourceAuditionEngine.js` |
+| Universal Source Matrix | `src/core/UniversalSourceMatrix.js` + `src/pipeline/USMNode.js` |
 | Export helper | `src/pipeline/ExportManager.js` |
 | Timeline UI | `src/presentation/TimelineRenderer.js` |
 | Transport sync | `src/presentation/TransportSync.js` |
@@ -54,11 +55,23 @@ See `analyzeAudio()` return value — includes segments, `visualLayers`, `recomm
 | High confidence | Auto-apply allowed |
 | Low confidence | Recommend only; user must Apply |
 
+## Universal Source Matrix (Creator / Forensic)
+
+Engineer Mode panel under **Source Analysis Workspace**:
+
+1. **Separate sources** — classical multi-component NMF soft masks (variable K, default 6). Optional ONNX `universal-separator.onnx` when shipped (`USMNode({ preferOnnx: true })`).
+2. **Query separate** — text priors (“AC hum”, “dog barking”, “speech”) for LASS/AudioSep-style targeting without cloud APIs.
+3. **Mute / Solo / Gain (dB)** — Live-Mix only; never re-runs ML. **Refine** is an intentional one-shot query on the retained mixture.
+4. **Apply mix** — writes the combined matrix mix into the processed buffer for export / A-B.
+
+Not used on the Live low-latency path (keep voice / ambient / music coarse stems there).
+
 ## Honesty rules
 
 - No fabricated words or ASR transcription unless a local ASR model is explicitly bundled later.
 - Layer quality badges: high (true stems), medium (ML/classical mix), low (best-effort residual).
 - Empty lanes show “not detected” — never decorative fake regions.
+- USM cannot produce a deterministic “one fader per atom of sound”; K semantic components + query refine is the practical ceiling.
 
 ## Performance
 

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -377,6 +377,45 @@
               <button id="audResetMix" class="btn btn-xs" type="button">Reset mix</button>
             </div>
             <div id="auditionStrip" class="audition-strip"></div>
+
+            <!-- Universal Source Matrix (Creator/Forensic) — mute/solo/gain per semantic stem -->
+            <div id="sourceMatrixPanel" class="source-matrix-panel" aria-label="Universal Source Matrix">
+              <div class="usm-hdr">
+                <h4 class="analysis-sub">Universal Source Matrix</h4>
+                <span id="usmMethodBadge" class="usm-method-badge" hidden>—</span>
+              </div>
+              <p class="usm-lead">Separate open-domain sources (speech, hum, dogs, TV, residual…) then mute/solo/gain each stem. 100% local — no cloud. Live mode keeps lightweight 2–3 stems only.</p>
+              <div class="usm-actions">
+                <button id="btnUsmSeparate" class="btn btn-primary btn-xs" type="button" title="Auto-discover K semantic sources (Creator/Forensic)">Separate sources</button>
+                <label class="usm-k-label">K
+                  <input id="usmNumSources" type="number" min="2" max="12" value="6" class="usm-k-input" aria-label="Number of sources" />
+                </label>
+                <input id="usmQueryInput" type="text" class="btn btn-outline usm-query-input" placeholder="Or describe a source… e.g. the AC hum" aria-label="Text query for source separation" />
+                <button id="btnUsmQuery" class="btn btn-outline btn-xs" type="button">Query separate</button>
+                <button id="btnUsmApplyMix" class="btn btn-reprocess btn-xs" type="button" title="Write combined matrix mix to processed buffer">Apply mix</button>
+              </div>
+              <div id="usmProgress" class="usm-progress" hidden>
+                <div class="usm-progress-bar"><div id="usmProgressFill" class="usm-progress-fill"></div></div>
+                <span id="usmProgressLabel" class="usm-progress-label">Idle</span>
+              </div>
+              <div id="usmError" class="usm-error" hidden role="alert"></div>
+              <div class="usm-table-wrap">
+                <table class="usm-table" aria-label="Source matrix stems">
+                  <thead>
+                    <tr>
+                      <th scope="col">M</th>
+                      <th scope="col">S</th>
+                      <th scope="col">Gain (dB)</th>
+                      <th scope="col">Label</th>
+                      <th scope="col">Refine</th>
+                    </tr>
+                  </thead>
+                  <tbody id="usmTableBody">
+                    <tr class="usm-empty-row"><td colspan="5">Run Separate sources after loading a file (Creator / Forensic).</td></tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
           </div>
         </div>
       </section>

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -390,7 +390,7 @@
                 <label class="usm-k-label">K
                   <input id="usmNumSources" type="number" min="2" max="12" value="6" class="usm-k-input" aria-label="Number of sources" />
                 </label>
-                <input id="usmQueryInput" type="text" class="btn btn-outline usm-query-input" placeholder="Or describe a source… e.g. the AC hum" aria-label="Text query for source separation" />
+                <input id="usmQueryInput" type="text" class="usm-query-input" placeholder="Or describe a source… e.g. the AC hum" aria-label="Text query for source separation" />
                 <button id="btnUsmQuery" class="btn btn-outline btn-xs" type="button">Query separate</button>
                 <button id="btnUsmApplyMix" class="btn btn-reprocess btn-xs" type="button" title="Write combined matrix mix to processed buffer">Apply mix</button>
               </div>

--- a/public/app/lib/analysis-workspace.js
+++ b/public/app/lib/analysis-workspace.js
@@ -165,6 +165,7 @@ export function installAnalysisWorkspace(app) {
         usmNode.setMute(id, next);
         // Mirror into audition for immediate hear (Live-Mix — no ML re-run)
         audition.setLayerMute(id, next);
+        refreshAuditionIfPlaying();
         renderUsmTable();
       });
       tr.querySelector('[data-usm-act="solo"]')?.addEventListener('click', () => {
@@ -173,6 +174,7 @@ export function installAnalysisWorkspace(app) {
         usmNode.setSolo(id, next);
         audition.setLayerSolo(id, next);
         if (next) audition.setMode('layer');
+        refreshAuditionIfPlaying();
         renderUsmTable();
       });
       tr.querySelector('[data-usm-act="gain"]')?.addEventListener('input', (e) => {
@@ -182,6 +184,7 @@ export function installAnalysisWorkspace(app) {
         audition.setLayerGain(id, lin);
         const val = tr.querySelector('.usm-gain-val');
         if (val) val.textContent = db.toFixed(1);
+        refreshAuditionIfPlaying();
       });
       tr.querySelector('[data-usm-act="label"]')?.addEventListener('change', (e) => {
         usmNode.setLabel(id, e.target.value);
@@ -208,11 +211,18 @@ export function installAnalysisWorkspace(app) {
     if (!ctx) return;
     if (ctx.state === 'suspended') await ctx.resume();
     const original = app.origBuffer || app.inputBuffer;
-    const packed = usmSourcesToAudioBuffers(ctx, usmNode.sources, usmNode._sampleRate);
+    const packed = usmSourcesToAudioBuffers(ctx, usmNode.sources, usmNode.sampleRate);
     audition.buildFromUSM(packed, ctx, original || null);
     transport.attachClock(() => audition.getCurrentTime());
     renderAuditionStrip();
     setModeButtons('layer');
+  }
+
+  /** Re-snap Live-Mix if audition is already playing (gain nodes are one-shot per play). */
+  function refreshAuditionIfPlaying() {
+    if (!audition._playing) return;
+    const t = typeof audition.getCurrentTime === 'function' ? audition.getCurrentTime() : 0;
+    audition.play(t).catch(() => {});
   }
 
   async function runUsmSeparate(mode) {
@@ -287,8 +297,12 @@ export function installAnalysisWorkspace(app) {
       return;
     }
     const mix = usmNode.renderMix();
-    const out = ctx.createBuffer(1, mix.length, usmNode._sampleRate || ctx.sampleRate);
-    out.copyToChannel(mix, 0);
+    const sr = usmNode.sampleRate || ctx.sampleRate;
+    // Preserve channel count of the loaded file (mono mix expanded to stereo if needed)
+    const srcBuf = app.origBuffer || app.inputBuffer;
+    const nCh = Math.max(1, Math.min(2, srcBuf?.numberOfChannels || 1));
+    const out = ctx.createBuffer(nCh, mix.length, sr);
+    for (let c = 0; c < nCh; c++) out.copyToChannel(mix, c);
     app.procBuffer = out;
     app.outputBuffer = out;
     // Also expose as processed audition layer

--- a/public/app/lib/analysis-workspace.js
+++ b/public/app/lib/analysis-workspace.js
@@ -19,6 +19,7 @@ import {
   analysisToHunterSliderTargets,
 } from '/src/core/AnalyzerWhisperBridge.js';
 import { analyzeAcousticEnvironment } from '../whisper-hunter.js';
+import { USMNode, usmSourcesToAudioBuffers } from '/src/pipeline/USMNode.js';
 
 /**
  * @param {object} app VoiceIsolatePro instance (legacy Engineer shell)
@@ -58,6 +59,19 @@ export function installAnalysisWorkspace(app) {
     btnAudStop: document.getElementById('audStop'),
     btnAudReset: document.getElementById('audResetMix'),
     btnExport: document.getElementById('btnExportAnalysisWav'),
+    // Universal Source Matrix
+    usmPanel: document.getElementById('sourceMatrixPanel'),
+    btnUsmSeparate: document.getElementById('btnUsmSeparate'),
+    btnUsmQuery: document.getElementById('btnUsmQuery'),
+    btnUsmApplyMix: document.getElementById('btnUsmApplyMix'),
+    usmNumSources: document.getElementById('usmNumSources'),
+    usmQueryInput: document.getElementById('usmQueryInput'),
+    usmTableBody: document.getElementById('usmTableBody'),
+    usmProgress: document.getElementById('usmProgress'),
+    usmProgressFill: document.getElementById('usmProgressFill'),
+    usmProgressLabel: document.getElementById('usmProgressLabel'),
+    usmError: document.getElementById('usmError'),
+    usmMethodBadge: document.getElementById('usmMethodBadge'),
   };
 
   const host = new FullAnalysisHost({
@@ -70,9 +84,18 @@ export function installAnalysisWorkspace(app) {
 
   const audition = new SourceAuditionEngine();
   const transport = new TransportSync();
+  const usmNode = new USMNode({
+    preferOnnx: false, // classical USM default; set true when universal-separator.onnx ships
+    onProgress: (pct, label) => {
+      if (els.usmProgress) els.usmProgress.hidden = false;
+      if (els.usmProgressFill) els.usmProgressFill.style.width = `${Math.round((pct || 0) * 100)}%`;
+      if (els.usmProgressLabel) els.usmProgressLabel.textContent = `${label || 'usm'}… ${Math.round((pct || 0) * 100)}%`;
+    },
+  });
   let timeline = null;
   let lastAnalysis = null;
   let cancelled = false;
+  let usmBusy = false;
 
   if (els.timeline) {
     timeline = new TimelineRenderer(els.timeline, {
@@ -103,6 +126,184 @@ export function installAnalysisWorkspace(app) {
     if (!els.error) return;
     els.error.hidden = !msg;
     els.error.textContent = msg || '';
+  }
+
+  function showUsmError(msg) {
+    if (!els.usmError) return;
+    els.usmError.hidden = !msg;
+    els.usmError.textContent = msg || '';
+  }
+
+  function renderUsmTable() {
+    if (!els.usmTableBody) return;
+    const rows = usmNode.sources;
+    if (!rows.length) {
+      els.usmTableBody.innerHTML =
+        '<tr class="usm-empty-row"><td colspan="5">Run Separate sources after loading a file (Creator / Forensic).</td></tr>';
+      return;
+    }
+    els.usmTableBody.innerHTML = rows.map((s) => `
+      <tr data-usm-id="${escapeHtml(s.id)}">
+        <td><button type="button" class="btn btn-xs ${s.mute ? 'active' : ''}" data-usm-act="mute" title="Mute">M</button></td>
+        <td><button type="button" class="btn btn-xs ${s.solo ? 'active' : ''}" data-usm-act="solo" title="Solo">S</button></td>
+        <td>
+          <input type="range" min="-48" max="12" step="0.5" value="${s.gainDb}" data-usm-act="gain" aria-label="Gain dB" />
+          <span class="usm-gain-val">${s.gainDb.toFixed(1)}</span>
+        </td>
+        <td>
+          <input type="text" class="usm-label-input" data-usm-act="label" value="${escapeHtml(s.label)}" />
+          <span class="usm-conf" title="Confidence">${Math.round((s.confidence || 0) * 100)}%</span>
+        </td>
+        <td><button type="button" class="btn btn-xs" data-usm-act="refine" title="Refine via text query">Refine</button></td>
+      </tr>`).join('');
+
+    els.usmTableBody.querySelectorAll('tr[data-usm-id]').forEach((tr) => {
+      const id = tr.dataset.usmId;
+      tr.querySelector('[data-usm-act="mute"]')?.addEventListener('click', () => {
+        const s = usmNode.sources.find((x) => x.id === id);
+        const next = !s?.mute;
+        usmNode.setMute(id, next);
+        // Mirror into audition for immediate hear (Live-Mix — no ML re-run)
+        audition.setLayerMute(id, next);
+        renderUsmTable();
+      });
+      tr.querySelector('[data-usm-act="solo"]')?.addEventListener('click', () => {
+        const s = usmNode.sources.find((x) => x.id === id);
+        const next = !s?.solo;
+        usmNode.setSolo(id, next);
+        audition.setLayerSolo(id, next);
+        if (next) audition.setMode('layer');
+        renderUsmTable();
+      });
+      tr.querySelector('[data-usm-act="gain"]')?.addEventListener('input', (e) => {
+        const db = Number(e.target.value);
+        usmNode.setGainDb(id, db);
+        const lin = Math.pow(10, db / 20);
+        audition.setLayerGain(id, lin);
+        const val = tr.querySelector('.usm-gain-val');
+        if (val) val.textContent = db.toFixed(1);
+      });
+      tr.querySelector('[data-usm-act="label"]')?.addEventListener('change', (e) => {
+        usmNode.setLabel(id, e.target.value);
+        const L = audition.layers.get(id);
+        if (L) L.label = e.target.value;
+      });
+      tr.querySelector('[data-usm-act="refine"]')?.addEventListener('click', async () => {
+        const q = window.prompt('Describe what to keep for this source (local query mask):', usmNode.sources.find((x) => x.id === id)?.label || '');
+        if (!q) return;
+        try {
+          showUsmError('');
+          await usmNode.refine(q);
+          await pushUsmToAudition();
+          renderUsmTable();
+        } catch (err) {
+          showUsmError(err?.message || String(err));
+        }
+      });
+    });
+  }
+
+  async function pushUsmToAudition() {
+    const ctx = app.ctx || app.audioCtx;
+    if (!ctx) return;
+    if (ctx.state === 'suspended') await ctx.resume();
+    const original = app.origBuffer || app.inputBuffer;
+    const packed = usmSourcesToAudioBuffers(ctx, usmNode.sources, usmNode._sampleRate);
+    audition.buildFromUSM(packed, ctx, original || null);
+    transport.attachClock(() => audition.getCurrentTime());
+    renderAuditionStrip();
+    setModeButtons('layer');
+  }
+
+  async function runUsmSeparate(mode) {
+    if (usmBusy) return;
+    showUsmError('');
+    if (typeof app.ensureDecoded === 'function') {
+      const decoded = await app.ensureDecoded();
+      if (!decoded) {
+        showUsmError('Load an audio or video file first.');
+        return;
+      }
+    }
+    const buf = app.origBuffer || app.inputBuffer;
+    if (!buf) {
+      showUsmError('Load an audio or video file first.');
+      return;
+    }
+    usmBusy = true;
+    [els.btnUsmSeparate, els.btnUsmQuery, els.btnUsmApplyMix].forEach((b) => {
+      if (b) b.disabled = true;
+    });
+    if (els.usmProgress) els.usmProgress.hidden = false;
+    try {
+      const channels = [];
+      for (let c = 0; c < buf.numberOfChannels; c++) {
+        channels.push(buf.getChannelData(c).slice());
+      }
+      const K = Math.max(2, Math.min(12, Number(els.usmNumSources?.value) || 6));
+      const queryText = (els.usmQueryInput?.value || '').trim();
+      const config = mode === 'query' || queryText
+        ? {
+          mode: 'query',
+          queries: queryText
+            ? queryText.split(/[,;|]/).map((s) => s.trim()).filter(Boolean)
+            : ['speech'],
+          numSources: K,
+        }
+        : { mode: 'auto', numSources: K };
+
+      const result = await usmNode.process(channels, buf.sampleRate, config);
+      app._usmResult = result;
+      app._usmNode = usmNode;
+
+      if (els.usmMethodBadge) {
+        els.usmMethodBadge.hidden = false;
+        els.usmMethodBadge.textContent = result.method || 'usm';
+      }
+      await pushUsmToAudition();
+      renderUsmTable();
+      if (typeof app.setStatus === 'function') {
+        app.setStatus(`USM: ${result.sources.length} sources (${result.method})`);
+      }
+    } catch (err) {
+      showUsmError(err?.message || String(err));
+    } finally {
+      usmBusy = false;
+      [els.btnUsmSeparate, els.btnUsmQuery, els.btnUsmApplyMix].forEach((b) => {
+        if (b) b.disabled = false;
+      });
+      if (els.usmProgress) els.usmProgress.hidden = true;
+    }
+  }
+
+  function applyUsmMixToProcessed() {
+    if (!usmNode.sources.length) {
+      showUsmError('Separate sources first.');
+      return;
+    }
+    const ctx = app.ctx || app.audioCtx;
+    if (!ctx) {
+      showUsmError('Audio context not ready');
+      return;
+    }
+    const mix = usmNode.renderMix();
+    const out = ctx.createBuffer(1, mix.length, usmNode._sampleRate || ctx.sampleRate);
+    out.copyToChannel(mix, 0);
+    app.procBuffer = out;
+    app.outputBuffer = out;
+    // Also expose as processed audition layer
+    audition.setLayer({
+      id: 'processed',
+      label: 'USM mix (processed)',
+      buffer: out,
+      confidence: 1,
+      quality: 'high',
+    });
+    renderAuditionStrip();
+    if (typeof app.setStatus === 'function') {
+      app.setStatus('USM mix applied to processed buffer');
+    }
+    showUsmError('');
   }
 
   function setBusy(busy) {
@@ -609,6 +810,17 @@ export function installAnalysisWorkspace(app) {
     else if (typeof app.setStatus === 'function') app.setStatus(`Exported ${result.filename}`);
   });
 
+  // Universal Source Matrix controls
+  els.btnUsmSeparate?.addEventListener('click', () => { runUsmSeparate('auto'); });
+  els.btnUsmQuery?.addEventListener('click', () => { runUsmSeparate('query'); });
+  els.btnUsmApplyMix?.addEventListener('click', () => applyUsmMixToProcessed());
+  els.usmQueryInput?.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      runUsmSeparate('query');
+    }
+  });
+
   // Inject calibrated presets into app if PRESETS exists
   try {
     const calibrated = getCalibratedPresets();
@@ -646,6 +858,9 @@ export function installAnalysisWorkspace(app) {
     getJointPlan: () => lastAnalysis?.jointPlan || app._jointIsolationPlan || null,
     audition,
     host,
+    usmNode,
+    runUsmSeparate,
+    applyUsmMixToProcessed,
     refreshCapability: renderCapability,
   };
   app._analysisWorkspace = api;

--- a/public/app/models/README.md
+++ b/public/app/models/README.md
@@ -13,6 +13,16 @@ No audio data leaves the device. WebGPU execution provider is preferred; WASM is
 | `demucs_v4_quantized.onnx` | Hybrid Demucs v4 source separation | ~83 MB | ⚠️ Manual download required |
 | `bsrnn_vocals.onnx` | Band-Split RNN vocals extraction | ~45 MB | ⚠️ Manual download required |
 | `rnnoise_suppressor.onnx` | Broadband noise suppression | ~180 KB | ⚠️ Manual download required |
+| `universal-separator.onnx` | Optional AudioSep-class query universal separator | — | ⬜ Optional (not shipped). Classical USM NMF + text priors run without it. |
+
+### Universal Source Matrix (USM)
+
+Engineer Mode → **Universal Source Matrix** panel (under Source Analysis Workspace):
+
+- **Separate sources** — unsupervised multi-component soft masks (classical NMF; FUSS-style variable-K).
+- **Query separate** — language priors (“AC hum”, “dog barking”, “speech”) for LASS/AudioSep-style control.
+- **Mute / Solo / Gain** — Live-Mix only (no ML re-run). **Refine** re-runs a one-shot query on the retained mixture.
+- Drop `universal-separator.onnx` under this folder and pin `sha256` in `src/core/ModelManifest.js` (`universal_separator`) to enable the ONNX path (`preferOnnx: true` on `USMNode`).
 
 ---
 

--- a/public/app/style.css
+++ b/public/app/style.css
@@ -2415,4 +2415,140 @@ body::after {
 }
 .aud-gain-label input[type="range"] { flex: 1; min-width: 60px; }
 .aud-empty { font-size: 0.8rem; color: #64748b; margin: 0; }
+
+/* Universal Source Matrix panel */
+.source-matrix-panel {
+  margin-top: 14px;
+  padding-top: 12px;
+  border-top: 1px solid #1e293b;
+}
+.usm-hdr {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.usm-method-badge {
+  font-size: 0.68rem;
+  padding: 2px 8px;
+  border-radius: 999px;
+  border: 1px solid #334155;
+  color: #94a3b8;
+  background: #0b1220;
+}
+.usm-lead {
+  font-size: 0.78rem;
+  color: #94a3b8;
+  margin: 4px 0 10px;
+  line-height: 1.4;
+}
+.usm-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+.usm-k-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.75rem;
+  color: #94a3b8;
+}
+.usm-k-input {
+  width: 3.2rem;
+  background: #0b1220;
+  border: 1px solid #334155;
+  color: #e2e8f0;
+  border-radius: 6px;
+  padding: 4px 6px;
+}
+.usm-query-input {
+  flex: 1;
+  min-width: 160px;
+  max-width: 320px;
+  text-align: left !important;
+}
+.usm-progress {
+  margin: 6px 0 8px;
+}
+.usm-progress-bar {
+  height: 4px;
+  background: #1e293b;
+  border-radius: 2px;
+  overflow: hidden;
+}
+.usm-progress-fill {
+  height: 100%;
+  width: 0%;
+  background: linear-gradient(90deg, #38bdf8, #818cf8);
+  transition: width 0.15s ease;
+}
+.usm-progress-label {
+  font-size: 0.7rem;
+  color: #64748b;
+}
+.usm-error {
+  font-size: 0.78rem;
+  color: #fca5a5;
+  margin: 6px 0;
+}
+.usm-table-wrap {
+  overflow-x: auto;
+  border: 1px solid #1e293b;
+  border-radius: 8px;
+  background: #0b1220;
+}
+.usm-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.78rem;
+  color: #e2e8f0;
+}
+.usm-table th,
+.usm-table td {
+  padding: 6px 8px;
+  border-bottom: 1px solid #1e293b;
+  text-align: left;
+  vertical-align: middle;
+}
+.usm-table th {
+  color: #94a3b8;
+  font-weight: 600;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+.usm-table tr:last-child td { border-bottom: none; }
+.usm-empty-row td { color: #64748b; font-style: italic; }
+.usm-table input[type="range"] { width: 100px; vertical-align: middle; }
+.usm-table input[type="text"].usm-label-input {
+  width: 100%;
+  min-width: 100px;
+  background: #0f172a;
+  border: 1px solid #334155;
+  color: #e2e8f0;
+  border-radius: 4px;
+  padding: 3px 6px;
+  font-size: 0.75rem;
+}
+.usm-gain-val {
+  display: inline-block;
+  min-width: 2.5rem;
+  color: #94a3b8;
+  font-variant-numeric: tabular-nums;
+  font-size: 0.7rem;
+  margin-left: 4px;
+}
+.usm-table .btn.active {
+  background: rgba(56, 189, 248, 0.15);
+  border-color: #38bdf8;
+}
+.usm-conf {
+  font-size: 0.65rem;
+  color: #64748b;
+  margin-left: 4px;
+}
+
 .vip-timeline-canvas { width: 100%; height: 100%; touch-action: manipulation; }

--- a/public/app/style.css
+++ b/public/app/style.css
@@ -2468,7 +2468,12 @@ body::after {
   flex: 1;
   min-width: 160px;
   max-width: 320px;
-  text-align: left !important;
+  background: #0b1220;
+  border: 1px solid #334155;
+  color: #e2e8f0;
+  border-radius: 6px;
+  padding: 6px 10px;
+  font-size: 0.8rem;
 }
 .usm-progress {
   margin: 6px 0 8px;
@@ -2487,7 +2492,7 @@ body::after {
 }
 .usm-progress-label {
   font-size: 0.7rem;
-  color: #64748b;
+  color: #94a3b8;
 }
 .usm-error {
   font-size: 0.78rem;
@@ -2521,7 +2526,7 @@ body::after {
   letter-spacing: 0.03em;
 }
 .usm-table tr:last-child td { border-bottom: none; }
-.usm-empty-row td { color: #64748b; font-style: italic; }
+.usm-empty-row td { color: #94a3b8; font-style: italic; }
 .usm-table input[type="range"] { width: 100px; vertical-align: middle; }
 .usm-table input[type="text"].usm-label-input {
   width: 100%;
@@ -2547,7 +2552,7 @@ body::after {
 }
 .usm-conf {
   font-size: 0.65rem;
-  color: #64748b;
+  color: #94a3b8;
   margin-left: 4px;
 }
 

--- a/src/core/ModelManifest.js
+++ b/src/core/ModelManifest.js
@@ -156,6 +156,35 @@ export const MODEL_MANIFEST = Object.freeze({
       output: 'output', // 4D complex spectrogram tensor
     }),
   }),
+
+  // ── Universal / query-based source separation (optional AudioSep-class) ──
+  // Weights are optional. When missing, USMNode falls back to classical NMF +
+  // language-prior masks in src/core/UniversalSourceMatrix.js (always available).
+  // Drop an ONNX export at the URL below and pin sha256 before shipping.
+  universal_separator: Object.freeze({
+    id: 'universal_separator',
+    name: 'Universal Query Separator (AudioSep-class)',
+    task: 'universal-source-separation',
+    url: '/app/models/universal-separator.onnx',
+    sizeBytes: null,
+    quantization: 'fp32',
+    delivery: 'optional',
+    sha256: null,
+    strategy: 'universal-query',
+    fftSize: 4096,
+    hopSize: 1024,
+    bins: 2049,
+    maxBatchFrames: 64,
+    sampleRate: 48000,
+    io: Object.freeze({
+      // Expected when a real AudioSep-class ONNX is provided:
+      //   audio  float32 [1, T]  and/or  mag [batch, 2049]
+      //   query  optional text embedding path handled inside the graph
+      //   masks  float32 [K, frames, bins] or [K, T]
+      input: 'input',
+      output: 'output',
+    }),
+  }),
 });
 
 /** Stable list of model ids. */

--- a/src/core/UniversalSourceMatrix.js
+++ b/src/core/UniversalSourceMatrix.js
@@ -386,11 +386,11 @@ export function nmfSoftMasks(mag, frames, bins, K, iterations = 40, seed = 42) {
   // Wiener soft masks M_k = (W_k H_k) / sum_j W_j H_j  (on compressed space; fine for partitioning)
   const masks = [];
   for (let k = 0; k < K; k++) masks.push(new Float32Array(frames * bins));
+  const parts = new Float32Array(K); // reuse per-bin buffer
 
   for (let t = 0; t < frames; t++) {
     for (let b = 0; b < bins; b++) {
       let sum = 0;
-      const parts = new Float32Array(K);
       for (let k = 0; k < K; k++) {
         let p = W[b * K + k] * H[k * frames + t];
         if (!Number.isFinite(p) || p < 0) p = 0;
@@ -522,6 +522,10 @@ export function querySoftMasks(mag, frames, bins, queries, sampleRate, fftSize) 
  * @param {USMConfig} [config]
  * @returns {USMResult}
  */
+function isPowerOfTwo(n) {
+  return Number.isInteger(n) && n > 0 && (n & (n - 1)) === 0;
+}
+
 export function separateUniversal(samples, sampleRate = SAMPLE_RATE, config = {}) {
   if (!(samples instanceof Float32Array) && !ArrayBuffer.isView(samples)) {
     throw new TypeError('[VIP][USM] samples must be a Float32Array');
@@ -530,6 +534,12 @@ export function separateUniversal(samples, sampleRate = SAMPLE_RATE, config = {}
   const sr = sampleRate || SAMPLE_RATE;
   const fftSize = config.fftSize || USM_FFT_SIZE;
   const hopSize = config.hopSize || USM_HOP_SIZE;
+  if (!isPowerOfTwo(fftSize) || fftSize < 256) {
+    throw new TypeError(`[VIP][USM] fftSize must be a power of two ≥ 256 (got ${fftSize})`);
+  }
+  if (!Number.isInteger(hopSize) || hopSize < 1 || hopSize > fftSize) {
+    throw new TypeError(`[VIP][USM] hopSize must be an integer in [1, fftSize] (got ${hopSize})`);
+  }
   const mode = config.mode === 'query' ? 'query' : 'auto';
   const Kreq = Math.max(2, Math.min(USM_MAX_SOURCES, config.numSources || USM_DEFAULT_SOURCES));
   const iterations = Math.max(8, Math.min(80, config.nmfIterations || 32));

--- a/src/core/UniversalSourceMatrix.js
+++ b/src/core/UniversalSourceMatrix.js
@@ -1,0 +1,659 @@
+/**
+ * VoiceIsolate Pro — Universal Source Matrix (Layer 1: Core)
+ *
+ * Open-domain, multi-component soft separation for Creator / Forensic modes.
+ * Produces K soft masks that partition the mixture STFT so each component can
+ * be muted / soloed / gained in Live-Mix without re-running heavy DSP.
+ *
+ * Two modes:
+ *   - auto   — unsupervised spectral NMF (FUSS-style variable-K discovery)
+ *   - query  — language-prior soft masks (AudioSep / LASS-style text control)
+ *
+ * Pure module: no DOM, no Web Audio, no network, no I/O.
+ * Optional ONNX AudioSep-class models plug in at the pipeline/worker layer;
+ * this file is the always-available classical + query backend.
+ *
+ * Single-pass contract for the mixture path:
+ *   one forward STFT on the mix → K soft masks → one iSTFT per stem.
+ */
+'use strict';
+
+import { SAMPLE_RATE } from './audio-config.js';
+import { FFT_SIZE_CREATOR } from './ring-buffer-constants.js';
+
+/** Default Creator-mode STFT (matches spectral-mask models: 4096 / 1024). */
+export const USM_FFT_SIZE = FFT_SIZE_CREATOR;
+export const USM_HOP_SIZE = 1024;
+export const USM_MAX_SOURCES = 12;
+export const USM_DEFAULT_SOURCES = 6;
+
+/** @typedef {{ mode?: 'auto'|'query', numSources?: number, queries?: string[], sampleRate?: number, fftSize?: number, hopSize?: number, nmfIterations?: number, seed?: number }} USMConfig */
+
+/** @typedef {{ id: string, label: string, mask: Float32Array, pcm: Float32Array, confidence: number, quality: 'high'|'medium'|'low', method: string }} USMSource */
+
+/** @typedef {{ sources: USMSource[], shape: { frames: number, bins: number }, method: string, stft: { re: Float32Array, im: Float32Array, mag: Float32Array } }} USMResult */
+
+// ─── FFT ─────────────────────────────────────────────────────────────────────
+
+const _fftCache = Object.create(null);
+
+function fftTables(n) {
+  if (_fftCache[n]) return _fftCache[n];
+  const rev = new Uint32Array(n);
+  const bits = Math.log2(n) | 0;
+  for (let i = 0; i < n; i++) {
+    let r = 0;
+    for (let b = 0; b < bits; b++) r |= ((i >> b) & 1) << (bits - 1 - b);
+    rev[i] = r;
+  }
+  const cos = new Float32Array(n / 2);
+  const sin = new Float32Array(n / 2);
+  for (let i = 0; i < n / 2; i++) {
+    cos[i] = Math.cos((-2 * Math.PI * i) / n);
+    sin[i] = Math.sin((-2 * Math.PI * i) / n);
+  }
+  _fftCache[n] = { rev, cos, sin };
+  return _fftCache[n];
+}
+
+function fftInPlace(re, im, inverse) {
+  const n = re.length;
+  const { rev, cos, sin } = fftTables(n);
+  for (let i = 0; i < n; i++) {
+    const r = rev[i];
+    if (r > i) {
+      let t = re[i]; re[i] = re[r]; re[r] = t;
+      t = im[i]; im[i] = im[r]; im[r] = t;
+    }
+  }
+  for (let size = 2; size <= n; size <<= 1) {
+    const half = size >> 1;
+    const step = n / size;
+    for (let i = 0; i < n; i += size) {
+      for (let j = 0, k = 0; j < half; j++, k += step) {
+        const wr = cos[k];
+        const wi = inverse ? -sin[k] : sin[k];
+        const a = i + j;
+        const b = a + half;
+        const tr = re[b] * wr - im[b] * wi;
+        const ti = re[b] * wi + im[b] * wr;
+        re[b] = re[a] - tr; im[b] = im[a] - ti;
+        re[a] += tr; im[a] += ti;
+      }
+    }
+  }
+  if (inverse) {
+    for (let i = 0; i < n; i++) { re[i] /= n; im[i] /= n; }
+  }
+}
+
+function hann(n) {
+  const w = new Float32Array(n);
+  for (let i = 0; i < n; i++) w[i] = 0.5 * (1 - Math.cos((2 * Math.PI * i) / (n - 1)));
+  return w;
+}
+
+/**
+ * Forward STFT of mono PCM.
+ * @returns {{ re: Float32Array, im: Float32Array, mag: Float32Array, frames: number, bins: number, fftSize: number, hopSize: number, win: Float32Array }}
+ */
+export function computeStft(samples, fftSize = USM_FFT_SIZE, hopSize = USM_HOP_SIZE) {
+  const N = fftSize;
+  const hop = hopSize;
+  const bins = (N >> 1) + 1;
+  const win = hann(N);
+  const frames = Math.max(1, Math.ceil(Math.max(0, samples.length - N) / hop) + 1);
+  const re = new Float32Array(frames * bins);
+  const im = new Float32Array(frames * bins);
+  const mag = new Float32Array(frames * bins);
+  const fre = new Float32Array(N);
+  const fim = new Float32Array(N);
+
+  for (let f = 0; f < frames; f++) {
+    const start = f * hop;
+    fre.fill(0); fim.fill(0);
+    const avail = Math.max(0, Math.min(N, samples.length - start));
+    for (let i = 0; i < avail; i++) fre[i] = samples[start + i] * win[i];
+    fftInPlace(fre, fim, false);
+    const off = f * bins;
+    for (let k = 0; k < bins; k++) {
+      re[off + k] = fre[k];
+      im[off + k] = fim[k];
+      mag[off + k] = Math.sqrt(fre[k] * fre[k] + fim[k] * fim[k]);
+    }
+  }
+  return { re, im, mag, frames, bins, fftSize: N, hopSize: hop, win };
+}
+
+/**
+ * Apply soft mask to complex STFT and inverse-overlap-add to PCM.
+ * One iSTFT path per stem (Caller already owns the single mixture STFT).
+ */
+export function maskToPcm(stft, mask, outLength) {
+  const { re, im, frames, bins, fftSize: N, hopSize: hop, win } = stft;
+  const out = new Float32Array(outLength);
+  const norm = new Float32Array(outLength);
+  const fre = new Float32Array(N);
+  const fim = new Float32Array(N);
+
+  for (let f = 0; f < frames; f++) {
+    const off = f * bins;
+    for (let k = 0; k < bins; k++) {
+      const m = mask[off + k];
+      fre[k] = re[off + k] * m;
+      fim[k] = im[off + k] * m;
+    }
+    for (let k = bins; k < N; k++) {
+      fre[k] = fre[N - k];
+      fim[k] = -fim[N - k];
+    }
+    fftInPlace(fre, fim, true);
+    const start = f * hop;
+    const avail = Math.max(0, Math.min(N, outLength - start));
+    for (let i = 0; i < avail; i++) {
+      out[start + i] += fre[i] * win[i];
+      norm[start + i] += win[i] * win[i];
+    }
+  }
+  for (let i = 0; i < outLength; i++) {
+    if (norm[i] > 1e-8) out[i] /= norm[i];
+  }
+  return out;
+}
+
+// ─── Query priors (language → spectral template) ─────────────────────────────
+
+/**
+ * Keyword → relative frequency emphasis template builder.
+ * Not ASR — a lightweight open-vocabulary prior so "AC hum" / "dog bark" map to
+ * useful soft masks without a cloud model.
+ */
+const QUERY_PRIORS = Object.freeze([
+  {
+    id: 'speech',
+    labels: ['speech', 'voice', 'vocal', 'talk', 'man', 'woman', 'person', 'speaker', 'dialogue', 'joke', 'laugh', 'whisper'],
+    // Formant-ish band 200 Hz – 4 kHz emphasis
+    band: [200, 4000],
+    transient: 0.2,
+    tonal: 0.6,
+  },
+  {
+    id: 'music',
+    labels: ['music', 'song', 'instrument', 'guitar', 'piano', 'drum', 'bass', 'melody', 'tv', 'television', 'radio'],
+    band: [80, 8000],
+    transient: 0.35,
+    tonal: 0.7,
+  },
+  {
+    id: 'hum',
+    labels: ['hum', 'ac', 'air conditioner', 'mains', 'buzz', '60hz', '50hz', 'electrical', 'fan'],
+    band: [40, 360],
+    transient: 0.05,
+    tonal: 0.95,
+    harmonicBase: 60,
+  },
+  {
+    id: 'noise',
+    labels: ['noise', 'hiss', 'static', 'wind', 'rain', 'traffic', 'crowd', 'ambience', 'room', 'background'],
+    band: [100, 12000],
+    transient: 0.15,
+    tonal: 0.1,
+  },
+  {
+    id: 'bark',
+    labels: ['dog', 'bark', 'barking', 'animal', 'woof'],
+    band: [300, 3500],
+    transient: 0.85,
+    tonal: 0.3,
+  },
+  {
+    id: 'bird',
+    labels: ['bird', 'chirp', 'tweet', 'sparrow', 'avian'],
+    band: [2000, 9000],
+    transient: 0.7,
+    tonal: 0.5,
+  },
+  {
+    id: 'thunder',
+    labels: ['thunder', 'rumble', 'storm', 'boom'],
+    band: [20, 400],
+    transient: 0.6,
+    tonal: 0.2,
+  },
+  {
+    id: 'click',
+    labels: ['click', 'clap', 'knock', 'squeak', 'chair', 'transient', 'snap', 'horn'],
+    band: [1000, 12000],
+    transient: 0.95,
+    tonal: 0.1,
+  },
+]);
+
+function matchPrior(query) {
+  const q = String(query || '').toLowerCase();
+  let best = null;
+  let bestScore = 0;
+  for (const p of QUERY_PRIORS) {
+    let score = 0;
+    for (const lab of p.labels) {
+      if (q.includes(lab)) score += lab.length;
+    }
+    if (score > bestScore) {
+      bestScore = score;
+      best = p;
+    }
+  }
+  return best || QUERY_PRIORS.find((p) => p.id === 'noise');
+}
+
+function hzToBin(hz, sampleRate, bins, fftSize) {
+  const b = Math.round((hz * fftSize) / sampleRate);
+  return Math.max(0, Math.min(bins - 1, b));
+}
+
+/**
+ * Build a per-bin spectral prior weight for a text query.
+ */
+export function querySpectralPrior(query, bins, sampleRate, fftSize) {
+  const prior = matchPrior(query);
+  const w = new Float32Array(bins);
+  const [loHz, hiHz] = prior.band;
+  const lo = hzToBin(loHz, sampleRate, bins, fftSize);
+  const hi = hzToBin(hiHz, sampleRate, bins, fftSize);
+  for (let k = 0; k < bins; k++) {
+    if (k >= lo && k <= hi) {
+      // Raised-cosine in-band
+      const t = (k - lo) / Math.max(1, hi - lo);
+      w[k] = 0.55 + 0.45 * Math.sin(Math.PI * t);
+    } else {
+      const dist = k < lo ? (lo - k) / Math.max(1, lo) : (k - hi) / Math.max(1, bins - hi);
+      w[k] = Math.max(0.02, 0.25 * Math.exp(-3 * dist));
+    }
+  }
+  if (prior.harmonicBase) {
+    for (let h = 1; h <= 8; h++) {
+      const f = prior.harmonicBase * h;
+      const k0 = hzToBin(f, sampleRate, bins, fftSize);
+      for (let d = -2; d <= 2; d++) {
+        const k = k0 + d;
+        if (k >= 0 && k < bins) w[k] = Math.min(1, w[k] + 0.45 / h);
+      }
+    }
+  }
+  return { weights: w, prior, label: String(query || prior.id).slice(0, 64) };
+}
+
+// ─── Auto NMF ────────────────────────────────────────────────────────────────
+
+function seededRandom(seed) {
+  let s = (seed >>> 0) || 1;
+  return () => {
+    s = (s * 1664525 + 1013904223) >>> 0;
+    return s / 0x100000000;
+  };
+}
+
+/**
+ * Multiplicative NMF on magnitude spectrogram → K non-negative bases + activations.
+ * Returns soft Wiener masks that sum to ~1 per TF bin.
+ *
+ * Uses log1p-compressed magnitude for stability, column-normalized W, and
+ * clamped multiplicative updates so masks never go NaN on sparse frames.
+ */
+export function nmfSoftMasks(mag, frames, bins, K, iterations = 40, seed = 42) {
+  const rand = seededRandom(seed);
+  const eps = 1e-6;
+  const W = new Float32Array(bins * K); // bins × K
+  const H = new Float32Array(K * frames); // K × frames
+
+  // Compress dynamic range — raw STFT mags span many orders of magnitude
+  const V = new Float32Array(frames * bins);
+  for (let i = 0; i < V.length; i++) {
+    const m = mag[i];
+    V[i] = Number.isFinite(m) && m > 0 ? Math.log1p(m) : 0;
+  }
+
+  // Init with spectral-band seeds so components diversify without random collapse
+  for (let k = 0; k < K; k++) {
+    const cLo = Math.floor((k / K) * bins * 0.9);
+    const cHi = Math.max(cLo + 1, Math.floor(((k + 1) / K) * bins));
+    for (let b = 0; b < bins; b++) {
+      const inBand = b >= cLo && b < cHi ? 1 : 0.08;
+      W[b * K + k] = inBand * (0.4 + 0.6 * rand());
+    }
+    for (let t = 0; t < frames; t++) {
+      H[k * frames + t] = 0.2 + 0.8 * rand();
+    }
+  }
+
+  const WH = new Float32Array(frames * bins);
+  const reconstruct = () => {
+    for (let t = 0; t < frames; t++) {
+      for (let b = 0; b < bins; b++) {
+        let s = 0;
+        for (let k = 0; k < K; k++) s += W[b * K + k] * H[k * frames + t];
+        WH[t * bins + b] = s + eps;
+      }
+    }
+  };
+
+  for (let iter = 0; iter < iterations; iter++) {
+    reconstruct();
+    // Update H: H <- H ⊙ (W^T (V/WH)) / (W^T 1)
+    for (let k = 0; k < K; k++) {
+      for (let t = 0; t < frames; t++) {
+        let num = 0;
+        let den = 0;
+        for (let b = 0; b < bins; b++) {
+          const w = W[b * K + k];
+          num += w * (V[t * bins + b] / WH[t * bins + b]);
+          den += w;
+        }
+        let h = H[k * frames + t] * ((num + eps) / (den + eps));
+        if (!Number.isFinite(h) || h < 0) h = eps;
+        H[k * frames + t] = Math.min(h, 1e6);
+      }
+    }
+    reconstruct();
+    // Update W
+    for (let k = 0; k < K; k++) {
+      for (let b = 0; b < bins; b++) {
+        let num = 0;
+        let den = 0;
+        for (let t = 0; t < frames; t++) {
+          const h = H[k * frames + t];
+          num += h * (V[t * bins + b] / WH[t * bins + b]);
+          den += h;
+        }
+        let w = W[b * K + k] * ((num + eps) / (den + eps));
+        if (!Number.isFinite(w) || w < 0) w = eps;
+        W[b * K + k] = Math.min(w, 1e6);
+      }
+    }
+    // Normalize each W column to unit L1 so scale lives in H
+    for (let k = 0; k < K; k++) {
+      let col = 0;
+      for (let b = 0; b < bins; b++) col += W[b * K + k];
+      if (col < eps) {
+        for (let b = 0; b < bins; b++) W[b * K + k] = 1 / bins;
+      } else {
+        for (let b = 0; b < bins; b++) W[b * K + k] /= col;
+        for (let t = 0; t < frames; t++) H[k * frames + t] *= col;
+      }
+    }
+  }
+
+  // Wiener soft masks M_k = (W_k H_k) / sum_j W_j H_j  (on compressed space; fine for partitioning)
+  const masks = [];
+  for (let k = 0; k < K; k++) masks.push(new Float32Array(frames * bins));
+
+  for (let t = 0; t < frames; t++) {
+    for (let b = 0; b < bins; b++) {
+      let sum = 0;
+      const parts = new Float32Array(K);
+      for (let k = 0; k < K; k++) {
+        let p = W[b * K + k] * H[k * frames + t];
+        if (!Number.isFinite(p) || p < 0) p = 0;
+        parts[k] = p;
+        sum += p;
+      }
+      if (sum < eps) {
+        // Silent bin — equal split keeps partition valid
+        const eq = 1 / K;
+        for (let k = 0; k < K; k++) masks[k][t * bins + b] = eq;
+      } else {
+        for (let k = 0; k < K; k++) {
+          const m = parts[k] / sum;
+          masks[k][t * bins + b] = Number.isFinite(m) ? m : 1 / K;
+        }
+      }
+    }
+  }
+
+  // Spectral centroid per component for labeling
+  const centroids = new Float32Array(K);
+  const energies = new Float32Array(K);
+  for (let k = 0; k < K; k++) {
+    let e = 0;
+    let c = 0;
+    for (let t = 0; t < frames; t++) {
+      for (let b = 0; b < bins; b++) {
+        const p = masks[k][t * bins + b] * mag[t * bins + b];
+        if (!Number.isFinite(p)) continue;
+        e += p;
+        c += p * b;
+      }
+    }
+    energies[k] = e;
+    centroids[k] = e > eps ? c / e : bins / 2;
+  }
+
+  return { masks, centroids, energies, W, H };
+}
+
+function labelFromCentroid(centroidBin, bins, sampleRate, fftSize, rankByEnergy) {
+  const hz = (centroidBin * sampleRate) / fftSize;
+  if (hz < 120) return rankByEnergy === 0 ? 'low rumble / hum' : 'bass / thunder';
+  if (hz < 400) return 'body / low speech';
+  if (hz < 1500) return 'speech / mid band';
+  if (hz < 4000) return 'presence / mid-high';
+  if (hz < 8000) return 'air / sibilance / birds';
+  return 'high noise / clicks';
+}
+
+// ─── Query masks ─────────────────────────────────────────────────────────────
+
+/**
+ * Soft mask for a text query using spectral prior × magnitude, plus optional
+ * residual partner so the partition remains invertible.
+ */
+export function querySoftMasks(mag, frames, bins, queries, sampleRate, fftSize) {
+  const list = (Array.isArray(queries) && queries.length ? queries : ['speech'])
+    .map((q) => String(q || '').trim())
+    .filter(Boolean)
+    .slice(0, USM_MAX_SOURCES);
+
+  const masks = [];
+  const labels = [];
+  const eps = 1e-8;
+
+  // Frame energy + flux for transient priors
+  const frameEnergy = new Float32Array(frames);
+  const flux = new Float32Array(frames);
+  for (let t = 0; t < frames; t++) {
+    let e = 0;
+    for (let b = 0; b < bins; b++) e += mag[t * bins + b];
+    frameEnergy[t] = e;
+    if (t > 0) {
+      let fl = 0;
+      for (let b = 0; b < bins; b++) {
+        const d = mag[t * bins + b] - mag[(t - 1) * bins + b];
+        if (d > 0) fl += d;
+      }
+      flux[t] = fl;
+    }
+  }
+  let maxFlux = eps;
+  for (let t = 0; t < frames; t++) if (flux[t] > maxFlux) maxFlux = flux[t];
+
+  for (const q of list) {
+    const { weights, prior, label } = querySpectralPrior(q, bins, sampleRate, fftSize);
+    const mask = new Float32Array(frames * bins);
+    for (let t = 0; t < frames; t++) {
+      const trans = flux[t] / maxFlux;
+      const gate = prior.transient * trans + (1 - prior.transient) * 0.55
+        + prior.tonal * 0.25;
+      for (let b = 0; b < bins; b++) {
+        const m = weights[b] * Math.min(1.5, gate);
+        mask[t * bins + b] = Math.max(0, Math.min(1, m));
+      }
+    }
+    masks.push(mask);
+    labels.push(label);
+  }
+
+  // Normalize so query masks + residual sum to 1 (Wiener partition)
+  const K = masks.length;
+  const residual = new Float32Array(frames * bins);
+  for (let i = 0; i < frames * bins; i++) {
+    let s = 0;
+    for (let k = 0; k < K; k++) s += masks[k][i];
+    const scale = s > 1 ? 1 / s : 1;
+    let used = 0;
+    for (let k = 0; k < K; k++) {
+      masks[k][i] *= scale;
+      used += masks[k][i];
+    }
+    residual[i] = Math.max(0, 1 - used);
+  }
+  masks.push(residual);
+  labels.push('residual / other');
+
+  return { masks, labels };
+}
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+/**
+ * Separate mono (or first-channel) PCM into K semantic sources.
+ *
+ * @param {Float32Array} samples
+ * @param {number} [sampleRate]
+ * @param {USMConfig} [config]
+ * @returns {USMResult}
+ */
+export function separateUniversal(samples, sampleRate = SAMPLE_RATE, config = {}) {
+  if (!(samples instanceof Float32Array) && !ArrayBuffer.isView(samples)) {
+    throw new TypeError('[VIP][USM] samples must be a Float32Array');
+  }
+  const pcm = samples instanceof Float32Array ? samples : new Float32Array(samples);
+  const sr = sampleRate || SAMPLE_RATE;
+  const fftSize = config.fftSize || USM_FFT_SIZE;
+  const hopSize = config.hopSize || USM_HOP_SIZE;
+  const mode = config.mode === 'query' ? 'query' : 'auto';
+  const Kreq = Math.max(2, Math.min(USM_MAX_SOURCES, config.numSources || USM_DEFAULT_SOURCES));
+  const iterations = Math.max(8, Math.min(80, config.nmfIterations || 32));
+
+  const stft = computeStft(pcm, fftSize, hopSize);
+  const { mag, frames, bins } = stft;
+
+  /** @type {Float32Array[]} */
+  let masks;
+  /** @type {string[]} */
+  let labels;
+  let method = 'classical-nmf';
+
+  if (mode === 'query' && Array.isArray(config.queries) && config.queries.length) {
+    const q = querySoftMasks(mag, frames, bins, config.queries, sr, fftSize);
+    masks = q.masks;
+    labels = q.labels;
+    method = 'query-prior';
+  } else {
+    const nmf = nmfSoftMasks(mag, frames, bins, Kreq, iterations, config.seed ?? 42);
+    // Sort by energy descending for stable UI order.
+    // NOTE: do not use Float32Array.map for object tuples — it returns a
+    // Float32Array and coerces objects to NaN.
+    const order = Array.from(nmf.energies, (e, i) => ({ e: Number(e) || 0, i }))
+      .sort((a, b) => b.e - a.e)
+      .map((x) => x.i);
+    masks = order.map((i) => nmf.masks[i]);
+    labels = order.map((i, rank) =>
+      labelFromCentroid(nmf.centroids[i], bins, sr, fftSize, rank));
+    method = 'classical-nmf';
+  }
+
+  const sources = masks.map((mask, i) => {
+    // Sanitize mask before iSTFT
+    for (let j = 0; j < mask.length; j++) {
+      const m = mask[j];
+      if (!Number.isFinite(m) || m < 0) mask[j] = 0;
+      else if (m > 1) mask[j] = 1;
+    }
+    const stem = maskToPcm(stft, mask, pcm.length);
+    // Confidence from mask sharpness
+    let sharp = 0;
+    for (let j = 0; j < mask.length; j++) sharp += mask[j] * mask[j];
+    const conf = Math.max(0.15, Math.min(0.95, 0.35 + sharp / (mask.length + 1e-8)));
+    return {
+      id: `usm_${i + 1}`,
+      label: labels[i] || `Source ${i + 1}`,
+      mask,
+      pcm: stem,
+      confidence: Number.isFinite(conf) ? conf : 0.5,
+      quality: 'medium',
+      method,
+    };
+  });
+
+  return {
+    sources,
+    shape: { frames, bins },
+    method,
+    stft: { re: stft.re, im: stft.im, mag: stft.mag },
+  };
+}
+
+/**
+ * Mix sources with mute / solo / gain (linear gain, not dB).
+ * Live-Mix contract: pure sample math — no ML, no STFT.
+ *
+ * @param {Array<{ pcm: Float32Array, mute?: boolean, solo?: boolean, gain?: number }>} sources
+ * @param {number} length
+ * @returns {Float32Array}
+ */
+export function mixSources(sources, length) {
+  const out = new Float32Array(length);
+  if (!sources?.length) return out;
+  const anySolo = sources.some((s) => s.solo);
+  for (const s of sources) {
+    if (!s?.pcm) continue;
+    if (s.mute) continue;
+    if (anySolo && !s.solo) continue;
+    const g = s.gain == null ? 1 : Number(s.gain);
+    const pcm = s.pcm;
+    const n = Math.min(length, pcm.length);
+    for (let i = 0; i < n; i++) out[i] += pcm[i] * g;
+  }
+  return out;
+}
+
+/**
+ * dB → linear gain. -Infinity / mute → 0.
+ */
+export function dbToGain(db) {
+  if (db == null || db === -Infinity || Number(db) <= -120) return 0;
+  return Math.pow(10, Number(db) / 20);
+}
+
+/**
+ * Identity check helper: sum of auto masks ≈ 1 (for tests).
+ */
+export function maskPartitionError(masks, frames, bins) {
+  let maxErr = 0;
+  let sumErr = 0;
+  let n = 0;
+  for (let i = 0; i < frames * bins; i++) {
+    let s = 0;
+    for (const m of masks) s += m[i];
+    const e = Math.abs(s - 1);
+    maxErr = Math.max(maxErr, e);
+    sumErr += e;
+    n++;
+  }
+  return { maxErr, meanErr: sumErr / Math.max(1, n) };
+}
+
+export default {
+  separateUniversal,
+  mixSources,
+  dbToGain,
+  computeStft,
+  maskToPcm,
+  querySpectralPrior,
+  nmfSoftMasks,
+  maskPartitionError,
+  USM_FFT_SIZE,
+  USM_HOP_SIZE,
+  USM_MAX_SOURCES,
+  USM_DEFAULT_SOURCES,
+};

--- a/src/pipeline/SourceAuditionEngine.js
+++ b/src/pipeline/SourceAuditionEngine.js
@@ -77,6 +77,8 @@ export class SourceAuditionEngine {
     for (const id of [...this.layers.keys()]) {
       if (id.startsWith('usm_')) this.layers.delete(id);
     }
+    // Duration must reflect the current separation, not a prior file max
+    this._duration = 0;
     if (original) {
       this.setLayer({
         id: 'original',

--- a/src/pipeline/SourceAuditionEngine.js
+++ b/src/pipeline/SourceAuditionEngine.js
@@ -65,6 +65,41 @@ export class SourceAuditionEngine {
   }
 
   /**
+   * Register Universal Source Matrix stems as audition layers (Creator/Forensic).
+   * Replaces previous usm_* layers; keeps original/processed when present.
+   * @param {Array<{ id: string, label: string, buffer: AudioBuffer, confidence?: number, quality?: string }>} stems
+   * @param {AudioContext} ctx
+   * @param {AudioBuffer} [original]
+   */
+  buildFromUSM(stems, ctx, original) {
+    this.setContext(ctx);
+    // Drop previous USM layers only
+    for (const id of [...this.layers.keys()]) {
+      if (id.startsWith('usm_')) this.layers.delete(id);
+    }
+    if (original) {
+      this.setLayer({
+        id: 'original',
+        label: 'Original mix',
+        buffer: original,
+        confidence: 1,
+        quality: 'high',
+      });
+    }
+    for (const s of stems || []) {
+      if (!s?.buffer) continue;
+      this.setLayer({
+        id: s.id,
+        label: s.label || s.id,
+        buffer: s.buffer,
+        confidence: s.confidence ?? 0.6,
+        quality: s.quality || 'medium',
+      });
+    }
+    this.setMode('layer');
+  }
+
+  /**
    * Build classical preview layers from mono original + optional clean/noise stems.
    * Honest quality tags.
    * @param {object} args

--- a/src/pipeline/USMNode.js
+++ b/src/pipeline/USMNode.js
@@ -1,0 +1,370 @@
+/**
+ * VoiceIsolate Pro — Universal Source Matrix Node (Layer 3: Pipeline)
+ *
+ * Upgrades the offline ML separation slot for Creator / Forensic modes:
+ *   mixture PCM → K soft-masked stems + labels → Source Matrix Live-Mix.
+ *
+ * Does NOT re-run on slider / mute / solo changes (Live-Mix contract).
+ * Text "Refine" intentionally re-runs query separation once.
+ *
+ * Prefer classical core USM always available; optionally ask MLWorker for an
+ * ONNX AudioSep-class model when `universal_separator` is in the manifest
+ * and the weights are present.
+ */
+'use strict';
+
+import {
+  separateUniversal,
+  mixSources,
+  dbToGain,
+  USM_DEFAULT_SOURCES,
+  USM_MAX_SOURCES,
+} from '../core/UniversalSourceMatrix.js';
+import { SAMPLE_RATE } from '../core/audio-config.js';
+import { createMLWorker, initMLWorker } from './MLWorkerHost.js';
+
+/**
+ * @typedef {{ id: string, label: string, gainDb: number, mute: boolean, solo: boolean, pcm: Float32Array, confidence?: number, quality?: string, method?: string }} USMSourceState
+ */
+
+let _worker = null;
+let _ready = null;
+let _seq = 0;
+
+function getWorker() {
+  if (_worker) return _worker;
+  _worker = createMLWorker();
+  return _worker;
+}
+
+function ensureWorkerReady() {
+  if (_ready) return _ready;
+  const w = getWorker();
+  _ready = new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error('[VIP][USMNode] MLWorker init timeout'));
+    }, 30000);
+    const onMsg = (ev) => {
+      const msg = ev.data || {};
+      if (msg.type === 'ready') {
+        cleanup();
+        resolve(msg.backend || 'wasm');
+      } else if (msg.type === 'error' && !msg.requestId) {
+        cleanup();
+        reject(new Error(msg.message || 'MLWorker init failed'));
+      }
+    };
+    const onErr = (e) => {
+      cleanup();
+      reject(new Error(e.message || 'MLWorker error'));
+    };
+    const cleanup = () => {
+      clearTimeout(timer);
+      w.removeEventListener('message', onMsg);
+      w.removeEventListener('error', onErr);
+    };
+    w.addEventListener('message', onMsg);
+    w.addEventListener('error', onErr);
+    initMLWorker(w);
+  });
+  return _ready;
+}
+
+/**
+ * Try ONNX universal separator via MLWorker; return null if unavailable.
+ * @returns {Promise<import('../core/UniversalSourceMatrix.js').USMResult|null>}
+ */
+async function tryOnnxUniversal(samples, sampleRate, config) {
+  try {
+    await ensureWorkerReady();
+  } catch {
+    return null;
+  }
+  const w = getWorker();
+  const requestId = ++_seq;
+  const copy = new Float32Array(samples);
+
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      cleanup();
+      resolve(null);
+    }, 120000);
+    const onMsg = (ev) => {
+      const m = ev.data || {};
+      if (m.requestId !== requestId) return;
+      if (m.type === 'universal_separate_result') {
+        cleanup();
+        resolve({
+          sources: (m.sources || []).map((s, i) => ({
+            id: s.id || `usm_${i + 1}`,
+            label: s.label || `Source ${i + 1}`,
+            mask: s.mask,
+            pcm: s.pcm,
+            confidence: s.confidence ?? 0.7,
+            quality: s.quality || 'high',
+            method: 'onnx-universal',
+          })),
+          shape: m.shape || { frames: 0, bins: 0 },
+          method: 'onnx-universal',
+          stft: null,
+        });
+      } else if (m.type === 'error') {
+        cleanup();
+        resolve(null);
+      }
+    };
+    const onErr = () => {
+      cleanup();
+      resolve(null);
+    };
+    const cleanup = () => {
+      clearTimeout(timer);
+      w.removeEventListener('message', onMsg);
+      w.removeEventListener('error', onErr);
+    };
+    w.addEventListener('message', onMsg);
+    w.addEventListener('error', onErr);
+    w.postMessage({
+      type: 'universal_separate',
+      requestId,
+      waveform: copy,
+      sampleRate,
+      mode: config.mode || 'auto',
+      numSources: config.numSources || USM_DEFAULT_SOURCES,
+      queries: config.queries || [],
+    }, [copy.buffer]);
+  });
+}
+
+/**
+ * Downmix multi-channel to mono Float32Array (copy).
+ * @param {Float32Array[]} channels
+ */
+export function downmixChannels(channels) {
+  if (!channels?.length) return new Float32Array(0);
+  if (channels.length === 1) {
+    return channels[0] instanceof Float32Array
+      ? new Float32Array(channels[0])
+      : new Float32Array(channels[0]);
+  }
+  const len = channels[0].length;
+  const out = new Float32Array(len);
+  const n = channels.length;
+  for (let i = 0; i < len; i++) {
+    let s = 0;
+    for (let c = 0; c < n; c++) s += channels[c][i];
+    out[i] = s / n;
+  }
+  return out;
+}
+
+/**
+ * USMNode — drop-in offline separation stage.
+ */
+export class USMNode {
+  /**
+   * @param {object} [options]
+   * @param {boolean} [options.preferOnnx=true]
+   * @param {(p: number, label?: string) => void} [options.onProgress]
+   */
+  constructor(options = {}) {
+    this.id = 'usm';
+    this.name = 'Universal Source Matrix';
+    this.enabled = true;
+    this.requiresML = true;
+    this.requiresGPU = false;
+    // ONNX path is opt-in until universal-separator.onnx is shipped + pinned.
+    this.preferOnnx = options.preferOnnx === true;
+    this.onProgress = options.onProgress || (() => {});
+    /** @type {USMSourceState[]} */
+    this.sources = [];
+    this._lastResult = null;
+    this._sampleRate = SAMPLE_RATE;
+    /** @type {Float32Array|null} mixture mono retained for refine() */
+    this._mixtureMono = null;
+  }
+
+  /**
+   * @param {USMConfig} config
+   */
+  configure(config = {}) {
+    this._config = {
+      mode: config.mode === 'query' ? 'query' : 'auto',
+      numSources: Math.max(2, Math.min(USM_MAX_SOURCES, config.numSources || USM_DEFAULT_SOURCES)),
+      queries: Array.isArray(config.queries) ? config.queries.slice(0, USM_MAX_SOURCES) : [],
+      nmfIterations: config.nmfIterations,
+      seed: config.seed,
+    };
+  }
+
+  /**
+   * Process mono or multi-channel PCM.
+   * @param {Float32Array|Float32Array[]} channelData
+   * @param {number} sampleRate
+   * @param {object} [config]
+   */
+  async process(channelData, sampleRate = SAMPLE_RATE, config = {}) {
+    if (config && Object.keys(config).length) this.configure(config);
+    const cfg = this._config || { mode: 'auto', numSources: USM_DEFAULT_SOURCES, queries: [] };
+    const channels = Array.isArray(channelData) && channelData[0]?.length != null
+      ? channelData
+      : [channelData];
+    const mono = downmixChannels(channels);
+    this._mixtureMono = mono;
+    this._sampleRate = sampleRate || SAMPLE_RATE;
+
+    this.onProgress(0.05, 'universal-separate');
+
+    let result = null;
+    if (this.preferOnnx) {
+      this.onProgress(0.1, 'try-onnx-universal');
+      result = await tryOnnxUniversal(mono, this._sampleRate, cfg);
+    }
+
+    if (!result || !result.sources?.length) {
+      this.onProgress(0.2, 'classical-usm');
+      result = separateUniversal(mono, this._sampleRate, cfg);
+    }
+
+    this.onProgress(0.9, 'pack-sources');
+    this._lastResult = result;
+    this.sources = result.sources.map((s) => ({
+      id: s.id,
+      label: s.label,
+      gainDb: 0,
+      mute: false,
+      solo: false,
+      pcm: s.pcm,
+      confidence: s.confidence,
+      quality: s.quality,
+      method: s.method,
+      mask: s.mask,
+    }));
+
+    this.onProgress(1, 'complete');
+    return {
+      sources: this.sources,
+      shape: result.shape,
+      method: result.method,
+      sampleRate: this._sampleRate,
+    };
+  }
+
+  /**
+   * Refine: run a single text query and append (or replace matching) source.
+   * Intentional one-shot inference — not a slider event.
+   * @param {string} query
+   */
+  async refine(query) {
+    if (!query || !String(query).trim()) {
+      throw new Error('[VIP][USMNode] refine() requires a non-empty text query');
+    }
+    if (!this._mixtureMono?.length) {
+      throw new Error('[VIP][USMNode] Run process() before refine()');
+    }
+    const mono = this._mixtureMono;
+
+    const result = separateUniversal(mono, this._sampleRate, {
+      mode: 'query',
+      queries: [String(query).trim()],
+    });
+    // Keep the first (target) stem from query mode; drop residual unless empty
+    const target = result.sources[0];
+    if (!target) return this.sources;
+
+    const id = `usm_refine_${Date.now().toString(36)}`;
+    this.sources.push({
+      id,
+      label: target.label || String(query).trim(),
+      gainDb: 0,
+      mute: false,
+      solo: false,
+      pcm: target.pcm,
+      confidence: target.confidence,
+      quality: 'medium',
+      method: 'query-refine',
+      mask: target.mask,
+    });
+    // Cap visible sources
+    if (this.sources.length > USM_MAX_SOURCES) {
+      this.sources = this.sources.slice(-USM_MAX_SOURCES);
+    }
+    return this.sources;
+  }
+
+  /**
+   * Combined Live-Mix buffer from current mute/solo/gainDb state.
+   */
+  renderMix() {
+    const states = this.sources.map((s) => ({
+      pcm: s.pcm,
+      mute: s.mute,
+      solo: s.solo,
+      gain: dbToGain(s.gainDb),
+    }));
+    const len = states[0]?.pcm?.length || 0;
+    return mixSources(states, len);
+  }
+
+  setMute(id, mute) {
+    const s = this.sources.find((x) => x.id === id);
+    if (s) s.mute = Boolean(mute);
+  }
+
+  setSolo(id, solo) {
+    if (solo) {
+      for (const s of this.sources) s.solo = s.id === id;
+    } else {
+      const s = this.sources.find((x) => x.id === id);
+      if (s) s.solo = false;
+    }
+  }
+
+  setGainDb(id, gainDb) {
+    const s = this.sources.find((x) => x.id === id);
+    if (s) s.gainDb = Math.max(-120, Math.min(24, Number(gainDb) || 0));
+  }
+
+  setLabel(id, label) {
+    const s = this.sources.find((x) => x.id === id);
+    if (s) s.label = String(label || s.label).slice(0, 64);
+  }
+
+  /** Float32Array[] of stem PCMs for export / audition. */
+  getStemBuffers() {
+    return this.sources.map((s) => s.pcm);
+  }
+
+  clear() {
+    this.sources = [];
+    this._lastResult = null;
+    this._mixtureMono = null;
+  }
+
+  dispose() {
+    this.clear();
+    if (_worker) {
+      try { _worker.terminate(); } catch { /* ignore */ }
+      _worker = null;
+      _ready = null;
+    }
+  }
+}
+
+/**
+ * Build AudioBuffers for each USM source (browser only).
+ * @param {AudioContext} ctx
+ * @param {USMSourceState[]} sources
+ * @param {number} sampleRate
+ */
+export function usmSourcesToAudioBuffers(ctx, sources, sampleRate) {
+  if (!ctx) throw new TypeError('[VIP][USMNode] AudioContext required');
+  return sources.map((s) => {
+    const buf = ctx.createBuffer(1, s.pcm.length, sampleRate || SAMPLE_RATE);
+    buf.copyToChannel(s.pcm, 0);
+    return { id: s.id, label: s.label, buffer: buf, confidence: s.confidence, quality: s.quality || 'medium' };
+  });
+}
+
+export default USMNode;

--- a/src/pipeline/USMNode.js
+++ b/src/pipeline/USMNode.js
@@ -78,7 +78,8 @@ function ensureWorkerReady() {
 async function tryOnnxUniversal(samples, sampleRate, config) {
   try {
     await ensureWorkerReady();
-  } catch {
+  } catch (err) {
+    console.warn('[VIP][USMNode] MLWorker init failed for ONNX USM:', err?.message || err);
     return null;
   }
   const w = getWorker();
@@ -88,6 +89,7 @@ async function tryOnnxUniversal(samples, sampleRate, config) {
   return new Promise((resolve) => {
     const timer = setTimeout(() => {
       cleanup();
+      console.warn('[VIP][USMNode] universal_separate timed out — classical fallback');
       resolve(null);
     }, 120000);
     const onMsg = (ev) => {
@@ -111,11 +113,13 @@ async function tryOnnxUniversal(samples, sampleRate, config) {
         });
       } else if (m.type === 'error') {
         cleanup();
+        console.warn('[VIP][USMNode] universal_separate error:', m.message || 'unknown');
         resolve(null);
       }
     };
-    const onErr = () => {
+    const onErr = (e) => {
       cleanup();
+      console.warn('[VIP][USMNode] universal_separate worker error:', e?.message || e);
       resolve(null);
     };
     const cleanup = () => {
@@ -183,6 +187,11 @@ export class USMNode {
     this._sampleRate = SAMPLE_RATE;
     /** @type {Float32Array|null} mixture mono retained for refine() */
     this._mixtureMono = null;
+  }
+
+  /** Public sample-rate accessor (UI must not read `_sampleRate`). */
+  get sampleRate() {
+    return this._sampleRate || SAMPLE_RATE;
   }
 
   /**
@@ -286,9 +295,12 @@ export class USMNode {
       method: 'query-refine',
       mask: target.mask,
     });
-    // Cap visible sources
     if (this.sources.length > USM_MAX_SOURCES) {
-      this.sources = this.sources.slice(-USM_MAX_SOURCES);
+      // Reject rather than silently dropping stems (keeps audition layers consistent)
+      this.sources.pop();
+      throw new Error(
+        `[VIP][USMNode] Max sources (${USM_MAX_SOURCES}) reached — remove a stem before refine`
+      );
     }
     return this.sources;
   }
@@ -360,11 +372,21 @@ export class USMNode {
  */
 export function usmSourcesToAudioBuffers(ctx, sources, sampleRate) {
   if (!ctx) throw new TypeError('[VIP][USMNode] AudioContext required');
-  return sources.map((s) => {
-    const buf = ctx.createBuffer(1, s.pcm.length, sampleRate || SAMPLE_RATE);
+  const sr = sampleRate || SAMPLE_RATE;
+  const out = [];
+  for (const s of sources || []) {
+    if (!s?.pcm || !(s.pcm.length > 0)) continue;
+    const buf = ctx.createBuffer(1, s.pcm.length, sr);
     buf.copyToChannel(s.pcm, 0);
-    return { id: s.id, label: s.label, buffer: buf, confidence: s.confidence, quality: s.quality || 'medium' };
-  });
+    out.push({
+      id: s.id,
+      label: s.label,
+      buffer: buf,
+      confidence: s.confidence,
+      quality: s.quality || 'medium',
+    });
+  }
+  return out;
 }
 
 export default USMNode;

--- a/src/workers/MLWorker.js
+++ b/src/workers/MLWorker.js
@@ -699,7 +699,7 @@ async function runUniversalSeparate(msg) {
   const entry = MANIFEST.universal_separator;
   if (!entry) {
     throw new Error(
-      "[VIP][MLWorker] universal_separator not in manifest — use classical USM"
+      '[VIP][MLWorker] universal_separator not in manifest — use classical USM'
     );
   }
 
@@ -731,11 +731,9 @@ async function runUniversalSeparate(msg) {
     const inName = entry.io?.input || 'input';
     const outName = entry.io?.output || 'output';
 
-    // Chunk long audio to bound GPU memory (3–5 s windows, 50% overlap)
+    // Chunk long audio to bound GPU memory (≈4 s windows; hop reserved for future OLA)
     const winSec = 4;
-    const hopSec = 2;
     const winSamples = Math.max(1, Math.round(sr * winSec));
-    const hopSamples = Math.max(1, Math.round(sr * hopSec));
     const K = Math.max(2, Math.min(12, numSources || 6));
 
     // If the model cannot accept our feeds, fail → classical fallback.

--- a/src/workers/MLWorker.js
+++ b/src/workers/MLWorker.js
@@ -702,6 +702,12 @@ async function runUniversalSeparate(msg) {
       '[VIP][MLWorker] universal_separator not in manifest — use classical USM'
     );
   }
+  // Refuse unverified weights — null sha is development-only and must not ship
+  if (!entry.sha256 || !/^[0-9a-f]{64}$/.test(entry.sha256)) {
+    throw new Error(
+      '[VIP][MLWorker] universal_separator has no pinned SHA-256 — use classical USM'
+    );
+  }
 
   ACTIVE_REQUEST_ID = requestId;
   try {
@@ -721,41 +727,40 @@ async function runUniversalSeparate(msg) {
 
     // Contract for future AudioSep-class exports:
     //   input  'input'  float32 [1, T]  waveform
-    //   output 'output' float32 [K, T]  time-domain stems  OR  [K, F, T] masks
-    // Until a real export lands, attempt a single waveform run and split channels.
+    //   output 'output' float32 [K, T]  time-domain stems
     if (entry.strategy !== 'universal-query' && entry.strategy !== 'waveform') {
       throw new Error(`[VIP][MLWorker] Unsupported universal strategy '${entry.strategy}'`);
+    }
+
+    // Text query requires a graph-owned encoder; without it, force classical path
+    if (mode === 'query' && queries?.length && !entry.io?.query) {
+      throw new Error(
+        '[VIP][MLWorker] Text query I/O not wired on universal model — use classical query'
+      );
     }
 
     postStage('universal-separate', 20, { modelId: entry.id });
     const inName = entry.io?.input || 'input';
     const outName = entry.io?.output || 'output';
 
-    // Chunk long audio to bound GPU memory (≈4 s windows; hop reserved for future OLA)
+    // Single-window only until full OLA is implemented — longer files fall back
     const winSec = 4;
     const winSamples = Math.max(1, Math.round(sr * winSec));
     const K = Math.max(2, Math.min(12, numSources || 6));
+    if (pcm.length > winSamples) {
+      throw new Error(
+        `[VIP][MLWorker] universal ONNX path supports ≤${winSec}s until multi-window OLA lands`
+      );
+    }
 
-    // If the model cannot accept our feeds, fail → classical fallback.
-    // Try full-file first for short clips; else first window as smoke.
-    const segment = pcm.length <= winSamples
-      ? pcm
-      : pcm.subarray(0, Math.min(pcm.length, winSamples));
     const padded = new Float32Array(winSamples);
-    padded.set(segment.subarray(0, Math.min(segment.length, winSamples)));
+    padded.set(pcm.subarray(0, Math.min(pcm.length, winSamples)));
 
     let feeds;
     try {
       feeds = { [inName]: new ort.Tensor('float32', padded, [1, 1, winSamples]) };
     } catch {
       feeds = { [inName]: new ort.Tensor('float32', padded, [1, winSamples]) };
-    }
-
-    // Optional text queries: only if model declares a query input name
-    if (mode === 'query' && queries?.length && entry.io?.query) {
-      // Placeholder embedding length — real AudioSep graphs own tokenization.
-      // Without a text encoder in-graph, skip and let classical query handle it.
-      console.warn('[VIP][MLWorker] Text query I/O not fully wired; prefer classical query mode.');
     }
 
     const result = await queuedSessionRun(entry.id, session, feeds);
@@ -766,40 +771,33 @@ async function runUniversalSeparate(msg) {
 
     postStage('universal-separate', 80, { modelId: entry.id });
 
-    // Interpret [K, T] or [1, K, T] as stems for this window; tile/OLA for full file.
+    // Interpret [K, T] or [1, K, T] only — never treat frequency bins as stem count
     const data = outTensor.data;
     const dims = outTensor.dims || [];
     let stemsK = K;
     let stemLen = padded.length;
     if (dims.length === 3) {
-      // [1, K, T] or [K, 1, T]
-      stemsK = dims[1] === 1 ? dims[0] : dims[1];
+      // Prefer [1, K, T] layout
+      stemsK = dims[0] === 1 ? dims[1] : dims[0];
       stemLen = dims[2] || stemLen;
     } else if (dims.length === 2) {
       stemsK = dims[0];
       stemLen = dims[1];
     } else {
-      // Flat — partition into K equal chunks
       stemsK = K;
       stemLen = Math.floor(data.length / K) || pcm.length;
     }
+    stemsK = Math.max(1, Math.min(12, stemsK | 0));
+    stemLen = Math.max(1, Math.min(stemLen | 0, data.length));
 
     const sources = [];
     const transfers = [];
     for (let k = 0; k < stemsK; k++) {
       const stem = new Float32Array(pcm.length);
-      // Copy first-window estimate; for multi-window production models extend OLA here.
       const off = k * stemLen;
+      if (off >= data.length) break;
       const n = Math.min(stemLen, pcm.length, data.length - off);
       for (let i = 0; i < n; i++) stem[i] = data[off + i];
-      // Scale residual energy into remaining samples for long files (best-effort)
-      if (pcm.length > n && n > 0) {
-        for (let i = n; i < pcm.length; i++) {
-          const src = pcm[i];
-          const ref = Math.abs(pcm[i % n]) > 1e-8 ? data[off + (i % n)] / (pcm[i % n] || 1e-8) : 0;
-          stem[i] = src * Math.max(0, Math.min(1, Math.abs(ref)));
-        }
-      }
       sources.push({
         id: `usm_onnx_${k + 1}`,
         label: (queries && queries[k]) || `ONNX source ${k + 1}`,
@@ -808,6 +806,9 @@ async function runUniversalSeparate(msg) {
         quality: 'high',
       });
       transfers.push(stem.buffer);
+    }
+    if (!sources.length) {
+      throw new Error('[VIP][MLWorker] universal model produced zero stems');
     }
 
     self.postMessage({

--- a/src/workers/MLWorker.js
+++ b/src/workers/MLWorker.js
@@ -29,6 +29,10 @@
  *   → { type: 'vad', requestId, samples: Float32Array, sampleRate }
  *   ← { type: 'vad-result', requestId, scores: Float32Array, times: Float32Array,
  *       hopSec, source: 'silero'|'unavailable' }
+ *   → { type: 'universal_separate', requestId, waveform, sampleRate,
+ *       mode?: 'auto'|'query', numSources?: number, queries?: string[] }
+ *   ← { type: 'universal_separate_result', requestId, sources: [{id,label,pcm,mask?}],
+ *       shape: { frames, bins } }
  *   ← { type: 'error', requestId?, message }
  *
  * This worker NEVER touches the DOM, never opens a microphone, and never
@@ -678,6 +682,148 @@ async function runVadRequest({ requestId, samples, sampleRate }) {
   }, [scores.buffer, times.buffer]);
 }
 
+/**
+ * Optional AudioSep-class ONNX path for Universal Source Matrix.
+ * When weights are absent or strategy unsupported, posts an error so the
+ * pipeline USMNode falls back to classical NMF + query priors (core).
+ */
+async function runUniversalSeparate(msg) {
+  const {
+    requestId,
+    waveform,
+    sampleRate,
+    mode = 'auto',
+    numSources = 6,
+    queries = [],
+  } = msg;
+  const entry = MANIFEST.universal_separator;
+  if (!entry) {
+    throw new Error(
+      "[VIP][MLWorker] universal_separator not in manifest — use classical USM"
+    );
+  }
+
+  ACTIVE_REQUEST_ID = requestId;
+  try {
+    postStage('universal-separate', 5, { modelId: entry.id });
+    let session;
+    try {
+      session = await getSession(entry, entry.id);
+    } catch (err) {
+      throw new Error(
+        `[VIP][MLWorker] universal-separator.onnx unavailable (${err?.message || err}). ` +
+        'USMNode will use classical separation.'
+      );
+    }
+
+    const pcm = waveform instanceof Float32Array ? waveform : new Float32Array(waveform || []);
+    const sr = sampleRate || 48000;
+
+    // Contract for future AudioSep-class exports:
+    //   input  'input'  float32 [1, T]  waveform
+    //   output 'output' float32 [K, T]  time-domain stems  OR  [K, F, T] masks
+    // Until a real export lands, attempt a single waveform run and split channels.
+    if (entry.strategy !== 'universal-query' && entry.strategy !== 'waveform') {
+      throw new Error(`[VIP][MLWorker] Unsupported universal strategy '${entry.strategy}'`);
+    }
+
+    postStage('universal-separate', 20, { modelId: entry.id });
+    const inName = entry.io?.input || 'input';
+    const outName = entry.io?.output || 'output';
+
+    // Chunk long audio to bound GPU memory (3–5 s windows, 50% overlap)
+    const winSec = 4;
+    const hopSec = 2;
+    const winSamples = Math.max(1, Math.round(sr * winSec));
+    const hopSamples = Math.max(1, Math.round(sr * hopSec));
+    const K = Math.max(2, Math.min(12, numSources || 6));
+
+    // If the model cannot accept our feeds, fail → classical fallback.
+    // Try full-file first for short clips; else first window as smoke.
+    const segment = pcm.length <= winSamples
+      ? pcm
+      : pcm.subarray(0, Math.min(pcm.length, winSamples));
+    const padded = new Float32Array(winSamples);
+    padded.set(segment.subarray(0, Math.min(segment.length, winSamples)));
+
+    let feeds;
+    try {
+      feeds = { [inName]: new ort.Tensor('float32', padded, [1, 1, winSamples]) };
+    } catch {
+      feeds = { [inName]: new ort.Tensor('float32', padded, [1, winSamples]) };
+    }
+
+    // Optional text queries: only if model declares a query input name
+    if (mode === 'query' && queries?.length && entry.io?.query) {
+      // Placeholder embedding length — real AudioSep graphs own tokenization.
+      // Without a text encoder in-graph, skip and let classical query handle it.
+      console.warn('[VIP][MLWorker] Text query I/O not fully wired; prefer classical query mode.');
+    }
+
+    const result = await queuedSessionRun(entry.id, session, feeds);
+    const outTensor = result[outName] || result.output;
+    if (!outTensor?.data) {
+      throw new Error('[VIP][MLWorker] universal model returned no output tensor');
+    }
+
+    postStage('universal-separate', 80, { modelId: entry.id });
+
+    // Interpret [K, T] or [1, K, T] as stems for this window; tile/OLA for full file.
+    const data = outTensor.data;
+    const dims = outTensor.dims || [];
+    let stemsK = K;
+    let stemLen = padded.length;
+    if (dims.length === 3) {
+      // [1, K, T] or [K, 1, T]
+      stemsK = dims[1] === 1 ? dims[0] : dims[1];
+      stemLen = dims[2] || stemLen;
+    } else if (dims.length === 2) {
+      stemsK = dims[0];
+      stemLen = dims[1];
+    } else {
+      // Flat — partition into K equal chunks
+      stemsK = K;
+      stemLen = Math.floor(data.length / K) || pcm.length;
+    }
+
+    const sources = [];
+    const transfers = [];
+    for (let k = 0; k < stemsK; k++) {
+      const stem = new Float32Array(pcm.length);
+      // Copy first-window estimate; for multi-window production models extend OLA here.
+      const off = k * stemLen;
+      const n = Math.min(stemLen, pcm.length, data.length - off);
+      for (let i = 0; i < n; i++) stem[i] = data[off + i];
+      // Scale residual energy into remaining samples for long files (best-effort)
+      if (pcm.length > n && n > 0) {
+        for (let i = n; i < pcm.length; i++) {
+          const src = pcm[i];
+          const ref = Math.abs(pcm[i % n]) > 1e-8 ? data[off + (i % n)] / (pcm[i % n] || 1e-8) : 0;
+          stem[i] = src * Math.max(0, Math.min(1, Math.abs(ref)));
+        }
+      }
+      sources.push({
+        id: `usm_onnx_${k + 1}`,
+        label: (queries && queries[k]) || `ONNX source ${k + 1}`,
+        pcm: stem,
+        confidence: 0.75,
+        quality: 'high',
+      });
+      transfers.push(stem.buffer);
+    }
+
+    self.postMessage({
+      type: 'universal_separate_result',
+      requestId,
+      sources,
+      shape: { frames: 0, bins: 0 },
+      method: 'onnx-universal',
+    }, transfers);
+  } finally {
+    ACTIVE_REQUEST_ID = null;
+  }
+}
+
 async function processRequest({ requestId, modelId, modelIds, channelData, sampleRate }) {
   // A chain (`modelIds`) runs models in series for maximum isolation —
   // e.g. ['bsrnn_vocals', 'rnnoise'] extracts the voice, then strips any
@@ -798,6 +944,12 @@ self.onmessage = async (event) => {
         break;
       case 'vad': {
         const run = _processChain.then(() => runVadRequest(msg));
+        _processChain = run.catch(() => {});
+        await run;
+        break;
+      }
+      case 'universal_separate': {
+        const run = _processChain.then(() => runUniversalSeparate(msg));
         _processChain = run.catch(() => {});
         await run;
         break;

--- a/tests/universal-source-matrix.test.js
+++ b/tests/universal-source-matrix.test.js
@@ -1,0 +1,211 @@
+/**
+ * Universal Source Matrix — unit tests (classical core + mix).
+ */
+'use strict';
+
+let separateUniversal;
+let mixSources;
+let dbToGain;
+let maskPartitionError;
+let computeStft;
+let maskToPcm;
+let querySpectralPrior;
+let USMNode;
+let SAMPLE_RATE;
+
+beforeAll(async () => {
+  const core = await import('../src/core/UniversalSourceMatrix.js');
+  separateUniversal = core.separateUniversal;
+  mixSources = core.mixSources;
+  dbToGain = core.dbToGain;
+  maskPartitionError = core.maskPartitionError;
+  computeStft = core.computeStft;
+  maskToPcm = core.maskToPcm;
+  querySpectralPrior = core.querySpectralPrior;
+
+  const nodeMod = await import('../src/pipeline/USMNode.js');
+  USMNode = nodeMod.USMNode;
+
+  const ac = await import('../src/core/audio-config.js');
+  SAMPLE_RATE = ac.SAMPLE_RATE;
+});
+
+/** 440 Hz sine + soft noise + 60 Hz hum. */
+function syntheticMix(seconds = 0.5, sr = 48000) {
+  const n = Math.floor(sr * seconds);
+  const x = new Float32Array(n);
+  for (let i = 0; i < n; i++) {
+    const t = i / sr;
+    const speech = 0.35 * Math.sin(2 * Math.PI * 440 * t)
+      + 0.15 * Math.sin(2 * Math.PI * 880 * t);
+    const hum = 0.2 * Math.sin(2 * Math.PI * 60 * t);
+    // Deterministic pseudo-noise (tests must be stable)
+    const noise = 0.05 * Math.sin(2 * Math.PI * 3333 * t + i * 0.17);
+    x[i] = speech + hum + noise;
+  }
+  return x;
+}
+
+describe('UniversalSourceMatrix core', () => {
+  test('auto mode yields K sources with partitionable masks', () => {
+    const mix = syntheticMix(0.4, SAMPLE_RATE);
+    const K = 4;
+    const result = separateUniversal(mix, SAMPLE_RATE, {
+      mode: 'auto',
+      numSources: K,
+      nmfIterations: 16,
+      seed: 7,
+    });
+    expect(result.sources).toHaveLength(K);
+    expect(result.method).toBe('classical-nmf');
+    expect(result.shape.frames).toBeGreaterThan(0);
+    expect(result.shape.bins).toBe(2049);
+
+    const masks = result.sources.map((s) => s.mask);
+    const { maxErr, meanErr } = maskPartitionError(
+      masks,
+      result.shape.frames,
+      result.shape.bins,
+    );
+    expect(maxErr).toBeLessThan(1e-3);
+    expect(meanErr).toBeLessThan(1e-4);
+
+    for (const s of result.sources) {
+      expect(s.pcm).toBeInstanceOf(Float32Array);
+      expect(s.pcm.length).toBe(mix.length);
+      expect(s.label).toBeTruthy();
+      expect(s.id).toMatch(/^usm_/);
+    }
+  });
+
+  test('identity: sum of auto stems ≈ mixture (energy)', () => {
+    const mix = syntheticMix(0.35, SAMPLE_RATE);
+    const result = separateUniversal(mix, SAMPLE_RATE, {
+      mode: 'auto',
+      numSources: 3,
+      nmfIterations: 20,
+      seed: 1,
+    });
+    const sum = new Float32Array(mix.length);
+    for (const s of result.sources) {
+      for (let i = 0; i < mix.length; i++) sum[i] += s.pcm[i];
+    }
+    let err = 0;
+    let eMix = 0;
+    for (let i = 0; i < mix.length; i++) {
+      const d = sum[i] - mix[i];
+      err += d * d;
+      eMix += mix[i] * mix[i];
+    }
+    const rel = Math.sqrt(err / (eMix + 1e-12));
+    expect(rel).toBeLessThan(0.35);
+  });
+
+  test('mute all sources → silent mix', () => {
+    const mix = syntheticMix(0.25, SAMPLE_RATE);
+    const result = separateUniversal(mix, SAMPLE_RATE, {
+      mode: 'auto',
+      numSources: 3,
+      nmfIterations: 12,
+    });
+    const muted = result.sources.map((s) => ({ pcm: s.pcm, mute: true, gain: 1 }));
+    const out = mixSources(muted, mix.length);
+    let peak = 0;
+    for (let i = 0; i < out.length; i++) peak = Math.max(peak, Math.abs(out[i]));
+    expect(peak).toBe(0);
+  });
+
+  test('solo one source isolates that stem', () => {
+    const mix = syntheticMix(0.25, SAMPLE_RATE);
+    const result = separateUniversal(mix, SAMPLE_RATE, {
+      mode: 'auto',
+      numSources: 3,
+      nmfIterations: 12,
+    });
+    const states = result.sources.map((s, i) => ({
+      pcm: s.pcm,
+      solo: i === 1,
+      mute: false,
+      gain: 1,
+    }));
+    const out = mixSources(states, mix.length);
+    const target = result.sources[1].pcm;
+    let maxDiff = 0;
+    for (let i = 0; i < out.length; i++) {
+      maxDiff = Math.max(maxDiff, Math.abs(out[i] - target[i]));
+    }
+    expect(maxDiff).toBeLessThan(1e-6);
+  });
+
+  test('query mode produces speech-like + residual labels', () => {
+    const mix = syntheticMix(0.3, SAMPLE_RATE);
+    const result = separateUniversal(mix, SAMPLE_RATE, {
+      mode: 'query',
+      queries: ['speech', 'AC hum'],
+    });
+    expect(result.method).toBe('query-prior');
+    expect(result.sources.length).toBeGreaterThanOrEqual(2);
+    const labels = result.sources.map((s) => s.label.toLowerCase());
+    expect(labels.some((l) => l.includes('speech') || l.includes('hum') || l.includes('ac'))).toBe(true);
+    expect(labels.some((l) => l.includes('residual'))).toBe(true);
+  });
+
+  test('dbToGain maps known values', () => {
+    expect(dbToGain(0)).toBeCloseTo(1, 5);
+    expect(dbToGain(-6)).toBeCloseTo(0.501, 2);
+    expect(dbToGain(-Infinity)).toBe(0);
+    expect(dbToGain(-120)).toBe(0);
+  });
+
+  test('querySpectralPrior hum emphasizes low bins', () => {
+    const { weights, prior } = querySpectralPrior('the AC hum', 2049, 48000, 4096);
+    expect(prior.id).toBe('hum');
+    const low = weights[10];
+    const high = weights[1800];
+    expect(low).toBeGreaterThan(high);
+  });
+
+  test('STFT + full mask round-trips energy', () => {
+    const mix = syntheticMix(0.2, SAMPLE_RATE);
+    const stft = computeStft(mix, 4096, 1024);
+    const mask = new Float32Array(stft.frames * stft.bins);
+    mask.fill(1);
+    const pcm = maskToPcm(stft, mask, mix.length);
+    let eIn = 0;
+    let eOut = 0;
+    for (let i = 0; i < mix.length; i++) {
+      eIn += mix[i] * mix[i];
+      eOut += pcm[i] * pcm[i];
+    }
+    const ratio = Math.sqrt(eOut / (eIn + 1e-12));
+    expect(ratio).toBeGreaterThan(0.7);
+    expect(ratio).toBeLessThan(1.3);
+  });
+});
+
+describe('USMNode pipeline', () => {
+  test('process auto populates source state for Live-Mix', async () => {
+    const mix = syntheticMix(0.3, SAMPLE_RATE);
+    const node = new USMNode({ preferOnnx: false });
+    const result = await node.process(mix, SAMPLE_RATE, {
+      mode: 'auto',
+      numSources: 3,
+      nmfIterations: 12,
+    });
+    expect(result.sources).toHaveLength(3);
+    expect(node.sources.every((s) => s.gainDb === 0 && !s.mute && !s.solo)).toBe(true);
+
+    node.setMute(result.sources[0].id, true);
+    node.setGainDb(result.sources[1].id, -6);
+    const mixPcm = node.renderMix();
+    expect(mixPcm.length).toBe(mix.length);
+    let peak = 0;
+    for (let i = 0; i < mixPcm.length; i++) peak = Math.max(peak, Math.abs(mixPcm[i]));
+    expect(peak).toBeGreaterThan(0);
+
+    await node.refine('dog barking');
+    expect(node.sources.length).toBeGreaterThanOrEqual(3);
+
+    node.dispose();
+  });
+});

--- a/tests/universal-source-matrix.test.js
+++ b/tests/universal-source-matrix.test.js
@@ -204,7 +204,10 @@ describe('USMNode pipeline', () => {
     expect(peak).toBeGreaterThan(0);
 
     await node.refine('dog barking');
-    expect(node.sources.length).toBeGreaterThanOrEqual(3);
+    expect(node.sources.length).toBeGreaterThanOrEqual(4);
+    const refined = node.sources.find((s) => s.method === 'query-refine');
+    expect(refined).toBeTruthy();
+    expect(String(refined.label).toLowerCase()).toMatch(/dog|bark/);
 
     node.dispose();
   });


### PR DESCRIPTION
## Summary
- Adds **Universal Source Matrix (USM)** for Creator/Forensic: open-domain multi-component separation with mute/solo/gain and optional text-query refine
- Classical path always available (NMF soft masks + language priors); optional AudioSep-class ONNX when `universal-separator.onnx` is shipped
- Engineer Mode UI panel under Source Analysis Workspace; Live-Mix only for faders (no ML re-run on mute/solo/gain)

## Architecture
- `src/core/UniversalSourceMatrix.js` — pure separation + mix helpers
- `src/pipeline/USMNode.js` — offline node; ONNX opt-in via MLWorker
- `src/workers/MLWorker.js` — `universal_separate` task (graceful fallback)
- Wires into `SourceAuditionEngine` + `analysis-workspace.js` without changing Demucs/BSRNN paths

## Test plan
- [x] `tests/universal-source-matrix.test.js` (9 tests: partition, identity, mute, solo, query, USMNode)
- [ ] Engineer Mode: load mixed file → Separate sources → mute/solo/gain audibly change stems
- [ ] Query separate with text (e.g. "AC hum") appends/refines a targeted stem
- [ ] Apply mix writes processed buffer; export still works
- [ ] Existing isolation (BSRNN/Demucs) and Live-Mix sliders unchanged

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Universal Source Matrix for multi-source separation, mute/solo/mix in Engineer Mode
> - Adds [UniversalSourceMatrix.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/723/files#diff-f64f9fdfe5fe24a48f574554ab882a367adaf280ffec0b3a48efe977537e7d7d) implementing STFT-based NMF auto-separation and query-driven spectral masking to split mono audio into K labeled stems without ML weights.
> - Adds [USMNode.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/723/files#diff-6c2088a46a4250e8834a7649a65190e85e989d4db5212a493f1cbf689ef9be70) as the pipeline node managing separation, per-stem gain/mute/solo state, live mix rendering, and optional ONNX inference via `MLWorker` with classical NMF fallback.
> - Extends [MLWorker.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/723/files#diff-feb98479b700cf9bcf10c1482f1408a8217b243653a510f90b27c617f61cf8a4) with a `universal_separate` handler that runs ONNX inference when a pinned `universal_separator.onnx` model is present, returning stem PCM arrays.
> - Adds a USM panel to [index.html](https://github.com/Joker5514/VoiceIsolate-Pro/pull/723/files#diff-4400aa5aa5292d143f7e2f1308aa82756255552567d5558874c994833e907ce4) with Separate, Query, and Apply Mix controls plus a per-stem table for mute/solo/gain/label/refine, wired up in [analysis-workspace.js](https://github.com/Joker5514/VoiceIsolate-Pro/pull/723/files#diff-42b7079e7ed2c396f1836b0be66d72e91b9f3a84241ceefe3b6506caaa4fa3b1).
> - Risk: ONNX path requires a manually pinned `sha256` in `ModelManifest`; without it, all separation falls back to classical NMF, and the `universal_separator` manifest entry ships with `sha256: null`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3cfbdb5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Universal Source Matrix workspace for separating audio into editable sources.
  * Added automatic and query-based source separation, with optional ONNX acceleration.
  * Added per-source mute, solo, gain, labeling, and refinement controls.
  * Added the ability to apply the adjusted source mix back to the processed audio.
  * Added model setup guidance and expanded Analysis Workspace documentation.

* **Tests**
  * Added coverage for separation, mixing controls, reconstruction, query refinement, and audio quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->