### PR TITLE
chore(platforms): document Android/desktop rebuild @9466892

### DIFF
--- a/docs/DOWNLOADS.md
+++ b/docs/DOWNLOADS.md
@@ -3,14 +3,19 @@
 **In-repo version:** **25.0.0** (Android `versionName` / Electron artifact / API version)  
 **Build number:** **250000** (`versionCode` / iOS `CFBundleVersion`)
 
+**Platform web-shell sync (local rebuild):** last run from `main` @ **`9466892`**  
+(PRs **#725** + **#726** — USM/lock/A-B + slider expand + separation→isolation Live-Mix).  
+See [PLATFORM_SYNC.md](releases/PLATFORM_SYNC.md).  
+`build/`, `android/.../assets/public`, and `dist/*` binaries are **gitignored** — regenerate after pulling.
+
 Published GitHub Release assets are cut separately. Until a **v25.0.0** release is uploaded, the **latest** tag may still serve prior **v24.0.0** binaries.
 
 ## Current code target
 
 | Platform | Artifact name | Notes |
 |----------|---------------|--------|
-| **Android** | `VoiceIsolate-Pro-android-debug.apk` | `versionName "25.0.0"`, `versionCode 250000` |
-| **Windows** | `VoiceIsolate-Pro-25.0.0-win-x64.exe` | electron-builder `${version}` |
+| **Android** | `VoiceIsolate-Pro-android-debug.apk` | `versionName "25.0.0"`, `versionCode 250000` · Engineer expand + stem Live-Mix |
+| **Windows** | `VoiceIsolate-Pro-25.0.0-win-x64.exe` | electron-builder `${version}` · loads `build/` shell |
 
 ### Prior published tag (v24.0.0)
 

--- a/docs/releases/PLATFORM_SYNC.md
+++ b/docs/releases/PLATFORM_SYNC.md
@@ -1,0 +1,45 @@
+# Platform sync status
+
+Tracks when Android (Capacitor) and Desktop (Electron) web shells were rebuilt against `main`.
+
+| Field | Value |
+|-------|--------|
+| **Git SHA** | `9466892` |
+| **Package version** | `25.0.0` / build `250000` |
+| **Synced at (UTC)** | 2026-07-28 |
+| **Includes** | PR #725 (USM backend, lock accent, process pause, A/B) · PR #726 (collapsible expand, separation→isolation Live-Mix) |
+
+## What was run
+
+1. `node scripts/sync-src.js` — `src/` → `public/src/` (dev imports)
+2. `node scripts/build.mjs` — `public/` + `src/` → `build/`
+3. `node scripts/prepare-android-complete.mjs` — offline Android package under `build/`
+4. `npx cap sync android` — `build/` → `android/app/src/main/assets/public`
+5. `pnpm android:build:win` — debug APK → `dist/android/VoiceIsolate-Pro-android-debug.apk` (~96 MB)
+6. `pnpm build:electron:dir` — unpacked desktop → `dist/electron/win-unpacked/VoiceIsolate Pro.exe`
+
+## Git policy (do not commit)
+
+| Path | Why ignored |
+|------|-------------|
+| `build/` | Generated static shell |
+| `public/src/` | Mirror of `src/` for static serving |
+| `android/app/src/main/assets/public` | Capacitor copy of `build/` |
+| `dist/android/*.apk`, `dist/electron/*` | Binaries → GitHub Releases only |
+
+Canonical source remains **`public/app/`** + **`src/`** on `main`. Always rebuild platforms after pulling Engineer Mode changes:
+
+```bash
+pnpm android:build:win
+pnpm build:electron:dir   # or build:electron for installer
+```
+
+## Verify markers after sync
+
+```bash
+# Expect hits for loadStemPair / _loadSeparationStemsToBridge
+rg -n "loadStemPair|_loadSeparationStemsToBridge" build/app/app.js build/src/pipeline/EngineerModeBridge.js
+rg -n "loadStemPair" android/app/src/main/assets/public/src/pipeline/EngineerModeBridge.js
+```
+
+Worklets: `pnpm worklets:verify:build` with Android assets present.

--- a/download/README.md
+++ b/download/README.md
@@ -9,6 +9,19 @@ Web download page: https://voice-isolate-pro.vercel.app/download/
 
 **In-repo version:** **25.0.0** · build **250000**
 
+**Synced web shell (Engineer Mode + pipeline):** rebuild from `main` @ **`9466892`**  
+(PRs **#725** + **#726** — expand/collapse, separation→isolation Live-Mix, USM backend, lock accent).
+
+Local rebuild (artifacts under `dist/`, not committed):
+
+```bash
+pnpm run build
+pnpm android:build:win          # → dist/android/VoiceIsolate-Pro-android-debug.apk
+pnpm build:electron:dir         # → dist/electron/win-unpacked/
+# optional full installer:
+pnpm build:electron             # → dist/electron/VoiceIsolate-Pro-25.0.0-win-x64.exe
+```
+
 ---
 
 ## Android APK


### PR DESCRIPTION
## Summary

Local platform rebuild completed against `main` @ `9466892` (Engineer Mode PRs **#725** + **#726**):

- `build/` + Capacitor Android assets synced
- Debug APK: `dist/android/VoiceIsolate-Pro-android-debug.apk` (~96 MB)
- Electron unpacked: `dist/electron/win-unpacked/VoiceIsolate Pro.exe`

This PR only commits **docs** (`PLATFORM_SYNC.md`, DOWNLOADS, download README). Binaries and `build/` remain gitignored per project policy.

## Test plan
- [x] `pnpm android:build:win` success
- [x] `pnpm build:electron:dir` success
- [x] Marker strings present in `build/` and Android assets


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document Android and desktop rebuild status at Git SHA 9466892
> Adds documentation capturing the platform web-shell sync state for Android and Electron builds at commit `9466892`, referencing PRs #725 and #726.
>
> - [docs/DOWNLOADS.md](https://github.com/Joker5514/VoiceIsolate-Pro/pull/727/files#diff-57ec16e25588ea3da6b120b50114a0ede9025e9546f5110011e40d216fa1f2cd) adds a sync status block noting that `build/`, `android/.../assets/public`, and `dist/*` are gitignored and must be regenerated locally.
> - [docs/releases/PLATFORM_SYNC.md](https://github.com/Joker5514/VoiceIsolate-Pro/pull/727/files#diff-9c05e953170d3d0fbdc13469064630d50eb388efa21c8ccb7bd853f09d55a885) is a new file listing the six commands used to rebuild shells, ignored paths, canonical sources, and ripgrep verification steps.
> - [download/README.md](https://github.com/Joker5514/VoiceIsolate-Pro/pull/727/files#diff-b9fefb8047c707594f1ddca4ca12dfc12a82283a69aeafb1ea2e7308f9b08709) adds a local rebuild section with the full command sequence and output locations under `dist/`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2f9eb1e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->