### PR TITLE
fix(engineer): USM backend, lock accent, process pause, A/B, freeze hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@
 | Route | Surface | What it does |
 |-------|---------|--------------|
 | [`/`](https://voice-isolate-pro.vercel.app/) | **Landing — Stem-Split** | Fast ML stem separation (vocals / accompaniment / noise). Upload → auto-process → preview stems. |
-| [`/app/`](https://voice-isolate-pro.vercel.app/app/) | **Engineer Mode v25** | Full 67-slider DSP suite with calibrated separation discipline, per-slider locks, collapsible sections, stage-aware processing overlay, scene presets, 3D spectrogram, A/B transport, forensic audit log, WhisperHunter AI. |
+| [`/app/`](https://voice-isolate-pro.vercel.app/app/) | **Engineer Mode v25** | Full 67-slider DSP suite with calibrated separation discipline, per-slider locks, collapsible sections (localStorage), stage-aware processing overlay, scene presets, 3D spectrogram, **Compare Original** A/B transport, forensic audit log, WhisperHunter AI. Universal Source Matrix runs as an **internal backend** after Analyze (stems for chips + WhisperHunter) — not a separate user Process panel. |
 | [`/download/`](https://voice-isolate-pro.vercel.app/download/) | **Downloads** | Android APK + Windows installer (GitHub Releases), web app links. |
 
 **Upload controls (both pages):** Browse Files (`<label for="fileInput">`), click the drop zone, drag-and-drop, or **Upload Audio or Video** in the Engineer hero. Shared wiring lives in `src/presentation/UploadWiring.js`.

--- a/docs/ANALYSIS_WORKSPACE.md
+++ b/docs/ANALYSIS_WORKSPACE.md
@@ -1,3 +1,101 @@
-# Moved
+# Full-Audio Analysis Workspace
 
-This guide now lives at **[guides/ANALYSIS_WORKSPACE.md](guides/ANALYSIS_WORKSPACE.md)**.
+Production analysis path for Engineer Mode (`/app/`).
+
+## Modules
+
+| Concern | Canonical path |
+|---------|----------------|
+| Features | `src/core/FeatureExtractor.js` |
+| Segments | `src/core/SegmentMerger.js` |
+| Whisper / faint speech | `src/core/WhisperLogic.js` |
+| Full analysis | `src/core/FullAnalysis.js` |
+| Recommendations | `src/core/RecommendationEngine.js` |
+| **Analyzer ↔ WhisperHunter bridge** | `src/core/AnalyzerWhisperBridge.js` |
+| DSP defaults | `src/core/DspCalibration.js` |
+| Presets | `src/core/PresetCalibration.js` |
+| Capabilities | `src/core/CapabilityChecker.js` |
+| Worker | `src/workers/FullAnalysisWorker.js` |
+| Host | `src/pipeline/FullAnalysisHost.js` |
+| Audition | `src/pipeline/SourceAuditionEngine.js` |
+| **USM (backend)** | `src/core/UniversalSourceMatrix.js` + `src/pipeline/USMNode.js` + `src/workers/USMWorker.js` |
+| Export helper | `src/pipeline/ExportManager.js` |
+| Timeline UI | `src/presentation/TimelineRenderer.js` |
+| Transport sync | `src/presentation/TransportSync.js` |
+| Engineer wiring | `public/app/lib/analysis-workspace.js` |
+
+## Engineer Mode flow
+
+1. **Upload** audio/video (local; decode deferred until Analyze/Process).
+2. **Analyze Full Audio** — `FullAnalysisHost` → `FullAnalysisWorker` (features, segments, recommendations) with progress/heartbeat + stall timeout.
+3. **USM backend (automatic)** — after analysis, `USMNode.ensureComputed()` runs once per file in `USMWorker` (classical NMF / optional ONNX). Stems are cached; UI shows a read-only **Detected Sources** chip list.
+4. **Joint map** — `AnalyzerWhisperBridge` fuses analysis with WhisperHunter environment profiling:
+   - **Protect** speech / whisper / difficult regions
+   - **Suppress** music, broadband noise, hum, impulses, reverb, crowd/traffic
+5. **WhisperHunter AI** (or **Analyze + WhisperHunter**) consumes the joint plan + `getSourceStems()` when available.
+6. **Process** — pauses transport if playing (retains playhead, no auto-resume) → MLWorker / DSP once → Live-Mix.
+7. **Playback / Compare Original** — transport A/B swaps original vs processed sample-accurately.
+8. Live-Mix preview / export.
+
+WhisperHunter alone still works without prior analysis, but quality is better when the workspace map is available (`app._lastFullAnalysis` / `app._jointIsolationPlan` / `app.getSourceStems()`).
+
+Facades under `public/app/lib/*` re-export `/src/...` for stable relative URLs.
+
+## Analysis object
+
+See `analyzeAudio()` return value — includes segments, `visualLayers`, `recommendedPreset`, `recommendedStageConfig`, `recommendedProcessingPlan`, and `recommendation` (findings + reasons + confidence).
+
+## Analysis → DSP map
+
+| Finding | Response |
+|---------|----------|
+| Low SNR | Stronger NR / forensic or surveillance preset |
+| Hum | Hum Removal / phase + hum strength |
+| High reverb | Room Echo Reduction, ↑ dereverb |
+| Whisper regions | Shallower gate, whisperLift in-region, protect consonants |
+| Music bed | Aggressive Isolate, musicKill / bgSuppress |
+| Overlaps | Reduced voiceIso, crosstalk cancel modest |
+| High confidence | Auto-apply allowed |
+| Low confidence | Recommend only; user must Apply |
+
+## Universal Source Matrix — backend service
+
+USM is **not** a user-facing Separate/mute/solo panel in Engineer Mode.
+
+| Consumer | API |
+|----------|-----|
+| Analyzer (post-analysis) | `USMNode.ensureComputed()` → chips via `getSourceLabels()` |
+| WhisperHunter | `getSourceStems()` for per-source PCM targets |
+| Audition strip | `buildFromUSM()` + mute/solo/gain on layers only |
+
+### Internal API (`USMNode`)
+
+```js
+await usmNode.ensureComputed(channels, sampleRate, { mode: 'auto', numSources: 6 });
+usmNode.getSourceLabels(); // [{ id, label, confidence, quality }]
+usmNode.getSourceStems();  // [{ id, label, pcm, confidence, quality, method }]
+usmNode.isReady();
+```
+
+### Live-Mix contract
+
+- **Never** recompute USM on slider drag, mute, solo, or preset apply.
+- Mute/solo/gain on stems = `SourceAuditionEngine` / Live-Mix gains only.
+- Optional `refine(query)` remains a deliberate one-shot (not wired to Engineer sliders).
+
+Not used on the Live low-latency path (keep voice / ambient / music coarse stems there).
+
+## Honesty rules
+
+- No fabricated words or ASR transcription unless a local ASR model is explicitly bundled later.
+- Layer quality badges: high (true stems), medium (ML/classical mix), low (best-effort residual).
+- Empty lanes show “not detected” — never decorative fake regions.
+- USM cannot produce a deterministic “one fader per atom of sound”; K semantic components + query refine is the practical ceiling.
+
+## Performance
+
+- Default frame 25 ms / hop 10 ms classical analysis.
+- Long files: mono downmix for analysis; worker + heartbeats.
+- USM classical path in `USMWorker` with progress/heartbeat and hard timeout.
+- Lazy audition buffers; dispose on Clear / new file (host responsibility).
+- Collapsible Engineer panels persist open/closed state in `localStorage` without re-processing.

--- a/docs/guides/ANALYSIS_WORKSPACE.md
+++ b/docs/guides/ANALYSIS_WORKSPACE.md
@@ -18,7 +18,7 @@ Production analysis path for Engineer Mode (`/app/`).
 | Worker | `src/workers/FullAnalysisWorker.js` |
 | Host | `src/pipeline/FullAnalysisHost.js` |
 | Audition | `src/pipeline/SourceAuditionEngine.js` |
-| Universal Source Matrix | `src/core/UniversalSourceMatrix.js` + `src/pipeline/USMNode.js` |
+| **USM (backend)** | `src/core/UniversalSourceMatrix.js` + `src/pipeline/USMNode.js` + `src/workers/USMWorker.js` |
 | Export helper | `src/pipeline/ExportManager.js` |
 | Timeline UI | `src/presentation/TimelineRenderer.js` |
 | Transport sync | `src/presentation/TransportSync.js` |
@@ -26,15 +26,18 @@ Production analysis path for Engineer Mode (`/app/`).
 
 ## Engineer Mode flow
 
-1. **Upload** audio/video (local decode only).
-2. **Analyze Full Audio** — classical full-file map (speech, whisper, music, noise, hum, impulses).
-3. **Joint map** — `AnalyzerWhisperBridge` fuses analysis with WhisperHunter environment profiling:
-   - **Protect** speech / whisper / difficult regions (amplify & isolate)
-   - **Suppress** music, broadband noise, hum, impulses (horns, barks, claps), reverb, crowd/traffic
-4. **WhisperHunter AI** (or **Analyze + WhisperHunter**) consumes the joint plan for preset + slider morph + single-pass isolation.
-5. Live-Mix preview / export.
+1. **Upload** audio/video (local; decode deferred until Analyze/Process).
+2. **Analyze Full Audio** — `FullAnalysisHost` → `FullAnalysisWorker` (features, segments, recommendations) with progress/heartbeat + stall timeout.
+3. **USM backend (automatic)** — after analysis, `USMNode.ensureComputed()` runs once per file in `USMWorker` (classical NMF / optional ONNX). Stems are cached; UI shows a read-only **Detected Sources** chip list.
+4. **Joint map** — `AnalyzerWhisperBridge` fuses analysis with WhisperHunter environment profiling:
+   - **Protect** speech / whisper / difficult regions
+   - **Suppress** music, broadband noise, hum, impulses, reverb, crowd/traffic
+5. **WhisperHunter AI** (or **Analyze + WhisperHunter**) consumes the joint plan + `getSourceStems()` when available.
+6. **Process** — pauses transport if playing (retains playhead, no auto-resume) → MLWorker / DSP once → Live-Mix.
+7. **Playback / Compare Original** — transport A/B swaps original vs processed sample-accurately.
+8. Live-Mix preview / export.
 
-WhisperHunter alone still works without prior analysis, but quality is better when the workspace map is available (`app._lastFullAnalysis` / `app._jointIsolationPlan`).
+WhisperHunter alone still works without prior analysis, but quality is better when the workspace map is available (`app._lastFullAnalysis` / `app._jointIsolationPlan` / `app.getSourceStems()`).
 
 Facades under `public/app/lib/*` re-export `/src/...` for stable relative URLs.
 
@@ -55,14 +58,30 @@ See `analyzeAudio()` return value — includes segments, `visualLayers`, `recomm
 | High confidence | Auto-apply allowed |
 | Low confidence | Recommend only; user must Apply |
 
-## Universal Source Matrix (Creator / Forensic)
+## Universal Source Matrix — backend service
 
-Engineer Mode panel under **Source Analysis Workspace**:
+USM is **not** a user-facing Separate/mute/solo panel in Engineer Mode.
 
-1. **Separate sources** — classical multi-component NMF soft masks (variable K, default 6). Optional ONNX `universal-separator.onnx` when shipped (`USMNode({ preferOnnx: true })`).
-2. **Query separate** — text priors (“AC hum”, “dog barking”, “speech”) for LASS/AudioSep-style targeting without cloud APIs.
-3. **Mute / Solo / Gain (dB)** — Live-Mix only; never re-runs ML. **Refine** is an intentional one-shot query on the retained mixture.
-4. **Apply mix** — writes the combined matrix mix into the processed buffer for export / A-B.
+| Consumer | API |
+|----------|-----|
+| Analyzer (post-analysis) | `USMNode.ensureComputed()` → chips via `getSourceLabels()` |
+| WhisperHunter | `getSourceStems()` for per-source PCM targets |
+| Audition strip | `buildFromUSM()` + mute/solo/gain on layers only |
+
+### Internal API (`USMNode`)
+
+```js
+await usmNode.ensureComputed(channels, sampleRate, { mode: 'auto', numSources: 6 });
+usmNode.getSourceLabels(); // [{ id, label, confidence, quality }]
+usmNode.getSourceStems();  // [{ id, label, pcm, confidence, quality, method }]
+usmNode.isReady();
+```
+
+### Live-Mix contract
+
+- **Never** recompute USM on slider drag, mute, solo, or preset apply.
+- Mute/solo/gain on stems = `SourceAuditionEngine` / Live-Mix gains only.
+- Optional `refine(query)` remains a deliberate one-shot (not wired to Engineer sliders).
 
 Not used on the Live low-latency path (keep voice / ambient / music coarse stems there).
 
@@ -76,5 +95,7 @@ Not used on the Live low-latency path (keep voice / ambient / music coarse stems
 ## Performance
 
 - Default frame 25 ms / hop 10 ms classical analysis.
-- Long files: mono downmix for analysis; yield via worker.
+- Long files: mono downmix for analysis; worker + heartbeats.
+- USM classical path in `USMWorker` with progress/heartbeat and hard timeout.
 - Lazy audition buffers; dispose on Clear / new file (host responsibility).
+- Collapsible Engineer panels persist open/closed state in `localStorage` without re-processing.

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -11,10 +11,35 @@
  *
  * Single-Pass Spectral Contract:
  *   ONE forward STFT  → in-place spectral ops → ONE iSTFT
- *   All spectral work delegated to pipeline-orchestrator.js.
- *   app.js provides DSP helpers used by the pipeline.
+ *   Heavy DSP/ML runs in workers (MLWorker, FullAnalysisWorker, USMWorker).
+ *   app.js wires UI → pipeline hosts; never re-runs ML from slider events.
  *
  * 100 % local — no cloud APIs, no external fetch except /app/models/*.onnx.
+ *
+ * ── Engineer Mode data flow (path correctness) ─────────────────────────────
+ *   Upload  →  File selected (blob kept; decode deferred)
+ *        ↓
+ *   Decode  →  ensureDecoded() / FileIngestion (main thread yield + OfflineAudio)
+ *        ↓
+ *   Analyze →  FullAnalysisHost → FullAnalysisWorker (features, segments, recs)
+ *              + USM backend (USMNode / USMWorker) once per file — stems cached
+ *              → chips + audition layers; does NOT block sliders or Process
+ *        ↓
+ *   Config  →  Slider / preset / WhisperHunter map (Live-Mix GainNodes only)
+ *        ↓
+ *   Process →  runPipeline(): pause transport if playing → MLWorker isolation
+ *              (or DSP fallback) → stems → Live-Mix load. Heartbeats + timeout.
+ *        ↓
+ *   Playback / A-B  →  Transport + toggleAB() swaps original vs processed
+ *                      sample-accurate (playhead retained); no re-decode
+ *        ↓
+ *   Export  →  Save Original / Save Processed (local download only)
+ *
+ * Non-blocking contracts:
+ *   - Analysis does not freeze slider interaction (worker + yield).
+ *   - USM runs post-analysis off-main; never on mute/solo/slider drag.
+ *   - Process pauses playback intentionally but does not auto-resume.
+ *   - Transport A/B and playhead remain available after Process completes.
  */
 
 import { SLIDER_REGISTRY, STAGES } from './slider-map.js';
@@ -1002,27 +1027,55 @@ class VoiceIsolatePro {
   }
 
   /**
-   * Collapsible sections defaults:
-   * open: Upload, Processing, active slider family (Noise/Gate)
-   * collapsed on small viewports: Waveform/Spectrum + inactive slider tabs
+   * Collapsible sections:
+   *  - defaults: Upload, Processing, active slider family (Noise/Gate) open
+   *  - collapsed on small viewports: Waveform/Spectrum + inactive slider tabs
+   *  - open/closed state persisted per section id in localStorage
+   *  - toggle never triggers re-process or analysis
    */
   _initCollapsibleSections() {
     if (typeof document === 'undefined') return;
+    const STORAGE_KEY = 'vip.engineer.sectionOpen.v1';
+    let stored = {};
+    try {
+      if (typeof localStorage !== 'undefined') {
+        stored = JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}') || {};
+      }
+    } catch { stored = {}; }
+
     const narrow = typeof window !== 'undefined'
       && window.matchMedia
       && window.matchMedia('(max-width: 900px)').matches;
-    const openIds = new Set(['section-upload', 'section-presets', 'section-processing', 'section-gate']);
-    if (!narrow) openIds.add('vizCard');
+    const defaultOpen = new Set(['section-upload', 'section-presets', 'section-processing', 'section-gate', 'section-analysis']);
+    if (!narrow) defaultOpen.add('vizCard');
+
+    const persist = () => {
+      try {
+        if (typeof localStorage === 'undefined') return;
+        const next = {};
+        document.querySelectorAll('details.vip-section[id]').forEach((el) => {
+          if (el.id) next[el.id] = !!el.open;
+        });
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+      } catch { /* private mode */ }
+    };
+
     document.querySelectorAll('details.vip-section').forEach((el) => {
-      if (openIds.has(el.id) || el.classList.contains('active')) {
+      const id = el.id || '';
+      if (id && Object.prototype.hasOwnProperty.call(stored, id)) {
+        el.open = !!stored[id];
+      } else if (defaultOpen.has(id) || el.classList.contains('active')) {
         el.open = true;
-      } else if (narrow || el.id === 'vizCard' || el.classList.contains('slider-group')) {
-        // Secondary / inactive slider tabs collapsed by default on small screens;
-        // on desktop keep viz open, leave inactive slider groups closed.
-        if (el.id === 'vizCard') el.open = !narrow;
+      } else if (narrow || id === 'vizCard' || el.classList.contains('slider-group')) {
+        if (id === 'vizCard') el.open = !narrow;
         else if (el.classList.contains('slider-group') && !el.classList.contains('active')) {
           el.open = false;
         }
+      }
+      // Persist user toggles only — never re-run DSP on collapse/expand.
+      if (!el.dataset.vipCollapseWired) {
+        el.dataset.vipCollapseWired = '1';
+        el.addEventListener('toggle', () => { persist(); });
       }
     });
   }
@@ -1339,9 +1392,10 @@ class VoiceIsolatePro {
 
   _syncSliderLockUi(id) {
     const row = document.querySelector(`.slider-row[data-slider-id="${id}"], .sr-row[data-slider-id="${id}"]`);
-    const btn = row?.querySelector('.slider-lock-btn');
+    const btn = row?.querySelector('.slider-lock-btn, .sr-lock-btn');
     if (!row || !btn) return;
     const locked = this._isSliderLocked(id);
+    // Both data-locked and class toggles: style.css + slider-theme.css key off both.
     row.dataset.locked = locked ? 'true' : 'false';
     row.classList.toggle('slider-locked', locked);
     row.classList.toggle('is-locked', locked);
@@ -1356,6 +1410,12 @@ class VoiceIsolatePro {
       input.style.pointerEvents = locked ? 'none' : '';
       if (locked) input.setAttribute('aria-readonly', 'true');
       else input.removeAttribute('aria-readonly');
+      // slider-ticks.css keys off .slider-tick-wrapper.is-locked — keep in sync.
+      const tickWrap = input.closest('.slider-tick-wrapper');
+      if (tickWrap) {
+        tickWrap.classList.toggle('is-locked', locked);
+        tickWrap.dataset.locked = locked ? 'true' : 'false';
+      }
     }
   }
 
@@ -1805,6 +1865,9 @@ class VoiceIsolatePro {
     // the bridge handles it, the change is an immediate AudioParam update — no
     // Reprocess, no ML re-run (CLAUDE.md §1). Unsupported ids (spectral/worker
     // effects) fall through and still apply on the next Reprocess.
+    //
+    // rAF-coalesce rapid drag events so we never queue redundant worklet/
+    // bridge recalcs mid-frame (calibration pipeline safety).
 
     // If the bridge is still initializing, wait for it so early slider moves are
     // not dropped (race where sliders fire before async _ensureBridge resolves).
@@ -1813,6 +1876,26 @@ class VoiceIsolatePro {
       return;
     }
 
+    this._pendingSliderParams = this._pendingSliderParams || Object.create(null);
+    this._pendingSliderParams[id] = value;
+    if (this._sliderFlushRaf) return;
+    const flush = () => {
+      this._sliderFlushRaf = 0;
+      const batch = this._pendingSliderParams || {};
+      this._pendingSliderParams = Object.create(null);
+      for (const [sid, sval] of Object.entries(batch)) {
+        this._applySliderImmediate(sid, sval);
+      }
+    };
+    if (typeof requestAnimationFrame === 'function') {
+      this._sliderFlushRaf = requestAnimationFrame(flush);
+    } else {
+      this._sliderFlushRaf = setTimeout(flush, 0);
+    }
+  }
+
+  /** Immediate Live-Mix / worklet application (one id). Called from rAF flush. */
+  _applySliderImmediate(id, value) {
     if (this._bridge && typeof this._bridge.applyParam === 'function') {
       try {
         if (this._bridge.applyParam(id, value)) return;
@@ -1821,7 +1904,7 @@ class VoiceIsolatePro {
       }
     }
 
-    const orch = window._vipOrch;
+    const orch = typeof window !== 'undefined' ? window._vipOrch : null;
     if (id === 'outGain' && this._outGainNode && this.currentSource && this.ctx) {
       const gain = Math.pow(10, value / 20);
       this._outGainNode.gain.setTargetAtTime(gain, this.ctx.currentTime, 0.01);
@@ -2221,8 +2304,15 @@ class VoiceIsolatePro {
   _setProcessedPlaybackMode() {
     this.abMode = 'processed';
     this._bridgeBuf = null;
-    if (this.dom?.tpAB) this.dom.tpAB.classList.add('active');
-    if (this.dom?.tpABLabel) this.dom.tpABLabel.textContent = 'Processed';
+    if (this.dom?.tpAB) {
+      this.dom.tpAB.classList.add('active');
+      this.dom.tpAB.disabled = false;
+      this.dom.tpAB.title = 'Compare Original / Processed (X) — sample-accurate, keeps playhead';
+    }
+    if (this.dom?.tpABLabel) {
+      this.dom.tpABLabel.dataset.version = 'B';
+      this.dom.tpABLabel.innerHTML = '<span class="tp-ab-tag">B</span><span class="tp-ab-name">Processed</span>';
+    }
   }
 
   _resetSliders({ unlockedOnly = true } = {}) {
@@ -2938,6 +3028,26 @@ class VoiceIsolatePro {
     this.abortFlag = false;
     this._mlIsolationSucceeded = false;
     this._pipelinePct = 0;
+    // Pause active playback before heavy work; retain playhead; do NOT auto-resume.
+    // Prevents overlapping graph nodes / double STFT races with AudioWorklet.
+    this._pausedForProcess = false;
+    this._playheadBeforeProcess = null;
+    try {
+      const bridgePlaying = this._bridge && typeof this._bridge.isPlaying === 'function'
+        && this._bridge.isPlaying();
+      if (this.isPlaying || bridgePlaying) {
+        if (typeof this._getTransportPosition === 'function') {
+          this._playheadBeforeProcess = this._getTransportPosition();
+        } else {
+          this._playheadBeforeProcess = this.playOffset || 0;
+        }
+        this.pause();
+        this._pausedForProcess = true;
+      }
+    } catch (pauseErr) {
+      structuredLog('warn', '[VIP] pause-before-process failed', { err: pauseErr?.message });
+    }
+    this._setTransportProcessingState(true);
     this._updateProcessButtonsState();
     stageStart('pipeline');
     // Let the browser paint the processing overlay before heavy work.
@@ -3070,6 +3180,16 @@ class VoiceIsolatePro {
     } finally {
       // Always unlock the UI — never leave the bar stuck mid-process.
       this.isProcessing = false;
+      // Restore transport controls; restore playhead if we paused — never auto-resume.
+      this._setTransportProcessingState(false);
+      if (this._playheadBeforeProcess != null && Number.isFinite(this._playheadBeforeProcess)) {
+        try {
+          if (typeof this.seekTo === 'function') this.seekTo(this._playheadBeforeProcess);
+          else this.playOffset = this._playheadBeforeProcess;
+        } catch { /* keep current offset */ }
+      }
+      this._pausedForProcess = false;
+      this._playheadBeforeProcess = null;
       this._updateProcessButtonsState();
       // Highest-risk regression: stuck-open overlay. Always hide here too
       // (processing-overlay.js also wraps runPipeline in try/finally).
@@ -3085,6 +3205,46 @@ class VoiceIsolatePro {
       if (this.dom.mobileStopBtn) {
         this.dom.mobileStopBtn.style.display='none';
       }
+    }
+  }
+
+  /**
+   * During Process: disable transport except visible "processing" state.
+   * Restores on completion/error without starting playback.
+   */
+  _setTransportProcessingState(busy) {
+    const ids = ['tpPlay', 'tpPause', 'tpStop', 'tpRew', 'tpFwd', 'tpSeek', 'tpSpeed', 'tpLoop', 'tpCropIn', 'tpCropOut', 'tpCropClear', 'tpAB'];
+    for (const id of ids) {
+      const el = this.dom?.[id] || (typeof document !== 'undefined' ? document.getElementById(id) : null);
+      if (!el) continue;
+      if (busy) {
+        if (el.dataset.vipPrevDisabled == null) {
+          el.dataset.vipPrevDisabled = el.disabled ? '1' : '0';
+        }
+        el.disabled = true;
+      } else if (el.dataset.vipPrevDisabled != null) {
+        // Leave disabled if no buffer / no processed yet for A/B; else restore.
+        const had = el.dataset.vipPrevDisabled === '1';
+        delete el.dataset.vipPrevDisabled;
+        if (id === 'tpAB') {
+          el.disabled = !(this.outputBuffer || this.procBuffer);
+        } else {
+          el.disabled = had && !(this.inputBuffer || this.origBuffer || this.outputBuffer);
+          if (this.inputBuffer || this.origBuffer || this.outputBuffer) {
+            el.disabled = false;
+          }
+        }
+      }
+    }
+    const card = typeof document !== 'undefined' ? document.querySelector('.transport-card') : null;
+    if (card) {
+      card.dataset.processing = busy ? 'true' : 'false';
+      card.setAttribute('aria-busy', busy ? 'true' : 'false');
+    }
+    const ab = this.dom?.tpAB || (typeof document !== 'undefined' ? document.getElementById('tpAB') : null);
+    if (ab && !busy) {
+      ab.title = 'Compare Original / Processed (X) — sample-accurate, keeps playhead';
+      ab.setAttribute('aria-label', 'Compare Original vs Processed');
     }
   }
 
@@ -4613,6 +4773,11 @@ class VoiceIsolatePro {
     }
   }
 
+  /**
+   * Instant original ↔ processed swap during playback (transport bar).
+   * Sample-accurate: retains playhead; does not reload the file.
+   * vip-fixes may own this path when _fixABPatched is set.
+   */
   toggleAB() {
     if (this._fixABPatched) return;
     const buf = this.outputBuffer || this.procBuffer;
@@ -4625,9 +4790,26 @@ class VoiceIsolatePro {
     }
     this._bridgeBuf = null;
     this.abMode = this.abMode === 'original' ? 'processed' : 'original';
-    if (this.dom.tpAB) this.dom.tpAB.classList.toggle('active', this.abMode === 'processed');
-    // PATCHED BY vip-fixes.js — consider merging
-    if (this.dom.tpABLabel) this.dom.tpABLabel.textContent = this.abMode === 'processed' ? 'Processed' : 'Original';
+    if (this.dom.tpAB) {
+      if (this.dom.tpAB.classList && typeof this.dom.tpAB.classList.toggle === 'function') {
+        this.dom.tpAB.classList.toggle('active', this.abMode === 'processed');
+      }
+      if (typeof this.dom.tpAB.setAttribute === 'function') {
+        this.dom.tpAB.setAttribute('aria-pressed', this.abMode === 'processed' ? 'true' : 'false');
+      }
+    }
+    if (this.dom.tpABLabel) {
+      const isProc = this.abMode === 'processed';
+      const labelText = isProc ? 'Processed' : 'Original';
+      if (this.dom.tpABLabel.dataset) this.dom.tpABLabel.dataset.version = isProc ? 'B' : 'A';
+      // Tests mock textContent; real DOM also gets structured A/B tags when possible.
+      this.dom.tpABLabel.textContent = labelText;
+      if (typeof Element !== 'undefined' && this.dom.tpABLabel instanceof Element) {
+        this.dom.tpABLabel.innerHTML = isProc
+          ? '<span class="tp-ab-tag">B</span><span class="tp-ab-name">Processed</span>'
+          : '<span class="tp-ab-tag">A</span><span class="tp-ab-name">Original</span>';
+      }
+    }
     if (this.isPlaying) this.play();
     // Keep Voice/Noise/SNR in sync across every readout on A/B toggle.
     this.updateAudioMetrics(this._computeAudioMetricsState());

--- a/public/app/index.html
+++ b/public/app/index.html
@@ -336,11 +336,13 @@
       </details>
 
       <!-- Full-audio analysis workspace (local-only) — sits under upload; WhisperHunter collaborates via joint map -->
-      <section id="analysisWorkspace" class="card analysis-workspace" data-state="idle" aria-label="Full audio analysis workspace">
-        <div class="analysis-hdr">
-          <h3 class="analysis-title">1 · Source Analysis Workspace</h3>
+      <details class="card analysis-workspace vip-section" id="section-analysis" open>
+        <summary class="vip-section-summary analysis-hdr">
+          <span class="analysis-title">1 · Source Analysis Workspace</span>
           <span id="analysisConfidence" class="analysis-conf" data-level="low">Confidence —</span>
-        </div>
+        </summary>
+        <div class="vip-section-body">
+      <section id="analysisWorkspace" class="analysis-workspace-inner" data-state="idle" aria-label="Full audio analysis workspace">
         <p class="analysis-lead">Upload above (instant — no decode freeze). Analyze starts local PCM decode and maps voices, whispers, music, horns, barks, and other noise — then shares that map with WhisperHunter so isolation protects speech and suppresses interference. Audio never leaves this device.</p>
         <div id="capabilityPanel" class="capability-panel" aria-live="polite"></div>
         <div class="analysis-actions">
@@ -383,21 +385,23 @@
             </div>
             <div id="auditionStrip" class="audition-strip"></div>
 
-            <!-- Universal Source Matrix (Creator/Forensic) — mute/solo/gain per semantic stem -->
-            <div id="sourceMatrixPanel" class="source-matrix-panel" aria-label="Universal Source Matrix">
-              <div class="usm-hdr">
-                <h4 class="analysis-sub">Universal Source Matrix</h4>
+            <!-- USM backend summary — computed after Analyze; mute/solo via Audition only -->
+            <details class="source-matrix-panel vip-section" id="sourceMatrixPanel" open aria-label="Detected sources summary">
+              <summary class="vip-section-summary usm-hdr">
+                <span class="analysis-sub">Detected Sources</span>
                 <span id="usmMethodBadge" class="usm-method-badge" hidden>—</span>
-              </div>
-              <p class="usm-lead">Separate open-domain sources (speech, hum, dogs, TV, residual…) then mute/solo/gain each stem. 100% local — no cloud. Live mode keeps lightweight 2–3 stems only.</p>
-              <div class="usm-actions">
-                <button id="btnUsmSeparate" class="btn btn-primary btn-xs" type="button" title="Auto-discover K semantic sources (Creator/Forensic)">Separate sources</button>
+              </summary>
+              <div class="vip-section-body">
+              <p class="usm-lead">Open-domain sources (speech, hum, residual…) are discovered automatically after Analyze and cached for WhisperHunter. Audition layers below support mute/solo — not a separate process button. 100% local.</p>
+              <!-- Legacy ids kept hidden for API/tests that still query them -->
+              <div class="usm-actions" hidden aria-hidden="true">
+                <button id="btnUsmSeparate" class="btn btn-primary btn-xs" type="button" hidden tabindex="-1">Separate sources</button>
                 <label class="usm-k-label">K
                   <input id="usmNumSources" type="number" min="2" max="12" value="6" class="usm-k-input" aria-label="Number of sources" />
                 </label>
-                <input id="usmQueryInput" type="text" class="usm-query-input" placeholder="Or describe a source… e.g. the AC hum" aria-label="Text query for source separation" />
-                <button id="btnUsmQuery" class="btn btn-outline btn-xs" type="button">Query separate</button>
-                <button id="btnUsmApplyMix" class="btn btn-reprocess btn-xs" type="button" title="Write combined matrix mix to processed buffer">Apply mix</button>
+                <input id="usmQueryInput" type="text" class="usm-query-input" aria-label="Text query" hidden />
+                <button id="btnUsmQuery" type="button" hidden tabindex="-1">Query separate</button>
+                <button id="btnUsmApplyMix" type="button" hidden tabindex="-1">Apply mix</button>
               </div>
               <div id="usmProgress" class="usm-progress" hidden>
                 <div class="usm-progress-bar"><div id="usmProgressFill" class="usm-progress-fill"></div></div>
@@ -405,25 +409,25 @@
               </div>
               <div id="usmError" class="usm-error" hidden role="alert"></div>
               <div class="usm-table-wrap">
-                <table class="usm-table" aria-label="Source matrix stems">
+                <table class="usm-table" aria-label="Detected source labels">
                   <thead>
                     <tr>
-                      <th scope="col">M</th>
-                      <th scope="col">S</th>
-                      <th scope="col">Gain (dB)</th>
                       <th scope="col">Label</th>
-                      <th scope="col">Refine</th>
+                      <th scope="col">Confidence</th>
                     </tr>
                   </thead>
                   <tbody id="usmTableBody">
-                    <tr class="usm-empty-row"><td colspan="5">Run Separate sources after loading a file (Creator / Forensic).</td></tr>
+                    <tr class="usm-empty-row"><td colspan="2">Sources appear after Analyze Full Audio (computed automatically).</td></tr>
                   </tbody>
                 </table>
               </div>
-            </div>
+              </div>
+            </details>
           </div>
         </div>
       </section>
+        </div>
+      </details>
 
       <details class="card vip-section" id="section-presets" open>
         <summary class="vip-section-summary">Presets &amp; Processing Controls</summary>
@@ -456,11 +460,13 @@
             <button class="btn btn-preset" type="button" data-preset="Surveillance">Surveillance</button>
           </div>
         </div>
-        <div class="whisper-hunter-row">
-          <span class="whisper-hunter-label">2 · WhisperHunter AI</span>
+        <details class="whisper-hunter-row vip-section" id="section-whisper-hunter" open>
+          <summary class="vip-section-summary whisper-hunter-label">2 · WhisperHunter AI</summary>
+          <div class="vip-section-body">
           <button id="btn-whisper-hunter" type="button" title="Uses the analyzer joint map when available (protect voice/whisper, suppress music/horns/noise)">🎙️ WhisperHunter AI</button>
-          <p class="whisper-hunter-hint">Best after Analyze Full Audio — collaborates with the workspace above to remove unwanted sound and lift voices/whispers.</p>
-        </div>
+          <p class="whisper-hunter-hint">Best after Analyze Full Audio — collaborates with the workspace above to remove unwanted sound and lift voices/whispers. Uses USM stems when available.</p>
+          </div>
+        </details>
         <div class="control-search-row">
           <input type="text" id="sliderSearch" class="btn btn-outline" placeholder="Search controls…" aria-label="Search controls" style="width:100%;" />
           <button id="resetSlidersBtn" class="btn btn-outline" type="button" title="Reset controls (prompts for unlocked-only vs all)">Reset Controls</button>
@@ -579,10 +585,11 @@
             </div>
             <div class="tp-ab">
               <button id="tpAB" class="btn btn-ab" type="button"
-                aria-label="Toggle A/B Comparison"
+                aria-label="Compare Original vs Processed"
                 aria-describedby="tpABLabel"
-                title="Toggle A/B — X key shortcut"
-                disabled>A/B</button>
+                aria-pressed="false"
+                title="Compare Original / Processed (X) — sample-accurate, keeps playhead"
+                disabled>Compare Original</button>
               <button id="abToggle" class="btn btn-ab vip-tp-alias" type="button" hidden aria-hidden="true" tabindex="-1">A/B</button>
               <span id="tpABLabel" class="tp-ab-label" data-version="A" aria-live="polite">
                 <span class="tp-ab-tag">A</span>

--- a/public/app/lib/analysis-workspace.js
+++ b/public/app/lib/analysis-workspace.js
@@ -2,6 +2,11 @@
  * Engineer Mode — Analysis Workspace Controller
  * Wires full analysis, timeline, audition, recommendations into the UI.
  * 100% local. Imports canonical logic from /src/.
+ *
+ * Universal Source Matrix is an **internal backend** (not a user Separate panel):
+ * after Full Analysis completes, USMNode.ensureComputed() runs once per file
+ * (worker-backed), caches stems, and exposes getSourceStems()/getSourceLabels()
+ * for chips + WhisperHunter. Mute/solo live only in SourceAuditionEngine.
  */
 'use strict';
 
@@ -134,76 +139,69 @@ export function installAnalysisWorkspace(app) {
     els.usmError.textContent = msg || '';
   }
 
-  function renderUsmTable() {
-    if (!els.usmTableBody) return;
-    const rows = usmNode.sources;
-    if (!rows.length) {
-      els.usmTableBody.innerHTML =
-        '<tr class="usm-empty-row"><td colspan="5">Run Separate sources after loading a file (Creator / Forensic).</td></tr>';
-      return;
+  /**
+   * Read-only Detected Sources summary (backend USM). Mute/solo live in
+   * the Audition strip only — not Engineer sliders.
+   */
+  function renderUsmSummary() {
+    const labels = typeof usmNode.getSourceLabels === 'function'
+      ? usmNode.getSourceLabels()
+      : (usmNode.sources || []).map((s) => ({
+        id: s.id,
+        label: s.label,
+        confidence: s.confidence ?? 0,
+        quality: s.quality || 'medium',
+      }));
+    if (els.usmMethodBadge) {
+      const method = usmNode._lastResult?.method || (labels.length ? 'usm' : '');
+      els.usmMethodBadge.hidden = !method;
+      if (method) els.usmMethodBadge.textContent = method;
     }
-    els.usmTableBody.innerHTML = rows.map((s) => `
-      <tr data-usm-id="${escapeHtml(s.id)}">
-        <td><button type="button" class="btn btn-xs ${s.mute ? 'active' : ''}" data-usm-act="mute" title="Mute">M</button></td>
-        <td><button type="button" class="btn btn-xs ${s.solo ? 'active' : ''}" data-usm-act="solo" title="Solo">S</button></td>
-        <td>
-          <input type="range" min="-48" max="12" step="0.5" value="${s.gainDb}" data-usm-act="gain" aria-label="Gain dB" />
-          <span class="usm-gain-val">${s.gainDb.toFixed(1)}</span>
-        </td>
-        <td>
-          <input type="text" class="usm-label-input" data-usm-act="label" value="${escapeHtml(s.label)}" />
-          <span class="usm-conf" title="Confidence">${Math.round((s.confidence || 0) * 100)}%</span>
-        </td>
-        <td><button type="button" class="btn btn-xs" data-usm-act="refine" title="Refine via text query">Refine</button></td>
-      </tr>`).join('');
+    // Compact chip list inside USM panel (if present)
+    if (els.usmTableBody) {
+      if (!labels.length) {
+        els.usmTableBody.innerHTML =
+          '<tr class="usm-empty-row"><td colspan="2">Sources appear after Analyze Full Audio (computed automatically).</td></tr>';
+      } else {
+        els.usmTableBody.innerHTML = labels.map((s) => `
+          <tr data-usm-id="${escapeHtml(s.id)}">
+            <td>${escapeHtml(s.label)}</td>
+            <td><span class="usm-conf" title="Confidence">${Math.round((s.confidence || 0) * 100)}%</span>
+              <span class="aud-quality q-${escapeHtml(s.quality || 'medium')}">${escapeHtml(s.quality || 'medium')}</span>
+            </td>
+          </tr>`).join('');
+      }
+    }
+    // Also merge into analysis source chips when USM labels available
+    if (els.chips && labels.length) {
+      const existing = new Set(
+        [...els.chips.querySelectorAll('.source-chip')].map((b) => b.dataset.source),
+      );
+      for (const s of labels) {
+        if (existing.has(s.id)) continue;
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'source-chip source-chip--usm';
+        btn.dataset.source = s.id;
+        btn.title = `USM · confidence ${Math.round((s.confidence || 0) * 100)}%`;
+        btn.innerHTML = `${escapeHtml(s.label)} <span class="chip-conf">${Math.round((s.confidence || 0) * 100)}%</span>`;
+        btn.addEventListener('click', () => {
+          audition.setMode('layer');
+          for (const L of audition.layers.values()) L.solo = false;
+          const layer = audition.layers.get(s.id);
+          if (layer) {
+            layer.solo = true;
+            audition.play().catch(() => {});
+          }
+        });
+        els.chips.appendChild(btn);
+      }
+    }
+  }
 
-    els.usmTableBody.querySelectorAll('tr[data-usm-id]').forEach((tr) => {
-      const id = tr.dataset.usmId;
-      tr.querySelector('[data-usm-act="mute"]')?.addEventListener('click', () => {
-        const s = usmNode.sources.find((x) => x.id === id);
-        const next = !s?.mute;
-        usmNode.setMute(id, next);
-        // Mirror into audition for immediate hear (Live-Mix — no ML re-run)
-        audition.setLayerMute(id, next);
-        refreshAuditionIfPlaying();
-        renderUsmTable();
-      });
-      tr.querySelector('[data-usm-act="solo"]')?.addEventListener('click', () => {
-        const s = usmNode.sources.find((x) => x.id === id);
-        const next = !s?.solo;
-        usmNode.setSolo(id, next);
-        audition.setLayerSolo(id, next);
-        if (next) audition.setMode('layer');
-        refreshAuditionIfPlaying();
-        renderUsmTable();
-      });
-      tr.querySelector('[data-usm-act="gain"]')?.addEventListener('input', (e) => {
-        const db = Number(e.target.value);
-        usmNode.setGainDb(id, db);
-        const lin = Math.pow(10, db / 20);
-        audition.setLayerGain(id, lin);
-        const val = tr.querySelector('.usm-gain-val');
-        if (val) val.textContent = db.toFixed(1);
-        refreshAuditionIfPlaying();
-      });
-      tr.querySelector('[data-usm-act="label"]')?.addEventListener('change', (e) => {
-        usmNode.setLabel(id, e.target.value);
-        const L = audition.layers.get(id);
-        if (L) L.label = e.target.value;
-      });
-      tr.querySelector('[data-usm-act="refine"]')?.addEventListener('click', async () => {
-        const q = window.prompt('Describe what to keep for this source (local query mask):', usmNode.sources.find((x) => x.id === id)?.label || '');
-        if (!q) return;
-        try {
-          showUsmError('');
-          await usmNode.refine(q);
-          await pushUsmToAudition();
-          renderUsmTable();
-        } catch (err) {
-          showUsmError(err?.message || String(err));
-        }
-      });
-    });
+  /** @deprecated name kept for any external callers */
+  function renderUsmTable() {
+    renderUsmSummary();
   }
 
   async function pushUsmToAudition() {
@@ -225,70 +223,65 @@ export function installAnalysisWorkspace(app) {
     audition.play(t).catch(() => {});
   }
 
-  async function runUsmSeparate(mode) {
-    if (usmBusy) return;
+  /**
+   * Backend USM: compute once after analysis (or on demand for WhisperHunter).
+   * Never called from mute/solo/slider. Progress updates chips only.
+   */
+  async function runUsmBackend(opts = {}) {
+    if (usmBusy) return usmNode.isReady?.() ? {
+      sources: usmNode.sources,
+      method: usmNode._lastResult?.method,
+      cached: true,
+    } : null;
     showUsmError('');
-    if (typeof app.ensureDecoded === 'function') {
-      const decoded = await app.ensureDecoded();
-      if (!decoded) {
-        showUsmError('Load an audio or video file first.');
-        return;
-      }
-    }
     const buf = app.origBuffer || app.inputBuffer;
-    if (!buf) {
-      showUsmError('Load an audio or video file first.');
-      return;
-    }
+    if (!buf) return null;
     usmBusy = true;
-    [els.btnUsmSeparate, els.btnUsmQuery, els.btnUsmApplyMix].forEach((b) => {
-      if (b) b.disabled = true;
-    });
     if (els.usmProgress) els.usmProgress.hidden = false;
     try {
       const channels = [];
       for (let c = 0; c < buf.numberOfChannels; c++) {
         channels.push(buf.getChannelData(c).slice());
       }
-      const K = Math.max(2, Math.min(12, Number(els.usmNumSources?.value) || 6));
-      const queryText = (els.usmQueryInput?.value || '').trim();
-      const config = mode === 'query' || queryText
-        ? {
-          mode: 'query',
-          queries: queryText
-            ? queryText.split(/[,;|]/).map((s) => s.trim()).filter(Boolean)
-            : ['speech'],
-          numSources: K,
-        }
-        : { mode: 'auto', numSources: K };
-
-      const result = await usmNode.process(channels, buf.sampleRate, config);
+      const K = Math.max(2, Math.min(12, Number(opts.numSources) || 6));
+      const config = {
+        mode: opts.mode === 'query' ? 'query' : 'auto',
+        numSources: K,
+        queries: opts.queries || [],
+        nmfIterations: opts.nmfIterations || 20,
+      };
+      const result = typeof usmNode.ensureComputed === 'function'
+        ? await usmNode.ensureComputed(channels, buf.sampleRate, config)
+        : await usmNode.process(channels, buf.sampleRate, config);
       app._usmResult = result;
       app._usmNode = usmNode;
+      // Expose internal API on app for WhisperHunter / Process consumers
+      app.getSourceStems = () => usmNode.getSourceStems();
+      app.getSourceLabels = () => usmNode.getSourceLabels();
 
-      if (els.usmMethodBadge) {
-        els.usmMethodBadge.hidden = false;
-        els.usmMethodBadge.textContent = result.method || 'usm';
-      }
       await pushUsmToAudition();
-      renderUsmTable();
-      if (typeof app.setStatus === 'function') {
-        app.setStatus(`USM: ${result.sources.length} sources (${result.method})`);
+      renderUsmSummary();
+      if (typeof app.setStatus === 'function' && !result.cached) {
+        app.setStatus(`Detected ${result.sources.length} sources (${result.method})`);
       }
+      return result;
     } catch (err) {
       showUsmError(err?.message || String(err));
+      return null;
     } finally {
       usmBusy = false;
-      [els.btnUsmSeparate, els.btnUsmQuery, els.btnUsmApplyMix].forEach((b) => {
-        if (b) b.disabled = false;
-      });
       if (els.usmProgress) els.usmProgress.hidden = true;
     }
   }
 
+  /** @deprecated user-facing Separate removed — maps to backend auto mode */
+  async function runUsmSeparate(mode) {
+    return runUsmBackend({ mode: mode === 'query' ? 'query' : 'auto' });
+  }
+
   function applyUsmMixToProcessed() {
     if (!usmNode.sources.length) {
-      showUsmError('Separate sources first.');
+      showUsmError('Run Analyze Full Audio first (USM computes automatically).');
       return;
     }
     const ctx = app.ctx || app.audioCtx;
@@ -298,14 +291,12 @@ export function installAnalysisWorkspace(app) {
     }
     const mix = usmNode.renderMix();
     const sr = usmNode.sampleRate || ctx.sampleRate;
-    // Preserve channel count of the loaded file (mono mix expanded to stereo if needed)
     const srcBuf = app.origBuffer || app.inputBuffer;
     const nCh = Math.max(1, Math.min(2, srcBuf?.numberOfChannels || 1));
     const out = ctx.createBuffer(nCh, mix.length, sr);
     for (let c = 0; c < nCh; c++) out.copyToChannel(mix, c);
     app.procBuffer = out;
     app.outputBuffer = out;
-    // Also expose as processed audition layer
     audition.setLayer({
       id: 'processed',
       label: 'USM mix (processed)',
@@ -483,11 +474,14 @@ export function installAnalysisWorkspace(app) {
     app._lastFullAnalysis = null;
     app._jointIsolationPlan = null;
     app._hunterEnvFromAnalysis = null;
+    app._usmResult = null;
+    usmNode.clear?.();
     host.dispose();
     audition.stop(true);
     audition.resetMix();
     transport.stop(true);
     transport.setDuration(0);
+    renderUsmSummary();
     if (timeline) {
       timeline.setAnalysis(null);
       timeline.setPlayhead(0);
@@ -615,6 +609,10 @@ export function installAnalysisWorkspace(app) {
       } else if (els.progressLabel) {
         els.progressLabel.textContent = 'Analysis complete · Analyzer ↔ WhisperHunter linked';
       }
+      // Post-analysis USM backend (does not block Process; runs off-main via worker)
+      runUsmBackend({ mode: 'auto', numSources: 6 }).catch((e) => {
+        console.warn('[VIP] USM backend skipped:', e?.message || e);
+      });
       return analysis;
     } catch (err) {
       showError(err.message || String(err));
@@ -824,16 +822,21 @@ export function installAnalysisWorkspace(app) {
     else if (typeof app.setStatus === 'function') app.setStatus(`Exported ${result.filename}`);
   });
 
-  // Universal Source Matrix controls
-  els.btnUsmSeparate?.addEventListener('click', () => { runUsmSeparate('auto'); });
-  els.btnUsmQuery?.addEventListener('click', () => { runUsmSeparate('query'); });
-  els.btnUsmApplyMix?.addEventListener('click', () => applyUsmMixToProcessed());
-  els.usmQueryInput?.addEventListener('keydown', (e) => {
-    if (e.key === 'Enter') {
-      e.preventDefault();
-      runUsmSeparate('query');
+  // USM is backend-only: hide legacy Separate/Query buttons if still in DOM.
+  [els.btnUsmSeparate, els.btnUsmQuery, els.btnUsmApplyMix].forEach((b) => {
+    if (b) {
+      b.hidden = true;
+      b.setAttribute('aria-hidden', 'true');
     }
   });
+  if (els.usmQueryInput) {
+    els.usmQueryInput.hidden = true;
+    els.usmQueryInput.setAttribute('aria-hidden', 'true');
+  }
+  if (els.usmNumSources) {
+    const wrap = els.usmNumSources.closest?.('.usm-k-label') || els.usmNumSources;
+    if (wrap) wrap.hidden = true;
+  }
 
   // Inject calibrated presets into app if PRESETS exists
   try {
@@ -873,7 +876,11 @@ export function installAnalysisWorkspace(app) {
     audition,
     host,
     usmNode,
-    runUsmSeparate,
+    /** Backend API */
+    runUsmBackend,
+    getSourceStems: () => usmNode.getSourceStems(),
+    getSourceLabels: () => usmNode.getSourceLabels(),
+    runUsmSeparate, // deprecated alias
     applyUsmMixToProcessed,
     refreshCapability: renderCapability,
   };

--- a/public/app/slider-theme.css
+++ b/public/app/slider-theme.css
@@ -601,11 +601,14 @@ input[type="range"].slider:disabled::-webkit-slider-thumb,
    LOCK BUTTON  — protects a slider from preset / reset changes
    ══════════════════════════════════════════════════════════════ */
 
-/* Amber palette for lock state */
+/* Cyan "protected" lock accent — must match style.css / slider-ticks.css */
 :root {
-  --vip-lock:      #ffcc44;
-  --vip-lock-soft: rgba(255, 204, 68, 0.13);
-  --vip-lock-glow: rgba(255, 204, 68, 0.40);
+  --vip-lock-accent: #67e8f9;
+  --vip-lock:        var(--vip-lock-accent);
+  --vip-lock-soft:   rgba(103, 232, 249, 0.14);
+  --vip-lock-glow:   rgba(103, 232, 249, 0.40);
+  --vip-lock-border: rgba(103, 232, 249, 0.55);
+  --vip-lock-text:   #a5f3fc;
 }
 
 .sr-lock-btn {
@@ -636,45 +639,50 @@ input[type="range"].slider:disabled::-webkit-slider-thumb,
 
 .sr-lock-btn:hover {
   opacity:      1 !important;
-  color:        var(--vip-lock);
+  color:        var(--vip-lock-accent);
   background:   var(--vip-lock-soft);
-  border-color: rgba(255, 204, 68, 0.40);
+  border-color: var(--vip-lock-border);
   box-shadow:   0 0 8px var(--vip-lock-glow);
 }
 
 .sr-lock-btn:focus-visible {
-  outline:      2px solid var(--vip-lock);
+  outline:      2px solid var(--vip-lock-accent);
   outline-offset: 2px;
 }
 
-/* Locked state — amber, always visible */
-.sr-lock-btn[aria-pressed="true"] {
+/* Locked state — cyan protected, always visible */
+.sr-lock-btn[aria-pressed="true"],
+.sr-lock-btn.is-locked {
   opacity:      1;
-  color:        var(--vip-lock);
+  color:        var(--vip-lock-accent);
   background:   var(--vip-lock-soft);
-  border-color: rgba(255, 204, 68, 0.52);
+  border-color: var(--vip-lock-border);
   box-shadow:   0 0 10px var(--vip-lock-glow);
 }
 
-/* Locked row — amber left bar + warm tint */
+/* Locked row — cyan left bar + cool tint */
 .sr-row.is-locked,
-.slider-row.is-locked {
-  box-shadow:  inset 3px 0 0 var(--vip-lock),
-               inset 0 0 28px rgba(255, 204, 68, 0.04);
+.slider-row.is-locked,
+.sr-row[data-locked="true"],
+.slider-row[data-locked="true"] {
+  box-shadow:  inset 3px 0 0 var(--vip-lock-accent),
+               inset 0 0 28px rgba(103, 232, 249, 0.04);
   background:  linear-gradient(
                  to right,
-                 rgba(255, 204, 68, 0.05) 0%,
+                 rgba(103, 232, 249, 0.06) 0%,
                  rgba(255, 255, 255, 0.012) 60%,
                  transparent 100%
                );
 }
 
-/* Value chip turns amber when row is locked */
+/* Value chip turns cyan when row is locked */
 .sr-row.is-locked .sr-val,
-.slider-row.is-locked .slider-val {
-  color:        var(--vip-lock);
-  background:   rgba(255, 204, 68, 0.09);
-  border-color: rgba(255, 204, 68, 0.32);
+.slider-row.is-locked .slider-val,
+.sr-row[data-locked="true"] .sr-val,
+.slider-row[data-locked="true"] .slider-val {
+  color:        var(--vip-lock-text, var(--vip-lock-accent));
+  background:   rgba(103, 232, 249, 0.09);
+  border-color: var(--vip-lock-border);
 }
 
 .sr-row.is-locked:hover .sr-val,

--- a/public/app/slider-ticks.css
+++ b/public/app/slider-ticks.css
@@ -83,15 +83,18 @@
   );
 }
 
-/* Locked sliders (amber accent) */
+/* Locked sliders — cyan protected accent (same token as style.css / slider-theme) */
 .slider-tick-wrapper.is-locked::after {
   background: repeating-linear-gradient(
     to right,
     rgba(255, 255, 255, 0.0) 0%,
     rgba(255, 255, 255, 0.0) calc(var(--tick-pct-step, 10%) - 0.5px),
-    rgba(255, 204, 68, 0.40) calc(var(--tick-pct-step, 10%) - 0.5px),
-    rgba(255, 204, 68, 0.40) var(--tick-pct-step, 10%)
+    rgba(103, 232, 249, 0.45) calc(var(--tick-pct-step, 10%) - 0.5px),
+    rgba(103, 232, 249, 0.45) var(--tick-pct-step, 10%)
   );
+}
+.slider-tick-wrapper.is-locked > input[type="range"] {
+  accent-color: var(--vip-lock-accent, #67e8f9);
 }
 
 /* ── Active state: brighten ticks when dragging ─────────────── */

--- a/public/app/style.css
+++ b/public/app/style.css
@@ -164,6 +164,14 @@ input[type='range']{
 /* ---- SLIDERS ---- */
 .sr{display:grid;grid-template-columns:1fr;gap:0;margin-bottom:2px}
 .sr-row{display:grid;grid-template-columns:130px 1fr 52px 22px 22px 22px;align-items:center;gap:8px;padding:4px 8px 4px 10px;border-radius:5px;position:relative;transition:background 0.1s;border-left:2px solid transparent}
+/* Locked ≠ disabled: single cyan "protected" accent (shared with slider-theme / ticks) */
+:root{
+  --vip-lock-accent:#67e8f9;
+  --vip-lock-soft:rgba(103,232,249,0.14);
+  --vip-lock-glow:rgba(103,232,249,0.40);
+  --vip-lock-border:rgba(103,232,249,0.55);
+  --vip-lock-text:#a5f3fc;
+}
 .slider-lock-btn{
   flex:0 0 22px;width:22px;height:22px;border-radius:50%;
   display:inline-flex;align-items:center;justify-content:center;
@@ -179,31 +187,37 @@ input[type='range']{
 .sr-row[data-locked="true"] .slider-lock-btn .lock-icon--locked{display:block}
 .slider-row[data-locked="true"] .slider-lock-btn .lock-icon--unlocked,
 .sr-row[data-locked="true"] .slider-lock-btn .lock-icon--unlocked{display:none}
-.slider-lock-btn:hover{color:#67e8f9;border-color:rgba(103,232,249,0.45);background:rgba(103,232,249,0.1)}
+.slider-lock-btn:hover{color:var(--vip-lock-accent);border-color:var(--vip-lock-border);background:var(--vip-lock-soft)}
 .slider-lock-btn.is-locked,
 .slider-row[data-locked="true"] .slider-lock-btn,
+.sr-row[data-locked="true"] .slider-lock-btn,
 .slider-row.slider-locked .slider-lock-btn{
-  color:#67e8f9;border-color:rgba(103,232,249,0.6);background:rgba(103,232,249,0.14);
-  box-shadow:0 0 0 1px rgba(103,232,249,0.2);
+  color:var(--vip-lock-accent);border-color:var(--vip-lock-border);background:var(--vip-lock-soft);
+  box-shadow:0 0 0 1px rgba(103,232,249,0.2),0 0 8px var(--vip-lock-glow);
 }
-/* Locked ≠ disabled: cool cyan protected accent (not red, not muted gray) */
+/* Locked row + tick wrapper share the same cyan protected accent */
 .slider-row[data-locked="true"],
 .sr-row[data-locked="true"],
-.slider-row.slider-locked{
-  border-left-color:#67e8f9;
+.slider-row.slider-locked,
+.sr-row.is-locked,
+.slider-row.is-locked{
+  border-left-color:var(--vip-lock-accent);
   background:linear-gradient(90deg, rgba(103,232,249,0.08) 0%, transparent 70%);
   box-shadow:inset 0 0 0 1px rgba(103,232,249,0.12);
 }
-.slider-row[data-locked="true"] > input[type="range"],
-.sr-row[data-locked="true"] > input[type="range"],
-.slider-row.slider-locked > input[type="range"]{
+.slider-row[data-locked="true"] input[type="range"],
+.sr-row[data-locked="true"] input[type="range"],
+.slider-row.slider-locked input[type="range"],
+.slider-tick-wrapper.is-locked > input[type="range"]{
   opacity:1;
-  accent-color:#67e8f9;
+  accent-color:var(--vip-lock-accent);
   cursor:not-allowed;
 }
 .slider-row[data-locked="true"] .sr-val,
-.sr-row[data-locked="true"] .sr-val{
-  color:#a5f3fc;
+.sr-row[data-locked="true"] .sr-val,
+.slider-row[data-locked="true"] .slider-val,
+.sr-row.is-locked .sr-val{
+  color:var(--vip-lock-text);
 }
 .slider-hint-btn{
   flex:0 0 22px;width:22px;height:22px;border-radius:50%;

--- a/src/pipeline/FullAnalysisHost.js
+++ b/src/pipeline/FullAnalysisHost.js
@@ -82,16 +82,27 @@ export class FullAnalysisHost {
     const requestId = ++this._requestId;
     return new Promise((resolve, reject) => {
       const timeoutMs = enriched.timeoutMs ?? 180000;
-      const timer = setTimeout(() => {
-        cleanup();
-        reject(new Error('Full analysis timed out'));
-      }, timeoutMs);
+      // Stall = no heartbeat/progress for stallMs (hard timeout still overall).
+      const stallMs = enriched.stallMs ?? 45000;
+      let lastActivity = Date.now();
+      const hardDeadline = Date.now() + timeoutMs;
+      const timer = setInterval(() => {
+        const now = Date.now();
+        if (now - lastActivity > stallMs) {
+          cleanup();
+          reject(new Error('Full analysis stalled (no worker heartbeat) — retry Analyze'));
+        } else if (now > hardDeadline) {
+          cleanup();
+          reject(new Error('Full analysis timed out'));
+        }
+      }, 2000);
 
       const onMessage = (event) => {
         const msg = event.data || {};
         if (msg.requestId !== requestId) return;
-        if (msg.type === 'progress') {
-          this.onProgress(msg.percent || 0, msg.stage || 'analysis');
+        if (msg.type === 'progress' || msg.type === 'heartbeat') {
+          lastActivity = Date.now();
+          this.onProgress(msg.percent || 0, msg.stage || (msg.type === 'heartbeat' ? 'working' : 'analysis'));
         } else if (msg.type === 'result') {
           cleanup();
           resolve(msg.analysis);
@@ -114,7 +125,7 @@ export class FullAnalysisHost {
       };
 
       const cleanup = () => {
-        clearTimeout(timer);
+        clearInterval(timer);
         worker.removeEventListener('message', onMessage);
         worker.removeEventListener('error', onError);
       };

--- a/src/pipeline/USMNode.js
+++ b/src/pipeline/USMNode.js
@@ -1,15 +1,18 @@
 /**
  * VoiceIsolate Pro — Universal Source Matrix Node (Layer 3: Pipeline)
  *
- * Upgrades the offline ML separation slot for Creator / Forensic modes:
- *   mixture PCM → K soft-masked stems + labels → Source Matrix Live-Mix.
+ * **Internal backend service** (not a user-facing panel). Consumed by:
+ *   a) Full Analysis pipeline — source segmentation / labeling chips
+ *   b) WhisperHunter — per-source stems for whisper isolation targeting
+ *
+ * Flow: mixture PCM → K soft-masked stems + labels (once per file, cached).
+ * Public API for consumers: getSourceStems(), getSourceLabels(), ensureComputed().
  *
  * Does NOT re-run on slider / mute / solo changes (Live-Mix contract).
- * Text "Refine" intentionally re-runs query separation once.
+ * Mute/solo/gain stay for SourceAuditionEngine only — not Engineer slider UI.
  *
- * Prefer classical core USM always available; optionally ask MLWorker for an
- * ONNX AudioSep-class model when `universal_separator` is in the manifest
- * and the weights are present.
+ * Classical NMF runs in USMWorker (off main thread). Optional ONNX via MLWorker
+ * when `universal_separator` is in the manifest and weights are present.
  */
 'use strict';
 
@@ -30,11 +33,77 @@ import { createMLWorker, initMLWorker } from './MLWorkerHost.js';
 let _worker = null;
 let _ready = null;
 let _seq = 0;
+/** Classical USM module worker (separate from ONNX MLWorker). */
+let _usmWorker = null;
+let _usmSeq = 0;
 
 function getWorker() {
   if (_worker) return _worker;
   _worker = createMLWorker();
   return _worker;
+}
+
+function getUsmWorker() {
+  if (_usmWorker) return _usmWorker;
+  if (typeof Worker === 'undefined') return null;
+  try {
+    const url = new URL('/src/workers/USMWorker.js', globalThis.location?.href || 'http://localhost/');
+    _usmWorker = new Worker(url.href, { type: 'module' });
+    return _usmWorker;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Classical separateUniversal via USMWorker (heartbeat + timeout).
+ * Falls back to main-thread if workers unavailable.
+ * @returns {Promise<import('../core/UniversalSourceMatrix.js').USMResult>}
+ */
+function runClassicalInWorker(mono, sampleRate, cfg, onProgress, timeoutMs = 120000) {
+  const w = getUsmWorker();
+  if (!w) {
+    onProgress?.(0.25, 'classical-usm-main');
+    return Promise.resolve(separateUniversal(mono, sampleRate, cfg));
+  }
+  const requestId = ++_usmSeq;
+  const copy = mono instanceof Float32Array ? new Float32Array(mono) : new Float32Array(mono);
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error('[VIP][USMNode] USMWorker timed out'));
+    }, timeoutMs);
+    const onMsg = (ev) => {
+      const m = ev.data || {};
+      if (m.requestId !== requestId) return;
+      if (m.type === 'progress' || m.type === 'heartbeat') {
+        const pct = Math.max(0.15, Math.min(0.95, (m.percent || 0) / 100));
+        onProgress?.(pct, m.stage || 'usm');
+      } else if (m.type === 'result') {
+        cleanup();
+        resolve(m.result);
+      } else if (m.type === 'error') {
+        cleanup();
+        reject(new Error(m.message || 'USMWorker failed'));
+      }
+    };
+    const onErr = (e) => {
+      cleanup();
+      reject(new Error(e?.message || 'USMWorker error'));
+    };
+    const cleanup = () => {
+      clearTimeout(timer);
+      w.removeEventListener('message', onMsg);
+      w.removeEventListener('error', onErr);
+    };
+    w.addEventListener('message', onMsg);
+    w.addEventListener('error', onErr);
+    onProgress?.(0.12, 'dispatch-usm-worker');
+    w.postMessage(
+      { type: 'separate', requestId, samples: copy, sampleRate, config: cfg },
+      [copy.buffer],
+    );
+  });
 }
 
 function ensureWorkerReady() {
@@ -187,6 +256,8 @@ export class USMNode {
     this._sampleRate = SAMPLE_RATE;
     /** @type {Float32Array|null} mixture mono retained for refine() */
     this._mixtureMono = null;
+    /** @type {string|null} cache key for ensureComputed() */
+    this._cacheKey = null;
   }
 
   /** Public sample-rate accessor (UI must not read `_sampleRate`). */
@@ -233,7 +304,18 @@ export class USMNode {
 
     if (!result || !result.sources?.length) {
       this.onProgress(0.2, 'classical-usm');
-      result = separateUniversal(mono, this._sampleRate, cfg);
+      try {
+        result = await runClassicalInWorker(
+          mono,
+          this._sampleRate,
+          cfg,
+          (p, label) => this.onProgress(p, label),
+          config.timeoutMs || 120000,
+        );
+      } catch (err) {
+        console.warn('[VIP][USMNode] worker failed, main-thread fallback:', err?.message || err);
+        result = separateUniversal(mono, this._sampleRate, cfg);
+      }
     }
 
     this.onProgress(0.9, 'pack-sources');
@@ -244,12 +326,13 @@ export class USMNode {
       gainDb: 0,
       mute: false,
       solo: false,
-      pcm: s.pcm,
+      pcm: s.pcm instanceof Float32Array ? s.pcm : new Float32Array(s.pcm || []),
       confidence: s.confidence,
       quality: s.quality,
       method: s.method,
       mask: s.mask,
     }));
+    this._cacheKey = this._buildCacheKey(mono, this._sampleRate, cfg);
 
     this.onProgress(1, 'complete');
     return {
@@ -258,6 +341,77 @@ export class USMNode {
       method: result.method,
       sampleRate: this._sampleRate,
     };
+  }
+
+  /**
+   * Ensure stems exist for this mixture (once per file). Skips recompute if
+   * cache key matches. Safe to call from Analyze / WhisperHunter — never from
+   * slider or mute/solo handlers.
+   * @param {Float32Array|Float32Array[]} channelData
+   * @param {number} sampleRate
+   * @param {object} [config]
+   */
+  async ensureComputed(channelData, sampleRate = SAMPLE_RATE, config = {}) {
+    if (config && Object.keys(config).length) this.configure(config);
+    const cfg = this._config || { mode: 'auto', numSources: USM_DEFAULT_SOURCES, queries: [] };
+    const channels = Array.isArray(channelData) && channelData[0]?.length != null
+      ? channelData
+      : [channelData];
+    const mono = downmixChannels(channels);
+    const key = this._buildCacheKey(mono, sampleRate || SAMPLE_RATE, cfg);
+    if (this.sources?.length && this._cacheKey === key) {
+      return {
+        sources: this.sources,
+        shape: this._lastResult?.shape,
+        method: this._lastResult?.method || 'cached',
+        sampleRate: this._sampleRate,
+        cached: true,
+      };
+    }
+    return this.process(mono, sampleRate, config);
+  }
+
+  _buildCacheKey(mono, sampleRate, cfg) {
+    const n = mono?.length || 0;
+    const mid = n ? mono[n >> 1] : 0;
+    const end = n ? mono[n - 1] : 0;
+    let sum = 0;
+    const step = Math.max(1, Math.floor(n / 64));
+    for (let i = 0; i < n; i += step) sum += Math.abs(mono[i]);
+    return `${sampleRate}|${n}|${sum.toFixed(4)}|${mid}|${end}|${cfg.mode}|${cfg.numSources}|${(cfg.queries || []).join(',')}`;
+  }
+
+  /**
+   * Internal API: soft-mask stems (Float32Array PCM) for WhisperHunter / audition.
+   * @returns {{ id: string, label: string, pcm: Float32Array, confidence: number, quality: string, method: string }[]}
+   */
+  getSourceStems() {
+    return this.sources.map((s) => ({
+      id: s.id,
+      label: s.label,
+      pcm: s.pcm,
+      confidence: s.confidence ?? 0,
+      quality: s.quality || 'medium',
+      method: s.method || 'classical-nmf',
+    }));
+  }
+
+  /**
+   * Internal API: labels + confidence for Analyzer summary chips (no PCM).
+   * @returns {{ id: string, label: string, confidence: number, quality: string }[]}
+   */
+  getSourceLabels() {
+    return this.sources.map((s) => ({
+      id: s.id,
+      label: s.label,
+      confidence: s.confidence ?? 0,
+      quality: s.quality || 'medium',
+    }));
+  }
+
+  /** True when at least one stem is cached from the last ensureComputed/process. */
+  isReady() {
+    return Array.isArray(this.sources) && this.sources.length > 0;
   }
 
   /**
@@ -352,6 +506,7 @@ export class USMNode {
     this.sources = [];
     this._lastResult = null;
     this._mixtureMono = null;
+    this._cacheKey = null;
   }
 
   dispose() {
@@ -360,6 +515,10 @@ export class USMNode {
       try { _worker.terminate(); } catch { /* ignore */ }
       _worker = null;
       _ready = null;
+    }
+    if (_usmWorker) {
+      try { _usmWorker.terminate(); } catch { /* ignore */ }
+      _usmWorker = null;
     }
   }
 }

--- a/src/workers/FullAnalysisWorker.js
+++ b/src/workers/FullAnalysisWorker.js
@@ -3,9 +3,12 @@
  *
  * Runs analyzeAudio off the main thread. Message protocol:
  *   { type: 'analyze', requestId, channels: Float32Array[], sampleRate, opts? }
- *   → { type: 'progress', requestId, percent, stage }
+ *   → { type: 'progress'|'heartbeat', requestId, percent, stage }
  *   → { type: 'result', requestId, analysis }
  *   → { type: 'error', requestId, message }
+ *
+ * Heartbeats keep the Engineer processing overlay from appearing stuck while
+ * classical feature extraction runs (sync work inside analyzeAudio).
  */
 'use strict';
 
@@ -15,8 +18,12 @@ self.onmessage = (event) => {
   const msg = event.data || {};
   if (msg.type !== 'analyze') return;
   const requestId = msg.requestId;
+  let heartbeat = null;
   try {
-    self.postMessage({ type: 'progress', requestId, percent: 5, stage: 'prepare' });
+    const post = (type, percent, stage) => {
+      self.postMessage({ type, requestId, percent, stage });
+    };
+    post('progress', 5, 'prepare');
     const channels = (msg.channels || []).map((c) => {
       if (c instanceof Float32Array) return c;
       return new Float32Array(c);
@@ -25,12 +32,24 @@ self.onmessage = (event) => {
       throw new Error('No channel data for analysis');
     }
     const sampleRate = msg.sampleRate || 48000;
-    self.postMessage({ type: 'progress', requestId, percent: 20, stage: 'features' });
+    post('progress', 20, 'features');
+    // Heartbeat while sync analyzeAudio runs — host timeout reset / UI pulse.
+    let tick = 22;
+    heartbeat = setInterval(() => {
+      tick = Math.min(90, tick + 3);
+      post('heartbeat', tick, 'analyze');
+    }, 500);
+
     const analysis = analyzeAudio(channels, sampleRate, msg.opts || {});
-    self.postMessage({ type: 'progress', requestId, percent: 95, stage: 'recommend' });
+    if (heartbeat) {
+      clearInterval(heartbeat);
+      heartbeat = null;
+    }
+    post('progress', 95, 'recommend');
     // Structured clone — analysis is plain data (no transfer needed for result object)
     self.postMessage({ type: 'result', requestId, analysis });
   } catch (err) {
+    if (heartbeat) clearInterval(heartbeat);
     self.postMessage({
       type: 'error',
       requestId,

--- a/src/workers/USMWorker.js
+++ b/src/workers/USMWorker.js
@@ -1,0 +1,91 @@
+/**
+ * VoiceIsolate Pro — Universal Source Matrix Worker (Layer 2)
+ *
+ * Runs classical separateUniversal off the main thread so Analyze/Process
+ * never freeze the Engineer UI. Message protocol:
+ *   { type: 'separate', requestId, samples: Float32Array, sampleRate, config? }
+ *   → { type: 'heartbeat'|'progress', requestId, percent, stage }
+ *   → { type: 'result', requestId, result }  (stems transferred)
+ *   → { type: 'error', requestId, message }
+ *
+ * Live-Mix contract: this worker is NEVER invoked from slider/mute/solo.
+ */
+'use strict';
+
+import { separateUniversal } from '../core/UniversalSourceMatrix.js';
+
+self.onmessage = (event) => {
+  const msg = event.data || {};
+  if (msg.type !== 'separate') return;
+  const requestId = msg.requestId;
+  let heartbeat = null;
+  try {
+    const post = (type, extra = {}) => {
+      self.postMessage({ type, requestId, ...extra });
+    };
+    post('progress', { percent: 5, stage: 'prepare' });
+    // Heartbeat while classical NMF runs (sync) so host can show "not stuck".
+    let tick = 8;
+    heartbeat = setInterval(() => {
+      tick = Math.min(88, tick + 4);
+      post('heartbeat', { percent: tick, stage: 'nmf' });
+    }, 400);
+
+    let samples = msg.samples;
+    if (!(samples instanceof Float32Array)) {
+      samples = new Float32Array(samples || []);
+    }
+    if (!samples.length) {
+      throw new Error('No samples for USM separation');
+    }
+    const sampleRate = msg.sampleRate || 48000;
+    const config = msg.config || { mode: 'auto', numSources: 6 };
+
+    post('progress', { percent: 15, stage: 'stft-nmf' });
+    const result = separateUniversal(samples, sampleRate, config);
+    if (heartbeat) {
+      clearInterval(heartbeat);
+      heartbeat = null;
+    }
+    post('progress', { percent: 95, stage: 'pack' });
+
+    // Transfer PCM + masks to avoid structured-clone cost on large stems.
+    const transfer = [];
+    const sources = (result.sources || []).map((s) => {
+      const pcm = s.pcm instanceof Float32Array ? s.pcm : new Float32Array(s.pcm || []);
+      const mask = s.mask instanceof Float32Array ? s.mask : null;
+      if (pcm.buffer) transfer.push(pcm.buffer);
+      if (mask?.buffer) transfer.push(mask.buffer);
+      return {
+        id: s.id,
+        label: s.label,
+        pcm,
+        mask,
+        confidence: s.confidence,
+        quality: s.quality,
+        method: s.method,
+      };
+    });
+
+    self.postMessage(
+      {
+        type: 'result',
+        requestId,
+        result: {
+          sources,
+          shape: result.shape,
+          method: result.method,
+          // stft dropped — large; stems already rendered
+        },
+      },
+      transfer,
+    );
+  } catch (err) {
+    if (heartbeat) clearInterval(heartbeat);
+    self.postMessage({
+      type: 'error',
+      requestId,
+      message: err && err.message ? err.message : String(err),
+    });
+  }
+};

--- a/tests/engineer-lock-ui.test.js
+++ b/tests/engineer-lock-ui.test.js
@@ -1,0 +1,126 @@
+/**
+ * Engineer Mode — slider lock visual state + process pause + A/B + collapsibles.
+ * DOM-level contracts (no browser paint — assert class/token wiring).
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const appSrc = fs.readFileSync(path.join(ROOT, 'public/app/app.js'), 'utf8');
+const styleCss = fs.readFileSync(path.join(ROOT, 'public/app/style.css'), 'utf8');
+const themeCss = fs.readFileSync(path.join(ROOT, 'public/app/slider-theme.css'), 'utf8');
+const ticksCss = fs.readFileSync(path.join(ROOT, 'public/app/slider-ticks.css'), 'utf8');
+const indexHtml = fs.readFileSync(path.join(ROOT, 'public/app/index.html'), 'utf8');
+
+describe('slider lock accent token (cyan protected)', () => {
+  test('style.css defines --vip-lock-accent and uses it for locked state', () => {
+    expect(styleCss).toMatch(/--vip-lock-accent\s*:\s*#67e8f9/i);
+    expect(styleCss).toMatch(/var\(--vip-lock-accent/);
+    // No amber lock hardcodes in locked thumb/row rules
+    expect(styleCss).not.toMatch(/data-locked[\s\S]{0,200}#ffcc44/);
+  });
+
+  test('slider-theme.css lock tokens are cyan, not amber', () => {
+    expect(themeCss).toMatch(/--vip-lock-accent\s*:\s*#67e8f9/i);
+    expect(themeCss).not.toMatch(/--vip-lock\s*:\s*#ffcc44/);
+    expect(themeCss).toMatch(/var\(--vip-lock-accent/);
+  });
+
+  test('slider-ticks.css locked ticks use cyan, not amber', () => {
+    expect(ticksCss).toMatch(/\.slider-tick-wrapper\.is-locked/);
+    expect(ticksCss).toMatch(/103,\s*232,\s*249/);
+    expect(ticksCss).not.toMatch(/255,\s*204,\s*68/);
+  });
+
+  test('locked computed color path: data-locked + is-locked both wired', () => {
+    expect(styleCss).toMatch(/\[data-locked="true"\]/);
+    expect(themeCss).toMatch(/\.is-locked/);
+    expect(ticksCss).toMatch(/\.is-locked/);
+  });
+});
+
+describe('process pauses playback contract', () => {
+  test('runPipeline pauses when playing and restores without auto-resume', () => {
+    expect(appSrc).toMatch(/_pausedForProcess/);
+    expect(appSrc).toMatch(/_playheadBeforeProcess/);
+    expect(appSrc).toMatch(/_setTransportProcessingState/);
+    expect(appSrc).toMatch(/pause-before-process failed/);
+    // finally must clear processing transport state
+    expect(appSrc).toMatch(/_setTransportProcessingState\(false\)/);
+    // Extract only the runPipeline finally block (anchor on isProcessing unlock)
+    const pipeFinally = appSrc.match(
+      /this\.isProcessing = false;\s*\/\/ Restore transport controls[\s\S]*?this\._playheadBeforeProcess = null;/,
+    );
+    expect(pipeFinally).toBeTruthy();
+    expect(pipeFinally[0]).not.toMatch(/this\.play\s*\(/);
+    expect(pipeFinally[0]).toMatch(/seekTo|_playheadBeforeProcess/);
+  });
+
+  test('isProcessing guard prevents overlapping Process', () => {
+    expect(appSrc).toMatch(/if \(this\.isProcessing\)[\s\S]{0,80}already in progress/);
+  });
+});
+
+describe('A/B Compare Original transport', () => {
+  test('transport exposes Compare Original control', () => {
+    expect(indexHtml).toMatch(/Compare Original/);
+    expect(indexHtml).toMatch(/id="tpAB"/);
+  });
+
+  test('toggleAB swaps modes and updates label structure', () => {
+    expect(appSrc).toMatch(/toggleAB\s*\(/);
+    expect(appSrc).toMatch(/abMode === 'original' \? 'processed' : 'original'/);
+    expect(appSrc).toMatch(/tp-ab-name/);
+  });
+});
+
+describe('collapsible panels + persistence', () => {
+  test('analysis workspace and key sections are details/summary', () => {
+    expect(indexHtml).toMatch(/id="section-analysis"/);
+    expect(indexHtml).toMatch(/id="section-upload"/);
+    expect(indexHtml).toMatch(/id="section-presets"/);
+    expect(indexHtml).toMatch(/id="section-whisper-hunter"/);
+    expect(indexHtml).toMatch(/id="sourceMatrixPanel"/);
+    expect(indexHtml).toMatch(/vip-section-summary/);
+  });
+
+  test('collapsible open state persisted in localStorage', () => {
+    expect(appSrc).toMatch(/vip\.engineer\.sectionOpen\.v1/);
+    expect(appSrc).toMatch(/_initCollapsibleSections/);
+    expect(appSrc).toMatch(/addEventListener\('toggle'/);
+  });
+});
+
+describe('data-flow documentation in app.js', () => {
+  test('documents Upload → Analyze → Process → A-B → Export path', () => {
+    expect(appSrc).toMatch(/Engineer Mode data flow/);
+    expect(appSrc).toMatch(/Upload/);
+    expect(appSrc).toMatch(/FullAnalysisWorker/);
+    expect(appSrc).toMatch(/USM/);
+    expect(appSrc).toMatch(/toggleAB/);
+    expect(appSrc).toMatch(/Export/);
+  });
+});
+
+describe('worker heartbeats', () => {
+  const fullWorker = fs.readFileSync(path.join(ROOT, 'src/workers/FullAnalysisWorker.js'), 'utf8');
+  const usmWorker = fs.readFileSync(path.join(ROOT, 'src/workers/USMWorker.js'), 'utf8');
+  const host = fs.readFileSync(path.join(ROOT, 'src/pipeline/FullAnalysisHost.js'), 'utf8');
+
+  test('FullAnalysisWorker posts heartbeat messages', () => {
+    expect(fullWorker).toMatch(/heartbeat/);
+    expect(fullWorker).toMatch(/setInterval/);
+  });
+
+  test('USMWorker posts heartbeat messages', () => {
+    expect(usmWorker).toMatch(/heartbeat/);
+    expect(usmWorker).toMatch(/separateUniversal/);
+  });
+
+  test('FullAnalysisHost treats heartbeat as activity and supports stall timeout', () => {
+    expect(host).toMatch(/heartbeat/);
+    expect(host).toMatch(/stalled|stallMs/);
+  });
+});

--- a/tests/slider-calibration-hardening.test.js
+++ b/tests/slider-calibration-hardening.test.js
@@ -166,6 +166,12 @@ describe('lock persistence (app.js contract)', () => {
     expect(appSrc).toMatch(/dataset\.locked/);
   });
 
+  test('_syncSliderLockUi toggles tick wrapper is-locked for CSS parity', () => {
+    expect(appSrc).toMatch(/slider-tick-wrapper/);
+    expect(appSrc).toMatch(/classList\.toggle\('is-locked'/);
+    expect(appSrc).toMatch(/tickWrap\.dataset\.locked/);
+  });
+
   test('reset supports unlocked-only path', () => {
     expect(appSrc).toMatch(/_resetSliders\s*\(/);
     expect(appSrc).toMatch(/unlockedOnly/);

--- a/tests/universal-source-matrix.test.js
+++ b/tests/universal-source-matrix.test.js
@@ -211,4 +211,106 @@ describe('USMNode pipeline', () => {
 
     node.dispose();
   });
+
+  test('internal API: getSourceStems / getSourceLabels / isReady / ensureComputed cache', async () => {
+    const mix = syntheticMix(0.25, SAMPLE_RATE);
+    const node = new USMNode({ preferOnnx: false });
+    expect(node.isReady()).toBe(false);
+    expect(node.getSourceStems()).toEqual([]);
+    expect(node.getSourceLabels()).toEqual([]);
+
+    const first = await node.ensureComputed(mix, SAMPLE_RATE, {
+      mode: 'auto',
+      numSources: 3,
+      nmfIterations: 10,
+    });
+    expect(first.sources).toHaveLength(3);
+    expect(first.cached).toBeFalsy();
+    expect(node.isReady()).toBe(true);
+
+    const stems = node.getSourceStems();
+    expect(stems).toHaveLength(3);
+    expect(stems[0].pcm).toBeInstanceOf(Float32Array);
+    expect(stems[0].label).toBeTruthy();
+    expect(stems[0].id).toMatch(/^usm_/);
+
+    const labels = node.getSourceLabels();
+    expect(labels).toHaveLength(3);
+    expect(labels[0]).toEqual(expect.objectContaining({
+      id: expect.any(String),
+      label: expect.any(String),
+      confidence: expect.any(Number),
+    }));
+    // Labels must not expose PCM (UI summary only)
+    expect(labels[0].pcm).toBeUndefined();
+
+    const second = await node.ensureComputed(mix, SAMPLE_RATE, {
+      mode: 'auto',
+      numSources: 3,
+      nmfIterations: 10,
+    });
+    expect(second.cached).toBe(true);
+    expect(second.sources).toHaveLength(3);
+
+    node.dispose();
+  });
+
+  test('Live-Mix contract: mute/solo/gain do not re-invoke process', async () => {
+    const mix = syntheticMix(0.2, SAMPLE_RATE);
+    const node = new USMNode({ preferOnnx: false });
+    await node.ensureComputed(mix, SAMPLE_RATE, { mode: 'auto', numSources: 3, nmfIterations: 8 });
+    const processSpy = jest.spyOn(node, 'process');
+    const ensureSpy = jest.spyOn(node, 'ensureComputed');
+
+    const id = node.sources[0].id;
+    node.setMute(id, true);
+    node.setSolo(id, true);
+    node.setGainDb(id, -3);
+    node.setLabel(id, 'renamed');
+    node.renderMix();
+
+    expect(processSpy).not.toHaveBeenCalled();
+    expect(ensureSpy).not.toHaveBeenCalled();
+    processSpy.mockRestore();
+    ensureSpy.mockRestore();
+    node.dispose();
+  });
+});
+
+describe('USM engineer UI contract (source)', () => {
+  const fs = require('fs');
+  const path = require('path');
+  const workspace = fs.readFileSync(
+    path.join(__dirname, '..', 'public', 'app', 'lib', 'analysis-workspace.js'),
+    'utf8',
+  );
+  const usmNodeSrc = fs.readFileSync(
+    path.join(__dirname, '..', 'src', 'pipeline', 'USMNode.js'),
+    'utf8',
+  );
+  const indexHtml = fs.readFileSync(
+    path.join(__dirname, '..', 'public', 'app', 'index.html'),
+    'utf8',
+  );
+
+  test('analysis-workspace auto-runs USM backend after analysis', () => {
+    expect(workspace).toMatch(/runUsmBackend/);
+    expect(workspace).toMatch(/ensureComputed/);
+    expect(workspace).toMatch(/getSourceStems/);
+    expect(workspace).toMatch(/getSourceLabels/);
+  });
+
+  test('USMNode documents backend role and Live-Mix contract', () => {
+    expect(usmNodeSrc).toMatch(/Internal backend service/);
+    expect(usmNodeSrc).toMatch(/getSourceStems/);
+    expect(usmNodeSrc).toMatch(/getSourceLabels/);
+    expect(usmNodeSrc).toMatch(/USMWorker/);
+  });
+
+  test('Engineer HTML shows Detected Sources summary, not Separate controls as primary', () => {
+    expect(indexHtml).toMatch(/Detected Sources/);
+    expect(indexHtml).toMatch(/computed automatically/i);
+    // Separate buttons exist only as hidden legacy ids
+    expect(indexHtml).toMatch(/btnUsmSeparate[\s\S]*hidden/);
+  });
 });


### PR DESCRIPTION
## Summary

Full Engineer Mode audit + fix pass for freezes, USM architecture, slider lock visuals, collapsibles, process/playback races, and A/B transport.

### Changes

1. **Main-thread freezes** — Classical analysis/USM heartbeats; `FullAnalysisHost` stall timeout; new `USMWorker` keeps NMF off the UI thread.
2. **USM as backend service** — Not a user Separate/mute/solo panel. Post-Analyze `ensureComputed()` + `getSourceStems()` / `getSourceLabels()` for chips + WhisperHunter. Mute/solo only in Audition (Live-Mix contract).
3. **Slider lock visual** — Single cyan token `--vip-lock-accent` across `style.css` / `slider-theme.css` / `slider-ticks.css`. `_syncSliderLockUi` sets `data-locked` on the row **and** `.slider-tick-wrapper.is-locked`.
4. **Collapsible panels** — Analysis / Detected Sources / WhisperHunter wrapped in `<details>`; open state in `localStorage` (`vip.engineer.sectionOpen.v1`).
5. **Pause on Process** — Pause playback, retain playhead, disable transport; restore without auto-resume.
6. **Compare Original** — Always-visible transport A/B with sample-accurate swap.
7. **Data-flow docs** in `app.js` header + ANALYSIS_WORKSPACE / README updates.
8. **Extras** — rAF-coalesced slider updates; worker progress/heartbeat.

### Verification

- `node scripts/validate.js` — clean ×2
- Full Jest suite — **115 suites / 2479 tests** — clean ×2 consecutive passes

### Cross-validation (item 9)

Reconciled against `CLAUDE.md` Stem-Split & Live-Mix contracts and existing `transport` / `universal-source-matrix` tests. External AI tools (Perplexity/Claude/Jules/Qwen/Z.ai) were not available in this environment; no conflicting recommendations needed reconciliation beyond product architecture docs.

## Test plan

- [x] `pnpm`/node validate.js
- [x] Full `tests/*.test.js` including `universal-source-matrix.test.js` and new `engineer-lock-ui.test.js`
- [ ] Manual smoke (when convenient): upload → analyze → lock 3 sliders → collapse/expand panels → process while playing → Compare Original → export


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add USM backend, worker heartbeats, process pause, A/B compare, and locked accent hardening to Engineer Mode
> - Universal Source Matrix now runs as an internal backend after Analyze Full Audio via [`USMNode.ensureComputed`](https://github.com/Joker5514/VoiceIsolate-Pro/pull/725/files#diff-6c2088a46a4250e8834a7649a65190e85e989d4db5212a493f1cbf689ef9be70) and [`runUsmBackend`](https://github.com/Joker5514/VoiceIsolate-Pro/pull/725/files#diff-42b7079e7ed2c396f1836b0be66d72e91b9f3a84241ceefe3b6506caaa4fa3b1), populating read-only detected-source chips and stems for WhisperHunter instead of requiring a separate user action; legacy Separate/Query/Apply controls are hidden
> - [`USMWorker.js`](https://github.com/Joker5514/VoiceIsolate-Pro/pull/725/files#diff-52d7b5c213dea8251865d8b2a0eff6d03547b5886f777219dba64128df5528fe) offloads classical NMF separation off-main-thread with periodic heartbeat messages; [`FullAnalysisWorker.js`](https://github.com/Joker5514/VoiceIsolate-Pro/pull/725/files#diff-5b55e8678b96915b82667bc5f689c38b6b2ceb8a616d7ceb63fa91af09a8d7eb) similarly emits heartbeats during analysis
> - [`FullAnalysisHost`](https://github.com/Joker5514/VoiceIsolate-Pro/pull/725/files#diff-9b74638ff93144bd3c556c044f70cc1190fff264782c71cca25a6fe51488e264) replaces a single hard timeout with stall detection: rejects early if no heartbeat/progress arrives within 45 s, retaining an overall hard deadline
> - Starting processing in [`runPipeline`](https://github.com/Joker5514/VoiceIsolate-Pro/pull/725/files#diff-8a8b7ea624d7fccc12a516d122dcb07bd67c6a8f796c80e33b898ee6a7557650) now pauses playback, saves the playhead, disables transport controls, and restores state afterward without auto-resuming
> - The A/B transport button gains `aria-pressed`, structured B/Original labeling, and is enabled only after a processed buffer is available
> - Collapsible analysis/WhisperHunter panels persist open/closed state to `localStorage` under key `vip.engineer.sectionOpen.v1`
> - Locked slider rows now render with a cyan accent via CSS variables (`--vip-lock-accent`) across [`style.css`](https://github.com/Joker5514/VoiceIsolate-Pro/pull/725/files#diff-35b8006cad11f725a0bc3cee37866f6a39b941ae71d953d622c215dbd1a8d389), [`slider-theme.css`](https://github.com/Joker5514/VoiceIsolate-Pro/pull/725/files#diff-b620efcd953a2a3ca64395268e2ed6988df35c3f6ea26f6cb2cca3c02d664318), and [`slider-ticks.css`](https://github.com/Joker5514/VoiceIsolate-Pro/pull/725/files#diff-127d9f14164b16edd4bcd5bdea9218d9c4847e864231b05f441b67f800f53d05), with `is-locked`/`data-locked` selectors unified
> - Rapid slider drags are coalesced via rAF into one flush per frame to reduce redundant worklet calls
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 81487c6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic full-audio analysis with detected-source summaries.
  - Added “Compare Original vs Processed” playback controls.
  - Added persistent collapsible analysis sections.
  - Improved processing responsiveness with safer slider updates and playback state handling.
  - Added clearer protected-slider styling and accessibility states.

- **Bug Fixes**
  - Improved long-running analysis reliability with progress monitoring and stall detection.
  - Prevented unnecessary recomputation during live mixing.

- **Documentation**
  - Expanded the analysis workspace guide and updated the feature overview.

- **Tests**
  - Added coverage for analysis, source detection, controls, persistence, and protected sliders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->